### PR TITLE
General cleanup of bash completion code

### DIFF
--- a/src/misc/plz_complete.sh
+++ b/src/misc/plz_complete.sh
@@ -8,18 +8,10 @@ _PleaseCompleteMe() {
   COMPREPLY=()
   _get_comp_words_by_ref -n : cur
 
-  if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $( compgen -W "`plz --help 2>&1 | grep -Eo -- '--?[a-z_]+'`" -- $cur ) )
+  if [[ "$cur" == -* || "$COMP_CWORD" == "1" || ("$COMP_CWORD" == "2" && "${COMP_WORDS[1]}" == "query")]]; then
+      COMPREPLY=( $( compgen -W "`GO_FLAGS_COMPLETION=1 plz ${cur}`" -- $cur) )
   else
-      if [[ "$COMP_CWORD" == "1" ]]; then
-	  COMPREPLY=( $( compgen -W "build test cover query clean run update" -- $cur ) )
-      else
-	      if [[ "$COMP_CWORD" == "2" && "${COMP_WORDS[1]}" == "query" ]]; then
-	          COMPREPLY=( $( compgen -W "somepath alltargets deps print completions affectedtests input output" -- $cur ) )
-	      else
-	          COMPREPLY=( $( compgen -W "`plz --noupdate -p query completions --cmd ${COMP_WORDS[1]} $cur 2>/dev/null`" -- $cur ) )
-	      fi
-      fi
+	  COMPREPLY=( $( compgen -W "`plz --noupdate -p query completions --cmd ${COMP_WORDS[1]} $cur 2>/dev/null`" -- $cur ) )
   fi
   __ltrim_colon_completions "$cur"
   return 0


### PR DESCRIPTION
Does not fix the actual bug, that still eludes me :(
Just cleans up some indentation, removes a couple of unnecessary bits and doesn't stomp COMP_WORDBREAKS which is a Bad Idea.
