### PR TITLE
Correctly exclude embedded_parser.py.

### DIFF
--- a/src/parse/BUILD
+++ b/src/parse/BUILD
@@ -19,8 +19,15 @@ filegroup(
 )
 
 genrule(
+    name = 'embedded_parser',
+    srcs = ['//src/parse/cffi:embedded_parser'],
+    outs = ['rules/embedded_parser.py'],
+    cmd = 'cp $SRC $OUT',
+)
+
+genrule(
     name = 'builtin_rules',
-    srcs = glob(['rules/*.py'], excludes=['embedded_parser.py']) + ['//src/parse/cffi:embedded_parser'],
+    srcs = glob(['rules/*.py'], excludes=['rules/embedded_parser.py']) + [':embedded_parser'],
     outs = ['builtin_rules.go'],
     cmd = '$TOOL -o $OUT -nomemcopy -nometadata -nocompress -pkg parse -prefix ${PKG}/rules ${PKG}/rules',
     tools = [


### PR DESCRIPTION
 Previously the rule was picking up the artifact from bootstrap instead of the one it had generated itself, so you had to bootstrap once for it to work.
