### PR TITLE
Levenshtein-based suggestion code

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,6 +21,7 @@ go get github.com/golang/lint/golint
 go get google.golang.org/grpc
 go get github.com/kardianos/osext
 go get github.com/Songmu/prompter
+go get github.com/texttheater/golang-levenshtein/levenshtein
 
 # Clean out old artifacts.
 rm -rf plz-out src/parse/cffi/parser_interface.py src/parse/rules/embedded_parser.py

--- a/src/parse/BUILD
+++ b/src/parse/BUILD
@@ -2,7 +2,7 @@ subinclude('//build_defs:go_bindata')
 
 cgo_library(
     name = 'parse',
-    srcs = glob(['parse_step.go', 'interpreter.*']) + [':builtin_rules'],
+    srcs = glob(['parse_step.go', 'suggest.go', 'interpreter.*']) + [':builtin_rules'],
     env = {'CGO_LDFLAGS': '-L${TMP_DIR}/${PKG}/rules'},
     deps = [
         ':defs_hdr',
@@ -10,6 +10,7 @@ cgo_library(
         '//src/core',
         '//third_party/go:logging',
         '//third_party/go:gcfg',
+        '//third_party/go:levenshtein',
     ],
     visibility = ['PUBLIC'],
 )
@@ -61,6 +62,15 @@ cgo_test(
         '//third_party/go:testify',
     ],
     data = glob(['test_data/**/TEST_BUILD', 'test_data/**/test.py']),
+)
+
+cgo_test(
+    name = 'suggest_test',
+    srcs = ['suggest_test.go'],
+    deps = [
+        ':parse',
+        '//third_party/go:testify',
+    ],
 )
 
 # Simulates a code generating rule to test the require / provide mechanism.

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -6,13 +6,16 @@
 // will work as expected.
 package parse
 
-import "core"
-import "fmt"
-import "os"
-import "path"
-import "path/filepath"
-import "strings"
-import "sync"
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"core"
+)
 
 // Parses the package corresponding to a single build label. The label can be :all to add all targets in a package.
 // It is not an error if the package has already been parsed.
@@ -75,7 +78,7 @@ func activateTarget(state *core.BuildState, pkg *core.Package, label, dependor c
 		if dependor != core.OriginalTarget {
 			msg += fmt.Sprintf(" (depended on by %s)", dependor)
 		}
-		panic(msg)
+		panic(msg + suggestTargets(pkg, label, dependor))
 	}
 	if noDeps && !dependor.IsAllTargets() { // IsAllTargets indicates requirement for parse
 		return // Some kinds of query don't need a full recursive parse.
@@ -380,7 +383,7 @@ func FindAllSubpackages(config core.Configuration, rootPath string, prefix strin
 	return ch
 }
 
-// Returns true if given filename is a build file name.
+// isABuildFile returns true if given filename is a build file name.
 func isABuildFile(name string, config core.Configuration) bool {
 	for _, buildFileName := range config.Please.BuildFileName {
 		if name == buildFileName {

--- a/src/parse/suggest.go
+++ b/src/parse/suggest.go
@@ -1,0 +1,57 @@
+package parse
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/texttheater/golang-levenshtein/levenshtein"
+
+	"core"
+)
+
+// Max levenshtein distance that we'll suggest at.
+const maxSuggestionDistance = 3
+
+// suggestTargets suggests the targets in the given package that might be misspellings of
+// the requested one.
+func suggestTargets(pkg *core.Package, label, dependor core.BuildLabel) string {
+	r := []rune(label.Name)
+	options := make(suggestions, 0, len(pkg.Targets))
+	for t := range pkg.Targets {
+		distance := levenshtein.DistanceForStrings(r, []rune(t), levenshtein.DefaultOptions)
+		if distance <= maxSuggestionDistance {
+			options = append(options, suggestion{name: t, dist: distance})
+		}
+	}
+	if len(options) == 0 {
+		return ""
+	}
+	sort.Sort(options)
+	// Obviously there's now more code to pretty-print the suggestions than to do the calculation...
+	msg := "\nMaybe you meant "
+	for i, o := range options {
+		if i > 0 {
+			if i < len(options)-1 {
+				msg += ", "
+			} else {
+				msg += " or "
+			}
+		}
+		if pkg.Name == dependor.PackageName {
+			msg += ":" + o.name
+		} else {
+			msg += fmt.Sprintf("//%s:%s", pkg.Name, o.name)
+		}
+	}
+	return msg + " ?" // Leave a space so you can select them without getting the question mark
+}
+
+type suggestion struct {
+	name string
+	dist int
+}
+type suggestions []suggestion
+
+func (s suggestions) Len() int           { return len(s) }
+func (s suggestions) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s suggestions) Less(i, j int) bool { return s[i].dist < s[j].dist }

--- a/src/parse/suggest_test.go
+++ b/src/parse/suggest_test.go
@@ -1,0 +1,63 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"core"
+)
+
+func TestSuggestNoTargetFromSamePackage(t *testing.T) {
+	pkg := makePackage("src/core", "wobble", "wibble")
+	s := suggestTargets(pkg, bl("//src/core:target2"), bl("//src/core:wibble"))
+	assert.Equal(t, s, "", "No suggestion because they're not similar at all.")
+}
+
+func TestSuggestSingleTargetFromSamePackage(t *testing.T) {
+	pkg := makePackage("src/core", "target1", "wibble")
+	s := suggestTargets(pkg, bl("//src/core:target2"), bl("//src/core:wibble"))
+	assert.Equal(t, s, "\nMaybe you meant :target1 ?")
+}
+
+func TestSuggestTwoTargetsFromSamePackage(t *testing.T) {
+	pkg := makePackage("src/core", "target1", "target21", "wibble")
+	s := suggestTargets(pkg, bl("//src/core:target"), bl("//src/core:blibble"))
+	assert.Equal(t, s, "\nMaybe you meant :target1 or :target21 ?")
+}
+
+func TestSuggestSeveralTargetsFromSamePackage(t *testing.T) {
+	pkg := makePackage("src/core", "target1", "target21", "target_21", "wibble")
+	s := suggestTargets(pkg, bl("//src/core:target"), bl("//src/core:blibble"))
+	assert.Equal(t, s, "\nMaybe you meant :target1, :target21 or :target_21 ?")
+}
+
+func TestSuggestSingleTargetFromAnotherPackage(t *testing.T) {
+	pkg := makePackage("src/core", "target1", "wibble")
+	s := suggestTargets(pkg, bl("//src/core:target2"), bl("//src/parse:wibble"))
+	assert.Equal(t, s, "\nMaybe you meant //src/core:target1 ?")
+}
+
+func TestSuggestTwoTargetsFromAnotherPackage(t *testing.T) {
+	pkg := makePackage("src/core", "target1", "target21", "wibble")
+	s := suggestTargets(pkg, bl("//src/core:target"), bl("//src/parse:blibble"))
+	assert.Equal(t, s, "\nMaybe you meant //src/core:target1 or //src/core:target21 ?")
+}
+
+func TestSuggestSeveralTargetsFromAnotherPackage(t *testing.T) {
+	pkg := makePackage("src/core", "target1", "target21", "target_21", "wibble")
+	s := suggestTargets(pkg, bl("//src/core:target"), bl("//src/parse:blibble"))
+	assert.Equal(t, s, "\nMaybe you meant //src/core:target1, //src/core:target21 or //src/core:target_21 ?")
+}
+
+func makePackage(name string, targets ...string) *core.Package {
+	pkg := core.NewPackage(name)
+	for _, target := range targets {
+		pkg.Targets[target] = nil
+	}
+	return pkg
+}
+
+func bl(label string) core.BuildLabel {
+	return core.ParseBuildLabel(label, "")
+}

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -108,3 +108,9 @@ go_get(
     revision = 'f8ecfdb6b66ec67ca930b39806519a2b72d1eaca',
     binary = True,
 )
+
+go_get(
+    name = 'levenshtein',
+    get = 'github.com/texttheater/golang-levenshtein/levenshtein',
+    revision = '14026fface0cb806188c85e792a93d625dc37d0f',
+)


### PR DESCRIPTION
Makes suggestions when you mistype a dependency, eg.

```
Parsed build file common/protos/BUILD but it doesn't contain target healthcheck (depended on by //platform:whatever)
Maybe you meant //common/protos:health_check ?
```
