### PR TITLE
Link cache files instead of copying

### DIFF
--- a/src/cache/dir_cache.go
+++ b/src/cache/dir_cache.go
@@ -45,7 +45,7 @@ func (cache *dirCache) StoreExtra(target *core.BuildTarget, key []byte, out stri
 	} else if err := os.MkdirAll(cacheDir, core.DirPermissions); err != nil {
 		log.Warning("Failed to create cache directory %s: %s", cacheDir, err)
 		return
-	} else if err := core.RecursiveCopyFile(outFile, cachedFile, fileMode(target), false); err != nil {
+	} else if err := core.RecursiveCopyFile(outFile, cachedFile, fileMode(target), true); err != nil {
 		// Cannot hardlink files into the cache, must copy them for reals.
 		log.Warning("Failed to store cache file %s: %s", cachedFile, err)
 	}


### PR DESCRIPTION
As discussed earlier, we'll save space by hardlinking files into the cache instead of copying. It'll also be faster. Downside is that modifying a file in plz-out would also modify it in the cache.

This review is pretty trivial but I'd like someone to okay the concept :)
