### PR TITLE
Add a possibility of loading config from an architecture-specific config file.

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -8,12 +8,16 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime"
 
 	"gopkg.in/gcfg.v1"
 )
 
 // File name for the typical repo config - this is normally checked in
 const ConfigFileName string = ".plzconfig"
+
+// Architecture-specific config file which overrides the repo one. Also normally checked in if needed.
+var ArchConfigFileName string = fmt.Sprintf(".plzconfig_%s_%s", runtime.GOOS, runtime.GOARCH)
 
 // File name for the local repo config - this is not normally checked in and used to
 // override settings on the local machine.
@@ -32,6 +36,7 @@ func readConfigFile(config *Configuration, filename string) error {
 	} else if err != nil {
 		return err
 	}
+	log.Debug("Reading config from %s...", filename)
 	// TODO(pebers): Use gcfg's types thingy to parse this once it's finalised.
 	if config.Test.DefaultContainer != TestContainerNone && config.Test.DefaultContainer != TestContainerDocker {
 		return fmt.Errorf("Unknown container type %s", config.Test.DefaultContainer)

--- a/src/please.go
+++ b/src/please.go
@@ -136,7 +136,7 @@ var opts struct {
 		} `command:"deps" description:"Queries the dependencies of a target."`
 		ReverseDeps struct {
 			Args struct {
-				 Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to query" required:"true"`
+				Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to query" required:"true"`
 			} `positional-args:"true" required:"true"`
 		} `command:"reverseDeps" description:"Queries all the reverse dependencies of a target."`
 		SomePath struct {
@@ -489,6 +489,7 @@ func readConfig(forceUpdate bool) *core.Configuration {
 
 	config, err := core.ReadConfigFiles([]string{
 		path.Join(core.RepoRoot, core.ConfigFileName),
+		path.Join(core.RepoRoot, core.ArchConfigFileName),
 		core.MachineConfigFileName,
 		path.Join(core.RepoRoot, core.LocalConfigFileName),
 	})


### PR DESCRIPTION
Lets you configure things differently for different machine types. Probably should be used with some care so the build graph doesn't diverge drastically...
