### PR TITLE
Change hash clash message

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -365,7 +365,7 @@ func checkRuleHashes(target *core.BuildTarget, hash []byte) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("Bad output hash for rule %s: was %s, expected one of [%s]",
+	return fmt.Errorf("Bad output hash for rule %s: was %s but expected one of [%s]",
 		target.Label, hashStr, strings.Join(target.Hashes, ", "))
 }
 


### PR DESCRIPTION
Makes it easier to copy/paste the expected hash. With the comma next to it, double clicking in a terminal copies that too
