### PR TITLE
Fix bug with tools of transitive dependencies

### DIFF
--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -224,7 +224,7 @@ func IterSources(graph *BuildGraph, target *BuildTarget) <-chan sourcePair {
 		done[dependency.Label] = true
 		if target == dependency || (target.NeedsTransitiveDependencies && !dependency.OutputIsComplete) {
 			for _, dep := range dependency.Dependencies() {
-				if !done[dep.Label] && !target.IsTool(dep.Label) {
+				if !done[dep.Label] && !dependency.IsTool(dep.Label) {
 					inner(dep)
 				}
 			}


### PR DESCRIPTION
They could turn up in the temp dir, but not when they're the first level of dependency.
