### PR TITLE
Only return $(dir :blah) replacement once for all targets

### DIFF
--- a/src/build/command_replacements.go
+++ b/src/build/command_replacements.go
@@ -134,11 +134,11 @@ func checkAndReplaceSequence(target, dep *core.BuildTarget, in string, runnable,
 					log.Fatalf("Couldn't calculate relative path: %s", err)
 				}
 				output += quote(abs) + " "
-				if dir {
-					break
-				}
 			} else {
 				output += quote(fileDestination(target, dep, out, dir, outPrefix, test)) + " "
+			}
+			if dir {
+				break
 			}
 		}
 	}

--- a/src/build/command_replacements_test.go
+++ b/src/build/command_replacements_test.go
@@ -92,6 +92,7 @@ func TestToolReplacement(t *testing.T) {
 
 func TestDirReplacement(t *testing.T) {
 	target2 := makeTarget("//path/to:target2", "blah", nil)
+	target2.AddOutput("blah2.txt")
 	target1 := makeTarget("//path/to:target1", "$(dir //path/to:target2)", target2)
 
 	expected := "path/to"
@@ -103,6 +104,7 @@ func TestDirReplacement(t *testing.T) {
 
 func TestToolDirReplacement(t *testing.T) {
 	target2 := makeTarget("//path/to:target2", "blah", nil)
+	target2.AddOutput("blah2.txt")
 	target1 := makeTarget("//path/to:target1", "$(dir //path/to:target2)", target2)
 	target1.Tools = append(target1.Tools, target2.Label)
 


### PR DESCRIPTION
Fixes #86 
