### PR TITLE
Add a 'native' attribute to maven_jar 

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -1637,7 +1637,9 @@ but it still has issues with some Maven packages.</p>
 	<td>hash</td>
 	<td>None</td>
 	<td>string</td>
-	<td>Hash of final produced .jar. For brevity, implies combine=True.</td>
+	<td>Hash of final produced .jar. For brevity, implies combine=True.<br/>
+	  Can optionally be a list for cases where there are jars with multiple
+	  possible outputs, e.g. architecture-specific.</td>
       </tr>
 
       <tr>

--- a/src/parse/rules/java_rules.py
+++ b/src/parse/rules/java_rules.py
@@ -221,7 +221,7 @@ def maven_jars(name, id, repository=_MAVEN_CENTRAL, exclude=None, hashes=None, c
       exclude (list): Dependencies to ignore when fetching this one.
       hashes (dict): Map of Maven id -> rule hash for each rule produced.
       combine (bool): If True, we combine all downloaded .jar files into one uberjar.
-      hash (string): Hash of final produced .jar. For brevity, implies combine=True.
+      hash (string|list): Hash of final produced .jar. For brevity, implies combine=True.
       deps (list): Labels of dependencies, as usual.
       visibility (list): Visibility label.
       filename (str): Filename we attempt to download. Defaults to standard Maven name.
@@ -308,7 +308,7 @@ def maven_jars(name, id, repository=_MAVEN_CENTRAL, exclude=None, hashes=None, c
         )
         build_rule(
             name=name,
-            hashes=[hash],
+            hashes=hash if isinstance(hash, list) else [hash] if hash else None,
             output_is_complete=True,
             needs_transitive_deps=True,
             building_description="Creating jar...",


### PR DESCRIPTION
Attempts to fetch a .jar with native code (eg. netty-tcnative etc) by appending the architecture to the URL.
