### PR TITLE
Small reverse deps fixes

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -138,7 +138,7 @@ var opts struct {
 			Args struct {
 				Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to query" required:"true"`
 			} `positional-args:"true" required:"true"`
-		} `command:"reverseDeps" description:"Queries all the reverse dependencies of a target."`
+		} `command:"reverseDeps" alias:"revdeps" description:"Queries all the reverse dependencies of a target."`
 		SomePath struct {
 			Args struct {
 				Target1 core.BuildLabel `positional-arg-name:"target1" description:"First build target" required:"true"`
@@ -263,7 +263,8 @@ var buildFunctions = map[string]func() bool{
 		})
 	},
 	"reverseDeps": func() bool {
-		return runQuery(true, opts.Query.ReverseDeps.Args.Targets, func(state *core.BuildState) {
+		return runQuery(true, core.WholeGraph, func(state *core.BuildState) {
+			state.OriginalTargets = opts.Query.ReverseDeps.Args.Targets
 			query.ReverseDeps(state.Graph, state.ExpandOriginalTargets())
 		})
 	},

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -1,7 +1,11 @@
 package query
 
-import "core"
-import "fmt"
+import (
+	"fmt"
+	"sort"
+
+	"core"
+)
 
 // ReverseDeps For each input label, finds all targets which depend upon it.
 func ReverseDeps(graph *core.BuildGraph, labels []core.BuildLabel) {
@@ -10,11 +14,20 @@ func ReverseDeps(graph *core.BuildGraph, labels []core.BuildLabel) {
 
 	for _, label := range labels {
 		for _, target := range graph.ReverseDependencies(graph.TargetOrDie(label)) {
-			uniqueTargets[target.Label] = struct {}{}
+			if parent := target.Parent(graph); parent != nil {
+				uniqueTargets[parent.Label] = struct{}{}
+			} else {
+				uniqueTargets[target.Label] = struct{}{}
+			}
 		}
 	}
 
+	targets := make(core.BuildLabels, 0, len(uniqueTargets))
 	for target := range uniqueTargets {
+		targets = append(targets, target)
+	}
+	sort.Sort(targets)
+	for _, target := range targets {
 		fmt.Printf("%s\n", target)
 	}
 }


### PR DESCRIPTION
Read the entire graph initially, because otherwise it won't know about all the reverse deps.
Sort output which is easier to read when there are lots of targets.
Add alias 'revdeps'
