### PR TITLE
Reasonably principled solution to the plz run situation with java_binary rules.

### DIFF
--- a/src/build/command_replacements.go
+++ b/src/build/command_replacements.go
@@ -142,6 +142,10 @@ func checkAndReplaceSequence(target, dep *core.BuildTarget, in string, runnable,
 			}
 		}
 	}
+	if runnable && dep.HasLabel("java_non_exe") {
+		// The target is a Java target that isn't self-executable, hence it needs something to run it.
+		output = "java -jar " + output
+	}
 	return strings.TrimRight(output, " ")
 }
 

--- a/src/build/command_replacements_test.go
+++ b/src/build/command_replacements_test.go
@@ -45,6 +45,19 @@ func TestExe(t *testing.T) {
 	}
 }
 
+func TestJavaExe(t *testing.T) {
+	target2 := makeTarget("//path/to:target2", "", nil)
+	target2.IsBinary = true
+	target2.AddLabel("java_non_exe") // This label tells us to prefix it with java -jar.
+	target1 := makeTarget("//path/to:target1", "$(exe //path/to:target2) -o ${OUT}", target2)
+
+	expected := "java -jar path/to/target2.py -o ${OUT}"
+	cmd := replaceSequences(target1)
+	if cmd != expected {
+		t.Errorf("Replacement sequence not as expected; is %s, should be %s", cmd, expected)
+	}
+}
+
 func TestReplacementsForTest(t *testing.T) {
 	target2 := makeTarget("//path/to:target2", "", nil)
 	target1 := makeTarget("//path/to:target1", "$(exe //path/to:target1) $(location //path/to:target2)", target2)

--- a/src/parse/rules/java_rules.py
+++ b/src/parse/rules/java_rules.py
@@ -144,6 +144,7 @@ def java_binary(name, main_class=None, srcs=None, deps=None, data=None, visibili
         requires=['java'],
         visibility=visibility,
         tools=tools,
+        labels=None if self_executable else ['java_non_exe'],
     )
 
 
@@ -179,7 +180,7 @@ def java_test(name, srcs, data=None, deps=None, labels=None, visibility=None,
     )
     # As above, would be nicer if we could make the jars self-executing again.
     cmd, tools = _jarcat_cmd('net.thoughtmachine.please.test.TestMain')
-    junit_runner, tools = _tool_path(CONFIG.JUNIT_RUNNER, tools)
+    junit_runner, tools = _tool_path(CONFIG.JUNIT_RUNNER, tools, binary=False)
     cmd = 'ln -s %s . && %s' % (junit_runner, cmd)
     test_cmd = 'java -Dnet.thoughtmachine.please.testpackage=%s %s -jar $(location :%s) ' % (
         test_package, jvm_args, name)
@@ -410,7 +411,7 @@ def _java_binary_cmd(main_class, jvm_args, test_package=None):
     prop = '-Dnet.thoughtmachine.please.testpackage=' + test_package if test_package else ''
     preamble = '#!/bin/sh\nexec java %s %s -jar $0 $@' % (prop, jvm_args or '')
     jarcat_cmd, tools = _jarcat_cmd(main_class, preamble)
-    junit_runner, tools = _tool_path(CONFIG.JUNIT_RUNNER, tools)
+    junit_runner, tools = _tool_path(CONFIG.JUNIT_RUNNER, tools, binary=False)
     return ('ln -s %s . && %s' % (junit_runner, jarcat_cmd) if test_package else jarcat_cmd), tools
 
 

--- a/src/parse/rules/misc_rules.py
+++ b/src/parse/rules/misc_rules.py
@@ -429,13 +429,13 @@ _COMPRESSION = {
 }
 
 
-def _tool_path(tool, tools=None):
+def _tool_path(tool, tools=None, binary=True):
     """Returns the invocation of a tool and the list of tools for a rule to depend on.
 
     Used for tools like pex_tool and jarcat_tool which might be repo rules or just filesystem paths.
     """
     if tool.startswith('//'):
-        return '$(exe %s)' % tool, [tool] + (tools or [])
+        return '$(%s %s)' % ('exe' if binary else 'location', tool), [tool] + (tools or [])
     return tool, tools
 
 


### PR DESCRIPTION
Invoke them with java -jar when doing $(exe //target), but only when not tagged as self_executable so we don't overwrite jvm_args etc. This also covers plz run, but needs some minor changes for the builtin rules to be a bit more principled about which things they find via $(exe ) and which via $(location ).
