### PR TITLE
Don't add --start-group / --end-group on OSX, it only makes things worse.

### DIFF
--- a/src/parse/rules/cc_rules.py
+++ b/src/parse/rules/cc_rules.py
@@ -474,7 +474,13 @@ def _build_flags(compiler_flags, linker_flags, pkg_config_libs, pkg_config_cflag
     linker_flags = ['-Xlinker ' + flag for flag in (linker_flags or [])]
     pkg_config_cmd = ' '.join('`pkg-config --cflags --libs %s`' % x for x in pkg_config_libs or [])
     pkg_config_cmd_2 = ' '.join('`pkg-config --cflags %s`' % x for x in pkg_config_cflags or [])
-    objs = '-Wl,--start-group `find . -name "*.o" -or -name "*.a" | sort` -Wl,--end-group' if binary else ''
+    objs = '`find . -name "*.o" -or -name "*.a" | sort`' if binary else ''
+    if binary and CONFIG.OS != 'darwin':
+        # We don't order libraries in a way that is especially useful for the linker, which is
+        # nicely solved by --start-group / --end-group. Unfortunately the OSX linker doesn't
+        # support those flags; in many cases it will work without, so try that.
+        # Ordering them would be ideal but we lack a convenient way of working that out from here.
+        objs = '-Wl,--start-group %s -Wl,--end-group' % objs
     return ' '.join([' '.join(compiler_flags), objs, ' '.join(linker_flags), pkg_config_cmd, pkg_config_cmd_2])
 
 


### PR DESCRIPTION
We do actually need it generally because we don't order the libraries properly, but OSX's ld doesn't support them so better not to pass them and it will work in at least some cases :)
