### PR TITLE
Remove SkipCache property from build_rule

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+Version 3.6.2
+-------------
+
+    * Remove undocumented skip_cache argument to build_rule; filegroups implicitly have this
+      and it's nicer not to expose it to anyone else.
+
+
 Version 3.6.1
 -------------
 

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -123,7 +123,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 	}
 
 	cacheKey := mustShortTargetHash(state, target)
-	if state.Cache != nil && !target.SkipCache {
+	if state.Cache != nil {
 		// Note that ordering here is quite sensitive since the post-build function can modify
 		// what we would retrieve from the cache.
 		if target.PostBuildFunction != 0 {
@@ -179,7 +179,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 	} else {
 		target.SetState(core.Unchanged)
 	}
-	if state.Cache != nil && !target.SkipCache {
+	if state.Cache != nil {
 		state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Storing...")
 		(*state.Cache).Store(target, mustShortTargetHash(state, target))
 		if target.PostBuildFunction != 0 {

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -110,10 +110,6 @@ type BuildTarget struct {
 	// Timeouts for build/test actions, in seconds.
 	BuildTimeout int
 	TestTimeout  int
-	// Indication that we should skip caching this rule. This shouldn't be used as an out for
-	// making targets indeterminate, it's a hint for rules like filegroup which simply symlink
-	// their inputs - so it's faster to relink them than copying their contents.
-	SkipCache bool
 	// Indicates that the target can only be depended on by tests or other rules with this set.
 	// Used to restrict non-deployable code and also affects coverage detection.
 	TestOnly bool

--- a/src/parse/cffi/please_parser.py
+++ b/src/parse/cffi/please_parser.py
@@ -175,7 +175,7 @@ def build_rule(globals_dict, package, name, cmd, test_cmd=None, srcs=None, data=
                deps=None, exported_deps=None, tools=None, labels=None, visibility=None, hashes=None,
                binary=False, test=False, test_only=None, building_description='Building...',
                needs_transitive_deps=False, output_is_complete=False, container=False,
-               skip_cache=False, no_test_output=False, flaky=0, build_timeout=0, test_timeout=0,
+               no_test_output=False, flaky=0, build_timeout=0, test_timeout=0,
                pre_build=None, post_build=None, requires=None, provides=None, licences=None,
                test_outputs=None, system_srcs=None, stamp=False, tag=''):
     if name == 'all':
@@ -210,7 +210,6 @@ def build_rule(globals_dict, package, name, cmd, test_cmd=None, srcs=None, data=
                          output_is_complete,
                          bool(container),
                          no_test_output,
-                         skip_cache,
                          test_only or test,  # Tests are implicitly test_only
                          stamp,
                          3 if flaky is True else flaky,  # Default is to rerun three times.

--- a/src/parse/interpreter.c
+++ b/src/parse/interpreter.c
@@ -49,7 +49,7 @@ int InitialiseInterpreter(char* parser_location) {
   //               like reg("_add_target", typeof(AddTarget), AddTarget) would be sweet.
   //               As far as I know this is only possible in C++ using typeid though :(
   reg("_add_target", "size_t (*)(size_t, char*, char*, char*, uint8, uint8, uint8, uint8, "
-      "uint8, uint8, uint8, uint8, uint8, int64, int64, int64, char*)", AddTarget);
+      "uint8, uint8, uint8, uint8, int64, int64, int64, char*)", AddTarget);
   reg("_add_src", "char* (*)(size_t, char*)", AddSource);
   reg("_add_data", "char* (*)(size_t, char*)", AddData);
   reg("_add_dep", "char* (*)(size_t, char*)", AddDep);

--- a/src/parse/interpreter.go
+++ b/src/parse/interpreter.go
@@ -265,7 +265,7 @@ func IsValidTargetName(name *C.char) bool {
 
 //export AddTarget
 func AddTarget(pkgPtr uintptr, cName, cCmd, cTestCmd *C.char, binary, test, needsTransitiveDeps,
-	outputIsComplete, containerise, noTestOutput, skipCache, testOnly, stamp bool,
+	outputIsComplete, containerise, noTestOutput, testOnly, stamp bool,
 	flakiness, buildTimeout, testTimeout int, cBuildingDescription *C.char) (ret C.size_t) {
 	buildingDescription := ""
 	if cBuildingDescription != nil {
@@ -273,13 +273,13 @@ func AddTarget(pkgPtr uintptr, cName, cCmd, cTestCmd *C.char, binary, test, need
 	}
 	return sizet(addTarget(pkgPtr, C.GoString(cName), C.GoString(cCmd), C.GoString(cTestCmd),
 		binary, test, needsTransitiveDeps, outputIsComplete, containerise, noTestOutput,
-		skipCache, testOnly, stamp, flakiness, buildTimeout, testTimeout, buildingDescription))
+		testOnly, stamp, flakiness, buildTimeout, testTimeout, buildingDescription))
 }
 
 // addTarget adds a new build target to the graph.
 // Separated from AddTarget to make it possible to test (since you can't mix cgo and go test).
 func addTarget(pkgPtr uintptr, name, cmd, testCmd string, binary, test, needsTransitiveDeps,
-	outputIsComplete, containerise, noTestOutput, skipCache, testOnly, stamp bool,
+	outputIsComplete, containerise, noTestOutput, testOnly, stamp bool,
 	flakiness, buildTimeout, testTimeout int, buildingDescription string) *core.BuildTarget {
 	pkg := unsizep(pkgPtr)
 	target := core.NewBuildTarget(core.NewBuildLabel(pkg.Name, name))
@@ -289,7 +289,6 @@ func addTarget(pkgPtr uintptr, name, cmd, testCmd string, binary, test, needsTra
 	target.OutputIsComplete = outputIsComplete
 	target.Containerise = containerise
 	target.NoTestOutput = noTestOutput
-	target.SkipCache = skipCache
 	target.TestOnly = testOnly
 	target.Flakiness = flakiness
 	target.BuildTimeout = buildTimeout

--- a/src/parse/interpreter_test.go
+++ b/src/parse/interpreter_test.go
@@ -60,7 +60,7 @@ func TestAddTarget(t *testing.T) {
 	pkg := core.NewPackage("src/parse")
 	addTargetTest1 := func(name string, binary, container, test bool, testCmd string) *core.BuildTarget {
 		return addTarget(uintptr(unsafe.Pointer(pkg)), name, "true", testCmd, binary, test,
-			false, false, container, false, false, false, false, 0, 0, 0, "Building...")
+			false, false, container, false, false, false, 0, 0, 0, "Building...")
 	}
 	addTargetTest := func(name string, binary, container bool) *core.BuildTarget {
 		return addTargetTest1(name, binary, container, false, "")

--- a/src/parse/rules/misc_rules.py
+++ b/src/parse/rules/misc_rules.py
@@ -210,7 +210,6 @@ def filegroup(name, srcs=None, deps=None, exported_deps=None, visibility=None, l
         output_is_complete=output_is_complete,
         # This just symlinks its inputs so it's faster not to copy to the cache and back,
         # especially if the files it's collecting are large.
-        skip_cache=True,
         requires=requires,
         provides=provides,
         test_only=test_only,

--- a/src/query/print.go
+++ b/src/query/print.go
@@ -62,7 +62,6 @@ func QueryPrint(graph *core.BuildGraph, labels []core.BuildLabel) {
 		pythonBool("needs_transitive_deps", target.NeedsTransitiveDependencies)
 		if !target.IsFilegroup() {
 			pythonBool("output_is_complete", target.OutputIsComplete)
-			pythonBool("skip_cache", target.SkipCache)
 			if target.BuildingDescription != core.DefaultBuildingDescription {
 				fmt.Printf("      building_description = '%s',\n", target.BuildingDescription)
 			}

--- a/src/query/print_test.go
+++ b/src/query/print_test.go
@@ -34,7 +34,6 @@ var KnownFields = map[string]bool{
 	"PostBuildFunction":           true,
 	"Provides":                    true,
 	"Requires":                    true,
-	"SkipCache":                   true,
 	"Sources":                     true,
 	"Stamp":                       true,
 	"TestCommand":                 true,


### PR DESCRIPTION
It's only really needed on filegroups and they are identified specially anyway.
