### PR TITLE
Make outputs read-only

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -321,12 +321,12 @@ func moveOutput(target *core.BuildTarget, tmpOutput, realOutput string, filegrou
 			return true, err
 		}
 	} else {
-		if err := core.RecursiveCopyFile(tmpOutput, realOutput, 0, filegroup); err != nil {
+		if err := core.RecursiveCopyFile(tmpOutput, realOutput, target.OutMode(), filegroup); err != nil {
 			return true, err
 		}
 	}
 	if target.IsBinary {
-		if err := os.Chmod(realOutput, 0775); err != nil {
+		if err := os.Chmod(realOutput, target.OutMode()); err != nil {
 			return true, err
 		}
 	}

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -699,6 +700,14 @@ func (target *BuildTarget) SetContainerSetting(name, value string) error {
 		}
 	}
 	return fmt.Errorf("Field %s isn't a valid container setting", name)
+}
+
+// OutMode returns the mode to set outputs of a target to.
+func (target *BuildTarget) OutMode() os.FileMode {
+	if target.IsBinary {
+		return 0555
+	}
+	return 0444
 }
 
 // Parent finds the parent of a build target, or nil if the target is parentless.

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -265,6 +265,15 @@ func TestParent(t *testing.T) {
 	assert.Equal(t, (*BuildTarget)(nil), parent.Parent(graph))
 }
 
+func TestOutMode(t *testing.T) {
+	// Check that output modes match the binary flag correctly.
+	// This feels a little fatuous but it's hard to have any less specific assertions on it.
+	target := makeTarget("//src/core:target1", "")
+	assert.Equal(t, os.FileMode(0444), target.OutMode())
+	target.IsBinary = true
+	assert.Equal(t, os.FileMode(0555), target.OutMode())
+}
+
 func makeTarget(label, visibility string, deps ...*BuildTarget) *BuildTarget {
 	target := NewBuildTarget(ParseBuildLabel(label, ""))
 	if visibility == "PUBLIC" {


### PR DESCRIPTION
This makes most things readonly, but not necessarily everything; we have to be a bit careful around things like filegroups where the underlying file is actually in the repo, and we don't want that to become readonly.
