### PR TITLE
Add flag to display test output always, even on success.

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -90,6 +90,8 @@ type BuildState struct {
 	CleanWorkdirs bool
 	// True if we're forcing a rebuild of the original targets.
 	ForceRebuild bool
+	// True to always show test output, even on success.
+	ShowTestOutput bool
 	// Number of running workers
 	numWorkers int
 	// Used to count the number of currently active/pending targets

--- a/src/please.go
+++ b/src/please.go
@@ -92,6 +92,7 @@ var opts struct {
 		FailingTestsOk  bool   `long:"failing_tests_ok" hidden:"true" description:"Exit with status 0 even if tests fail (nonzero only if catastrophe happens)"`
 		NumRuns         int    `long:"num_runs" short:"n" description:"Number of times to run each test target."`
 		TestResultsFile string `long:"test_results_file" default:"plz-out/log/test_results.xml" description:"File to write combined test results to."`
+		ShowOutput      bool   `long:"show_output" description:"Always show output of tests, even on success."`
 		// Slightly awkward since we can specify a single test with arguments or multiple test targets.
 		Args struct {
 			Target core.BuildLabel `positional-arg-name:"target" description:"Target to test"`
@@ -108,6 +109,7 @@ var opts struct {
 		IncludeFile         []string `long:"include_file" description:"Filenames to filter coverage display to"`
 		TestResultsFile     string   `long:"test_results_file" default:"plz-out/log/test_results.xml" description:"File to write combined test results to."`
 		CoverageResultsFile string   `long:"coverage_results_file" default:"plz-out/log/coverage.json" description:"File to write combined coverage results to."`
+		ShowOutput          bool     `long:"show_output" description:"Always show output of tests, even on success."`
 		Args                struct {
 			Target core.BuildLabel `positional-arg-name:"target" description:"Target to test" group:"one test"`
 			Args   []string        `positional-arg-name:"arguments" description:"Arguments or test selectors" group:"one test"`
@@ -447,6 +449,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, prettyOutput,
 	state.PrepareOnly = opts.Build.Prepare
 	state.CleanWorkdirs = !opts.FeatureFlags.KeepWorkdirs
 	state.ForceRebuild = len(opts.Rebuild.Args.Targets) > 0
+	state.ShowTestOutput = opts.Test.ShowOutput || opts.Cover.ShowOutput
 	state.SetIncludeAndExclude(opts.BuildFlags.Include, opts.BuildFlags.Exclude)
 	metrics.InitFromConfig(config)
 	// Acquire the lock before we start building

--- a/src/please.go
+++ b/src/please.go
@@ -92,7 +92,7 @@ var opts struct {
 		FailingTestsOk  bool   `long:"failing_tests_ok" hidden:"true" description:"Exit with status 0 even if tests fail (nonzero only if catastrophe happens)"`
 		NumRuns         int    `long:"num_runs" short:"n" description:"Number of times to run each test target."`
 		TestResultsFile string `long:"test_results_file" default:"plz-out/log/test_results.xml" description:"File to write combined test results to."`
-		ShowOutput      bool   `long:"show_output" description:"Always show output of tests, even on success."`
+		ShowOutput      bool   `short:"s" long:"show_output" description:"Always show output of tests, even on success."`
 		// Slightly awkward since we can specify a single test with arguments or multiple test targets.
 		Args struct {
 			Target core.BuildLabel `positional-arg-name:"target" description:"Target to test"`
@@ -109,7 +109,7 @@ var opts struct {
 		IncludeFile         []string `long:"include_file" description:"Filenames to filter coverage display to"`
 		TestResultsFile     string   `long:"test_results_file" default:"plz-out/log/test_results.xml" description:"File to write combined test results to."`
 		CoverageResultsFile string   `long:"coverage_results_file" default:"plz-out/log/coverage.json" description:"File to write combined coverage results to."`
-		ShowOutput          bool     `long:"show_output" description:"Always show output of tests, even on success."`
+		ShowOutput          bool     `short:"s" long:"show_output" description:"Always show output of tests, even on success."`
 		Args                struct {
 			Target core.BuildLabel `positional-arg-name:"target" description:"Target to test" group:"one test"`
 			Args   []string        `positional-arg-name:"arguments" description:"Arguments or test selectors" group:"one test"`

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -212,6 +212,10 @@ func test(tid int, state *core.BuildState, label core.BuildLabel, target *core.B
 				numFlakes++
 			} else {
 				numSucceeded++
+				if !state.ShowTestOutput {
+					// Save a bit of memory, if we're not printing results on success we will never use them again.
+					target.Results.Output = ""
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #136 

Output gets printed after each test result at the end. If using `-p` it will be printed as each individual test completes too.