### PR TITLE
Allow attaching arbitrary labels to metrics

### DIFF
--- a/docs/config.html
+++ b/docs/config.html
@@ -191,6 +191,33 @@
         <code>.pb.go</code>, <code>_pb2.py</code>, etc.</li>
     </ul>
 
+    <h3>[Metrics]</h3>
+
+    <p>Options related to metric collection. Currently the only metrics implementation pushes
+      to a <a href="https://prometheus.io/">Prometheus</a>
+      <a href="https://github.com/prometheus/pushgateway">pushgateway</a> for collection.</p>
+
+    <ul>
+      <li><b>PushGatewayURL</b><br/>
+	The URL of the pushgateway to send metrics to.</li>
+
+      <li><b>PushFrequency</b> (integer)<br/>
+	The frequency, in milliseconds, to push statistics at. Defaults to 100.</li>
+    </ul>
+
+    <h3>[CustomMetricLabels]</h3>
+
+    <p>Describes optional labels to attach to metrics.<br/>
+      For technical reasons this is a separate section to the main metrics options.</p>
+
+    <p>These are defined as key-value pairs, where the key is the label attached to the metric
+      and the value is a command to run on the system that defines the value to attach.<br/>
+      Hence these labels are constant across all build targets.</p>
+
+    <p>For example:<br/>
+      <pre><code>branch = git rev-parse --abbrev-ref HEAD</code></pre>
+      to attach the current git branch to all metrics reported.</p>
+
     <h3>[Docker]</h3>
 
     <p>Options relating to tests that are run inside Docker containers.</p>
@@ -484,4 +511,3 @@
 
     <p>There is a <code>--bazel_compat</code> flag to <code>plz init</code> which sets this
       on initialising a new repo.</p>
-

--- a/docs/config.html
+++ b/docs/config.html
@@ -219,10 +219,7 @@
       to attach the current git branch to all metrics reported.</p>
 
     <p>In general it's a good idea not to let the cardinality of your labels become too large,
-      so in the example above, we might decide that we mostly care about whether the user is
-      on master or not, and express it as follows:
-      <pre><code>branch = bash -c "[[ `git rev-parse --abbrev-ref HEAD` == 'master' ]] && echo 'master' || echo 'not_master'"</code></pre>
-      </p>
+      so you might want to filter it to only print whether the user is on master or not.</p>
 
     <h3>[Docker]</h3>
 

--- a/docs/config.html
+++ b/docs/config.html
@@ -212,11 +212,17 @@
 
     <p>These are defined as key-value pairs, where the key is the label attached to the metric
       and the value is a command to run on the system that defines the value to attach.<br/>
-      Hence these labels are constant across all build targets.</p>
+      Hence these labels are run once at startup and constant across all build targets.</p>
 
     <p>For example:<br/>
       <pre><code>branch = git rev-parse --abbrev-ref HEAD</code></pre>
       to attach the current git branch to all metrics reported.</p>
+
+    <p>In general it's a good idea not to let the cardinality of your labels become too large,
+      so in the example above, we might decide that we mostly care about whether the user is
+      on master or not, and express it as follows:
+      <pre><code>branch = bash -c "[[ `git rev-parse --abbrev-ref HEAD` == 'master' ]] && echo 'master' || echo 'not_master'"</code></pre>
+      </p>
 
     <h3>[Docker]</h3>
 

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -188,7 +188,8 @@ type Configuration struct {
 		PushGatewayURL string
 		PushFrequency  int
 	}
-	Test struct {
+	CustomMetricLabels map[string]string
+	Test               struct {
 		Timeout          int
 		DefaultContainer string
 	}

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -85,3 +85,24 @@ func TestConfigOverrideUnknownName(t *testing.T) {
 	err := config.ApplyOverrides(map[string]string{"build.blah": "whatevs"})
 	assert.Error(t, err)
 }
+
+func TestDynamicSection(t *testing.T) {
+	config, err := ReadConfigFiles([]string{"src/core/test_data/aliases.plzconfig"})
+	assert.NoError(t, err)
+	expected := map[string]string{
+		"deploy":      "run //deployment:deployer --",
+		"deploy dev":  "run //deployment:deployer -- --env=dev",
+		"deploy prod": "run //deployment:deployer -- --env=prod",
+	}
+	assert.Equal(t, expected, config.Aliases)
+}
+
+func TestDynamicSubsection(t *testing.T) {
+	config, err := ReadConfigFiles([]string{"src/core/test_data/metrics.plzconfig"})
+	assert.NoError(t, err)
+	assert.Equal(t, "http://localhost:9091", config.Metrics.PushGatewayURL)
+	expected := map[string]string{
+		"branch": "git rev-parse --abbrev-ref HEAD",
+	}
+	assert.Equal(t, expected, config.CustomMetricLabels)
+}

--- a/src/core/test_data/aliases.plzconfig
+++ b/src/core/test_data/aliases.plzconfig
@@ -1,0 +1,6 @@
+[aliases]
+deploy = run //deployment:deployer --
+
+[aliases "deploy"]
+dev = run //deployment:deployer -- --env=dev
+prod = run //deployment:deployer -- --env=prod

--- a/src/core/test_data/metrics.plzconfig
+++ b/src/core/test_data/metrics.plzconfig
@@ -1,0 +1,5 @@
+[metrics]
+pushgatewayurl = http://localhost:9091
+
+[custommetriclabels]
+branch = git rev-parse --abbrev-ref HEAD

--- a/src/metrics/BUILD
+++ b/src/metrics/BUILD
@@ -6,6 +6,7 @@ go_library(
         '//src/core',
         '//third_party/go:logging',
         '//third_party/go:prometheus',
+        '//third_party/go:shlex',
     ],
 )
 

--- a/src/metrics/prometheus.go
+++ b/src/metrics/prometheus.go
@@ -6,10 +6,13 @@
 package metrics
 
 import (
+	"os/exec"
 	"os/user"
 	"runtime"
+	"strings"
 	"time"
 
+	"github.com/google/shlex"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	"gopkg.in/op/go-logging.v1"
@@ -39,7 +42,7 @@ var m *metrics
 // InitFromConfig sets up the initial metrics from the configuration.
 func InitFromConfig(config *core.Configuration) {
 	if config.Metrics.PushGatewayURL != "" {
-		m = initMetrics(config.Metrics.PushGatewayURL, config.Metrics.PushFrequency)
+		m = initMetrics(config.Metrics.PushGatewayURL, config.Metrics.PushFrequency, config.CustomMetricLabels)
 		prometheus.MustRegister(m.buildCounter)
 		prometheus.MustRegister(m.cacheCounter)
 		prometheus.MustRegister(m.testCounter)
@@ -51,7 +54,7 @@ func InitFromConfig(config *core.Configuration) {
 
 // initMetrics initialises a new metrics instance.
 // This is deliberately not exposed but is useful for testing.
-func initMetrics(url string, frequency int) *metrics {
+func initMetrics(url string, frequency int, customLabels map[string]string) *metrics {
 	u, err := user.Current()
 	if err != nil {
 		log.Warning("Can't determine current user name for metrics")
@@ -60,6 +63,9 @@ func initMetrics(url string, frequency int) *metrics {
 	constLabels := prometheus.Labels{
 		"user": u.Username,
 		"arch": runtime.GOOS + "_" + runtime.GOARCH,
+	}
+	for k, v := range customLabels {
+		constLabels[k] = deriveLabelValue(v)
 	}
 
 	m = &metrics{
@@ -204,4 +210,22 @@ func (m *metrics) pushMetrics() int {
 	m.pushes += 1
 	log.Debug("Push #%d of metrics in %0.3fs", m.pushes, time.Since(start).Seconds())
 	return 0
+}
+
+// deriveLabelValue runs a command and returns its output.
+// It returns the empty string on error; we assume it's better to keep the set of labels constant on failure.
+func deriveLabelValue(cmd string) string {
+	parts, err := shlex.Split(cmd)
+	if err != nil {
+		log.Error("Invalid custom metric command [%s]: %s", cmd, err)
+		return ""
+	}
+	log.Debug("Running custom label command: %s", cmd)
+	b, err := exec.Command(parts[0], parts[1:]...).Output()
+	log.Debug("Got output: %s", b)
+	if err != nil {
+		log.Warning("Custom metric command [%s] failed: %s", cmd, err)
+		return ""
+	}
+	return strings.TrimSpace(string(b))
 }

--- a/src/metrics/prometheus_test.go
+++ b/src/metrics/prometheus_test.go
@@ -82,19 +82,27 @@ func TestCustomLabelsShlex(t *testing.T) {
 }
 
 func TestCustomLabelsShlexInvalid(t *testing.T) {
-	m := initMetrics(url, verySlow, map[string]string{
-		"mylabel": "bash -c 'echo hello", // missing trailing quote
+	assert.Panics(t, func() {
+		initMetrics(url, verySlow, map[string]string{
+			"mylabel": "bash -c 'echo hello", // missing trailing quote
+		})
 	})
-	c := m.cacheCounter.WithLabelValues("//src/metrics:metrics_test", "false")
-	assert.Contains(t, c.Desc().String(), `mylabel=""`)
 }
 
 func TestCustomLabelsCommandFails(t *testing.T) {
-	m := initMetrics(url, verySlow, map[string]string{
-		"mylabel": "wibble",
+	assert.Panics(t, func() {
+		initMetrics(url, verySlow, map[string]string{
+			"mylabel": "wibble",
+		})
 	})
-	c := m.cacheCounter.WithLabelValues("//src/metrics:metrics_test", "false")
-	assert.Contains(t, c.Desc().String(), `mylabel=""`)
+}
+
+func TestCustomLabelsCommandNewlines(t *testing.T) {
+	assert.Panics(t, func() {
+		initMetrics(url, verySlow, map[string]string{
+			"mylabel": "echo 'hello\nworld\n'",
+		})
+	})
 }
 
 func TestExportedFunctions(t *testing.T) {

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -84,9 +84,9 @@ go_get(
 
 go_get(
     name = 'protoc-gen-go',
+    binary = True,
     get = 'github.com/golang/protobuf/protoc-gen-go',
     revision = 'f592bd283e9ef86337a432eb50e592278c3d534d',
-    binary = True,
     deps = [
         ':protobuf',
     ],
@@ -159,4 +159,10 @@ go_get(
     get = 'github.com/prometheus/procfs',
     revision = 'abf152e5f3e97f2fafac028d2cc06c1feb87ffa5',
     strip = ['fixtures'],  # Test fixture has a symlink to /usr/bin/vim which might not exist
+)
+
+go_get(
+    name = 'shlex',
+    get = 'github.com/google/shlex',
+    revision = '6f45313302b9c56850fc17f99e40caebce98c716',
 )


### PR DESCRIPTION
As we discussed in #133, it'd be nice to be able to attach the git branch or similar, but I don't think plz should have too much knowledge about the specifics of the version control system. This seems like a pretty generic middle ground such that the users can customise it to their workflow.