### PR TITLE
Fix race condition with concurrently building filegroup rules

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -112,6 +112,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 		}
 	}
 	if target.IsFilegroup() {
+		log.Debug("Building %s...", target.Label)
 		return buildFilegroup(tid, state, target)
 	}
 	oldOutputHash, outputHashErr := OutputHash(target)
@@ -340,6 +341,7 @@ func moveOutput(target *core.BuildTarget, tmpOutput, realOutput string, filegrou
 	// TODO(pebers): The logic here is quite tortured, consider a (very careful) rewrite.
 	dereferencedOutput, _ := filepath.EvalSymlinks(realOutput)
 	if absOutput, _ := filepath.Abs(realOutput); tmpOutput == absOutput || realOutput == tmpOutput || dereferencedOutput == tmpOutput {
+		log.Debug("%s and %s are the same file, nothing to do", tmpOutput, realOutput)
 		return false, nil
 	}
 	if core.PathExists(realOutput) {

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -353,9 +353,9 @@ func moveOutput(target *core.BuildTarget, tmpOutput, realOutput string, filegrou
 			log.Debug("Checking %s vs. %s, hashes match", tmpOutput, realOutput)
 			return false, nil
 		}
-	}
-	if err := os.RemoveAll(realOutput); err != nil {
-		return true, err
+		if err := os.RemoveAll(realOutput); err != nil {
+			return true, err
+		}
 	}
 	movePathHash(tmpOutput, realOutput, filegroup)
 	// Check if we need a directory for this output.
@@ -373,6 +373,12 @@ func moveOutput(target *core.BuildTarget, tmpOutput, realOutput string, filegrou
 		}
 	} else {
 		if err := core.RecursiveCopyFile(tmpOutput, realOutput, target.OutMode(), filegroup); err != nil {
+			if filegroup && os.IsExist(err) && core.IsSameFile(tmpOutput, realOutput) {
+				// It's possible for two filegroups to race building simultaneously. In that
+				// case one will fail with an ErrExist, which is OK as far as we're concerned
+				// here as long as the file we tried to write really is the same as the input.
+				return true, nil
+			}
 			return true, err
 		}
 	}

--- a/src/core/utils_test.go
+++ b/src/core/utils_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"crypto/sha1"
 	"encoding/base64"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -128,6 +129,18 @@ func TestLookPathColons(t *testing.T) {
 	info, err := os.Stat(path)
 	assert.NoError(t, err)
 	assert.Equal(t, "bash", info.Name())
+}
+
+func TestIsSameFile(t *testing.T) {
+	err := ioutil.WriteFile("issamefile1.txt", []byte("hello"), 0644)
+	assert.NoError(t, err)
+	err = ioutil.WriteFile("issamefile2.txt", []byte("hello"), 0644)
+	assert.NoError(t, err)
+	err = os.Link("issamefile1.txt", "issamefile3.txt")
+	assert.NoError(t, err)
+	assert.True(t, IsSameFile("issamefile1.txt", "issamefile3.txt"))
+	assert.False(t, IsSameFile("issamefile1.txt", "issamefile2.txt"))
+	assert.False(t, IsSameFile("issamefile1.txt", "doesntexist.txt"))
 }
 
 func TestLookPathDoesntExist(t *testing.T) {

--- a/test/filegroup/BUILD
+++ b/test/filegroup/BUILD
@@ -1,0 +1,14 @@
+subinclude('//build_defs:plz_e2e_test')
+
+genrule(
+    name = 'gen',
+    outs = ['gen.txt'],
+    # This being nondeterministic would normally be a bad idea, but here makes the test work better.
+    cmd = 'dd if=/dev/urandom of=$OUT bs=10000 count=1',
+    visibility = ['//test/filegroup/many:all'],
+)
+
+plz_e2e_test(
+    name = 'filegroup_concurrent_build_test',
+    cmd = 'plz clean //test/filegroup:gen && plz build //test/filegroup/many:all',
+)

--- a/test/filegroup/many/BUILD
+++ b/test/filegroup/many/BUILD
@@ -1,0 +1,5 @@
+for i in range(100):
+    filegroup(
+        name = 'f%02d' % i,
+        srcs = ['//test/filegroup:gen'],
+    )


### PR DESCRIPTION
Basically builds can sometimes fail with mysterious errors when there are multiple filegroups outputting the same file. That's normally banned but we make a special case for filegroups because they're often implicitly created by other rules and since they're special-cased we know they're OK.

But as we saw once or twice yesterday that can still fail. There are various implicit guards like checking if the hash is the same, but turns out that's not always enough; the different rules race attempting to link the same file, one fails and then tries to copy it, then others can do a partial read on it and get bad hash values.

Have fixed by removing the fallback to copy behaviour and adding a check that if the error was that the file already existed and the two have the same inode, then it's effectively been linked anyway so we can just carry on.