### PR TITLE
Add a --unique flag on query deps to only output each target once

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -151,7 +151,8 @@ var opts struct {
 
 	Query struct {
 		Deps struct {
-			Args struct {
+			Unique bool `long:"unique" short:"u" description:"Only output each dependency once"`
+			Args   struct {
 				Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to query" required:"true"`
 			} `positional-args:"true" required:"true"`
 		} `command:"deps" description:"Queries the dependencies of a target."`
@@ -310,7 +311,7 @@ var buildFunctions = map[string]func() bool{
 	},
 	"deps": func() bool {
 		return runQuery(true, opts.Query.Deps.Args.Targets, func(state *core.BuildState) {
-			query.QueryDeps(state, state.ExpandOriginalTargets())
+			query.QueryDeps(state, state.ExpandOriginalTargets(), opts.Query.Deps.Unique)
 		})
 	},
 	"reverseDeps": func() bool {

--- a/src/query/deps.go
+++ b/src/query/deps.go
@@ -4,17 +4,25 @@ import "core"
 import "fmt"
 
 // QueryDeps prints all transitive dependencies of a set of targets.
-func QueryDeps(state *core.BuildState, labels []core.BuildLabel) {
+func QueryDeps(state *core.BuildState, labels []core.BuildLabel, unique bool) {
+	targets := map[*core.BuildTarget]bool{}
 	for _, label := range labels {
-		printTarget(state, state.Graph.TargetOrDie(label), "")
+		printTarget(state, state.Graph.TargetOrDie(label), "", targets, unique)
 	}
 }
 
-func printTarget(state *core.BuildState, target *core.BuildTarget, indent string) {
+func printTarget(state *core.BuildState, target *core.BuildTarget, indent string, targets map[*core.BuildTarget]bool, unique bool) {
+	if unique && targets[target] {
+		return
+	}
+	targets[target] = true
 	if target.ShouldInclude(state.Include, state.Exclude) {
 		fmt.Printf("%s%s\n", indent, target.Label)
 	}
+	if !unique {
+		indent = indent + "  "
+	}
 	for _, dep := range target.Dependencies() {
-		printTarget(state, dep, indent+"  ")
+		printTarget(state, dep, indent, targets, unique)
 	}
 }


### PR DESCRIPTION
The current implementation prints a complete tree, which is not always what you want and can produce a lot of output.