### PR TITLE
Refactor output capturing from external commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - 1.6
+  - 1.7
 
 python:
   - 2.7

--- a/README.md
+++ b/README.md
@@ -43,10 +43,9 @@ Building Please
 To build Please yourself, run `./bootstrap.sh` in the repo root.
 This will set up the minimal environment needed to build Please,
 build it once manually and then rebuild it again using itself.
-You'll need to have Go installed to build Please. It should
-compile under Go 1.5+ (1.4 is no longer supported because we use
-several minor standard library features from 1.5) and once compiled
-can target 1.4+.
+You'll need to have Go 1.7+ installed to build Please (we use some
+new standard library features like context) although once built it
+can target Go 1.4+.
 
 Similarly to the instructions above, you'll need a python interpreter.
 Having PyPy, python2 and python3 installed will allow you to build

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -165,14 +165,13 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 	replacedCmd := replaceSequences(target)
 	env := core.StampedBuildEnvironment(state, target, false, cacheKey)
 	log.Debug("Building target %s\nENVIRONMENT:\n%s\n%s", target.Label, strings.Join(env, "\n"), replacedCmd)
-	out, err := core.ExecWithTimeoutShell(target.TmpDir(), env, target.BuildTimeout, state.Config.Build.Timeout, state.ShowAllOutput, replacedCmd)
+	out, combined, err := core.ExecWithTimeoutShell(target.TmpDir(), env, target.BuildTimeout, state.Config.Build.Timeout, state.ShowAllOutput, replacedCmd)
 	if err != nil {
 		if state.Verbosity >= 4 {
 			return fmt.Errorf("Error building target %s: %s\nENVIRONMENT:\n%s\n%s\n%s",
-				target.Label, err, strings.Join(env, "\n"), target.GetCommand(), out)
-		} else {
-			return fmt.Errorf("Error building target %s: %s\n%s", target.Label, err, out)
+				target.Label, err, strings.Join(env, "\n"), target.GetCommand(), combined)
 		}
+		return fmt.Errorf("Error building target %s: %s\n%s", target.Label, err, combined)
 	}
 	if target.PostBuildFunction != 0 {
 		out = bytes.TrimSpace(out)

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -161,17 +160,16 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 	if err := prepareSources(state.Graph, target); err != nil {
 		return fmt.Errorf("Error preparing sources for %s: %s", target.Label, err)
 	}
+
 	state.LogBuildResult(tid, target.Label, core.TargetBuilding, target.BuildingDescription)
 	replacedCmd := replaceSequences(target)
-	cmd := exec.Command("bash", "-u", "-o", "pipefail", "-c", replacedCmd)
-	cmd.Dir = target.TmpDir()
-	cmd.Env = core.StampedBuildEnvironment(state, target, false, cacheKey)
-	log.Debug("Building target %s\nENVIRONMENT:\n%s\n%s", target.Label, strings.Join(cmd.Env, "\n"), replacedCmd)
-	out, err := core.ExecWithTimeout(cmd, target.BuildTimeout, state.Config.Build.Timeout)
+	env := core.StampedBuildEnvironment(state, target, false, cacheKey)
+	log.Debug("Building target %s\nENVIRONMENT:\n%s\n%s", target.Label, strings.Join(env, "\n"), replacedCmd)
+	out, err := core.ExecWithTimeoutShell(target.TmpDir(), env, target.BuildTimeout, state.Config.Build.Timeout, state.ShowAllOutput, replacedCmd)
 	if err != nil {
 		if state.Verbosity >= 4 {
 			return fmt.Errorf("Error building target %s: %s\nENVIRONMENT:\n%s\n%s\n%s",
-				target.Label, err, strings.Join(cmd.Env, "\n"), target.GetCommand(), out)
+				target.Label, err, strings.Join(env, "\n"), target.GetCommand(), out)
 		} else {
 			return fmt.Errorf("Error building target %s: %s\n%s", target.Label, err, out)
 		}

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -92,6 +92,8 @@ type BuildState struct {
 	ForceRebuild bool
 	// True to always show test output, even on success.
 	ShowTestOutput bool
+	// True to print all output of all tasks to stderr.
+	ShowAllOutput bool
 	// Number of running workers
 	numWorkers int
 	// Used to count the number of currently active/pending targets

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -211,8 +211,16 @@ func execWithTimeout(dir string, env []string, timeout, defaultTimeout int, show
 	cmd.Env = env
 
 	var out bytes.Buffer
-	cmd.Stderr = &out
-	return cmd.Output()
+	if showOutput {
+		w := io.MultiWriter(os.Stderr, &out)
+		cmd.Stderr = w
+		cmd.Stdout = w
+	} else {
+		cmd.Stderr = &out
+		cmd.Stdout = &out
+	}
+	err := cmd.Run()
+	return out.Bytes(), err
 }
 
 // ExecWithTimeoutShell runs an external command within a Bash shell.

--- a/src/parse/rules/python_rules.build_defs
+++ b/src/parse/rules/python_rules.build_defs
@@ -317,7 +317,7 @@ def pip_library(name, version, hashes=None, package_name=None, outs=None, test_o
     target = outs[0] if install_subdirectory else '.'
 
     cmd = '%s install --no-deps --no-compile --no-cache-dir --default-timeout=60 --target=%s' % (CONFIG.PIP_TOOL, target)
-    cmd += ' -b build %s %s %s %s' % (repo_flag, index_flag, pip_flags, package_name)
+    cmd += ' -q -b build %s %s %s %s' % (repo_flag, index_flag, pip_flags, package_name)
     cmd += ' && find . -name "*.pyc" -or -name "tests" | xargs rm -rf'
 
     if not licences:

--- a/src/please.go
+++ b/src/please.go
@@ -54,7 +54,7 @@ var opts struct {
 		Colour            bool   `long:"colour" description:"Forces coloured output from logging & other shell output."`
 		NoColour          bool   `long:"nocolour" description:"Forces colourless output from logging & other shell output."`
 		TraceFile         string `long:"trace_file" description:"File to write Chrome tracing output into"`
-		PrintCommands     bool   `long:"print_commands" description:"Print each build / test command as they're run" hidden:"true"`
+		ShowAllOutput     bool   `long:"show_all_output" description:"Show all output live from all commands. Implies --plain_output."`
 		Version           bool   `long:"version" description:"Print the version of the tool"`
 	} `group:"Options controlling output & logging"`
 
@@ -463,6 +463,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, prettyOutput,
 	state.CleanWorkdirs = !opts.FeatureFlags.KeepWorkdirs
 	state.ForceRebuild = len(opts.Rebuild.Args.Targets) > 0
 	state.ShowTestOutput = opts.Test.ShowOutput || opts.Cover.ShowOutput
+	state.ShowAllOutput = opts.OutputFlags.ShowAllOutput
 	state.SetIncludeAndExclude(opts.BuildFlags.Include, opts.BuildFlags.Exclude)
 	metrics.InitFromConfig(config)
 	// Acquire the lock before we start building
@@ -594,6 +595,9 @@ func main() {
 		output.SetColouredOutput(true)
 	} else if opts.OutputFlags.NoColour {
 		output.SetColouredOutput(false)
+	}
+	if opts.OutputFlags.ShowAllOutput {
+		opts.OutputFlags.PlainOutput = true
 	}
 	// Init logging, but don't do file output until we've chdir'd.
 	cli.InitLogging(opts.OutputFlags.Verbosity)

--- a/src/test/container.go
+++ b/src/test/container.go
@@ -3,6 +3,7 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 
@@ -47,8 +48,7 @@ func runContainerisedTest(state *core.BuildState, target *core.BuildTarget) ([]b
 	command = append(command, "-v", testDir+":/tmp/test_in", "-w", "/tmp/test_in", containerName, "bash", "-o", "pipefail", "-c", replacedCmd)
 	log.Debug("Running containerised test %s: %s", target.Label, strings.Join(command, " "))
 	_, out, err := core.ExecWithTimeout(target.TestDir(), nil, target.TestTimeout, state.Config.Test.Timeout, state.ShowAllOutput, command)
-	_, isTimeout := err.(core.TimeoutError)
-	retrieveResultsAndRemoveContainer(target, cidfile, !isTimeout)
+	retrieveResultsAndRemoveContainer(target, cidfile, err == context.DeadlineExceeded)
 	return out, err
 }
 

--- a/src/test/container.go
+++ b/src/test/container.go
@@ -2,15 +2,17 @@
 
 package test
 
-import "fmt"
-import "io/ioutil"
-import "os/exec"
-import "path"
-import "strings"
-import "time"
+import (
+	"fmt"
+	"io/ioutil"
 
-import "build"
-import "core"
+	"path"
+	"strings"
+	"time"
+
+	"build"
+	"core"
+)
 
 func runContainerisedTest(state *core.BuildState, target *core.BuildTarget) ([]byte, error) {
 	testDir := path.Join(core.RepoRoot, target.TestDir())
@@ -44,9 +46,7 @@ func runContainerisedTest(state *core.BuildState, target *core.BuildTarget) ([]b
 	replacedCmd = "mkdir -p /tmp/test && cp -r /tmp/test_in/* /tmp/test && cd /tmp/test && " + replacedCmd
 	command = append(command, "-v", testDir+":/tmp/test_in", "-w", "/tmp/test_in", containerName, "bash", "-o", "pipefail", "-c", replacedCmd)
 	log.Debug("Running containerised test %s: docker %s", target.Label, strings.Join(command, " "))
-	cmd := exec.Command("docker", command...)
-	cmd.Dir = target.TestDir()
-	out, err := core.ExecWithTimeout(cmd, target.TestTimeout, state.Config.Test.Timeout)
+	out, err := core.ExecWithTimeoutShell(target.TestDir(), nil, target.TestTimeout, state.Config.Test.Timeout, state.ShowAllOutput, command...)
 	_, isTimeout := err.(core.TimeoutError)
 	retrieveResultsAndRemoveContainer(target, cidfile, !isTimeout)
 	return out, err
@@ -92,8 +92,8 @@ func retrieveResultsAndRemoveContainer(target *core.BuildTarget, containerFile s
 	// to shut down immediately.
 	timeout := core.State.Config.Docker.RemoveTimeout
 	for i := 0; i < 5; i++ {
-		cmd := exec.Command("docker", "rm", "-f", string(cid))
-		if _, err := core.ExecWithTimeout(cmd, timeout, timeout); err == nil {
+		cmd := []string{"docker", "rm", "-f", string(cid)}
+		if _, err := core.ExecWithTimeoutSimple(timeout, cmd...); err == nil {
 			return
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -104,8 +104,8 @@ func retrieveResultsAndRemoveContainer(target *core.BuildTarget, containerFile s
 func retrieveFile(target *core.BuildTarget, cid []byte, filename string, warn bool) {
 	log.Debug("Attempting to retrieve file %s for %s...", filename, target.Label)
 	timeout := core.State.Config.Docker.ResultsTimeout
-	cmd := exec.Command("docker", "cp", string(cid)+":/tmp/test/"+filename, target.TestDir())
-	if out, err := core.ExecWithTimeout(cmd, timeout, timeout); err != nil {
+	cmd := []string{"docker", "cp", string(cid) + ":/tmp/test/" + filename, target.TestDir()}
+	if out, err := core.ExecWithTimeoutSimple(timeout, cmd...); err != nil {
 		if warn {
 			log.Warning("Failed to retrieve results for %s: %s [%s]", target.Label, err, out)
 		} else {

--- a/src/test/container.go
+++ b/src/test/container.go
@@ -29,7 +29,7 @@ func runContainerisedTest(state *core.BuildState, target *core.BuildTarget) ([]b
 	cidfile := path.Join(testDir, ".container_id")
 	// Using C.UTF-8 for LC_ALL because it works. Not sure it's strictly
 	// correct to mix that with LANG=en_GB.UTF-8
-	command := []string{"run", "--cidfile", cidfile, "-e", "LC_ALL=C.UTF-8"}
+	command := []string{"docker", "run", "--cidfile", cidfile, "-e", "LC_ALL=C.UTF-8"}
 	if target.ContainerSettings != nil {
 		if target.ContainerSettings.DockerRunArgs != "" {
 			command = append(command, strings.Split(target.ContainerSettings.DockerRunArgs, " ")...)
@@ -45,8 +45,8 @@ func runContainerisedTest(state *core.BuildState, target *core.BuildTarget) ([]b
 	}
 	replacedCmd = "mkdir -p /tmp/test && cp -r /tmp/test_in/* /tmp/test && cd /tmp/test && " + replacedCmd
 	command = append(command, "-v", testDir+":/tmp/test_in", "-w", "/tmp/test_in", containerName, "bash", "-o", "pipefail", "-c", replacedCmd)
-	log.Debug("Running containerised test %s: docker %s", target.Label, strings.Join(command, " "))
-	out, err := core.ExecWithTimeoutShell(target.TestDir(), nil, target.TestTimeout, state.Config.Test.Timeout, state.ShowAllOutput, command...)
+	log.Debug("Running containerised test %s: %s", target.Label, strings.Join(command, " "))
+	_, out, err := core.ExecWithTimeout(target.TestDir(), nil, target.TestTimeout, state.Config.Test.Timeout, state.ShowAllOutput, command)
 	_, isTimeout := err.(core.TimeoutError)
 	retrieveResultsAndRemoveContainer(target, cidfile, !isTimeout)
 	return out, err

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -153,9 +154,7 @@ func test(tid int, state *core.BuildState, label core.BuildLabel, target *core.B
 		if err != nil && target.Results.Output == "" {
 			target.Results.Output = err.Error()
 		}
-		if err != nil {
-			_, target.Results.TimedOut = err.(core.TimeoutError)
-		}
+		target.Results.TimedOut = err == context.DeadlineExceeded
 		coverage = parseCoverageFile(target, coverageFile)
 		target.Results.Duration += duration
 		if !core.PathExists(outputFile) {

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -283,7 +283,8 @@ func runTest(state *core.BuildState, target *core.BuildTarget, timeout int) ([]b
 		env = append(env, "TESTS="+args)
 	}
 	log.Debug("Running test %s\nENVIRONMENT:\n%s\n%s", target.Label, strings.Join(env, "\n"), replacedCmd)
-	return core.ExecWithTimeoutShell(target.TestDir(), env, target.TestTimeout, timeout, state.ShowAllOutput, replacedCmd)
+	_, out, err := core.ExecWithTimeoutShell(target.TestDir(), env, target.TestTimeout, timeout, state.ShowAllOutput, replacedCmd)
+	return out, err
 }
 
 // prepareAndRunTest sets up a test directory and runs the test.

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"time"
@@ -283,11 +282,8 @@ func runTest(state *core.BuildState, target *core.BuildTarget, timeout int) ([]b
 		replacedCmd += " " + args
 		env = append(env, "TESTS="+args)
 	}
-	cmd := exec.Command("bash", "-o", "pipefail", "-c", replacedCmd)
-	cmd.Dir = target.TestDir()
-	cmd.Env = env
-	log.Debug("Running test %s\nENVIRONMENT:\n%s\n%s", target.Label, strings.Join(cmd.Env, "\n"), replacedCmd)
-	return core.ExecWithTimeout(cmd, target.TestTimeout, timeout)
+	log.Debug("Running test %s\nENVIRONMENT:\n%s\n%s", target.Label, strings.Join(env, "\n"), replacedCmd)
+	return core.ExecWithTimeoutShell(target.TestDir(), env, target.TestTimeout, timeout, state.ShowAllOutput, replacedCmd)
 }
 
 // prepareAndRunTest sets up a test directory and runs the test.


### PR DESCRIPTION
Changed it to use contexts since Go 1.7 can natively impose a deadline on commands. This means we now require 1.7 to build but surely everyone's using that now anyway :-P

Added a flag --show_all_output that shows output from all commands as it goes. That's useful for following the progress of individual long-running targets.

Finally changed the way output is returned; we now capture stdout and merged stdout/stderr separately, so we can display the latter for things like "why did your build fail", and the former is used for things that consume it (post-build functions and the like). This is a breaking change but is deliberate, I'd like to avoid capturing so much bollocks from commands like pip and npm that tend to be very verbose (and in many cases that verbosity may not be consistent across machines).