### PR TITLE
Change caches to store asynchronously

### DIFF
--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -269,8 +269,8 @@ func (*mockCache) RetrieveExtra(target *core.BuildTarget, key []byte, file strin
 	return false
 }
 
-func (*mockCache) Clean(target *core.BuildTarget) {
-}
+func (*mockCache) Clean(target *core.BuildTarget) {}
+func (*mockCache) Shutdown()                      {}
 
 func TestMain(m *testing.M) {
 	cache = &mockCache{}

--- a/src/cache/BUILD
+++ b/src/cache/BUILD
@@ -50,13 +50,19 @@ go_test(
     name = 'http_cache_test',
     srcs = ['http_cache_test.go'],
     container = True,  # Brings up an internal server
-    data = [
-        'test_data/darwin_amd64',
-        'test_data/linux_amd64',
-    ],
+    data = [':test_data'],
     deps = [
         ':cache',
         '//src/cache/server',
         '//third_party/go:logging',
+    ],
+)
+
+go_test(
+    name = 'async_cache_test',
+    srcs = ['async_cache_test.go'],
+    deps = [
+        ':cache',
+        '//third_party/go:testify',
     ],
 )

--- a/src/cache/async_cache.go
+++ b/src/cache/async_cache.go
@@ -1,0 +1,83 @@
+package cache
+
+import (
+	"sync"
+
+	"core"
+)
+
+// An asyncCache is a wrapper around a Cache interface that handles incoming
+// store requests asynchronously and attempts to return immediately.
+// The requests are handled on an internal queue, if that fills up then
+// incoming requests will start to block again until it empties.
+// Retrieval requests are still handled synchronously.
+type asyncCache struct {
+	requests  chan cacheRequest
+	realCache core.Cache
+	wg        sync.WaitGroup
+}
+
+// A cacheRequest models an incoming cache request on our queue.
+type cacheRequest struct {
+	target *core.BuildTarget
+	key    []byte
+	file   string
+}
+
+func newAsyncCache(realCache core.Cache, config *core.Configuration) core.Cache {
+	c := &asyncCache{
+		requests:  make(chan cacheRequest),
+		realCache: realCache,
+	}
+	c.wg.Add(config.Cache.Workers)
+	for i := 0; i < config.Cache.Workers; i++ {
+		go c.run()
+	}
+	return c
+}
+
+func (c *asyncCache) Store(target *core.BuildTarget, key []byte) {
+	c.requests <- cacheRequest{
+		target: target,
+		key:    key,
+	}
+}
+
+func (c *asyncCache) StoreExtra(target *core.BuildTarget, key []byte, file string) {
+	c.requests <- cacheRequest{
+		target: target,
+		key:    key,
+		file:   file,
+	}
+}
+
+func (c *asyncCache) Retrieve(target *core.BuildTarget, key []byte) bool {
+	return c.realCache.Retrieve(target, key)
+}
+
+func (c *asyncCache) RetrieveExtra(target *core.BuildTarget, key []byte, file string) bool {
+	return c.realCache.RetrieveExtra(target, key, file)
+}
+
+func (c *asyncCache) Clean(target *core.BuildTarget) {
+	c.realCache.Clean(target)
+}
+
+func (c *asyncCache) Shutdown() {
+	log.Notice("Shutting down cache workers...")
+	close(c.requests)
+	c.wg.Wait()
+}
+
+// run implements the actual async logic.
+func (c *asyncCache) run() {
+	for r := range c.requests {
+		if r.file != "" {
+			c.realCache.StoreExtra(r.target, r.key, r.file)
+		} else {
+			c.realCache.Store(r.target, r.key)
+		}
+	}
+	log.Debug("Cache worker finished")
+	c.wg.Done()
+}

--- a/src/cache/async_cache_test.go
+++ b/src/cache/async_cache_test.go
@@ -1,0 +1,136 @@
+package cache
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"core"
+)
+
+func TestStore(t *testing.T) {
+	mCache, aCache := makeCaches()
+	target := makeTarget("//pkg1:test_store")
+	aCache.Store(target, nil)
+	aCache.Shutdown()
+	assert.False(t, mCache.inFlight[target])
+	assert.True(t, mCache.completed[target])
+}
+
+func TestStoreExtra(t *testing.T) {
+	mCache, aCache := makeCaches()
+	target := makeTarget("//pkg1:test_store_extra")
+	aCache.StoreExtra(target, nil, "some_other_file")
+	aCache.Shutdown()
+	assert.False(t, mCache.inFlight[target])
+	assert.True(t, mCache.completed[target])
+}
+
+func TestRetrieve(t *testing.T) {
+	mCache, aCache := makeCaches()
+	target := makeTarget("//pkg1:test_retrieve")
+	aCache.Retrieve(target, nil)
+	aCache.Shutdown()
+	assert.False(t, mCache.inFlight[target])
+	assert.True(t, mCache.completed[target])
+}
+
+func TestRetrieveExtra(t *testing.T) {
+	mCache, aCache := makeCaches()
+	target := makeTarget("//pkg1:test_retrieve_extra")
+	aCache.RetrieveExtra(target, nil, "some_other_file")
+	aCache.Shutdown()
+	assert.False(t, mCache.inFlight[target])
+	assert.True(t, mCache.completed[target])
+}
+
+func TestClean(t *testing.T) {
+	mCache, aCache := makeCaches()
+	target := makeTarget("//pkg1:test_clean")
+	aCache.Clean(target)
+	aCache.Shutdown()
+	assert.False(t, mCache.inFlight[target])
+	assert.True(t, mCache.completed[target])
+}
+
+func TestConcurrentStores(t *testing.T) {
+	// The cache shouldn't run multiple concurrent stores for the same target.
+	// Our mock cache will panic if it detects that, so here we just throw enough
+	// concurrent requests at it to try to make sure that we're likely to exercise that.
+	// It's pretty hard to really guarantee that it does happen though.
+	mCache, aCache := makeCaches()
+	target := makeTarget("//pkg1:test_concurrent")
+	expected := []string{}
+	for i := 0; i < 20; i++ {
+		s := fmt.Sprintf("file%02d", i)
+		aCache.StoreExtra(target, nil, s)
+		expected = append(expected, s)
+	}
+	aCache.Shutdown()
+	assert.False(t, mCache.inFlight[target])
+	assert.True(t, mCache.completed[target])
+	stored := mCache.stored[target]
+	sort.Strings(stored)
+	assert.Equal(t, expected, stored)
+}
+
+// Fake cache implementation to ensure our async cache behaves itself.
+type mockCache struct {
+	sync.Mutex
+	inFlight  map[*core.BuildTarget]bool
+	completed map[*core.BuildTarget]bool
+	stored    map[*core.BuildTarget][]string
+}
+
+func (c *mockCache) Store(target *core.BuildTarget, key []byte) {
+	c.StoreExtra(target, key, "")
+}
+
+func (c *mockCache) StoreExtra(target *core.BuildTarget, key []byte, file string) {
+	c.Lock()
+	if c.inFlight[target] {
+		panic("Concurrent store on " + target.Label.String())
+	}
+	c.inFlight[target] = true
+	c.Unlock()
+	time.Sleep(10 * time.Millisecond) // Fake a small delay to mimic the real thing
+	c.Lock()
+	c.inFlight[target] = false
+	c.completed[target] = true
+	c.stored[target] = append(c.stored[target], file)
+	c.Unlock()
+}
+
+func (c *mockCache) Retrieve(target *core.BuildTarget, key []byte) bool {
+	c.Lock()
+	c.completed[target] = true
+	c.Unlock()
+	return false
+}
+
+func (c *mockCache) RetrieveExtra(target *core.BuildTarget, key []byte, file string) bool {
+	return c.Retrieve(target, key)
+}
+
+func (c *mockCache) Clean(target *core.BuildTarget) {
+	c.Retrieve(target, nil)
+}
+
+func (*mockCache) Shutdown() {}
+
+func makeTarget(label string) *core.BuildTarget {
+	return core.NewBuildTarget(core.ParseBuildLabel(label, ""))
+}
+
+func makeCaches() (mockCache, core.Cache) {
+	mCache := mockCache{
+		inFlight:  make(map[*core.BuildTarget]bool),
+		completed: make(map[*core.BuildTarget]bool),
+		stored:    make(map[*core.BuildTarget][]string),
+	}
+	return mCache, newAsyncCache(&mCache, core.DefaultConfiguration())
+}

--- a/src/cache/dir_cache.go
+++ b/src/cache/dir_cache.go
@@ -113,6 +113,8 @@ func (cache *dirCache) Clean(target *core.BuildTarget) {
 	}
 }
 
+func (cache *dirCache) Shutdown() {}
+
 func (cache *dirCache) getPath(target *core.BuildTarget, key []byte) string {
 	// NB. Is very important to use a padded encoding here so lengths are consistent for cache_cleaner.
 	return path.Join(cache.Dir, target.Label.PackageName, target.Label.Name, base64.URLEncoding.EncodeToString(key))

--- a/src/cache/http_cache.go
+++ b/src/cache/http_cache.go
@@ -164,6 +164,8 @@ func (cache *httpCache) Clean(target *core.BuildTarget) {
 	response.Body.Close()
 }
 
+func (cache *httpCache) Shutdown() {}
+
 func newHttpCache(config *core.Configuration) *httpCache {
 	cache := new(httpCache)
 	cache.OSName = runtime.GOOS + "_" + runtime.GOARCH

--- a/src/cache/rpc_cache.go
+++ b/src/cache/rpc_cache.go
@@ -196,6 +196,8 @@ func (cache *rpcCache) Clean(target *core.BuildTarget) {
 	}
 }
 
+func (cache *rpcCache) Shutdown() {}
+
 func (cache *rpcCache) connect(config *core.Configuration) {
 	// Change grpc to log using our implementation
 	grpclog.SetLogger(&grpcLogMabob{})

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -109,6 +109,7 @@ func DefaultConfiguration() *Configuration {
 	config.Cache.Dir = ".plz-cache"
 	config.Cache.DirCacheHighWaterMark = "10G"
 	config.Cache.DirCacheLowWaterMark = "8G"
+	config.Cache.Workers = runtime.NumCPU() + 2 // Mirrors the number of workers in please.go.
 	config.Metrics.PushFrequency = Duration(400 * time.Millisecond)
 	config.Metrics.PushTimeout = Duration(500 * time.Millisecond)
 	config.Test.Timeout = Duration(10 * time.Minute)
@@ -185,6 +186,7 @@ type Configuration struct {
 	}
 	BuildConfig map[string]string
 	Cache       struct {
+		Workers               int
 		Dir                   string
 		DirCacheCleaner       string
 		DirCacheHighWaterMark string

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -368,6 +368,8 @@ type Cache interface {
 	RetrieveExtra(target *BuildTarget, key []byte, file string) bool
 	// Cleans any artifacts associated with this target from the cache, for any possible key.
 	Clean(target *BuildTarget)
+	// Shuts down the cache, blocking until any potentially pending requests are done.
+	Shutdown()
 }
 
 // This is a pretty simple coverage format; we record one int for each line

--- a/src/please.go
+++ b/src/please.go
@@ -495,6 +495,9 @@ func Please(targets []core.BuildLabel, config *core.Configuration, prettyOutput,
 	shouldRun := !opts.Run.Args.Target.IsEmpty()
 	success := output.MonitorState(state, config.Please.NumThreads, !prettyOutput, opts.BuildFlags.KeepGoing, shouldBuild, shouldTest, shouldRun, opts.OutputFlags.TraceFile)
 	metrics.Stop()
+	if c != nil {
+		(*c).Shutdown()
+	}
 	return success, state
 }
 


### PR DESCRIPTION
Should improve performance a bit since we can keep storing cache artifacts while future targets are compiling.