### PR TITLE
Add support for an experimental dir.

### DIFF
--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -199,7 +199,7 @@ func (label BuildLabel) IsAllTargets() bool {
 	return label.Name == "all"
 }
 
-// covers returns true if label includes the other label (//pkg:target1 is covered by //pkg:all etc).
+// includes returns true if label includes the other label (//pkg:target1 is covered by //pkg:all etc).
 func (label BuildLabel) includes(that BuildLabel) bool {
 	if (label.PackageName == "" && label.IsAllSubpackages()) ||
 		that.PackageName == label.PackageName ||

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestCanSee(t *testing.T) {
+	NewBuildState(1, nil, 1, DefaultConfiguration())
 	target1 := makeTarget("//src/build/python:lib1", "")
 	target2 := makeTarget("//src/build/python:lib2", "PUBLIC")
 	target3 := makeTarget("//src/test/python:lib3", "//src/test/...")
@@ -32,6 +33,20 @@ func TestCanSee(t *testing.T) {
 
 	// Targets in that subtree can though.
 	assert.True(t, target4.CanSee(target3), "couldn't see target within its visibility spec")
+}
+
+func TestCanSeeExperimental(t *testing.T) {
+	config := DefaultConfiguration()
+	config.Please.ExperimentalDir = "experimental"
+	NewBuildState(1, nil, 1, config)
+
+	target1 := makeTarget("//src/core:target1", "")
+	target2 := makeTarget("//experimental/user:target2", "PUBLIC")
+
+	// target2 can see target1 since it's in experimental, which suppress normal visibility constraints.
+	assert.True(t, target2.CanSee(target1))
+	// target1 can't see target2 because it's in experimental, even though it's public.
+	assert.False(t, target1.CanSee(target2))
 }
 
 func TestCheckDependencyVisibility(t *testing.T) {

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -179,6 +179,7 @@ type Configuration struct {
 		ParserEngine     string
 		Nonce            string
 		NumThreads       int
+		ExperimentalDir  string
 	}
 	Build struct {
 		Timeout        Duration

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -96,6 +96,8 @@ type BuildState struct {
 	ShowAllOutput bool
 	// Number of running workers
 	numWorkers int
+	// Experimental directory
+	experimentalLabel BuildLabel
 	// Used to count the number of currently active/pending targets
 	numActive  int64
 	numPending int64
@@ -279,18 +281,19 @@ func (state *BuildState) ExpandOriginalTargets() BuildLabels {
 
 func NewBuildState(numThreads int, cache *Cache, verbosity int, config *Configuration) *BuildState {
 	State = &BuildState{
-		Graph:        NewGraph(),
-		pendingTasks: queue.NewPriorityQueue(10000, true), // big hint, why not
-		Results:      make(chan *BuildResult, numThreads*100),
-		Config:       config,
-		Verbosity:    verbosity,
-		Cache:        cache,
-		VerifyHashes: true,
-		NeedBuild:    true,
-		numActive:    1, // One for the initial target adding on the main thread.
-		numPending:   1,
-		Coverage:     TestCoverage{Files: map[string][]LineCoverage{}},
-		numWorkers:   numThreads,
+		Graph:             NewGraph(),
+		pendingTasks:      queue.NewPriorityQueue(10000, true), // big hint, why not
+		Results:           make(chan *BuildResult, numThreads*100),
+		Config:            config,
+		Verbosity:         verbosity,
+		Cache:             cache,
+		VerifyHashes:      true,
+		NeedBuild:         true,
+		numActive:         1, // One for the initial target adding on the main thread.
+		numPending:        1,
+		Coverage:          TestCoverage{Files: map[string][]LineCoverage{}},
+		numWorkers:        numThreads,
+		experimentalLabel: BuildLabel{PackageName: config.Please.ExperimentalDir, Name: "..."},
 	}
 	State.Hashes.Config = config.Hash()
 	State.Hashes.Containerisation = config.ContainerisationHash()

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -78,13 +78,15 @@ func FindAllSubpackages(config *core.Configuration, rootPath string, prefix stri
 		if err := filepath.Walk(rootPath, func(name string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err // stop on any error
-			} else if name == "plz-out" || (info.IsDir() && strings.HasPrefix(info.Name(), ".") && name != ".") {
+			} else if name == core.OutDir || (info.IsDir() && strings.HasPrefix(info.Name(), ".") && name != ".") {
 				return filepath.SkipDir // Don't walk output or hidden directories
 			} else if info.IsDir() && !strings.HasPrefix(name, prefix) && !strings.HasPrefix(prefix, name) {
 				return filepath.SkipDir // Skip any directory without the prefix we're after (but not any directory beneath that)
 			} else if isABuildFile(info.Name(), config) && !info.IsDir() {
 				dir, _ := path.Split(name)
 				ch <- strings.TrimRight(dir, "/")
+			} else if name == config.Please.ExperimentalDir {
+				return filepath.SkipDir // Skip the experimental directory if it's set
 			}
 			// Check against blacklist
 			for _, dir := range config.Please.BlacklistDirs {


### PR DESCRIPTION
The rules are:
- Targets within that directory can depend on any target outside, even if they normally couldn't see it.
- Targets outside can never depend on any target inside it.
- When scanning the repo at the top level it is not recursed into.