### PR TITLE
Add the ability to horizontally scroll  in pre tags

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -55,6 +55,9 @@ pre {
     border-radius: 3px;
     padding: 2px;
     color: white;
+    overflow-y: hidden;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
 }
 :not(pre) > code {
     border: 1px #666666 solid;


### PR DESCRIPTION
When the screen is small enough (for example is you have the devtools open all the time :D) the pre blocks are too narrow and the content gets cut.

This adds horizontal scroll to all the pre elements so it doesn’t happen. It sets the vertical scroll to hidden since the presence of the horizontal scrollbar can produce little unnecessary vertical scroll in some browsers and I don’t think there will be any pre with vertical scroll.