### PR TITLE
Add proto.jsdep config option that gets used when building JS protos

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -159,6 +159,7 @@ func DefaultConfiguration() *Configuration {
 	config.Proto.PythonDep = "//third_party/python:protobuf"
 	config.Proto.JavaDep = "//third_party/java:protobuf"
 	config.Proto.GoDep = "//third_party/go:protobuf"
+	config.Proto.JsDep = ""
 	config.Proto.PythonGrpcDep = "//third_party/python:grpc"
 	config.Proto.JavaGrpcDep = "//third_party/java:grpc-all"
 	config.Proto.GoGrpcDep = "//third_party/go:grpc"
@@ -287,6 +288,7 @@ type Configuration struct {
 		PythonDep        string
 		JavaDep          string
 		GoDep            string
+		JsDep            string
 		PythonGrpcDep    string
 		JavaGrpcDep      string
 		GoGrpcDep        string

--- a/src/parse/interpreter.go
+++ b/src/parse/interpreter.go
@@ -130,6 +130,7 @@ func initializeInterpreter(config *core.Configuration) {
 	setConfigValue("PROTO_PYTHON_DEP", config.Proto.PythonDep)
 	setConfigValue("PROTO_JAVA_DEP", config.Proto.JavaDep)
 	setConfigValue("PROTO_GO_DEP", config.Proto.GoDep)
+	setConfigValue("PROTO_JS_DEP", config.Proto.JsDep)
 	setConfigValue("PROTO_PYTHON_PACKAGE", config.Proto.PythonPackage)
 	setConfigValue("GRPC_PYTHON_DEP", config.Proto.PythonGrpcDep)
 	setConfigValue("GRPC_JAVA_DEP", config.Proto.JavaGrpcDep)

--- a/src/parse/rules/proto_rules.build_defs
+++ b/src/parse/rules/proto_rules.build_defs
@@ -210,9 +210,10 @@ def proto_library(name, srcs, plugins=None, deps=None, visibility=None, labels=N
             provides['go_src'] = ':_%s#go_src' % name
 
         elif language == 'js':
-            export_file(
+            filegroup(
                 name = lang_name,
-                src = gen_dep,
+                srcs = [gen_dep],
+                deps = [CONFIG.PROTO_JS_DEP],
                 visibility = visibility,
                 test_only = test_only,
             )


### PR DESCRIPTION
I didn't add it to `config.json` since we don't really support JS yet. But I'm not sure I missed anything else? I did test it against our repo and it seems to work fine when I set the appropriate dependency in our .plzconfig