### PR TITLE
Fix bootstrap for Python 3.6

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -59,6 +59,7 @@ dircachecleaner = none
 
 [licences]
 accept = MIT
+accept = MIT License
 accept = BSD
 accept = BSD License
 accept = Simplified BSD

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -2,8 +2,8 @@ package(default_visibility = ['PUBLIC'])
 
 pip_library(
     name = 'pex',
-    version = '1.1.1',
-    hashes = ['sha1: 74d1cc64aab1d8ae5bea69822d690ef0eb4ecd53'],
+    version = '1.1.20',
+    hashes = ['sha1: e410ca1d350e852e705299b31c6c9ea7658257a4'],
     patch = [
         'never_cache_pex.patch',
         'bytecode_timestamps.patch',

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -28,9 +28,8 @@ pip_library(
 pip_library(
     name = 'pkg_resources',
     package_name = 'setuptools',
-    version = '6.1',
-    outs = ['pkg_resources.py'],
-    hashes = ['sha1: 33c8ea9686a15ca09ce96656d4a2074d75235dfe'],
+    version = '33.1.1',
+    hashes = ['sha1: 05f20a29a5dff7dd5b908afcf37c2b1bea8d3db6'],
 )
 
 pip_library(

--- a/tools/please_pex/BUILD
+++ b/tools/please_pex/BUILD
@@ -5,8 +5,6 @@ python_binary(
     shebang = '/usr/bin/env python',
     deps = [
         ':main_files',
-        '//third_party/python:pex',
-        '//third_party/python:pkg_resources',
     ],
     visibility = ['PUBLIC'],
 )
@@ -16,11 +14,6 @@ python_library(
     srcs = [
         'pex_main.py',
         'test_main.py',
-    ],
-    deps = [
-        '//third_party/python:coverage',
-        '//third_party/python:six',
-        '//third_party/python:xmlrunner',
     ],
 )
 

--- a/tools/please_pex/BUILD
+++ b/tools/please_pex/BUILD
@@ -51,7 +51,9 @@ build_rule(
         # Have to make sure these exist.
         'touch third_party/__init__.py third_party/python/__init__.py',
         'touch tools/__init__.py tools/please_pex/__init__.py',
-        'PYTHONPATH="." python -O tools/please_pex/pex.py --src_dir=${TMP_DIR} --out=${OUT} --entry_point=${PKG//\//.}.pex --interpreter ' + CONFIG.DEFAULT_PYTHON_INTERPRETER,
+        'mv third_party/python .bootstrap',
+        'mv .bootstrap/pex .bootstrap/_pex',
+        'PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=".:./.bootstrap" python -O tools/please_pex/pex.py --src_dir=${TMP_DIR} --out=${OUT} --entry_point=${PKG//\//.}.pex --interpreter ' + CONFIG.DEFAULT_PYTHON_INTERPRETER,
     ]),
     needs_transitive_deps = True,
     output_is_complete = True,

--- a/tools/please_pex/pex.py
+++ b/tools/please_pex/pex.py
@@ -5,13 +5,13 @@ import argparse
 import contextlib
 import json
 import os
-import pkg_resources
 import py_compile
 import shutil
 import sys
 import tempfile
 import zipfile
 
+from third_party.python import pkg_resources
 from third_party.python.pex.compatibility import to_bytes
 from third_party.python.pex.pex_builder import PEXBuilder
 from third_party.python.pex.interpreter import PythonInterpreter

--- a/tools/please_pex/pex.py
+++ b/tools/please_pex/pex.py
@@ -147,13 +147,12 @@ def main(args):
             args.interpreter = spawn.find_executable(args.interpreter)
 
     # Add pkg_resources and the bootstrapper
-    extract_directory('third_party.python',
-                      'pex',
-                      args.src_dir,
-                      '.bootstrap/_pex')
-    extract_file('third_party.python',
-                 os.path.join(args.src_dir, '.bootstrap'),
-                 'pkg_resources.py')
+    extract_directory('third_party.python', 'pex', args.src_dir, '.bootstrap/_pex')
+    extract_directory('third_party.python', 'pkg_resources', args.src_dir, '.bootstrap/pkg_resources')
+    extract_directory('third_party.python.pkg_resources', 'extern', args.src_dir, '.bootstrap/pkg_resources/extern')
+    extract_directory('third_party.python.pkg_resources', '_vendor', args.src_dir, '.bootstrap/pkg_resources/_vendor')
+    extract_directory('third_party.python.pkg_resources._vendor', 'packaging', args.src_dir,
+                      '.bootstrap/pkg_resources/_vendor/packaging')
 
     # Setup a temp dir that the PEX builder will use as its scratch dir.
     tmp_dir = tempfile.mkdtemp()

--- a/tools/please_pex/pex.py
+++ b/tools/please_pex/pex.py
@@ -11,10 +11,17 @@ import sys
 import tempfile
 import zipfile
 
-from third_party.python import pkg_resources
-from third_party.python.pex.compatibility import to_bytes
-from third_party.python.pex.pex_builder import PEXBuilder
-from third_party.python.pex.interpreter import PythonInterpreter
+# We need to load pkg_resources and pex; they must be shipped in .bootstrap
+# for pex to work, but that's already been scrubbed from the path so we must
+# re-add it here.
+# TODO(pebers): remove use of pkg_resources in this file and use zipfile
+#               for all operations.
+sys.path.insert(0, os.path.abspath(os.path.join(sys.argv[0], '.bootstrap')))
+
+import pkg_resources
+from _pex.compatibility import to_bytes
+from _pex.pex_builder import PEXBuilder
+from _pex.interpreter import PythonInterpreter
 
 
 def dereference_symlinks(src):
@@ -96,6 +103,20 @@ def extract_directory(in_pkg, in_req, out_dir, out_path, duplicates_allowed=Fals
             extract_file(full_dir, target_dir, filename)
 
 
+def extract_recursive_dir(dirname, out_dir):
+    """Extracts an entire directory and copies it to the output dir."""
+    try:
+        zf = zipfile.ZipFile(sys.argv[0])
+        for info in zf.infolist():
+            if info.filename.startswith(dirname):
+                zf.extract(info, path=out_dir)
+    except zipfile.BadZipfile:
+        # This happens during bootstrapping when we're not actually in a zipfile.
+        # In that case we might not need to do anything because .bootstrap is already there.
+        if not os.path.isdir(dirname):
+            raise
+
+
 def extract_file(in_pkg, out_dir, filename, duplicates_allowed=False):
     """Extracts a single file from the pex builder and adds it to the staging directory."""
     target = os.path.join(out_dir, filename)
@@ -147,16 +168,7 @@ def main(args):
             args.interpreter = spawn.find_executable(args.interpreter)
 
     # Add pkg_resources and the bootstrapper
-    extract_directory('third_party.python', 'pex', args.src_dir,
-                      '.bootstrap/_pex')
-    extract_directory('third_party.python', 'pkg_resources', args.src_dir,
-                      '.bootstrap/pkg_resources')
-    extract_directory('third_party.python.pkg_resources', 'extern', args.src_dir,
-                      '.bootstrap/pkg_resources/extern')
-    extract_directory('third_party.python.pkg_resources', '_vendor', args.src_dir,
-                      '.bootstrap/pkg_resources/_vendor')
-    extract_directory('third_party.python.pkg_resources._vendor', 'packaging', args.src_dir,
-                      '.bootstrap/pkg_resources/_vendor/packaging')
+    extract_recursive_dir('.bootstrap', args.src_dir)
 
     # Setup a temp dir that the PEX builder will use as its scratch dir.
     tmp_dir = tempfile.mkdtemp()

--- a/tools/please_pex/pex.py
+++ b/tools/please_pex/pex.py
@@ -147,10 +147,14 @@ def main(args):
             args.interpreter = spawn.find_executable(args.interpreter)
 
     # Add pkg_resources and the bootstrapper
-    extract_directory('third_party.python', 'pex', args.src_dir, '.bootstrap/_pex')
-    extract_directory('third_party.python', 'pkg_resources', args.src_dir, '.bootstrap/pkg_resources')
-    extract_directory('third_party.python.pkg_resources', 'extern', args.src_dir, '.bootstrap/pkg_resources/extern')
-    extract_directory('third_party.python.pkg_resources', '_vendor', args.src_dir, '.bootstrap/pkg_resources/_vendor')
+    extract_directory('third_party.python', 'pex', args.src_dir,
+                      '.bootstrap/_pex')
+    extract_directory('third_party.python', 'pkg_resources', args.src_dir,
+                      '.bootstrap/pkg_resources')
+    extract_directory('third_party.python.pkg_resources', 'extern', args.src_dir,
+                      '.bootstrap/pkg_resources/extern')
+    extract_directory('third_party.python.pkg_resources', '_vendor', args.src_dir,
+                      '.bootstrap/pkg_resources/_vendor')
     extract_directory('third_party.python.pkg_resources._vendor', 'packaging', args.src_dir,
                       '.bootstrap/pkg_resources/_vendor/packaging')
 


### PR DESCRIPTION
Basically just updating setuptools and pex, I don't have a machine convenient to test this on but the relevant code looks like it should be fixed.

Fixes #177 (hopefully)