### PR TITLE
Add 'binary' option for JS protos

### DIFF
--- a/src/parse/rules/proto_rules.build_defs
+++ b/src/parse/rules/proto_rules.build_defs
@@ -110,7 +110,7 @@ def proto_library(name, srcs, plugins=None, deps=None, visibility=None, labels=N
             # Go doesn't come by default, so add it here.
             lang_plugins.append('--plugin=protoc-gen-go=' + _plugin(CONFIG.PROTOC_GO_PLUGIN, lang_tools))
 
-        language_out_arguments = 'import_style=commonjs:' if language == 'js' else ''
+        language_out_arguments = 'import_style=commonjs,binary:' if language == 'js' else ''
 
         cmd = ' '.join([
             _plugin(CONFIG.PROTOC_TOOL, lang_tools),


### PR DESCRIPTION
This adds the code to the generated JS that allows you to (de)serialize the protos on the client