### PR TITLE
pass pkg_config_libs to cc_library in cc_binary

### DIFF
--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -348,6 +348,7 @@ def cc_binary(name, srcs=None, hdrs=None, private_hdrs=None, compiler_flags=None
             hdrs=hdrs,
             private_hdrs=private_hdrs,
             deps=deps,
+            pkg_config_libs=pkg_config_libs,
             compiler_flags=compiler_flags,
             test_only=test_only,
             _c=_c,


### PR DESCRIPTION
When building a binary with cc_binary, pkg_config_libs must be passed to cc_library to have pkg-config added to build command.

