### PR TITLE
Add third_party top level folder to default GOPATH

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+    * Add <root>/third_party/ to the default GOPATH
+
 Version 7.8.2
 -------------
 

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -122,7 +122,7 @@ func DefaultConfiguration() *Configuration {
 	config.Docker.RemoveTimeout = cli.Duration(20 * time.Second)
 	config.Go.CgoCCTool = "gcc"
 	config.Go.GoVersion = "1.6"
-	config.Go.GoPath = "$TMP_DIR:$TMP_DIR/src:$TMP_DIR/$PKG:$TMP_DIR/third_party/go"
+	config.Go.GoPath = "$TMP_DIR:$TMP_DIR/src:$TMP_DIR/$PKG:$TMP_DIR/third_party/go:$TMP_DIR/third_party/"
 	config.Python.PipTool = "pip"
 	config.Python.DefaultInterpreter = "python"
 	config.Python.UsePyPI = true


### PR DESCRIPTION
The current default only works with deps that are declared under
third_party/go/ . However, for a Go-only repo the subfolder is
unnecessary and it shouldn't be required, I think