### PR TITLE
Fix go_get with dependencies when in declared in repo root

### DIFF
--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -456,8 +456,16 @@ def go_get(name, get=None, outs=None, deps=None, exported_deps=None, visibility=
         if not binary:
             post_build = _extra_outs(get)
     cmd = [
-        'export GOPATH=$TMP_DIR:$TMP_DIR/$PKG',
+        # When PKG_DIR == ".", the install location likely coincides with the
+        # dependencies of this go_get (i.e they are all in the root's BUILD
+        # file). Thus we need to note which compiled .a files are already
+        # provided by the deps and filter these out from the
+        # output
+        'if [ -d $PKG_DIR ]; then '
+        'export EXISTING="$(find $PKG_DIR -name *.a)"; else export EXISTING=""; fi',
+
         'rm -rf pkg src',
+        'export GOPATH=$TMP_DIR:$TMP_DIR/$PKG',
         'go get -d ' + get,
     ]
     subdir = 'src/' + (get[:-4] if get.endswith('/...') else get)
@@ -468,7 +476,9 @@ def go_get(name, get=None, outs=None, deps=None, exported_deps=None, visibility=
         cmd.append('patch -s -d %s -p1 < ${TMP_DIR}/$(location %s)' % (subdir, patch))
     cmd.append('go install -gcflags "-trimpath $TMP_DIR" ' + ' '.join([get] + (install or [])))
     # Remove anything that was there already.
-    cmd.append('if [ -d $PKG_DIR ]; then find $PKG_DIR -name "*.a" | sed -e "s|$PKG_DIR/||g" | xargs rm -f; fi')
+    cmd.append('if [ -d $PKG_DIR ]; then '
+               'if [ $PKG_DIR = "." ]; then echo $EXISTING | xargs rm -f; '
+               'else echo $EXISTING | sed -e "s|$PKG_DIR/||g" | xargs rm -f; fi; fi')
     if not binary:
         cmd.extend([
             'find . -name .git | xargs rm -rf',

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -456,16 +456,23 @@ def go_get(name, get=None, outs=None, deps=None, exported_deps=None, visibility=
         if not binary:
             post_build = _extra_outs(get)
     cmd = [
-        # When PKG_DIR == ".", the install location likely coincides with the
-        # dependencies of this go_get (i.e they are all in the root's BUILD
-        # file). Thus we need to note which compiled .a files are already
-        # provided by the deps and filter these out from the
-        # output
-        'if [ -d $PKG_DIR ]; then '
-        'export EXISTING="$(find $PKG_DIR -name *.a)"; else export EXISTING=""; fi',
+        # the TMP_DIR contains all the compiled dependencies already. Later when
+        # we go install, it is difficult to seperate its outputs from the
+        # deps outputs, hence why we capture them here in advance
+        'export existing="$(find $TMP_DIR -name \"*.a\")"',
 
-        'rm -rf pkg src',
-        'export GOPATH=$TMP_DIR:$TMP_DIR/$PKG',
+        # go_get dependencies could be in different paths, make sure they are
+        # all available in the GOPATH by detecting their pkg/ folder and using its parent
+        'export GOPATH="$TMP_DIR"',
+        # loop done like this because the GOPATH export should not be in a SubShell
+        'while IFS= read -r dep_dir; do '
+        'if [ -n "$dep_dir" ]; then export GOPATH="${dep_dir}:${GOPATH}" ; fi ; done '
+        '< <(echo "$existing" | sed -e \'s|pkg/.*||g\' | sort -u)',
+
+        'export INSTALL_DIR=$(mktemp -d --tmpdir=$TMP_DIR)',
+        'export GOPATH="$INSTALL_DIR:$GOPATH"',
+
+        'cd $INSTALL_DIR',
         'go get -d ' + get,
     ]
     subdir = 'src/' + (get[:-4] if get.endswith('/...') else get)
@@ -474,11 +481,19 @@ def go_get(name, get=None, outs=None, deps=None, exported_deps=None, visibility=
         cmd.append('(cd %s && git checkout -q %s)' % (subdir, revision))
     if patch:
         cmd.append('patch -s -d %s -p1 < ${TMP_DIR}/$(location %s)' % (subdir, patch))
-    cmd.append('go install -gcflags "-trimpath $TMP_DIR" ' + ' '.join([get] + (install or [])))
+    cmd.append('go install -gcflags "-trimpath $INSTALL_DIR" ' + ' '.join([get] + (install or [])))
     # Remove anything that was there already.
-    cmd.append('if [ -d $PKG_DIR ]; then '
-               'if [ $PKG_DIR = "." ]; then echo $EXISTING | xargs rm -f; '
-               'else echo $EXISTING | sed -e "s|$PKG_DIR/||g" | xargs rm -f; fi; fi')
+    cmd.extend([
+        # go_get built dependencies could be in different dirs so we strip the prefix
+        # leading up to `/pkg/`. These have been cached in the "$INSTALL_DIR/pkg/.."
+        # during the `go install`. So clean them up from this target's outputs
+        'echo "$existing" | while IFS= read -r pathname; do '
+        'if [ -n "$pathname" ]; then rm -f "$INSTALL_DIR/pkg/${pathname#*/pkg/}" ; fi ; done',
+        'cd $TMP_DIR',
+        # delete all other dirs with deps. Only src,pkg and maybe bin will remain
+        'ls | grep -v $(basename $INSTALL_DIR) | xargs rm -rf',
+        'mv $INSTALL_DIR/* $TMP_DIR/'
+    ])
     if not binary:
         cmd.extend([
             'find . -name .git | xargs rm -rf',


### PR DESCRIPTION
When in the root, building a go_get with a dependency, also in the root,
fails because with PKG="" , PKG_DIR == "." , and
GOPATH=$TMP_DIR/TMP_DIR/$PKG both the deps and the buildable get built
in the same folder. Thus, the usual mechanism of filtering out the dep
files (find $PKG_DIR and delete the equivalent in the $TMP_DIR) does not
work because we cannot distinguish these anymore. Furthermore, using
"." in the sed command gets interpreted as a wildcard so the sed .. | rm
currently does not delete anything. The end result is that the buildable
produces .a outputs which are also produced by its dependencies and plz
detects that multiple targets output the same file.

The PR saves the existing outputs in the PKG_DIR before performing go
install and uses this for the clean up. It also special cases the "." to
make the sed command work as desired.