### PR TITLE
Add a flag to `plz build` to open a shell into build directories.

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -97,6 +97,8 @@ type BuildState struct {
 	NeedHashesOnly bool
 	// True if we only want to prepare build directories (ie. 'plz build --prepare')
 	PrepareOnly bool
+	// True if we're going to run a shell after builds are prepared.
+	PrepareShell bool
 	// Number of times to run each test target. 0 == once each, plus flakes if necessary.
 	NumTestRuns int
 	// True to clean working directories after successful builds.

--- a/src/please.go
+++ b/src/please.go
@@ -77,6 +77,7 @@ var opts struct {
 
 	Build struct {
 		Prepare    bool     `long:"prepare" description:"Prepare build directory for these targets but don't build them."`
+		Shell      bool     `long:"shell" description:"Like --prepare, but opens a shell in the build directory with the appropriate environment variables."`
 		ShowStatus bool     `long:"show_status" hidden:"true" description:"Show status of each target in output after build"`
 		Args       struct { // Inner nesting is necessary to make positional-args work :(
 			Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to build"`
@@ -529,7 +530,8 @@ func Please(targets []core.BuildLabel, config *core.Configuration, prettyOutput,
 	state.NeedBuild = shouldBuild
 	state.NeedTests = shouldTest
 	state.NeedHashesOnly = len(opts.Hash.Args.Targets) > 0
-	state.PrepareOnly = opts.Build.Prepare
+	state.PrepareOnly = opts.Build.Prepare || opts.Build.Shell
+	state.PrepareShell = opts.Build.Shell
 	state.CleanWorkdirs = !opts.FeatureFlags.KeepWorkdirs
 	state.ForceRebuild = len(opts.Rebuild.Args.Targets) > 0
 	state.ShowTestOutput = opts.Test.ShowOutput || opts.Cover.ShowOutput


### PR DESCRIPTION
It's like `--prepare` but opens a shell in the correct location with the environment variables set. Useful for investigating build failures while fiddling about with rules.