### PR TITLE
Fixate tarball timestamps to 2000-01-01 instead of 1970-01-01

### DIFF
--- a/src/parse/rules/misc_rules.build_defs
+++ b/src/parse/rules/misc_rules.build_defs
@@ -559,7 +559,7 @@ def tarball(name, srcs, out=None, deps=None, subdir=None,
             'cp -pr $(locations :_%s#files) _tmp/%s' % (name, subdir),
             'cd _tmp',
             # not using tar's --mtime because it's only available in GNU tar
-            'find . -exec touch -t 197001010000.00 {} +',
+            'find . -exec touch -t 200001010000.00 {} +',
             archive_cmd
         ]),
         outs=[out],


### PR DESCRIPTION
Should avoid getting "implausibly old timestamp" messages when extracting them.