### PR TITLE
Adding example Ubuntu Docker image

### DIFF
--- a/tools/images/README.md
+++ b/tools/images/README.md
@@ -1,0 +1,12 @@
+Docker images
+-------------
+
+These images describe a pre-set-up environment for building Please in.
+Currently we only have one for Ubuntu which is the canonical build environment
+on Linux; in future it'd be nice to add more (e.g. Alpine) once we can
+support them.
+
+Note that various dependencies can be seen as more or less optional
+(for example there are three Python engines, of which any one is needed
+for Please to work). The aspiration is to build all features in each image,
+but some may be harder than others if certain packages aren't available.

--- a/tools/images/ubuntu/Dockerfile
+++ b/tools/images/ubuntu/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:xenial
+MAINTAINER peter.ebden@gmail.com
+
+# Basic dependencies, Python and Java
+RUN apt-get update && apt-get install -y python2.7 python3.5 python-pip python3-pip openjdk-8-jdk curl unzip git
+RUN pip install cffi
+RUN pip3 install cffi
+
+# Go
+RUN curl -fsSL https://storage.googleapis.com/golang/go1.8.1.linux-amd64.tar.gz | tar -xzC /usr/local
+RUN ln -s /usr/local/go/bin/go /usr/local/bin/go
+
+# PyPy
+RUN curl -fsSL https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.1-linux64.tar.bz2 | tar -xjC /usr/local
+RUN mv /usr/local/pypy2-v5.7.1-linux64 /usr/local/pypy
+RUN ln -s /usr/local/pypy/bin/pypy /usr/local/bin/pypy
+RUN ln -s /usr/local/pypy/bin/libpypy-c.so /usr/lib
+
+# C++
+RUN apt-get install -y pkg-config clang
+RUN curl -fsSL https://github.com/unittest-cpp/unittest-cpp/releases/download/v2.0.0/unittest-cpp-2.0.0.tar.gz | tar -xzC /tmp
+RUN cd /tmp/unittest-cpp-2.0.0 && ./configure --prefix=/usr && make -j4 && make install
+RUN ln -s /usr/include/UnitTest++ /usr/include/unittest++
+RUN ln -s /usr/lib/libUnitTest++.a /usr/lib/libunittest++.a
+RUN rm -r /tmp/unittest-cpp-2.0.0
+
+# Protocol buffers
+RUN curl -fsSLo /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip
+RUN unzip /tmp/protoc.zip -x readme.txt -d /usr
+
+# Locale
+RUN locale-gen en_GB.UTF-8
+
+# Welcome message
+COPY /motd.txt /etc/motd
+RUN echo 'cat /etc/motd' >> /etc/bash.bashrc
+WORKDIR /tmp

--- a/tools/images/ubuntu/README.md
+++ b/tools/images/ubuntu/README.md
@@ -1,0 +1,21 @@
+Please Ubuntu image
+-------------------
+
+This image contains everything needed to build Please and all its
+parser engines and run all the additional tests. It's the canonical
+Linux build environment for Please.
+
+The only tests that are excluded are tests that run in Docker since
+it's not easily possible to spawn more Docker containers from inside
+a container.
+
+Notes
+-----
+
+ - We download a precompiled protoc to avoid trying to compile the whole
+   thing from scratch. A sufficiently recent packaged version would be
+   preferable.
+ - libunittest++-dev is available in Ubuntu but the version is fairly old
+   and core dumps on several tests. Installing v2.0.0 ourselves fixes this,
+   although the naming is a bit inconsistent (tracked in #200). Regardless,
+   we fix that up with a couple of judicious symlinks.

--- a/tools/images/ubuntu/motd.txt
+++ b/tools/images/ubuntu/motd.txt
@@ -1,0 +1,8 @@
+This is a prebuilt image based on Ubuntu Xenial which contains
+everything you should need to build Please.
+
+Run the following to get started:
+ git clone https://github.com/thought-machine/please.git
+ cd please
+ ./bootstrap.sh
+


### PR DESCRIPTION
As discussed in #199, this should make it a bit clearer how to set up an environment to build the whole thing.

I'd like to add some more images in future - e.g. Alpine, Ubuntu + prebuilt plz, etc.