### PR TITLE
Maven classifier

### DIFF
--- a/src/parse/rules/java_rules.build_defs
+++ b/src/parse/rules/java_rules.build_defs
@@ -379,7 +379,7 @@ def maven_jars(name, id, repository=None, exclude=None, hashes=None, combine=Fal
 def maven_jar(name, id=None, repository=None, hash=None, hashes=None, deps=None,
               visibility=None, filename=None, sources=True, licences=None,
               exclude_paths=None, native=False, artifact_type=None, test_only=False,
-              binary=False, classifier=""):
+              binary=False, classifier="", classifier_sources_override=""):
     """Fetches a single Java dependency from Maven.
 
     Args:
@@ -400,7 +400,10 @@ def maven_jar(name, id=None, repository=None, hash=None, hashes=None, deps=None,
       binary (bool): If True, we attempt to fetch and download an executable binary. The output
                      is marked as such. Implies native=True and sources=False.
       classifier (str): Maven classifier, allows to distinguish artifacts that were built from 
-                     the same POM but differ in their content. 
+                     the same POM but differ in their content.
+      classifier_sources_override (str): Allows to override the classifier used to fetch the 
+                     source artifact. 
+                     e.g. logback-core-1.1.3-tests.jar and logback-core-1.1.3-test-sources.jar  
     """
     if hash and hashes:
         raise ParseError('You can pass only one of hash or hashes to maven_jar')
@@ -453,6 +456,8 @@ def maven_jar(name, id=None, repository=None, hash=None, hashes=None, deps=None,
     srcs = [bin_rule]
 
     if sources:
+        if classifier_sources_override:
+            classifier = '-' + classifier_sources_override
         src_url = '%s/%s-%s%s-sources.jar' % (url_base, artifact, version, classifier)
         cmd = 'echo "Fetching %s..." && curl -fsSL %s -o $OUT' % (src_url, src_url)
         src_rule = build_rule(

--- a/src/parse/rules/java_rules.build_defs
+++ b/src/parse/rules/java_rules.build_defs
@@ -379,7 +379,7 @@ def maven_jars(name, id, repository=None, exclude=None, hashes=None, combine=Fal
 def maven_jar(name, id=None, repository=None, hash=None, hashes=None, deps=None,
               visibility=None, filename=None, sources=True, licences=None,
               exclude_paths=None, native=False, artifact_type=None, test_only=False,
-              binary=False, classifier="", classifier_sources_override=""):
+              binary=False, classifier='', classifier_sources_override=''):
     """Fetches a single Java dependency from Maven.
 
     Args:

--- a/src/parse/rules/java_rules.build_defs
+++ b/src/parse/rules/java_rules.build_defs
@@ -379,7 +379,7 @@ def maven_jars(name, id, repository=None, exclude=None, hashes=None, combine=Fal
 def maven_jar(name, id=None, repository=None, hash=None, hashes=None, deps=None,
               visibility=None, filename=None, sources=True, licences=None,
               exclude_paths=None, native=False, artifact_type=None, test_only=False,
-              binary=False):
+              binary=False, classifier=""):
     """Fetches a single Java dependency from Maven.
 
     Args:
@@ -399,6 +399,8 @@ def maven_jar(name, id=None, repository=None, hash=None, hashes=None, deps=None,
       test_only (bool): If True, this target can only be used by tests or other test_only rules.
       binary (bool): If True, we attempt to fetch and download an executable binary. The output
                      is marked as such. Implies native=True and sources=False.
+      classifier (str): Maven classifier, allows to distinguish artifacts that were built from 
+                     the same POM but differ in their content. 
     """
     if hash and hashes:
         raise ParseError('You can pass only one of hash or hashes to maven_jar')
@@ -409,6 +411,8 @@ def maven_jar(name, id=None, repository=None, hash=None, hashes=None, deps=None,
     group, artifact, version, sources, licences = _parse_maven_artifact(id, sources, licences)
     artifact_type = '.' + artifact_type
     out_artifact_type = artifact_type
+    if classifier:
+        classifier = '-' + classifier
     if binary:
         native = True
         sources = False
@@ -418,9 +422,10 @@ def maven_jar(name, id=None, repository=None, hash=None, hashes=None, deps=None,
         # Maven has slightly different names for these.
         os = 'osx' if CONFIG.OS == 'darwin' else CONFIG.OS
         arch = 'x86_64' if CONFIG.ARCH == 'amd64' else CONFIG.ARCH
-        filename = filename or '%s-%s-%s-%s%s' % (artifact, version, os, arch, artifact_type)
+        filename = filename or '%s-%s-%s%s-%s%s' % (artifact, version, classifier, os, arch,
+                                                    artifact_type)
     else:
-        filename = filename or '%s-%s%s' % (artifact, version, artifact_type)
+        filename = filename or '%s-%s%s%s' % (artifact, version, classifier, artifact_type)
     url_base = '/'.join([
         repository or CONFIG.DEFAULT_MAVEN_REPO,
         group.replace('.', '/'),
@@ -448,7 +453,7 @@ def maven_jar(name, id=None, repository=None, hash=None, hashes=None, deps=None,
     srcs = [bin_rule]
 
     if sources:
-        src_url = '%s/%s-%s-sources.jar' % (url_base, artifact, version)
+        src_url = '%s/%s-%s%s-sources.jar' % (url_base, artifact, version, classifier)
         cmd = 'echo "Fetching %s..." && curl -fsSL %s -o $OUT' % (src_url, src_url)
         src_rule = build_rule(
             name=name,

--- a/test/java_rules/BUILD
+++ b/test/java_rules/BUILD
@@ -21,7 +21,7 @@ maven_jar(
     id = 'ch.qos.logback:logback-core:1.1.3',
     classifier = 'tests',
     classifier_sources_override = 'test',
-    hash = '',
+    hash = '223eff0a4419ea839742a123199cfd609bf7249e',
     test_only = True,
 )
 

--- a/test/java_rules/BUILD
+++ b/test/java_rules/BUILD
@@ -20,6 +20,7 @@ maven_jar(
     name = 'logback-core-tests',
     id = 'ch.qos.logback:logback-core:1.1.3',
     classifier = 'tests',
+    classifier_sources_override = 'test',
     hash = '',
     test_only = True,
 )

--- a/test/java_rules/BUILD
+++ b/test/java_rules/BUILD
@@ -12,3 +12,23 @@ java_test(
         '//third_party/java:junit',
     ],
 )
+
+
+
+# Test for maven classifier
+maven_jar(
+    name = 'logback-core-tests',
+    id = 'ch.qos.logback:logback-core:1.1.3',
+    classifier = 'tests',
+    hash = '',
+    test_only = True,
+)
+
+java_test(
+    name = 'mvn_classifier_test',
+    srcs = ['MvnClassifierTest.java'],
+    deps = [
+         ':logback-core-tests',
+         '//third_party/java:junit',
+    ],
+)

--- a/test/java_rules/BUILD
+++ b/test/java_rules/BUILD
@@ -27,7 +27,7 @@ maven_jar(
 
 java_test(
     name = 'mvn_classifier_test',
-    srcs = ['MvnClassifierTest.java'],
+    srcs = ['test/build/please/java/test/MvnClassifierTest.java'],
     deps = [
          ':logback-core-tests',
          '//third_party/java:junit',

--- a/test/java_rules/MvnClassifierTest.java
+++ b/test/java_rules/MvnClassifierTest.java
@@ -1,0 +1,21 @@
+package test.java_rules;
+
+import static org.junit.Assert.assertTrue;
+
+import ch.qos.logback.core.testUtil.RandomUtil;
+import org.junit.Test;
+
+public class MvnClassifierTest {
+
+
+  @Test
+  public void shouldImportFromMvnArtifactWithClassifier() {
+    /**
+     * check that we can resolve the dependency to RandomUtil
+     * which is only included in ch.qos.logback:logback-core:1.1.3:tests
+     */
+
+    assertTrue(RandomUtil.getPositiveInt() > 0);
+
+  }
+}

--- a/test/java_rules/test/build/please/java/test/MvnClassifierTest.java
+++ b/test/java_rules/test/build/please/java/test/MvnClassifierTest.java
@@ -1,4 +1,4 @@
-package test.java_rules;
+package build.please.java.test;
 
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
Add support for maven classifier to the build definition maven_jar

from https://maven.apache.org/pom.html
> classifier:
> The classifier allows to distinguish artifacts that were built from the same POM but differ in their content. It is some optional and arbitrary string that - if present - is appended to the artifact name just after the version number.