### PR TITLE
Include exported dependencies in Dependencies()

### DIFF
--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -300,6 +300,20 @@ func TestDependencies(t *testing.T) {
 	assert.Equal(t, []*BuildTarget{target1, target2}, target3.Dependencies())
 }
 
+func TestDependenciesExported(t *testing.T) {
+	target1 := makeTarget("//src/core:target1", "")
+	target2 := makeTarget("//src/core:target2", "")
+	target2.AddMaybeExportedDependency(target1.Label, true)
+	target2.resolveDependency(target1.Label, target1)
+	target3 := makeTarget("//src/core:target3", "", target2)
+	assert.Equal(t, []BuildLabel{}, target1.DeclaredDependencies())
+	assert.Equal(t, []*BuildTarget{}, target1.Dependencies())
+	assert.Equal(t, []BuildLabel{target1.Label}, target2.DeclaredDependencies())
+	assert.Equal(t, []*BuildTarget{target1}, target2.Dependencies())
+	assert.Equal(t, []BuildLabel{target2.Label}, target3.DeclaredDependencies())
+	assert.Equal(t, []*BuildTarget{target1, target2}, target3.Dependencies())
+}
+
 func TestAddDependency(t *testing.T) {
 	target1 := makeTarget("//src/core:target1", "")
 	target2 := makeTarget("//src/core:target2", "")

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -96,7 +96,6 @@ def cc_library(name, srcs=None, hdrs=None, private_hdrs=None, deps=None, visibil
         exported_deps=deps,
         test_only=test_only,
         labels=labels,
-        output_is_complete=False,
     )
 
     cmds, tools = _library_cmds(_c, compiler_flags, pkg_config_libs)

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -96,6 +96,7 @@ def cc_library(name, srcs=None, hdrs=None, private_hdrs=None, deps=None, visibil
         exported_deps=deps,
         test_only=test_only,
         labels=labels,
+        output_is_complete=False,
     )
 
     cmds, tools = _library_cmds(_c, compiler_flags, pkg_config_libs)

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -13,7 +13,7 @@ _GO_TOOL = ['go']
 
 
 def go_library(name, srcs, out=None, deps=None, visibility=None, test_only=False,
-               go_tools=None, complete=True, _needs_transitive_deps=False, _all_srcs=False):
+               go_tools=None, complete=True, _needs_transitive_deps=False,_all_srcs=False):
     """Generates a Go library which can be reused by other rules.
 
     Args:
@@ -200,14 +200,9 @@ def cgo_library(name, srcs, go_srcs=None, c_srcs=None, hdrs=None, out=None, comp
         requires = ['cc'],
         tools = tools,
     )
-    srcs_rule = filegroup(
-        name = name,
-        tag = 'go_src',
-        srcs = [gen_go] + go_srcs,
-    )
-    go_library(
+    go_rule = go_library(
         name = '_%s#go' % name,
-        srcs = [srcs_rule],
+        srcs = [gen_go] + go_srcs,
         test_only = test_only,
         complete = False,
         deps = deps,
@@ -223,7 +218,7 @@ def cgo_library(name, srcs, go_srcs=None, c_srcs=None, hdrs=None, out=None, comp
         out=out,
         provides = {
             'go': ':' + name,
-            'go_src': srcs_rule,
+            'go_src': go_rule,
             'cgo_obj': cgo_o_rule,
         },
     )
@@ -325,7 +320,6 @@ def go_test(name, srcs, data=None, deps=None, visibility=None, flags='', contain
         deps = deps,
         test_only = True,
         _all_srcs = True,
-        _needs_transitive_deps = True,  # Need deps of our deps as well. Not ideal though.
         complete = False,
     )
     lib_rule = ':_%s#lib' % name

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -35,7 +35,6 @@ def go_library(name, srcs, out=None, deps=None, visibility=None, test_only=False
         srcs=srcs,
         exported_deps=deps,
         visibility=visibility,
-        output_is_complete=False,
         requires=['go'],
         test_only=test_only,
     )

--- a/test/cc_rules/labels/BUILD
+++ b/test/cc_rules/labels/BUILD
@@ -1,0 +1,17 @@
+cc_library(
+    name = 'lib1',
+    hdrs = ['lib1/include/lib.hpp'],
+    includes = ['lib1/include'],
+)
+
+cc_library(
+    name = 'another_lib',
+    srcs = ['another_lib.cpp'],
+    deps = [':lib1'],
+)
+
+cc_test(
+    name = 'lib_test',
+    srcs = ['lib_test.cpp'],
+    deps = [':another_lib'],
+)

--- a/test/cc_rules/labels/lib1/include/lib.hpp
+++ b/test/cc_rules/labels/lib1/include/lib.hpp
@@ -1,0 +1,3 @@
+inline int GetAnswer() {
+  return 42;
+}

--- a/test/cc_rules/labels/lib_test.cpp
+++ b/test/cc_rules/labels/lib_test.cpp
@@ -1,0 +1,9 @@
+#include <unittest++/UnitTest++.h>
+
+#include "lib.hpp"
+
+// The real test is at compilation time, this is here just to
+// have a test that proves we really are doing something.
+TEST(TheAnswer) {
+  CHECK_EQUAL(42, GetAnswer());
+}


### PR DESCRIPTION
Fixes #208 - basically, we now honour exported_deps in a more general way. Allows some small cleanups to Go rules as well.