### PR TITLE
Add a patch to make PEX-INFO files deterministic

### DIFF
--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -3,10 +3,11 @@ package(default_visibility = ['PUBLIC'])
 pip_library(
     name = 'pex',
     version = '1.1.20',
-    hashes = ['sha1: e410ca1d350e852e705299b31c6c9ea7658257a4'],
+    hashes = ['sha1: 336f91b0ecc026ae8dce72bad0d29b5fca3ec5dd'],
     patch = [
         'never_cache_pex.patch',
         'bytecode_timestamps.patch',
+        'deterministic_pex_info.patch',
     ],
 )
 

--- a/third_party/python/deterministic_pex_info.patch
+++ b/third_party/python/deterministic_pex_info.patch
@@ -1,0 +1,11 @@
+--- pex/pex_builder.py	2017-03-30 10:11:00.140019000 +0100
++++ pex/pex_builder.py.new	2017-05-04 10:32:49.555016007 +0100
+@@ -337,7 +337,7 @@
+       self._chroot.touch(compiled, label='bytecode')
+ 
+   def _prepare_manifest(self):
+-    self._chroot.write(self._pex_info.dump().encode('utf-8'), PexInfo.PATH, label='manifest')
++    self._chroot.write(self._pex_info.dump(sort_keys=True).encode('utf-8'), PexInfo.PATH, label='manifest')
+ 
+   def _prepare_main(self):
+     self._chroot.write(self._preamble + b'\n' + BOOTSTRAP_ENVIRONMENT,


### PR DESCRIPTION
i.e. sort their keys so they come out consistently.

I'm sending this upstream too (https://github.com/pantsbuild/pex/pull/384) but don't want to wait for that to merge & release before testing this ourselves.