### PR TITLE
Fix Java build performance regression

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -283,9 +283,7 @@ func (target *BuildTarget) Dependencies() []*BuildTarget {
 	ret := make(BuildTargets, 0, len(target.dependencies))
 	for _, deps := range target.dependencies {
 		for _, dep := range deps.deps {
-			// N.B. Include any exported dependencies of this guy too.
 			ret = append(ret, dep)
-			ret = append(ret, dep.transitiveExportedDependencies()...)
 		}
 	}
 	sort.Sort(ret)
@@ -298,20 +296,6 @@ func (target *BuildTarget) ExportedDependencies() []BuildLabel {
 	for _, info := range target.dependencies {
 		if info.exported {
 			ret = append(ret, info.declared)
-		}
-	}
-	return ret
-}
-
-// transitiveExportedDependencies returns the transitive set of exported dependencies of this target.
-func (target *BuildTarget) transitiveExportedDependencies() []*BuildTarget {
-	var ret []*BuildTarget
-	for _, info := range target.dependencies {
-		if info.exported {
-			for _, dep := range info.deps {
-				ret = append(ret, dep)
-				ret = append(ret, dep.transitiveExportedDependencies()...)
-			}
 		}
 	}
 	return ret

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -300,20 +300,6 @@ func TestDependencies(t *testing.T) {
 	assert.Equal(t, []*BuildTarget{target1, target2}, target3.Dependencies())
 }
 
-func TestDependenciesExported(t *testing.T) {
-	target1 := makeTarget("//src/core:target1", "")
-	target2 := makeTarget("//src/core:target2", "")
-	target2.AddMaybeExportedDependency(target1.Label, true)
-	target2.resolveDependency(target1.Label, target1)
-	target3 := makeTarget("//src/core:target3", "", target2)
-	assert.Equal(t, []BuildLabel{}, target1.DeclaredDependencies())
-	assert.Equal(t, []*BuildTarget{}, target1.Dependencies())
-	assert.Equal(t, []BuildLabel{target1.Label}, target2.DeclaredDependencies())
-	assert.Equal(t, []*BuildTarget{target1}, target2.Dependencies())
-	assert.Equal(t, []BuildLabel{target2.Label}, target3.DeclaredDependencies())
-	assert.Equal(t, []*BuildTarget{target1, target2}, target3.Dependencies())
-}
-
 func TestAddDependency(t *testing.T) {
 	target1 := makeTarget("//src/core:target1", "")
 	target2 := makeTarget("//src/core:target2", "")

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -93,9 +93,10 @@ def cc_library(name, srcs=None, hdrs=None, private_hdrs=None, deps=None, visibil
         tag = 'hdrs',
         srcs=hdrs,
         requires=['cc_hdrs'],
-        exported_deps=deps,
+        deps=deps,
         test_only=test_only,
         labels=labels,
+        output_is_complete=False,
     )
 
     cmds, tools = _library_cmds(_c, compiler_flags, pkg_config_libs)
@@ -119,6 +120,7 @@ def cc_library(name, srcs=None, hdrs=None, private_hdrs=None, deps=None, visibil
                 tools=tools,
                 # TODO(pebers): handle includes and defines in _library_cmds as well.
                 pre_build=_library_transitive_labels(_c, compiler_flags, pkg_config_libs) if (deps or includes or defines) else None,
+                needs_transitive_deps=True,
             )
             a_rules.append(':' + a_name)
 
@@ -169,6 +171,7 @@ def cc_library(name, srcs=None, hdrs=None, private_hdrs=None, deps=None, visibil
             labels=labels,
             tools=tools,
             pre_build=_library_transitive_labels(_c, compiler_flags, pkg_config_libs) if deps else None,
+            needs_transitive_deps=True,
         )
         if alwayslink:
             labels.append('cc:al:%s/%s.a' % (get_base_path(), name))

--- a/test/cc_rules/deps/BUILD
+++ b/test/cc_rules/deps/BUILD
@@ -1,0 +1,29 @@
+# Tests that a sequence of dependencies works as expected.
+cc_library(
+    name = 'lib1',
+    srcs = ['lib1.cc'],
+    hdrs = ['lib1.h'],
+)
+
+cc_library(
+    name = 'lib2',
+    srcs = [
+        'lib2_1.cc',
+        'lib2_2.cc',
+    ],
+    hdrs = ['lib2.h'],
+    deps = [':lib1'],
+)
+
+cc_library(
+    name = 'lib3',
+    srcs = ['lib3.cc'],
+    hdrs = ['lib3.h'],
+    deps = [':lib2'],
+)
+
+cc_test(
+    name = 'deps_test',
+    srcs = ['deps_test.cc'],
+    deps = [':lib3'],
+)

--- a/test/cc_rules/deps/deps_test.cc
+++ b/test/cc_rules/deps/deps_test.cc
@@ -1,0 +1,7 @@
+#include "test/cc_rules/deps/lib3.h"
+
+#include <unittest++/UnitTest++.h>
+
+TEST(Deps) {
+  CHECK_EQUAL(54, GetAnswer());
+}

--- a/test/cc_rules/deps/lib1.cc
+++ b/test/cc_rules/deps/lib1.cc
@@ -1,0 +1,5 @@
+#include "test/cc_rules/deps/lib1.h"
+
+int GetFirstQuestionPartSqrt() {
+  return 3;
+}

--- a/test/cc_rules/deps/lib1.h
+++ b/test/cc_rules/deps/lib1.h
@@ -1,0 +1,1 @@
+int GetFirstQuestionPartSqrt();

--- a/test/cc_rules/deps/lib2.h
+++ b/test/cc_rules/deps/lib2.h
@@ -1,0 +1,4 @@
+#include "test/cc_rules/deps/lib1.h"
+
+int GetFirstQuestionPart();
+int GetSecondQuestionPart();

--- a/test/cc_rules/deps/lib2_1.cc
+++ b/test/cc_rules/deps/lib2_1.cc
@@ -1,0 +1,5 @@
+#include "test/cc_rules/deps/lib2.h"
+
+int GetFirstQuestionPart() {
+  return GetFirstQuestionPartSqrt() * GetFirstQuestionPartSqrt();
+}

--- a/test/cc_rules/deps/lib2_2.cc
+++ b/test/cc_rules/deps/lib2_2.cc
@@ -1,0 +1,5 @@
+#include "test/cc_rules/deps/lib2.h"
+
+int GetSecondQuestionPart() {
+  return 6;
+}

--- a/test/cc_rules/deps/lib3.cc
+++ b/test/cc_rules/deps/lib3.cc
@@ -1,0 +1,5 @@
+#include "test/cc_rules/deps/lib3.h"
+
+int GetAnswer() {
+  return GetFirstQuestionPart() * GetSecondQuestionPart();
+}

--- a/test/cc_rules/deps/lib3.h
+++ b/test/cc_rules/deps/lib3.h
@@ -1,0 +1,3 @@
+#include "test/cc_rules/deps/lib2.h"
+
+int GetAnswer();


### PR DESCRIPTION
Reverted parts of #211 and implemented it in a different way. Basically making `exported_deps` transitive removes a lot of the benefit of using those over just requiring transitive deps in the first place.

I've added a little test set to prove to myself that it works the way it should. It's not very exciting though.