### PR TITLE
Support for named output groups

### DIFF
--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -307,6 +307,13 @@ func ruleHash(target *core.BuildTarget, runtime bool) []byte {
 	for _, out := range target.DeclaredOutputs() {
 		h.Write([]byte(out))
 	}
+	outs := target.DeclaredNamedOutputs()
+	for _, name := range target.DeclaredOutputNames() {
+		h.Write([]byte(name))
+		for _, out := range outs[name] {
+			h.Write([]byte(out))
+		}
+	}
 	for _, licence := range target.Licences {
 		h.Write([]byte(licence))
 	}

--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -37,6 +37,7 @@ var KnownFields = map[string]bool{
 	"PreBuildHash":                true,
 	"PostBuildHash":               true,
 	"outputs":                     true,
+	"namedOutputs":                true,
 	"Licences":                    true,
 	"Tools":                       true,
 	"TestOutputs":                 true,

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -134,3 +134,12 @@ go_test(
         '//third_party/go:testify',
     ],
 )
+
+go_test(
+    name = 'build_input_test',
+    srcs = ['build_input_test.go'],
+    deps = [
+        ':core',
+        '//third_party/go:testify',
+    ],
+)

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -34,6 +34,10 @@ func GeneralBuildEnvironment(config *Configuration) []string {
 		// The only concession is that ~ is expanded as the user's home directory
 		// in PATH entries.
 		"PATH=" + ExpandHomePath(strings.Join(config.Build.Path, ":")),
+		// Expose the requested build config. We might also want to expose
+		// the command that's actually running (although typically this is more useful,
+		// because targets using this want to avoid defining different commands).
+		"BUILD_CONFIG=" + config.Build.Config,
 	}
 	if config.Go.GoRoot != "" {
 		env = append(env, "GOROOT="+config.Go.GoRoot)

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -89,6 +89,10 @@ func BuildEnvironment(state *BuildState, target *BuildTarget, test bool) []strin
 			paths := target.SourcePaths(state.Graph, srcs)
 			env = append(env, "SRCS_"+strings.ToUpper(name)+"="+strings.Join(paths, " "))
 		}
+		// Named output groups similarly.
+		for name, outs := range target.DeclaredNamedOutputs() {
+			env = append(env, "OUTS_"+strings.ToUpper(name)+"="+strings.Join(outs, " "))
+		}
 		if state.Config.Bazel.Compatibility {
 			// Obviously this is only a subset of the variables Bazel would expose, but there's
 			// no point populating ones that we literally have no clue what they should be.

--- a/src/core/build_input_test.go
+++ b/src/core/build_input_test.go
@@ -6,30 +6,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseBuildOutputLabel(t *testing.T) {
-	input, err := TryParseBuildOutputLabel("//src/core:target1|test.go", "")
+func TestParseNamedOutputLabel(t *testing.T) {
+	input, err := TryParseNamedOutputLabel("//src/core:target1|test", "")
 	assert.NoError(t, err)
-	label, ok := input.(BuildOutputLabel)
+	label, ok := input.(NamedOutputLabel)
 	assert.True(t, ok)
 	assert.Equal(t, "src/core", label.PackageName)
 	assert.Equal(t, "target1", label.Name)
-	assert.Equal(t, "test.go", label.Output)
+	assert.Equal(t, "test", label.Output)
 }
 
-func TestParseBuildOutputLabelRelative(t *testing.T) {
-	input, err := TryParseBuildOutputLabel(":target1|test.go", "src/core")
+func TestParseNamedOutputLabelRelative(t *testing.T) {
+	input, err := TryParseNamedOutputLabel(":target1|test", "src/core")
 	assert.NoError(t, err)
-	label, ok := input.(BuildOutputLabel)
+	label, ok := input.(NamedOutputLabel)
 	assert.True(t, ok)
 	assert.Equal(t, "src/core", label.PackageName)
 	assert.Equal(t, "target1", label.Name)
-	assert.Equal(t, "test.go", label.Output)
+	assert.Equal(t, "test", label.Output)
 }
 
-func TestParseBuildOutputLabelNoOutput(t *testing.T) {
-	input, err := TryParseBuildOutputLabel("//src/core:target1", "")
+func TestParseNamedOutputLabelNoOutput(t *testing.T) {
+	input, err := TryParseNamedOutputLabel("//src/core:target1", "")
 	assert.NoError(t, err)
-	_, ok := input.(BuildOutputLabel)
+	_, ok := input.(NamedOutputLabel)
 	assert.False(t, ok)
 	label, ok := input.(BuildLabel)
 	assert.True(t, ok)
@@ -37,7 +37,7 @@ func TestParseBuildOutputLabelNoOutput(t *testing.T) {
 	assert.Equal(t, "target1", label.Name)
 }
 
-func TestParseBuildOutputLabelEmptyOutput(t *testing.T) {
-	_, err := TryParseBuildOutputLabel("//src/core:target1|", "")
+func TestParseNamedOutputLabelEmptyOutput(t *testing.T) {
+	_, err := TryParseNamedOutputLabel("//src/core:target1|", "")
 	assert.Error(t, err)
 }

--- a/src/core/build_input_test.go
+++ b/src/core/build_input_test.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBuildOutputLabel(t *testing.T) {
+	input, err := TryParseBuildOutputLabel("//src/core:target1|test.go", "")
+	assert.NoError(t, err)
+	label, ok := input.(BuildOutputLabel)
+	assert.True(t, ok)
+	assert.Equal(t, "src/core", label.PackageName)
+	assert.Equal(t, "target1", label.Name)
+	assert.Equal(t, "test.go", label.Output)
+}
+
+func TestParseBuildOutputLabelRelative(t *testing.T) {
+	input, err := TryParseBuildOutputLabel(":target1|test.go", "src/core")
+	assert.NoError(t, err)
+	label, ok := input.(BuildOutputLabel)
+	assert.True(t, ok)
+	assert.Equal(t, "src/core", label.PackageName)
+	assert.Equal(t, "target1", label.Name)
+	assert.Equal(t, "test.go", label.Output)
+}
+
+func TestParseBuildOutputLabelNoOutput(t *testing.T) {
+	input, err := TryParseBuildOutputLabel("//src/core:target1", "")
+	assert.NoError(t, err)
+	_, ok := input.(BuildOutputLabel)
+	assert.False(t, ok)
+	label, ok := input.(BuildLabel)
+	assert.True(t, ok)
+	assert.Equal(t, "src/core", label.PackageName)
+	assert.Equal(t, "target1", label.Name)
+}
+
+func TestParseBuildOutputLabelEmptyOutput(t *testing.T) {
+	_, err := TryParseBuildOutputLabel("//src/core:target1|", "")
+	assert.Error(t, err)
+}

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -256,12 +256,12 @@ func (label BuildLabel) FullPaths(graph *BuildGraph) []string {
 }
 
 // addPathPrefix adds a prefix to all the entries in a slice.
-// Note that this is done in-place and the slice is altered.
 func addPathPrefix(paths []string, prefix string) []string {
+	ret := make([]string, len(paths))
 	for i, output := range paths {
-		paths[i] = path.Join(prefix, output)
+		ret[i] = path.Join(prefix, output)
 	}
-	return paths
+	return ret
 }
 
 func (label BuildLabel) LocalPaths(graph *BuildGraph) []string {

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -247,23 +247,21 @@ func (this BuildLabel) Less(that BuildLabel) bool {
 
 // Implementation of BuildInput interface
 func (label BuildLabel) Paths(graph *BuildGraph) []string {
-	target := graph.TargetOrDie(label)
-	outputs := target.Outputs()
-	ret := make([]string, len(outputs), len(outputs))
-	for i, output := range outputs {
-		ret[i] = path.Join(label.PackageName, output)
-	}
-	return ret
+	return addPathPrefix(graph.TargetOrDie(label).Outputs(), label.PackageName)
 }
 
 func (label BuildLabel) FullPaths(graph *BuildGraph) []string {
 	target := graph.TargetOrDie(label)
-	outputs := target.Outputs()
-	ret := make([]string, len(outputs), len(outputs))
-	for i, output := range outputs {
-		ret[i] = path.Join(target.OutDir(), output)
+	return addPathPrefix(target.Outputs(), target.OutDir())
+}
+
+// addPathPrefix adds a prefix to all the entries in a slice.
+// Note that this is done in-place and the slice is altered.
+func addPathPrefix(paths []string, prefix string) []string {
+	for i, output := range paths {
+		paths[i] = path.Join(prefix, output)
 	}
-	return ret
+	return paths
 }
 
 func (label BuildLabel) LocalPaths(graph *BuildGraph) []string {

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -274,6 +274,10 @@ func (label BuildLabel) Label() *BuildLabel {
 	return &label
 }
 
+func (label BuildLabel) nonOutputLabel() *BuildLabel {
+	return &label
+}
+
 // UnmarshalFlag unmarshals a build label from a command line flag. Implementation of flags.Unmarshaler interface.
 func (label *BuildLabel) UnmarshalFlag(value string) error {
 	// This is only allowable here, not in any other usage of build labels.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -329,6 +329,17 @@ func (target *BuildTarget) DeclaredNamedOutputs() map[string][]string {
 	return target.namedOutputs
 }
 
+// DeclaredOutputNames is a convenience function to return the names of the declared
+// outputs in a consistent order.
+func (target *BuildTarget) DeclaredOutputNames() []string {
+	ret := make([]string, 0, len(target.namedOutputs))
+	for name := range target.namedOutputs {
+		ret = append(ret, name)
+	}
+	sort.Strings(ret)
+	return ret
+}
+
 // Outputs returns a slice of all the outputs of this rule.
 func (target *BuildTarget) Outputs() []string {
 	var ret []string

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -336,7 +336,12 @@ func (target *BuildTarget) Outputs() []string {
 		ret = make([]string, 0, len(target.Sources))
 		// Filegroups just re-output their inputs.
 		for _, src := range target.Sources {
-			if label := src.nonOutputLabel(); label == nil {
+			if namedLabel, ok := src.(NamedOutputLabel); ok {
+				// Bit of a hack, but this needs different treatment from either of the others.
+				for _, dep := range target.DependenciesFor(namedLabel.BuildLabel) {
+					ret = append(ret, dep.NamedOutputs(namedLabel.Output)...)
+				}
+			} else if label := src.nonOutputLabel(); label == nil {
 				ret = append(ret, src.LocalPaths(nil)[0])
 			} else {
 				for _, dep := range target.DependenciesFor(*label) {

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -390,6 +390,7 @@ func TestNamedOutputs(t *testing.T) {
 	assert.Equal(t, []string{"hdr1.h", "hdr2.h"}, target.NamedOutputs("hdrs"))
 	assert.Equal(t, []string{"src1.c", "src2.c"}, target.NamedOutputs("srcs"))
 	assert.Panics(t, func() { target.NamedOutputs("go_srcs") })
+	assert.Equal(t, []string{"hdrs", "srcs"}, target.DeclaredOutputNames())
 }
 
 func TestAllLocalSources(t *testing.T) {

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -363,7 +363,7 @@ func TestOutMode(t *testing.T) {
 
 func TestOutputOrdering(t *testing.T) {
 	// Check that outputs come out ordered, this is important for hash stability; previously
-	// we preseved the original order, but tools like buildifier may reorder them assuming
+	// we preserved the original order, but tools like buildifier may reorder them assuming
 	// that the order of arguments is not important.
 	target1 := makeTarget("//src/core:target1", "")
 	target1.AddOutput("file1.txt")
@@ -373,6 +373,23 @@ func TestOutputOrdering(t *testing.T) {
 	target2.AddOutput("file1.txt")
 	assert.Equal(t, target1.DeclaredOutputs(), target2.DeclaredOutputs())
 	assert.Equal(t, target1.Outputs(), target2.Outputs())
+}
+
+func TestNamedOutputs(t *testing.T) {
+	target := makeTarget("//src/core:target1", "")
+	target.AddOutput("a.txt")
+	target.AddOutput("z.txt")
+	target.AddNamedOutput("srcs", "src1.c")
+	target.AddNamedOutput("srcs", "src2.c")
+	target.AddNamedOutput("hdrs", "hdr1.h")
+	target.AddNamedOutput("hdrs", "hdr2.h")
+	target.AddNamedOutput("hdrs", "hdr2.h") // deliberate duplicate
+	assert.Equal(t, []string{"a.txt", "hdr1.h", "hdr2.h", "src1.c", "src2.c", "z.txt"}, target.Outputs())
+	assert.Equal(t, []string{"a.txt", "z.txt"}, target.DeclaredOutputs())
+	assert.Equal(t, map[string][]string{"srcs": {"src1.c", "src2.c"}, "hdrs": {"hdr1.h", "hdr2.h"}}, target.DeclaredNamedOutputs())
+	assert.Equal(t, []string{"hdr1.h", "hdr2.h"}, target.NamedOutputs("hdrs"))
+	assert.Equal(t, []string{"src1.c", "src2.c"}, target.NamedOutputs("srcs"))
+	assert.Panics(t, func() { target.NamedOutputs("go_srcs") })
 }
 
 func TestAllLocalSources(t *testing.T) {

--- a/src/core/file_label.go
+++ b/src/core/file_label.go
@@ -91,7 +91,7 @@ func (label NamedOutputLabel) Label() *BuildLabel {
 }
 
 func (label NamedOutputLabel) nonOutputLabel() *BuildLabel {
-	return &label.BuildLabel
+	return nil
 }
 
 func (label NamedOutputLabel) String() string {

--- a/src/core/file_label.go
+++ b/src/core/file_label.go
@@ -91,7 +91,7 @@ func (label NamedOutputLabel) Label() *BuildLabel {
 }
 
 func (label NamedOutputLabel) nonOutputLabel() *BuildLabel {
-	return nil
+	return &label.BuildLabel
 }
 
 func (label NamedOutputLabel) String() string {

--- a/src/core/file_label.go
+++ b/src/core/file_label.go
@@ -3,6 +3,7 @@
 package core
 
 import "path"
+import "strings"
 
 // FileLabel represents a file in the current package which is directly used by a target.
 type FileLabel struct {
@@ -25,6 +26,10 @@ func (label FileLabel) LocalPaths(graph *BuildGraph) []string {
 }
 
 func (label FileLabel) Label() *BuildLabel {
+	return nil
+}
+
+func (label FileLabel) nonOutputLabel() *BuildLabel {
 	return nil
 }
 
@@ -53,6 +58,50 @@ func (label SystemFileLabel) Label() *BuildLabel {
 	return nil
 }
 
+func (label SystemFileLabel) nonOutputLabel() *BuildLabel {
+	return nil
+}
+
 func (label SystemFileLabel) String() string {
 	return label.Path
+}
+
+// BuildOutputLabel represents a single output file from a particular build rule.
+type BuildOutputLabel struct {
+	BuildLabel
+	Output string
+}
+
+func (label BuildOutputLabel) Paths(graph *BuildGraph) []string {
+	return []string{path.Join(label.PackageName, label.Output)}
+}
+
+func (label BuildOutputLabel) FullPaths(graph *BuildGraph) []string {
+	return []string{path.Join(graph.TargetOrDie(label.BuildLabel).OutDir(), label.Output)}
+}
+
+func (label BuildOutputLabel) LocalPaths(graph *BuildGraph) []string {
+	return []string{label.Output}
+}
+
+func (label BuildOutputLabel) Label() *BuildLabel {
+	return &label.BuildLabel
+}
+
+func (label BuildOutputLabel) nonOutputLabel() *BuildLabel {
+	return nil
+}
+
+func (label BuildOutputLabel) String() string {
+	return label.BuildLabel.String() + "|" + label.Output
+}
+
+// TryParseBuildOutputLabel attempts to parse a build output label. It's allowed to just be
+// a normal build label as well.
+func TryParseBuildOutputLabel(target, currentPath string) (BuildInput, error) {
+	if index := strings.IndexRune(target, '|'); index != -1 && index != len(target)-1 {
+		label, err := TryParseBuildLabel(target[:index], currentPath)
+		return BuildOutputLabel{BuildLabel: label, Output: target[index+1:]}, err
+	}
+	return TryParseBuildLabel(target, currentPath)
 }

--- a/src/core/label_parse_test.go
+++ b/src/core/label_parse_test.go
@@ -126,3 +126,7 @@ func TestDotsArentAccepted(t *testing.T) {
 	assertNotLabel(t, "//src/core:....", ".... is not a valid label name")
 	assertLabel(t, "//src/core/...", "src/core", "...")
 }
+
+func TestPipesArentAccepted(t *testing.T) {
+	assertNotLabel(t, "//src/core:core|build_label.go", "| is not allowed in build labels")
+}

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -397,7 +397,7 @@ func recursivelyProvideFor(graph *BuildGraph, target, dependency *BuildTarget, d
 
 // maybeRecursivelyProvideFor is similar to recursivelyProvideFor but operates on a BuildInput.
 func recursivelyProvideSource(graph *BuildGraph, target *BuildTarget, src BuildInput) []BuildInput {
-	if label := src.Label(); label != nil {
+	if label := src.nonOutputLabel(); label != nil {
 		dep := graph.TargetOrDie(*label)
 		provided := recursivelyProvideFor(graph, target, dep, dep.Label)
 		ret := make([]BuildInput, len(provided))
@@ -467,13 +467,12 @@ func IterInputPaths(graph *BuildGraph, target *BuildTarget) <-chan string {
 	ch := make(chan string)
 	var inner func(*BuildTarget)
 	inner = func(target *BuildTarget) {
-
 		if !doneTargets[target] {
 			// First yield all the sources of the target only ever pushing declared paths to
 			// the channel to prevent us outputting any intermediate files.
 			for _, source := range target.AllSources() {
 				// If the label is nil add any input paths contained here.
-				if label := source.Label(); label == nil {
+				if label := source.nonOutputLabel(); label == nil {
 					for _, sourcePath := range source.FullPaths(graph) {
 						if !donePaths[sourcePath] {
 							ch <- sourcePath

--- a/src/parse/cffi/please_parser.py
+++ b/src/parse/cffi/please_parser.py
@@ -274,7 +274,6 @@ def build_rule(globals_dict, package, name, cmd, test_cmd=None, srcs=None, data=
     _add_strings(target, _add_dep, deps, 'deps')
     _add_strings(target, _add_exported_dep, exported_deps, 'exported_deps')
     _add_strings(target, _add_tool, tools, 'tools')
-    _add_strings(target, _add_out, outs, 'outs')
     _add_strings(target, _add_optional_out, optional_outs, 'optional_outs')
     _add_strings(target, _add_vis, visibility, 'visibility')
     _add_strings(target, _add_label, labels, 'labels')

--- a/src/parse/cffi/please_parser.py
+++ b/src/parse/cffi/please_parser.py
@@ -256,20 +256,8 @@ def build_rule(globals_dict, package, name, cmd, test_cmd=None, srcs=None, data=
         # Currently this is the only reason _add_target can fail, given that we validated
         # the target name earlier. Bit hacky but will have to do for now.
         raise DuplicateTargetError('Duplicate target %s' % name)
-    if isinstance(srcs, Mapping):
-        for src_name, src_list in srcs.items():
-            if isinstance(src_list, str):
-                raise ValueError('Value in named_srcs for target %s is a string, you probably '
-                                 'meant to use a list of strings instead' % name)
-            elif src_list:
-                for src in src_list:
-                    _check_c_error(_add_named_src(target, src_name, src))
-    elif srcs:
-        for src in srcs:
-            if src and src.startswith('/') and not src.startswith('//'):
-                raise ValueError('Entry "%s" in srcs of %s has an absolute path; that\'s not allowed. '
-                                 'You might want to try system_srcs instead' % (src, name))
-        _add_strings(target, _add_src, srcs, 'srcs')
+    _add_maybe_named(target, _add_named_src, _add_src, srcs, name, 'srcs')
+    _add_maybe_named(target, _add_named_out, _add_out, outs, name, 'outs')
     if isinstance(cmd, Mapping):
         for config, command in cmd.items():
             _check_c_error(_add_command(target, config, command.strip()))
@@ -345,6 +333,22 @@ def _add_strings(target, func, lst, name):
         for x in lst:
             if x:
                 _check_c_error(func(target, ffi_from_string(x)))
+
+
+def _add_maybe_named(target, named_func, unnamed_func, arg, name, arg_name):
+    if isinstance(arg, Mapping):
+        for k, v in arg.items():
+            if isinstance(v, str):
+                raise ValueError('Value in %s for target %s is a string, you probably '
+                                 'meant to use a list of strings instead' % (arg_name, name))
+            elif v:
+                for x in v:
+                    _check_c_error(named_func(target, k, x))
+    elif arg:
+        for v in arg:
+            if v and v.startswith('/') and not v.startswith('//'):
+                raise ValueError('Entry "%s" in %s of %s has an absolute path; that\'s not allowed.' % (v, arg_name, name))
+        _add_strings(target, unnamed_func, arg, arg_name)
 
 
 def _check_c_error(error):
@@ -434,7 +438,8 @@ def _get_globals(c_package, c_package_name):
     local_globals['get_base_path'] = lambda: package_name
     local_globals['add_dep'] = lambda target, dep: _check_c_error(_add_dependency(c_package, target, dep, False))
     local_globals['add_exported_dep'] = lambda target, dep: _check_c_error(_add_dependency(c_package, target, dep, True))
-    local_globals['add_out'] = lambda target, out: _check_c_error(_add_output(c_package, target, out))
+    local_globals['add_out'] = lambda target, name, out='': _check_c_error(_add_named_output(c_package, target, name, out) if out else
+                                                                           _add_output(c_package, target, name))
     local_globals['add_licence'] = lambda name, licence: _check_c_error(_add_licence_post(c_package, name, licence))
     local_globals['get_command'] = lambda name, config='': ffi_to_string(_get_command(c_package, name, config))
     local_globals['set_command'] = lambda name, config, command='': _check_c_error(_set_command(c_package, name, config, command))

--- a/src/parse/cffi/please_parser.py
+++ b/src/parse/cffi/please_parser.py
@@ -342,7 +342,8 @@ def _add_maybe_named(target, named_func, unnamed_func, arg, name, arg_name):
                                  'meant to use a list of strings instead' % (arg_name, name))
             elif v:
                 for x in v:
-                    _check_c_error(named_func(target, k, x))
+                    if x:
+                        _check_c_error(named_func(target, k, x))
     elif arg:
         for v in arg:
             if v and v.startswith('/') and not v.startswith('//'):

--- a/src/parse/interpreter.c
+++ b/src/parse/interpreter.c
@@ -66,6 +66,7 @@ int InitialiseInterpreter(char* parser_location) {
   reg("_add_exported_dep", "char* (*)(size_t, char*)", AddExportedDep);
   reg("_add_tool", "char* (*)(size_t, char*)", AddTool);
   reg("_add_out", "char* (*)(size_t, char*)", AddOutput);
+  reg("_add_named_out", "char* (*)(size_t, char*, char*)", AddNamedOutput);
   reg("_add_optional_out", "char* (*)(size_t, char*)", AddOptionalOutput);
   reg("_add_vis", "char* (*)(size_t, char*)", AddVis);
   reg("_add_label", "char* (*)(size_t, char*)", AddLabel);
@@ -86,6 +87,7 @@ int InitialiseInterpreter(char* parser_location) {
   reg("_set_post_build_callback", "char** (*)(void*, char*, size_t)", SetPostBuildFunction);
   reg("_add_dependency", "char* (*)(size_t, char*, char*, uint8)", AddDependency);
   reg("_add_output", "char* (*)(size_t, char*, char*)", AddOutputPost);
+  reg("_add_named_output", "char* (*)(size_t, char*, char*, char*)", AddNamedOutputPost);
   reg("_add_licence_post", "char* (*)(size_t, char*, char*)", AddLicencePost);
   reg("_get_command", "char* (*)(size_t, char*, char*)", GetCommand);
   reg("_set_command", "char* (*)(size_t, char*, char*, char*)", SetCommand);

--- a/src/parse/interpreter.go
+++ b/src/parse/interpreter.go
@@ -427,7 +427,7 @@ func AddDependency(cPackage uintptr, cTarget *C.char, cDep *C.char, exported boo
 }
 
 //export AddOutputPost
-func AddOutputPost(cPackage uintptr, cTarget *C.char, cOut *C.char) *C.char {
+func AddOutputPost(cPackage uintptr, cTarget, cOut *C.char) *C.char {
 	target, err := getTargetPost(cPackage, cTarget)
 	if err != nil {
 		return C.CString(err.Error())
@@ -438,6 +438,21 @@ func AddOutputPost(cPackage uintptr, cTarget *C.char, cOut *C.char) *C.char {
 		return C.CString(err.Error())
 	}
 	target.AddOutput(out)
+	return nil
+}
+
+//export AddNamedOutputPost
+func AddNamedOutputPost(cPackage uintptr, cTarget, cName, cOut *C.char) *C.char {
+	target, err := getTargetPost(cPackage, cTarget)
+	if err != nil {
+		return C.CString(err.Error())
+	}
+	out := C.GoString(cOut)
+	pkg := unsizep(cPackage)
+	if err := pkg.RegisterOutput(out, target); err != nil {
+		return C.CString(err.Error())
+	}
+	target.AddNamedOutput(C.GoString(cName), out)
 	return nil
 }
 
@@ -510,7 +525,7 @@ func AddSource(cTarget uintptr, cSource *C.char) *C.char {
 // Identifies if the file is owned by this package and returns an error if not.
 func parseSource(src, packageName string, systemAllowed bool) (core.BuildInput, error) {
 	if core.LooksLikeABuildLabel(src) {
-		return core.TryParseBuildOutputLabel(src, packageName)
+		return core.TryParseNamedOutputLabel(src, packageName)
 	} else if src == "" {
 		return nil, fmt.Errorf("Empty source path (in package %s)", packageName)
 	} else if strings.Contains(src, "../") {
@@ -578,6 +593,13 @@ func AddData(cTarget uintptr, cData *C.char) *C.char {
 func AddOutput(cTarget uintptr, cOutput *C.char) *C.char {
 	target := unsizet(cTarget)
 	target.AddOutput(C.GoString(cOutput))
+	return nil
+}
+
+//export AddNamedOutput
+func AddNamedOutput(cTarget uintptr, cName *C.char, cOutput *C.char) *C.char {
+	target := unsizet(cTarget)
+	target.AddNamedOutput(C.GoString(cName), C.GoString(cOutput))
 	return nil
 }
 

--- a/src/parse/interpreter.go
+++ b/src/parse/interpreter.go
@@ -510,7 +510,7 @@ func AddSource(cTarget uintptr, cSource *C.char) *C.char {
 // Identifies if the file is owned by this package and returns an error if not.
 func parseSource(src, packageName string, systemAllowed bool) (core.BuildInput, error) {
 	if core.LooksLikeABuildLabel(src) {
-		return core.TryParseBuildLabel(src, packageName)
+		return core.TryParseBuildOutputLabel(src, packageName)
 	} else if src == "" {
 		return nil, fmt.Errorf("Empty source path (in package %s)", packageName)
 	} else if strings.Contains(src, "../") {

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -105,7 +105,7 @@ def cc_library(name, srcs=None, hdrs=None, private_hdrs=None, deps=None, visibil
         # than giving them all to gcc in one invocation.
         a_rules = []
         for src in srcs:
-            a_name = '_%s#%s' % (name, src.replace('/', '_').replace('.', '_').replace(':', '_'))
+            a_name = '_%s#%s' % (name, src.replace('/', '_').replace('.', '_').replace(':', '_').replace('|', '_'))
             build_rule(
                 name=a_name,
                 srcs={'srcs': [src], 'hdrs': hdrs, 'priv': private_hdrs},

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -153,33 +153,34 @@ def cgo_library(name, srcs, go_srcs=None, c_srcs=None, hdrs=None, out=None, comp
     linker_flags = linker_flags or []
     generated_go_srcs = [src.replace('.go', '.cgo1.go') for src in srcs] + ['_cgo_gotypes.go']
     generated_c_srcs = [src.replace('.go', '.cgo2.c') for src in srcs] + ['_cgo_export.c']
-    generated_hdrs = ['_cgo_export.h']
+    generated_c_hdrs = ['_cgo_export.h']
+
     cgo_rule = build_rule(
         name = name,
         tag = 'cgo',
         srcs = srcs + hdrs,
-        outs = [name + '_cgo'],
+        outs = generated_go_srcs + generated_c_srcs + generated_c_hdrs,
         cmd = ' && '.join([
-            'mkdir $OUT',
             'cd $PKG_DIR',
-            '$TOOL tool cgo -objdir $OUT -importpath ${PKG#*src/} *.go',
+            '$TOOL tool cgo -objdir $TMP_DIR -importpath ${PKG#*src/} *.go',
             # cgo leaves absolute paths in these files which we must get rid of :(
-            'find $OUT -type f | xargs sed -i -e "s|$TMP_DIR/||g"',
+            'find $TMP_DIR -type f -maxdepth 1 | xargs sed -i -e "s|$TMP_DIR/||g"',
         ]),
         tools = _GO_TOOL,
         requires = ['go', 'cc_hdrs'],
     )
-    # Break up the outputs of the cgo rule into relevant bits.
-    # TODO(pebers): This would be easier if we could indicate a dependency on a single
-    #               output of a rule somehow...
-    gen_go = _collect_files(name, 'gen_go', cgo_rule, generated_go_srcs, '.go')
-    gen_c = _collect_files(name, 'gen_c', cgo_rule, generated_c_srcs, '.c')
-    gen_h = _collect_files(name, 'gen_hdr', cgo_rule, generated_hdrs, '.h')
+
+    # Take specific outputs from this rule for various languages.
+    outputs = lambda files: ['%s|%s' % (cgo_rule, file) for file in files]
+    gen_go = outputs(generated_go_srcs)
+    gen_c = outputs(generated_c_srcs)
+    gen_h = outputs(generated_c_hdrs)
+
     # Compile the various bits
     c_library(
         name = '_%s#c' % name,
-        srcs = [gen_c] + c_srcs,
-        hdrs = [gen_h] + hdrs,
+        srcs = gen_c + c_srcs,
+        hdrs = gen_h + hdrs,
         compiler_flags = compiler_flags + [
             '-Wno-error',
             '-Wno-unused-parameter',  # Generated code doesn't compile clean
@@ -202,7 +203,7 @@ def cgo_library(name, srcs, go_srcs=None, c_srcs=None, hdrs=None, out=None, comp
     )
     go_rule = go_library(
         name = '_%s#go' % name,
-        srcs = [gen_go] + go_srcs,
+        srcs = gen_go + go_srcs,
         test_only = test_only,
         complete = False,
         deps = deps,
@@ -584,31 +585,6 @@ def _go_tool(tools):
     Currently the tool invoked for 'go' is not configurable.
     """
     return (tools or []) + ['go']
-
-
-def _collect_files(name, tag, dep, outs, extension):
-    """Defines a rule to collect a subset of outputs from another rule.
-
-    Used mostly for cgo which spits out many different kinds of thing.
-    """
-    # Handle sources that are actually build rules.
-    # TODO(pebers): This is overly awkward to need to use a post-build rule for, can we do
-    #               something more lightweight?
-    file_outs = [out for out in outs if not out.startswith('/') and not out.startswith(':')]
-    return build_rule(
-        name = name,
-        tag = tag,
-        srcs = [dep],
-        outs = file_outs,
-        cmd = 'mv $PKG_DIR/%s_cgo/* . && ls *%s' % (name, extension),
-        post_build = _collect_rule_outs if file_outs != outs else None,
-    )
-
-
-def _collect_rule_outs(name, output):
-    for line in output:
-        if line != '_cgo_main.c':
-            add_out(name, line)
 
 
 def _go_library_cmds(complete=True, all_srcs=False):

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -151,15 +151,16 @@ def cgo_library(name, srcs, go_srcs=None, c_srcs=None, hdrs=None, out=None, comp
     hdrs = hdrs or []
     compiler_flags = compiler_flags or []
     linker_flags = linker_flags or []
-    generated_go_srcs = [src.replace('.go', '.cgo1.go') for src in srcs] + ['_cgo_gotypes.go']
-    generated_c_srcs = [src.replace('.go', '.cgo2.c') for src in srcs] + ['_cgo_export.c']
-    generated_c_hdrs = ['_cgo_export.h']
 
     cgo_rule = build_rule(
         name = name,
         tag = 'cgo',
         srcs = srcs + hdrs,
-        outs = generated_go_srcs + generated_c_srcs + generated_c_hdrs,
+        outs = {
+            'go': [src.replace('.go', '.cgo1.go') for src in srcs] + ['_cgo_gotypes.go'],
+            'c': [src.replace('.go', '.cgo2.c') for src in srcs] + ['_cgo_export.c'],
+            'h': ['_cgo_export.h'],
+        },
         cmd = ' && '.join([
             'cd $PKG_DIR',
             '$TOOL tool cgo -objdir $TMP_DIR -importpath ${PKG#*src/} *.go',
@@ -170,17 +171,11 @@ def cgo_library(name, srcs, go_srcs=None, c_srcs=None, hdrs=None, out=None, comp
         requires = ['go', 'cc_hdrs'],
     )
 
-    # Take specific outputs from this rule for various languages.
-    outputs = lambda files: ['%s|%s' % (cgo_rule, file) for file in files]
-    gen_go = outputs(generated_go_srcs)
-    gen_c = outputs(generated_c_srcs)
-    gen_h = outputs(generated_c_hdrs)
-
     # Compile the various bits
     c_library(
         name = '_%s#c' % name,
-        srcs = gen_c + c_srcs,
-        hdrs = gen_h + hdrs,
+        srcs = [cgo_rule + '|c'] + c_srcs,
+        hdrs = [cgo_rule + '|h'] + hdrs,
         compiler_flags = compiler_flags + [
             '-Wno-error',
             '-Wno-unused-parameter',  # Generated code doesn't compile clean
@@ -203,7 +198,7 @@ def cgo_library(name, srcs, go_srcs=None, c_srcs=None, hdrs=None, out=None, comp
     )
     go_rule = go_library(
         name = '_%s#go' % name,
-        srcs = gen_go + go_srcs,
+        srcs = [cgo_rule + '|go'] + go_srcs,
         test_only = test_only,
         complete = False,
         deps = deps,

--- a/src/query/print.go
+++ b/src/query/print.go
@@ -39,6 +39,17 @@ func QueryPrint(graph *core.BuildGraph, labels []core.BuildLabel) {
 				fmt.Printf("          '%s',\n", out)
 			}
 			fmt.Printf("      ],\n")
+		} else if names := target.DeclaredOutputNames(); len(names) > 0 {
+			fmt.Printf("      outs = {\n")
+			outs := target.DeclaredNamedOutputs()
+			for _, name := range names {
+				fmt.Printf("          '%s': [\n", name)
+				for _, out := range outs[name] {
+					fmt.Printf("              '%s'\n", out)
+				}
+				fmt.Printf("          ],\n")
+			}
+			fmt.Printf("      },\n")
 		}
 		stringList("optional_outs", target.OptionalOutputs)
 		if !target.IsFilegroup {

--- a/src/query/print_test.go
+++ b/src/query/print_test.go
@@ -26,6 +26,7 @@ var KnownFields = map[string]bool{
 	"Label":                       true, // this includes the target's name
 	"Labels":                      true,
 	"Licences":                    true,
+	"namedOutputs":                true,
 	"NamedSources":                true,
 	"NeedsTransitiveDependencies": true,
 	"NoTestOutput":                true,


### PR DESCRIPTION
The syntax is `//package:target|group`; I kicked around a few things, this seems distinctive and unlikely to happen by accident (nobody puts pipes in filenames, right?). It can't be specified on the command line.

There are already some motivating examples builtin; I've updated `cgo_library` to take advantage of this. Another is protos; currently we run protoc once per language (and twice for C...), with this we could do it once only.
Supporting Yarn nicely is what I'm looking at now; I'll keep that in pleasings for now since it's all a bit experimental.

Originally I was doing specific named output files, but that turns out to be too inflexible. Pretty certain I like this better.