### PR TITLE
Support for Go 'external' tests

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -1104,7 +1104,7 @@ rules to Go packages.</p>
 
     <h3><a name="go_test">go_test</a></h3>
 
-    <p><pre class="rule"><code>go_test(name, srcs, data=None, deps=None, visibility=None, container=False, timeout=0, flaky=False, test_outputs=None, labels=None)</code></pre></p>
+    <p><pre class="rule"><code>go_test(name, srcs, data=None, deps=None, visibility=None, container=False, external=False, timeout=0, flaky=False, test_outputs=None, labels=None)</code></pre></p>
 
     <p>Defines a Go test rule.</p>
 
@@ -1166,6 +1166,14 @@ rules to Go packages.</p>
 	<td>False</td>
 	<td>bool | dict</td>
 	<td>True to run this test in a container.</td>
+      </tr>
+
+      <tr>
+	<td>external</td>
+	<td>False</td>
+	<td>bool</td>
+	<td>True if this test is external to the library it's testing, i.e. it uses the
+        feature of Go that allows it to be in the same directory with a _test suffix.</td>
       </tr>
 
       <tr>

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -292,7 +292,7 @@ def go_binary(name, main=None, srcs=None, deps=None, visibility=None, test_only=
 
 
 def go_test(name, srcs, data=None, deps=None, visibility=None, flags='', container=False, cgo=False,
-            timeout=0, flaky=0, test_outputs=None, labels=None, size=None):
+            external=False, timeout=0, flaky=0, test_outputs=None, labels=None, size=None):
     """Defines a Go test rule.
 
     Args:
@@ -304,6 +304,8 @@ def go_test(name, srcs, data=None, deps=None, visibility=None, flags='', contain
       flags (str): Flags to apply to the test invocation.
       container (bool | dict): True to run this test in a container.
       cgo (bool): True if this test depends on a cgo_library.
+      external (bool): True if this test is external to the library it's testing, i.e. it uses the
+                       feature of Go that allows it to be in the same directory with a _test suffix.
       timeout (int): Timeout in seconds to allow the test to run for.
       flaky (int | bool): True to mark the test as flaky, or an integer to specify how many reruns.
       test_outputs (list): Extra test output files to generate from this test.
@@ -319,7 +321,7 @@ def go_test(name, srcs, data=None, deps=None, visibility=None, flags='', contain
         out = name + ('_lib.a' if cgo else '.a'),
         deps = deps,
         test_only = True,
-        _all_srcs = True,
+        _all_srcs = not external,
         complete = False,
     )
     lib_rule = ':_%s#lib' % name

--- a/test/go_rules/test/BUILD
+++ b/test/go_rules/test/BUILD
@@ -15,3 +15,14 @@ go_library(
     ],
     visibility = ['//test/...'],
 )
+
+# Tests a go 'external test', where you can have files in the same directory
+# with a _test suffix.
+go_test(
+    name = 'external_test',
+    srcs = ['external_test.go'],
+    deps = [
+        ':test',
+        '//third_party/go:testify',
+    ],
+)

--- a/test/go_rules/test/BUILD
+++ b/test/go_rules/test/BUILD
@@ -21,6 +21,7 @@ go_library(
 go_test(
     name = 'external_test',
     srcs = ['external_test.go'],
+    external = True,
     deps = [
         ':test',
         '//third_party/go:testify',

--- a/test/go_rules/test/external_test.go
+++ b/test/go_rules/test/external_test.go
@@ -1,0 +1,13 @@
+package test_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "test/go_rules/test"
+)
+
+func TestAnswer(t *testing.T) {
+	assert.Equal(t, 42, GetAnswer())
+}


### PR DESCRIPTION
Basically the special case where Go lets you have another package in the same directory with a `_test` suffix. Turns out not to be hard to support but does need to be explicitly marked on the test rule.