### PR TITLE
Creating tarballs in jarcat

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -2925,16 +2925,15 @@ This is just a convenience wrapper around remote_file but is somewhat clearer to
 	<td>subdir</td>
 	<td>None</td>
 	<td>str</td>
-	<td>Subdirectory to create in (defaults to 'name')</td>
+	<td>Subdirectory to create in (defaults to 'name').
+        All files will be flattened into this directory.</td>
       </tr>
 
       <tr>
-	<td>compression</td>
 	<td>gzip</td>
-	<td>str</td>
-	<td>Kind of compression to use. Either one of {gzip, bzip2, xz, lzma}
-to filter through known tar methods, an explicit flag, or None for
-no compression.</td>
+	<td>True</td>
+	<td>bool</td>
+	<td>If True, the output will be gzipped. If False, it will just be a tarball.</td>
       </tr>
 
       <tr>

--- a/src/parse/rules/misc_rules.build_defs
+++ b/src/parse/rules/misc_rules.build_defs
@@ -509,8 +509,8 @@ def _deb_deps(cmd, current_label):
     return _find_deb_deps
 
 
-def tarball(name, srcs, out=None, deps=None, subdir=None,
-            compression='gzip', visibility=None, labels=None):
+def tarball(name, srcs, out=None, deps=None, subdir=None, gzip=True,
+            visibility=None, labels=None, compression=None):
     """Defines a rule to create a tarball containing outputs of other rules.
 
     File mode and ownership are preserved. However, the atime and mtime of all
@@ -521,62 +521,31 @@ def tarball(name, srcs, out=None, deps=None, subdir=None,
       srcs (list): Source files to include in the tarball
       out (str): Name of output tarball (defaults to `name`.tar.gz, but see below re compression)
       subdir (str): Subdirectory to create in (defaults to 'name')
-      compression (str): Kind of compression to use. Either one of {gzip, bzip2, xz, lzma}
-                         to filter through known tar methods, an explicit flag, or None for
-                         no compression.
+      gzip (bool): If True, the output will be gzipped. If False, it will just be a tarball.
       deps (list): Dependencies
       visibility (list): Visibility specification.
       labels (list): Labels associated with this rule.
+      compression (str): Deprecated. No longer has any effect.
     """
     # A filegroup is a nice easy way to move all these files locally.
-    filegroup(
+    src_filegroup = filegroup(
         name = '_%s#files' % name,
         srcs = srcs,
     )
-    deps = deps or []
-    deps.append(':_%s#files' % name)
     subdir = subdir or name
-    if compression is not None and compression.startswith('-'):
-        if not out:
-            raise ValueError('Must pass "out" argument to tarball() if you pass an '
-                             'explicit flag for "compression"')
-    else:
-        compression, extension = _COMPRESSION.get(compression, ('-a', ''))
-
-    out = out or name + '.tar' + extension
-    # Unlike the rest of the compressions, gzip preserves the file's (the tar)
-    # timestamp by default, making the output unreproducible.
-    # Hence the compression is done with the -n flag in a separate step
-    if extension == '.gz' or out.endswith('.gz'):
-        archive_cmd = 'tar -c * | gzip -n > $OUT'
-    else:
-        archive_cmd = 'tar %s -cf $OUT *' % compression
+    out = out or name + ('.tar.gz' if compress else '.tar')
 
     build_rule(
-        name=name,
-        cmd=' && '.join([
-            'mkdir -p _tmp/' + subdir,
-            'cp -pr $(locations :_%s#files) _tmp/%s' % (name, subdir),
-            'cd _tmp',
-            # not using tar's --mtime because it's only available in GNU tar
-            'find . -exec touch -t 200001010000.00 {} +',
-            archive_cmd
-        ]),
-        outs=[out],
-        deps=deps,
-        visibility=visibility,
-        labels=(labels or []) + ['tar'],
+        name = name,
+        cmd = '$TOOL --tar',
+        srcs = [src_filegroup],
+        tools = [CONFIG.JARCAT_TOOL],
+        outs = [out],
+        deps = deps,
+        visibility = visibility,
+        labels = (labels or []) + ['tar'],
         output_is_complete = True,
     )
-
-
-_COMPRESSION = {
-    'gzip': ('-z', '.gz'),
-    'bzip2': ('-j', '.bz2'),
-    'xz': ('-J', '.xz'),
-    'lzma': ('--lzma', '.lzma'),
-    'compress': ('-Z', '.Z'),
-}
 
 
 def _tool_path(tool, tools=None, binary=True, worker=False):

--- a/src/parse/rules/misc_rules.build_defs
+++ b/src/parse/rules/misc_rules.build_defs
@@ -520,7 +520,7 @@ def tarball(name, srcs, out=None, deps=None, subdir=None, gzip=True,
       name (str): Rule name
       srcs (list): Source files to include in the tarball
       out (str): Name of output tarball (defaults to `name`.tar.gz, but see below re compression)
-      subdir (str): Subdirectory to create in (defaults to 'name')
+      subdir (str): Subdirectory to create in.
       gzip (bool): If True, the output will be gzipped. If False, it will just be a tarball.
       deps (list): Dependencies
       visibility (list): Visibility specification.
@@ -534,10 +534,15 @@ def tarball(name, srcs, out=None, deps=None, subdir=None, gzip=True,
     )
     subdir = subdir or name
     out = out or name + ('.tar.gz' if compress else '.tar')
+    cmd = '$TOOL --tar -i .'
+    if gzip:
+        cmd += ' -z'
+    if subdir:
+        cmd += ' --prefix ' + subdir
 
     build_rule(
         name = name,
-        cmd = '$TOOL --tar',
+        cmd = cmd,
         srcs = [src_filegroup],
         tools = [CONFIG.JARCAT_TOOL],
         outs = [out],

--- a/src/parse/rules/misc_rules.build_defs
+++ b/src/parse/rules/misc_rules.build_defs
@@ -510,7 +510,7 @@ def _deb_deps(cmd, current_label):
 
 
 def tarball(name, srcs, out=None, deps=None, subdir=None, gzip=True,
-            visibility=None, labels=None, compression=None):
+            visibility=None, labels=None):
     """Defines a rule to create a tarball containing outputs of other rules.
 
     File mode and ownership are preserved. However, the atime and mtime of all
@@ -520,12 +520,11 @@ def tarball(name, srcs, out=None, deps=None, subdir=None, gzip=True,
       name (str): Rule name
       srcs (list): Source files to include in the tarball
       out (str): Name of output tarball (defaults to `name`.tar.gz, but see below re compression)
-      subdir (str): Subdirectory to create in.
+      subdir (str): Subdirectory to create in. All files will be flattened into this directory.
       gzip (bool): If True, the output will be gzipped. If False, it will just be a tarball.
       deps (list): Dependencies
       visibility (list): Visibility specification.
       labels (list): Labels associated with this rule.
-      compression (str): Deprecated. No longer has any effect.
     """
     # A filegroup is a nice easy way to move all these files locally.
     src_filegroup = filegroup(
@@ -533,7 +532,7 @@ def tarball(name, srcs, out=None, deps=None, subdir=None, gzip=True,
         srcs = srcs,
     )
     subdir = subdir or name
-    out = out or name + ('.tar.gz' if compress else '.tar')
+    out = out or (name + ('.tar.gz' if gzip else '.tar'))
     cmd = '$TOOL --tar -i .'
     if gzip:
         cmd += ' -z'

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -93,6 +93,7 @@ go_get(
 go_get(
     name = 'testify',
     get = 'github.com/stretchr/testify',
+    install = ['github.com/stretchr/testify/require'],
     revision = 'f390dcf405f7b83c997eac1b06768bb9f44dec18',
 )
 

--- a/tools/jarcat/BUILD
+++ b/tools/jarcat/BUILD
@@ -16,6 +16,7 @@ go_binary(
         '//src/cli',
         '//third_party/go:logging',
         '//third_party/go/zip',
+        '//tools/jarcat/tar',
     ],
     visibility = ['PUBLIC'],
 )

--- a/tools/jarcat/jarcat.go
+++ b/tools/jarcat/jarcat.go
@@ -111,7 +111,7 @@ func matchesSuffix(path string, suffixes []string) bool {
 
 var opts = struct {
 	Usage                   string
-	Out                     string            `short:"o" long:"output" description:"Output filename" required:"true"`
+	Out                     string            `short:"o" long:"output" env:"OUT" description:"Output filename" required:"true"`
 	In                      string            `short:"i" long:"input" description:"Input directory" required:"true"`
 	Suffix                  []string          `short:"s" long:"suffix" default:".jar" description:"Suffix of files to include"`
 	ExcludeSuffix           []string          `short:"e" long:"exclude_suffix" default:"src.jar" description:"Suffix of files to exclude"`
@@ -128,6 +128,7 @@ var opts = struct {
 	NoDirEntries            bool              `short:"n" long:"nodir_entries" description:"Don't add directory entries to zip"`
 	RenameDirs              map[string]string `short:"r" long:"rename_dir" description:"Rename directories within zip file"`
 	StripBytecodeTimestamps bool              `short:"b" long:"strip_bytecode_timestamps" description:"Strips timestamps from any .pyc / .pyo files encountered."`
+	Tar                     bool              `long:"tar" description:"Write a tarball instead of a zipfile. Note that most other flags are not honoured if this is given."`
 }{
 	Usage: `
 Jarcat is a binary shipped with Please that helps it operate on .jar and .zip files.

--- a/tools/jarcat/jarcat.go
+++ b/tools/jarcat/jarcat.go
@@ -17,6 +17,7 @@ import (
 
 	"cli"
 	"tools/jarcat"
+	"tools/jarcat/tar"
 )
 
 var log = logging.MustGetLogger("jarcat")
@@ -128,7 +129,10 @@ var opts = struct {
 	NoDirEntries            bool              `short:"n" long:"nodir_entries" description:"Don't add directory entries to zip"`
 	RenameDirs              map[string]string `short:"r" long:"rename_dir" description:"Rename directories within zip file"`
 	StripBytecodeTimestamps bool              `short:"b" long:"strip_bytecode_timestamps" description:"Strips timestamps from any .pyc / .pyo files encountered."`
-	Tar                     bool              `long:"tar" description:"Write a tarball instead of a zipfile. Note that most other flags are not honoured if this is given."`
+
+	Tar    bool   `long:"tar" description:"Write a tarball instead of a zipfile. Note that most other flags are not honoured if this is given."`
+	Gzip   bool   `short:"z" long:"gzip" description:"Apply gzip compression to the tar file. Only has an effect if --tar is passed."`
+	Prefix string `long:"prefix" description:"Flatten all files into a directory with this name within the tarball."`
 }{
 	Usage: `
 Jarcat is a binary shipped with Please that helps it operate on .jar and .zip files.
@@ -157,6 +161,14 @@ func main() {
 		opts.IncludeOther = true
 	}
 	cli.InitLogging(opts.Verbosity)
+
+	if opts.Tar {
+		if err := tar.Write(opts.Out, opts.In, opts.Prefix, opts.Gzip); err != nil {
+			log.Fatalf("Error writing tarball: %s\n", err)
+		}
+		os.Exit(0)
+	}
+
 	if err := combine(opts.Out, opts.In, opts.Preamble, opts.StripPrefix, opts.MainClass,
 		opts.ExcludeInternalPrefix, opts.ExcludeSuffix, opts.Suffix, opts.IncludeInternalPrefix,
 		opts.Strict, opts.IncludeOther, opts.AddInitPy, !opts.NoDirEntries, opts.RenameDirs); err != nil {

--- a/tools/jarcat/tar/BUILD
+++ b/tools/jarcat/tar/BUILD
@@ -1,0 +1,15 @@
+go_library(
+    name = 'tar',
+    srcs = ['tar.go'],
+    visibility = ['//tools/jarcat/...'],
+)
+
+go_test(
+    name = 'tar_test',
+    srcs = ['tar_test.go'],
+    data = ['test_data'],
+    deps = [
+        ':tar',
+        '//third_party/go:testify',
+    ],
+)

--- a/tools/jarcat/tar/tar.go
+++ b/tools/jarcat/tar/tar.go
@@ -1,0 +1,78 @@
+// Package tar implements a tarball writer for Please.
+// This is not really dissimilar to the standard command-line tar utility,
+// but we would like some of the GNU tar flags which we can't rely on for all
+// platforms that we support, plus we'd like finer control over timestamps
+// and directories.
+package tar
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// mtime is the time we attach for the modification time of all files.
+var mtime = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// Write writes a tarball to output with all the files found in inputDir.
+// If prefix is given the files are all placed into a single directory with that name.
+// If compress is true the output will be gzip-compressed.
+func Write(output, inputDir, prefix string, compress bool) error {
+	f, err := os.Create(output)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if compress {
+		w := gzip.NewWriter(f)
+		defer w.Close()
+		return write(w, inputDir, prefix)
+	}
+	return write(f, inputDir, prefix)
+}
+
+// write writes a tarball to the given writer with all the files found in inputDir.
+// If prefix is given the files are all placed into a single directory with that name.
+func write(w io.Writer, inputDir, prefix string) error {
+	tw := tar.NewWriter(w)
+	defer tw.Close()
+
+	return filepath.Walk(inputDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		} else if info.IsDir() {
+			return nil // ignore directories
+		}
+		hdr, err := tar.FileInfoHeader(info, "") // We don't write symlinks into plz-out/tmp, so the argument doesn't matter.
+		if err != nil {
+			return err
+		}
+		// Set name appropriately (recall that FileInfoHeader does not set the full path).
+		if prefix != "" {
+			hdr.Name = filepath.Join(prefix, hdr.Name)
+		} else {
+			hdr.Name = strings.TrimLeft(strings.TrimPrefix(path, inputDir), "/")
+		}
+		// Zero out all timestamps.
+		hdr.ModTime = mtime
+		hdr.AccessTime = mtime
+		hdr.ChangeTime = mtime
+		// Strip user/group ids.
+		hdr.Uid = 0
+		hdr.Gid = 0
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = io.Copy(tw, f)
+		return err
+	})
+}

--- a/tools/jarcat/tar/tar.go
+++ b/tools/jarcat/tar/tar.go
@@ -30,14 +30,14 @@ func Write(output, inputDir, prefix string, compress bool) error {
 	if compress {
 		w := gzip.NewWriter(f)
 		defer w.Close()
-		return write(w, inputDir, prefix)
+		return write(w, output, inputDir, prefix)
 	}
-	return write(f, inputDir, prefix)
+	return write(f, output, inputDir, prefix)
 }
 
 // write writes a tarball to the given writer with all the files found in inputDir.
 // If prefix is given the files are all placed into a single directory with that name.
-func write(w io.Writer, inputDir, prefix string) error {
+func write(w io.Writer, output, inputDir, prefix string) error {
 	tw := tar.NewWriter(w)
 	defer tw.Close()
 
@@ -46,6 +46,8 @@ func write(w io.Writer, inputDir, prefix string) error {
 			return err
 		} else if info.IsDir() {
 			return nil // ignore directories
+		} else if abs, _ := filepath.Abs(path); abs == output {
+			return nil // don't write the output tarball into itself :)
 		}
 		hdr, err := tar.FileInfoHeader(info, "") // We don't write symlinks into plz-out/tmp, so the argument doesn't matter.
 		if err != nil {

--- a/tools/jarcat/tar/tar_test.go
+++ b/tools/jarcat/tar/tar_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const testDataDir = "tools/jarcat/tar/test_data"
@@ -18,7 +19,7 @@ const testDataDir = "tools/jarcat/tar/test_data"
 func TestNoCompression(t *testing.T) {
 	filename := "test_no_compression.tar"
 	err := Write(filename, testDataDir, "", false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	m := ReadTar(t, filename, false)
 	assert.EqualValues(t, map[string]string{
@@ -42,7 +43,7 @@ func TestNoCompression(t *testing.T) {
 func TestCompression(t *testing.T) {
 	filename := "test_compression.tar.gz"
 	err := Write(filename, testDataDir, "", true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	m := ReadTar(t, filename, true)
 	assert.EqualValues(t, map[string]string{
@@ -54,7 +55,7 @@ func TestCompression(t *testing.T) {
 func TestWithPrefix(t *testing.T) {
 	filename := "test_prefix.tar"
 	err := Write(filename, testDataDir, "wibble", false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	m := ReadTar(t, filename, false)
 	assert.EqualValues(t, map[string]string{
@@ -67,10 +68,10 @@ func TestWithPrefix(t *testing.T) {
 // their headers -> their contents.
 func ReadTar(t *testing.T, filename string, compress bool) map[*tar.Header]string {
 	f, err := os.Open(filename)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if compress {
 		r, err := gzip.NewReader(f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		return readTar(t, r)
 	}
 	return readTar(t, f)
@@ -86,10 +87,10 @@ func readTar(t *testing.T, r io.Reader) map[*tar.Header]string {
 		if err == io.EOF {
 			break
 		}
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		var buf bytes.Buffer
 		_, err = io.Copy(&buf, tr)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		m[hdr] = strings.TrimSpace(buf.String()) // Don't worry about newline, they're just test files...
 	}
 	return m

--- a/tools/jarcat/tar/tar_test.go
+++ b/tools/jarcat/tar/tar_test.go
@@ -1,0 +1,105 @@
+package tar
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testDataDir = "tools/jarcat/tar/test_data"
+
+func TestNoCompression(t *testing.T) {
+	filename := "test_no_compression.tar"
+	err := Write(filename, testDataDir, "", false)
+	assert.NoError(t, err)
+
+	m := ReadTar(t, filename, false)
+	assert.EqualValues(t, map[string]string{
+		"dir1/file1.txt": "test file 1",
+		"dir2/file2.txt": "test file 2",
+	}, toFilenameMap(m))
+
+	// All the timestamps should be fixated and there should be no user/group id.
+	var zeroTime time.Time
+	for h := range m {
+		assert.EqualValues(t, mtime, h.ModTime.In(time.UTC))
+		// These two seem to always be zero regardless of what we send in.
+		// We don't really care as long as they're always the same.
+		assert.EqualValues(t, zeroTime, h.AccessTime)
+		assert.EqualValues(t, zeroTime, h.ChangeTime)
+		assert.EqualValues(t, 0, h.Uid)
+		assert.EqualValues(t, 0, h.Gid)
+	}
+}
+
+func TestCompression(t *testing.T) {
+	filename := "test_compression.tar.gz"
+	err := Write(filename, testDataDir, "", true)
+	assert.NoError(t, err)
+
+	m := ReadTar(t, filename, true)
+	assert.EqualValues(t, map[string]string{
+		"dir1/file1.txt": "test file 1",
+		"dir2/file2.txt": "test file 2",
+	}, toFilenameMap(m))
+}
+
+func TestWithPrefix(t *testing.T) {
+	filename := "test_prefix.tar"
+	err := Write(filename, testDataDir, "wibble", false)
+	assert.NoError(t, err)
+
+	m := ReadTar(t, filename, false)
+	assert.EqualValues(t, map[string]string{
+		"wibble/file1.txt": "test file 1",
+		"wibble/file2.txt": "test file 2",
+	}, toFilenameMap(m))
+}
+
+// ReadTar is a test utility that reads all the files from a tarball and returns a map of
+// their headers -> their contents.
+func ReadTar(t *testing.T, filename string, compress bool) map[*tar.Header]string {
+	f, err := os.Open(filename)
+	assert.NoError(t, err)
+	if compress {
+		r, err := gzip.NewReader(f)
+		assert.NoError(t, err)
+		return readTar(t, r)
+	}
+	return readTar(t, f)
+}
+
+// readTar is a test utility that reads all the files from a tarball and returns a map of
+// their headers -> their contents.
+func readTar(t *testing.T, r io.Reader) map[*tar.Header]string {
+	tr := tar.NewReader(r)
+	m := map[*tar.Header]string{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		assert.NoError(t, err)
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, tr)
+		assert.NoError(t, err)
+		m[hdr] = strings.TrimSpace(buf.String()) // Don't worry about newline, they're just test files...
+	}
+	return m
+}
+
+// toFilenameMap converts one of the maps returned by above to a map of filenames to contents.
+func toFilenameMap(m map[*tar.Header]string) map[string]string {
+	r := map[string]string{}
+	for hdr, contents := range m {
+		r[hdr.Name] = contents
+	}
+	return r
+}

--- a/tools/jarcat/tar/test_data/dir1/file1.txt
+++ b/tools/jarcat/tar/test_data/dir1/file1.txt
@@ -1,0 +1,1 @@
+test file 1

--- a/tools/jarcat/tar/test_data/dir2/file2.txt
+++ b/tools/jarcat/tar/test_data/dir2/file2.txt
@@ -1,0 +1,1 @@
+test file 2


### PR DESCRIPTION
Means we can write our own fixated mtimes without having to struggle with OS-specific quirks or modify incoming files.

Is a breaking change though because it now only does gzip compression. We could pull in some third party packages to get bzip2 / xz writers but I'm not sure it's worth it.

Fixes #219 