### PR TITLE
Support for not specifying Java test package in config.

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -39,7 +39,6 @@ javacworker = //tools/javac_worker
 jarcattool = //tools/jarcat
 junitrunner = //tools/junit_runner
 pleasemaventool = //tools/please_maven
-defaulttestpackage = build.please
 ; We want the default to remain at java 8 because obviously it's significantly better,
 ; but the builtin packages here support java 7 fine so it's nice not to require more.
 sourcelevel = 7

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -257,7 +257,7 @@ type Configuration struct {
 		JarCatTool         string  `help:"Defines the tool used to concatenate .jar files which we use to build the output of java_binary, java_test and various other rules. Defaults to jarcat in the Please install directory." var:"JARCAT_TOOL"`
 		PleaseMavenTool    string  `help:"Defines the tool used to fetch information from Maven in maven_jars rules.\nDefaults to please_maven in the Please install directory." var:"PLEASE_MAVEN_TOOL"`
 		JUnitRunner        string  `help:"Defines the .jar containing the JUnit runner. This is built into all java_test rules since it's necessary to make JUnit do anything useful.\nDefaults to junit_runner.jar in the Please install directory." var:"JUNIT_RUNNER"`
-		DefaultTestPackage string  `help:"The Java classpath to search for functions annotated with @Test." var:"DEFAULT_TEST_PACKAGE"`
+		DefaultTestPackage string  `help:"The Java classpath to search for functions annotated with @Test." If not specified the compiled sources will be searched for files named *Test.java." var:"DEFAULT_TEST_PACKAGE"`
 		SourceLevel        string  `help:"The default Java source level when compiling. Defaults to 8." var:"JAVA_SOURCE_LEVEL"`
 		TargetLevel        string  `help:"The default Java bytecode level to target. Defaults to 8." var:"JAVA_TARGET_LEVEL"`
 		JavacFlags         string  `help:"Additional flags to pass to javac when compiling libraries." example:"-Xmx1200M" var:"JAVAC_FLAGS"`

--- a/test/BUILD
+++ b/test/BUILD
@@ -178,7 +178,7 @@ plz_e2e_test(
 
 java_test(
     name = 'individual_test_run_java',
-    srcs = ['IndividualTestRun.java'],
+    srcs = ['IndividualTest.java'],
     labels = ['manual'],
     deps = [
         '//third_party/java:junit',

--- a/test/IndividualTest.java
+++ b/test/IndividualTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 
-public class IndividualTestRun {
+public class IndividualTest {
   // Test for running individual Java tests.
 
   @Test

--- a/tools/junit_runner/src/build/please/test/ClassFinder.java
+++ b/tools/junit_runner/src/build/please/test/ClassFinder.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -23,10 +24,17 @@ import java.util.jar.JarFile;
 class ClassFinder {
 
     private final String prefix;
-    private final Set<Class> classes = new HashSet<Class>();
+    private final ClassLoader loader;
+    private final Set<Class> classes = new LinkedHashSet<Class>();
+
+    public ClassFinder(ClassLoader loader) throws IOException {
+        this.prefix = "";
+        this.loader = loader;
+    }
 
     public ClassFinder(ClassLoader loader, String prefix) throws IOException {
         this.prefix = prefix;
+        this.loader = loader;
         scan(getClassPathEntries(loader));
     }
 
@@ -123,5 +131,12 @@ class ClassFinder {
                 throw new IllegalStateException(ex);
             }
         }
+    }
+
+    /**
+     * Loads a single class by filename into our internal set.
+     */
+    public void loadClass(String filename) {
+        loadClass(loader, filename);
     }
 }

--- a/tools/junit_runner/src/build/please/test/TestCoverage.java
+++ b/tools/junit_runner/src/build/please/test/TestCoverage.java
@@ -5,8 +5,8 @@ import java.io.InputStreamReader;
 import java.io.InputStream;
 import java.io.IOException;
 import java.lang.Thread;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -15,7 +15,6 @@ import org.jacoco.core.analysis.Analyzer;
 import org.jacoco.core.analysis.CoverageBuilder;
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.ICounter;
-import org.jacoco.core.analysis.ILine;
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.data.SessionInfoStore;
 import org.jacoco.core.instr.Instrumenter;
@@ -25,11 +24,6 @@ import org.jacoco.core.runtime.RuntimeData;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -167,7 +161,7 @@ public class TestCoverage {
    * Read the sourcemap file that we use to map Java class names back to their path in the repo.
    */
   static Map<String, String> readSourceMap() {
-    Map<String, String> sourceMap = new HashMap<>();
+    Map<String, String> sourceMap = new LinkedHashMap<>();
     try {
       InputStream is = TestCoverage.class.getClassLoader().getResourceAsStream("META-INF/please_sourcemap");
       BufferedReader br = new BufferedReader(new InputStreamReader(is, UTF_8));
@@ -175,6 +169,9 @@ public class TestCoverage {
         String[] parts = line.trim().split(" ");
         if (parts.length == 2) {
           sourceMap.put(parts[1], deriveOriginalFilename(parts[0], parts[1]));
+        } else if (parts.length == 1 && line.startsWith(" ")) {
+          // Special case for repo root, where there is no first part.
+          sourceMap.put(parts[0], parts[0]);
         }
       }
     } catch (IOException ex) {

--- a/tools/junit_runner/src/build/please/test/TestCoverage.java
+++ b/tools/junit_runner/src/build/please/test/TestCoverage.java
@@ -160,7 +160,7 @@ public class TestCoverage {
   /**
    * Read the sourcemap file that we use to map Java class names back to their path in the repo.
    */
-  static Map<String, String> readSourceMap() {
+  public static Map<String, String> readSourceMap() {
     Map<String, String> sourceMap = new LinkedHashMap<>();
     try {
       InputStream is = TestCoverage.class.getClassLoader().getResourceAsStream("META-INF/please_sourcemap");
@@ -187,7 +187,7 @@ public class TestCoverage {
    * the class would be build/please/test/TestCoverage; we want to
    * produce src/build/java/build/please/test/TestCoverage.
    */
-  static String deriveOriginalFilename(String packageName, String className) {
+  public static String deriveOriginalFilename(String packageName, String className) {
     String packagePath[] = packageName.split("/");
     String classPath[] = className.split("/");
     for (int size = classPath.length - 1; size > 0; --size) {

--- a/tools/junit_runner/src/build/please/test/TestMain.java
+++ b/tools/junit_runner/src/build/please/test/TestMain.java
@@ -43,16 +43,14 @@ public class TestMain {
 
   public static void main(String[] args) throws Exception {
     String testPackage = System.getProperty("build.please.testpackage");
-    if (testPackage == null || testPackage.equals("")) {
-      throw new RuntimeException("Test package not provided (define with -Dbuild.please.testpackage)");
-    }
     program_args = args;
 
     Set<Class> classes = new HashSet<>();
-    Set<Class> allClasses = new HashSet<>();
-    ClassFinder finder = new ClassFinder(Thread.currentThread().getContextClassLoader(), testPackage);
-    for (Class testClass : finder.getClasses()) {
-      allClasses.add(testClass);
+    Set<Class> allClasses = findClasses(testPackage);
+    if (allClasses.isEmpty()) {
+      throw new RuntimeException("No test classes found");
+    }
+    for (Class testClass : allClasses) {
       if (testClass.getAnnotation(Ignore.class) == null) {
         for (Method method : testClass.getMethods()) {
           if (method.getAnnotation(Test.class) != null) {
@@ -75,6 +73,26 @@ public class TestMain {
       throw new RuntimeException("No tests were run.");
     }
     System.exit(exitCode);
+  }
+
+  /**
+   * Loads all the available test classes.
+   * This is a little complex because we want to try to avoid scanning every single class on our classpath.
+   * @param testPackage the test package to load from. If empty we'll look for them by filename.
+   */
+  private static Set<Class> findClasses(String testPackage) throws Exception {
+    ClassLoader loader = Thread.currentThread().getContextClassLoader();
+    if (testPackage != null && !testPackage.equals("")) {
+      return new ClassFinder(loader, testPackage).getClasses();
+    }
+    // Need to load by filename. Fortunately we have a list of the files we compiled in please_sourcemap.
+    ClassFinder finder = new ClassFinder(loader);
+    for (String key : TestCoverage.readSourceMap().keySet()) {
+      if (key.endsWith("Test.java")) {
+        finder.loadClass(key.replace(".java", ".class"));
+      }
+    }
+    return finder.getClasses();
   }
 
   public static void runClass(Class testClass) throws Exception {

--- a/tools/junit_runner/src/build/please/test/TestMain.java
+++ b/tools/junit_runner/src/build/please/test/TestMain.java
@@ -82,7 +82,7 @@ public class TestMain {
    */
   private static Set<Class> findClasses(String testPackage) throws Exception {
     ClassLoader loader = Thread.currentThread().getContextClassLoader();
-    if (testPackage != null && !testPackage.equals("")) {
+    if (testPackage != null && !testPackage.isEmpty()) {
       return new ClassFinder(loader, testPackage).getClasses();
     }
     // Need to load by filename. Fortunately we have a list of the files we compiled in please_sourcemap.


### PR DESCRIPTION
Instead we default to anything named `*Test.java`. Turned out not to be that hard since we've already got a list of the files we compiled in the .jar in case we need them for coverage.