### PR TITLE
Support for running multiple targets at once

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -31,6 +31,7 @@ function interpreter_target {
 notice "Installing Go dependencies..."
 export GOPATH="${PWD}"
 go get golang.org/x/crypto/ssh/terminal
+go get golang.org/x/sync/errgroup
 go get golang.org/x/tools/cover
 go get gopkg.in/op/go-logging.v1
 go get gopkg.in/gcfg.v1

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -205,6 +205,14 @@
       them last on the command line, after a <code>--</code>. This tells Please not
       to attempt to parse them as its own flags.</p>
 
+    <p>There are two optional subcommands <code>sequential</code> and <code>parallel</code>
+      which allow running multiple targets in one go. As the names suggest, they run targets
+      either one after the other or all in parallel.<br/>
+      In either case, the semantics are a little different to running a single target; it's
+      currently not possible to provide arguments and while stdout / stderr are connected to
+      the current terminal, stdin is not connected (because it'd not be clear which process
+      would consume it).</p>
+
     <h2>plz query</h2>
 
     <p>This allows you to introspect various aspects of the build graph. There are

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -208,10 +208,10 @@
     <p>There are two optional subcommands <code>sequential</code> and <code>parallel</code>
       which allow running multiple targets in one go. As the names suggest, they run targets
       either one after the other or all in parallel.<br/>
-      In either case, the semantics are a little different to running a single target; it's
-      currently not possible to provide arguments and while stdout / stderr are connected to
-      the current terminal, stdin is not connected (because it'd not be clear which process
-      would consume it).</p>
+      In either case, the semantics are a little different to running a single target; arguments
+      must be passed one by one via the <code>-a</code> flag, and while stdout / stderr are
+      connected to the current terminal, stdin is not connected (because it'd not be clear
+      which process would consume it).</p>
 
     <h2>plz query</h2>
 

--- a/src/please.go
+++ b/src/please.go
@@ -133,6 +133,11 @@ var opts struct {
 				Targets []core.BuildLabel `positional-arg-name:"target" description:"Targets to run"`
 			} `positional-args:"true" required:"true"`
 		} `command:"parallel" description:"Runs a sequence of targets in parallel"`
+		Sequential struct {
+			Args struct {
+				Targets []core.BuildLabel `positional-arg-name:"target" description:"Targets to run"`
+			} `positional-args:"true" required:"true"`
+		} `command:"sequential" description:"Runs a sequence of targets sequentially."`
 		Args struct {
 			Target core.BuildLabel `positional-arg-name:"target" required:"true" description:"Target to run"`
 			Args   []string        `positional-arg-name:"arguments" description:"Arguments to pass to target when running (to pass flags to the target, put -- before them)"`
@@ -321,6 +326,12 @@ var buildFunctions = map[string]func() bool{
 	"parallel": func() bool {
 		if success, state := runBuild(opts.Run.Parallel.Args.Targets, true, false); success {
 			run.Parallel(state.Graph, opts.Run.Parallel.Args.Targets)
+		}
+		return true // We do return from run.Parallel once it's all over.
+	},
+	"sequential": func() bool {
+		if success, state := runBuild(opts.Run.Sequential.Args.Targets, true, false); success {
+			run.Sequential(state.Graph, opts.Run.Sequential.Args.Targets)
 		}
 		return true // We do return from run.Parallel once it's all over.
 	},

--- a/src/please.go
+++ b/src/please.go
@@ -327,15 +327,15 @@ var buildFunctions = map[string]func() bool{
 	},
 	"parallel": func() bool {
 		if success, state := runBuild(opts.Run.Parallel.PositionalArgs.Targets, true, false); success {
-			run.Parallel(state.Graph, opts.Run.Parallel.PositionalArgs.Targets, opts.Run.Parallel.Args)
+			return run.Parallel(state.Graph, opts.Run.Parallel.PositionalArgs.Targets, opts.Run.Parallel.Args)
 		}
-		return true // We do return from run.Parallel once it's all over.
+		return false
 	},
 	"sequential": func() bool {
 		if success, state := runBuild(opts.Run.Sequential.PositionalArgs.Targets, true, false); success {
-			run.Sequential(state.Graph, opts.Run.Sequential.PositionalArgs.Targets, opts.Run.Sequential.Args)
+			return run.Sequential(state.Graph, opts.Run.Sequential.PositionalArgs.Targets, opts.Run.Sequential.Args)
 		}
-		return true // We do return from run.Parallel once it's all over.
+		return false
 	},
 	"clean": func() bool {
 		opts.NoCacheCleaner = true

--- a/src/please.go
+++ b/src/please.go
@@ -132,7 +132,12 @@ var opts struct {
 			Target core.BuildLabel `positional-arg-name:"target" description:"Target to run"`
 			Args   []string        `positional-arg-name:"arguments" description:"Arguments to pass to target when running (to pass flags to the target, put -- before them)"`
 		} `positional-args:"true" required:"true"`
-	} `command:"run" description:"Builds and runs a single target"`
+		Parallel struct {
+			Args struct {
+				Targets []core.BuildLabel `positional-arg-name:"target" description:"Targets to run"`
+			} `positional-args:"true" required:"true"`
+		} `command:"parallel" description:"Runs a sequence of targets in parallel"`
+	} `command:"run" subcommands-optional:"true" description:"Builds and runs a single target"`
 
 	Clean struct {
 		NoBackground bool     `long:"nobackground" short:"f" description:"Don't fork & detach until clean is finished."`
@@ -312,6 +317,12 @@ var buildFunctions = map[string]func() bool{
 			run.Run(state.Graph, opts.Run.Args.Target, opts.Run.Args.Args)
 		}
 		return false // We should never return from run.Run so if we make it here something's wrong.
+	},
+	"parallel": func() bool {
+		if success, state := runBuild(opts.Run.Parallel.Args.Targets, true, false); success {
+			run.Parallel(state.Graph, opts.Run.Parallel.Args.Targets)
+		}
+		return true // We do return from run.Parallel once it's all over.
 	},
 	"clean": func() bool {
 		opts.NoCacheCleaner = true

--- a/src/please.go
+++ b/src/please.go
@@ -128,15 +128,15 @@ var opts struct {
 	} `command:"cover" description:"Builds and tests one or more targets, and calculates coverage."`
 
 	Run struct {
-		Args struct {
-			Target core.BuildLabel `positional-arg-name:"target" description:"Target to run"`
-			Args   []string        `positional-arg-name:"arguments" description:"Arguments to pass to target when running (to pass flags to the target, put -- before them)"`
-		} `positional-args:"true" required:"true"`
 		Parallel struct {
 			Args struct {
 				Targets []core.BuildLabel `positional-arg-name:"target" description:"Targets to run"`
 			} `positional-args:"true" required:"true"`
 		} `command:"parallel" description:"Runs a sequence of targets in parallel"`
+		Args struct {
+			Target core.BuildLabel `positional-arg-name:"target" required:"true" description:"Target to run"`
+			Args   []string        `positional-arg-name:"arguments" description:"Arguments to pass to target when running (to pass flags to the target, put -- before them)"`
+		} `positional-args:"true"`
 	} `command:"run" subcommands-optional:"true" description:"Builds and runs a single target"`
 
 	Clean struct {

--- a/src/please.go
+++ b/src/please.go
@@ -129,14 +129,16 @@ var opts struct {
 
 	Run struct {
 		Parallel struct {
-			Args struct {
+			PositionalArgs struct {
 				Targets []core.BuildLabel `positional-arg-name:"target" description:"Targets to run"`
 			} `positional-args:"true" required:"true"`
+			Args []string `short:"a" long:"arg" description:"Arguments to pass to the called processes."`
 		} `command:"parallel" description:"Runs a sequence of targets in parallel"`
 		Sequential struct {
-			Args struct {
+			PositionalArgs struct {
 				Targets []core.BuildLabel `positional-arg-name:"target" description:"Targets to run"`
 			} `positional-args:"true" required:"true"`
+			Args []string `short:"a" long:"arg" description:"Arguments to pass to the called processes."`
 		} `command:"sequential" description:"Runs a sequence of targets sequentially."`
 		Args struct {
 			Target core.BuildLabel `positional-arg-name:"target" required:"true" description:"Target to run"`
@@ -324,14 +326,14 @@ var buildFunctions = map[string]func() bool{
 		return false // We should never return from run.Run so if we make it here something's wrong.
 	},
 	"parallel": func() bool {
-		if success, state := runBuild(opts.Run.Parallel.Args.Targets, true, false); success {
-			run.Parallel(state.Graph, opts.Run.Parallel.Args.Targets)
+		if success, state := runBuild(opts.Run.Parallel.PositionalArgs.Targets, true, false); success {
+			run.Parallel(state.Graph, opts.Run.Parallel.PositionalArgs.Targets, opts.Run.Parallel.Args)
 		}
 		return true // We do return from run.Parallel once it's all over.
 	},
 	"sequential": func() bool {
-		if success, state := runBuild(opts.Run.Sequential.Args.Targets, true, false); success {
-			run.Sequential(state.Graph, opts.Run.Sequential.Args.Targets)
+		if success, state := runBuild(opts.Run.Sequential.PositionalArgs.Targets, true, false); success {
+			run.Sequential(state.Graph, opts.Run.Sequential.PositionalArgs.Targets, opts.Run.Sequential.Args)
 		}
 		return true // We do return from run.Parallel once it's all over.
 	},

--- a/src/please.go
+++ b/src/please.go
@@ -327,13 +327,13 @@ var buildFunctions = map[string]func() bool{
 	},
 	"parallel": func() bool {
 		if success, state := runBuild(opts.Run.Parallel.PositionalArgs.Targets, true, false); success {
-			return run.Parallel(state.Graph, opts.Run.Parallel.PositionalArgs.Targets, opts.Run.Parallel.Args)
+			os.Exit(run.Parallel(state.Graph, opts.Run.Parallel.PositionalArgs.Targets, opts.Run.Parallel.Args))
 		}
 		return false
 	},
 	"sequential": func() bool {
 		if success, state := runBuild(opts.Run.Sequential.PositionalArgs.Targets, true, false); success {
-			return run.Sequential(state.Graph, opts.Run.Sequential.PositionalArgs.Targets, opts.Run.Sequential.Args)
+			os.Exit(run.Sequential(state.Graph, opts.Run.Sequential.PositionalArgs.Targets, opts.Run.Sequential.Args))
 		}
 		return false
 	},

--- a/src/run/BUILD
+++ b/src/run/BUILD
@@ -1,11 +1,12 @@
 go_library(
     name = 'run',
     srcs = glob(['*.go'], excludes = ['*_test.go']),
-    visibility = ['PUBLIC'],
     deps = [
         '//src/build',
         '//src/core',
         '//src/output',
+        '//third_party/go:errgroup',
         '//third_party/go:logging',
     ],
+    visibility = ['PUBLIC'],
 )

--- a/src/run/BUILD
+++ b/src/run/BUILD
@@ -1,6 +1,6 @@
 go_library(
     name = 'run',
-    srcs = glob(['*.go'], excludes = ['*_test.go']),
+    srcs = ['run_step.go'],
     deps = [
         '//src/build',
         '//src/core',
@@ -9,4 +9,14 @@ go_library(
         '//third_party/go:logging',
     ],
     visibility = ['PUBLIC'],
+)
+
+go_test(
+    name = 'run_test',
+    srcs = ['run_test.go'],
+    data = ['test_data'],
+    deps = [
+        ':run',
+        '//third_party/go:testify',
+    ],
 )

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"syscall"
 
 	"gopkg.in/op/go-logging.v1"
@@ -20,6 +21,28 @@ var log = logging.MustGetLogger("run")
 
 // Run implements the running part of 'plz run'.
 func Run(graph *core.BuildGraph, label core.BuildLabel, args []string) {
+	run(graph, label, args, false)
+}
+
+// Parallel runs a series of targets in parallel.
+// Currently it's not possible to provide arguments to them.
+func Parallel(graph *core.BuildGraph, labels []core.BuildLabel) {
+	var wg sync.WaitGroup
+	wg.Add(len(labels))
+	for _, label := range labels {
+		go func(label core.BuildLabel) {
+			run(graph, label, nil, true).Wait()
+			wg.Done()
+		}(label)
+	}
+	wg.Wait()
+}
+
+// run implements the internal logic about running a target.
+// If fork is true then we fork to run the target and return the started subprocess.
+// If it's false this function never returns (because we either win or die; it's like
+// Game of Thrones except rather less glamorous).
+func run(graph *core.BuildGraph, label core.BuildLabel, args []string, fork bool) *exec.Cmd {
 	target := graph.TargetOrDie(label)
 	if !target.IsBinary {
 		log.Fatalf("Target %s cannot be run; it's not marked as binary", label)
@@ -40,7 +63,18 @@ func Run(graph *core.BuildGraph, label core.BuildLabel, args []string) {
 	args = append(splitCmd, args...)
 	log.Info("Running target %s...", strings.Join(args, " "))
 	output.SetWindowTitle("plz run: " + strings.Join(args, " "))
+	if fork {
+		cmd := exec.Command(splitCmd[0], args[1:]...) // args here don't include argv[0]
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		// Note that we don't connect stdin. It doesn't make sense for multiple processes.
+		if err := cmd.Start(); err != nil {
+			log.Fatalf("Error running command %s: %s", strings.Join(args, " "), err)
+		}
+		return cmd
+	}
 	if err := syscall.Exec(splitCmd[0], args, os.Environ()); err != nil {
 		log.Fatalf("Error running command %s: %s", strings.Join(args, " "), err)
 	}
+	return nil // never happens
 }

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -38,6 +38,14 @@ func Parallel(graph *core.BuildGraph, labels []core.BuildLabel) {
 	wg.Wait()
 }
 
+// Sequential runs a series of targets sequentially.
+func Sequential(graph *core.BuildGraph, labels []core.BuildLabel) {
+	for _, label := range labels {
+		log.Notice("Running %s", label)
+		run(graph, label, nil, true).Wait()
+	}
+}
+
 // run implements the internal logic about running a target.
 // If fork is true then we fork to run the target and return the started subprocess.
 // If it's false this function never returns (because we either win or die; it's like

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -1,0 +1,45 @@
+package run
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"core"
+)
+
+func init() {
+	if err := os.Chdir("src/run/test_data"); err != nil {
+		panic(err)
+	}
+}
+
+func TestSequential(t *testing.T) {
+	graph, labels1, labels2 := makeGraph()
+	code := Sequential(graph, labels1, nil)
+	assert.Equal(t, 0, code)
+	code = Sequential(graph, labels2, nil)
+	assert.Equal(t, 1, code)
+}
+
+func TestParallel(t *testing.T) {
+	graph, labels1, labels2 := makeGraph()
+	code := Parallel(graph, labels1, nil)
+	assert.Equal(t, 0, code)
+	code = Parallel(graph, labels2, nil)
+	assert.Equal(t, 1, code)
+}
+
+func makeGraph() (*core.BuildGraph, []core.BuildLabel, []core.BuildLabel) {
+	state := core.NewBuildState(1, nil, 0, core.DefaultConfiguration())
+	target1 := core.NewBuildTarget(core.ParseBuildLabel("//:true", ""))
+	target1.IsBinary = true
+	target1.AddOutput("true")
+	state.Graph.AddTarget(target1)
+	target2 := core.NewBuildTarget(core.ParseBuildLabel("//:false", ""))
+	target2.IsBinary = true
+	target2.AddOutput("false")
+	state.Graph.AddTarget(target2)
+	return state.Graph, []core.BuildLabel{target1.Label}, []core.BuildLabel{target1.Label, target2.Label}
+}

--- a/src/run/test_data/plz-out/bin/false
+++ b/src/run/test_data/plz-out/bin/false
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 1

--- a/src/run/test_data/plz-out/bin/true
+++ b/src/run/test_data/plz-out/bin/true
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -35,7 +35,8 @@ go_get(
 go_get(
     name = 'go-flags',
     get = 'github.com/jessevdk/go-flags',
-    revision = '0a28dbe50f23d8fce6b016975b964cfe7b97a20a',
+    patch = 'flags_subcommand.patch',
+    revision = '5695738f733662da3e9afc2283bba6f3c879002d',
 )
 
 go_get(

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -185,3 +185,10 @@ go_get(
     get = 'github.com/djherbis/atime',
     revision = '89517e96e10b93292169a79fd4523807bdc5d5fa',
 )
+
+go_get(
+    name = 'errgroup',
+    get = 'golang.org/x/sync/errgroup',
+    revision = '457c5828408160d6a47e17645169cf8fa20218c4',
+    deps = [':context'],
+)

--- a/third_party/go/flags_subcommand.patch
+++ b/third_party/go/flags_subcommand.patch
@@ -1,0 +1,26 @@
+diff --git a/parser.go b/parser.go
+index fd2fd5f..3af2af9 100644
+--- a/parser.go
++++ b/parser.go
+@@ -633,10 +633,6 @@ func (p *parseState) addArgs(args ...string) error {
+ }
+ 
+ func (p *Parser) parseNonOption(s *parseState) error {
+-	if len(s.positional) > 0 {
+-		return s.addArgs(s.arg)
+-	}
+-
+ 	if len(s.command.commands) > 0 && len(s.retargs) == 0 {
+ 		if cmd := s.lookup.commands[s.arg]; cmd != nil {
+ 			s.command.Active = cmd
+@@ -649,6 +645,10 @@ func (p *Parser) parseNonOption(s *parseState) error {
+ 		}
+ 	}
+ 
++	if len(s.positional) > 0 {
++		return s.addArgs(s.arg)
++	}
++
+ 	if (p.Options & PassAfterNonOption) != None {
+ 		// If PassAfterNonOption is set then all remaining arguments
+ 		// are considered positional


### PR DESCRIPTION
Either sequentially or in parallel.

Required a little hacking of the flags library; it's a bit nonobvious how it should handle optional subcommands versus positional arguments. Would send them a PR but the fix for this breaks some other tests in their repo (not things we care about though).