### PR TITLE
Hash rewriting fix

### DIFF
--- a/src/hashes/hash_rewriter.py
+++ b/src/hashes/hash_rewriter.py
@@ -19,6 +19,12 @@ def is_a_target(node):
                     return keyword.value.s
 
 
+def replace_hash(line, before, after):
+    """Rewrites a hash within one particular line. Returns updated line."""
+    quote = lambda s, q: q + s + q
+    return line.replace(quote(before, '"'), quote(after, '"')).replace(quote(before, "'"), quote(after, "'"))
+
+
 with _open(FILENAME) as f:
     lines = f.readlines()
     tree = ast.parse(''.join(lines), filename=FILENAME)
@@ -40,12 +46,12 @@ for node in ast.iter_child_nodes(tree):
                 # Should really do something here about multiple hashes and working out which
                 # is which...
                 current, lineno = candidates.popitem()
-                lines[lineno] = lines[lineno].replace(current, prefix + TARGETS[name])
+                lines[lineno] = replace_hash(lines[lineno], current, prefix + TARGETS[name])
             elif keyword.arg == 'hash' and isinstance(keyword.value, ast.Str):
                 lineno = keyword.value.lineno - 1
                 current = keyword.value.s
                 prefix = current[:current.find(':') + 2] if ': ' in current else ''
-                lines[lineno] = lines[lineno].replace(current, prefix + TARGETS[name])
+                lines[lineno] = replace_hash(lines[lineno], current, prefix + TARGETS[name])
 
 with _open(FILENAME, 'w') as f:
     for line in lines:

--- a/src/hashes/hash_rewriter_test.go
+++ b/src/hashes/hash_rewriter_test.go
@@ -35,7 +35,7 @@ func TestRewriteHashes(t *testing.T) {
 		"test1": "b9643f8154a9e9912d730a931d329afc82a44a52",
 		"test2": "bd79dd61c1494072271f3d13350ccbc26c25a09e",
 		"test3": "94ead0b0422cad925910e5f8b6f9bd93b309f8f0",
-		"test4": "94ead0b0422cad925910e5f8b6f9bd93b309f8f0",
+		"test4": "ab2649b7e58f7e32b0c75be95d11e2979399d392",
 	}))
 	rewritten, err := ioutil.ReadFile("test.build")
 	assert.NoError(t, err)

--- a/src/hashes/hash_rewriter_test.go
+++ b/src/hashes/hash_rewriter_test.go
@@ -35,6 +35,7 @@ func TestRewriteHashes(t *testing.T) {
 		"test1": "b9643f8154a9e9912d730a931d329afc82a44a52",
 		"test2": "bd79dd61c1494072271f3d13350ccbc26c25a09e",
 		"test3": "94ead0b0422cad925910e5f8b6f9bd93b309f8f0",
+		"test4": "94ead0b0422cad925910e5f8b6f9bd93b309f8f0",
 	}))
 	rewritten, err := ioutil.ReadFile("test.build")
 	assert.NoError(t, err)

--- a/src/hashes/test_data/after.build
+++ b/src/hashes/test_data/after.build
@@ -19,3 +19,9 @@ maven_jar(
         'test_armhf: 1ff337975be0ae566b7e961932d82f5fe78b1cdc',
     ],
 )
+
+maven_jar(
+    name = 'test4',
+    id = 'net.thoughtmachine.please:test4:1.0',
+    hash = 'ab2649b7e58f7e32b0c75be95d11e2979399d392',
+)

--- a/src/hashes/test_data/before.build
+++ b/src/hashes/test_data/before.build
@@ -19,3 +19,9 @@ maven_jar(
         'test_armhf: 1ff337975be0ae566b7e961932d82f5fe78b1cdc',
     ],
 )
+
+maven_jar(
+    name = 'test4',
+    id = 'net.thoughtmachine.please:test4:1.0',
+    hash = '',
+)


### PR DESCRIPTION
Basically just be a bit more careful about replacing them; when we do the replacement, do it with quotes around it so we don't try to replace the empty string with something else.