### PR TITLE
Implement cleaning entire remote cache on plz clean

### DIFF
--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -279,6 +279,7 @@ func (*mockCache) RetrieveExtra(target *core.BuildTarget, key []byte, file strin
 }
 
 func (*mockCache) Clean(target *core.BuildTarget) {}
+func (*mockCache) CleanAll()                      {}
 func (*mockCache) Shutdown()                      {}
 
 type buildFunctionMap map[*core.BuildTarget]func(*core.BuildTarget, string) error

--- a/src/cache/async_cache.go
+++ b/src/cache/async_cache.go
@@ -65,6 +65,10 @@ func (c *asyncCache) Clean(target *core.BuildTarget) {
 	c.realCache.Clean(target)
 }
 
+func (c *asyncCache) CleanAll() {
+	c.realCache.CleanAll()
+}
+
 func (c *asyncCache) Shutdown() {
 	log.Info("Shutting down cache workers...")
 	close(c.requests)

--- a/src/cache/async_cache_test.go
+++ b/src/cache/async_cache_test.go
@@ -128,6 +128,8 @@ func (c *mockCache) Clean(target *core.BuildTarget) {
 	c.Retrieve(target, nil)
 }
 
+func (c *mockCache) CleanAll() {}
+
 func (*mockCache) Shutdown() {}
 
 func makeTarget(label string) *core.BuildTarget {

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -21,12 +21,6 @@ func NewCache(config *core.Configuration) core.Cache {
 	return c
 }
 
-// NewRemoteCache is a factory function for creating a cache setup for remote caches only.
-// It is never asynchronous.
-func NewRemoteCache(config *core.Configuration) core.Cache {
-	return newSyncCache(config, true)
-}
-
 // newSyncCache creates a new cache, possibly multiplexing many underneath.
 func newSyncCache(config *core.Configuration, remoteOnly bool) core.Cache {
 	mplex := &cacheMultiplexer{}

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -14,16 +14,23 @@ var log = logging.MustGetLogger("cache")
 
 // NewCache is the factory function for creating a cache setup from the given config.
 func NewCache(config *core.Configuration) core.Cache {
-	c := newSyncCache(config)
+	c := newSyncCache(config, false)
 	if config.Cache.Workers > 0 {
 		return newAsyncCache(c, config)
 	}
 	return c
 }
 
-func newSyncCache(config *core.Configuration) core.Cache {
+// NewRemoteCache is a factory function for creating a cache setup for remote caches only.
+// It is never asynchronous.
+func NewRemoteCache(config *core.Configuration) core.Cache {
+	return newSyncCache(config, true)
+}
+
+// newSyncCache creates a new cache, possibly multiplexing many underneath.
+func newSyncCache(config *core.Configuration, remoteOnly bool) core.Cache {
 	mplex := &cacheMultiplexer{}
-	if config.Cache.Dir != "" {
+	if config.Cache.Dir != "" && !remoteOnly {
 		mplex.caches = append(mplex.caches, newDirCache(config))
 	}
 	if config.Cache.RpcUrl != "" {
@@ -131,6 +138,12 @@ func (mplex cacheMultiplexer) RetrieveExtra(target *core.BuildTarget, key []byte
 func (mplex cacheMultiplexer) Clean(target *core.BuildTarget) {
 	for _, cache := range mplex.caches {
 		cache.Clean(target)
+	}
+}
+
+func (mplex cacheMultiplexer) CleanAll() {
+	for _, cache := range mplex.caches {
+		cache.CleanAll()
 	}
 }
 

--- a/src/cache/dir_cache.go
+++ b/src/cache/dir_cache.go
@@ -113,8 +113,8 @@ func (cache *dirCache) Clean(target *core.BuildTarget) {
 }
 
 func (cache *dirCache) CleanAll() {
-	if err := os.RemoveAll(cache.Dir); err != nil {
-		log.Warning("Failed to clean cache: %s", err)
+	if err := core.AsyncDeleteDir(cache.Dir); err != nil {
+		log.Error("Failed to clean cache: %s", err)
 	}
 }
 

--- a/src/cache/dir_cache.go
+++ b/src/cache/dir_cache.go
@@ -112,6 +112,12 @@ func (cache *dirCache) Clean(target *core.BuildTarget) {
 	}
 }
 
+func (cache *dirCache) CleanAll() {
+	if err := os.RemoveAll(cache.Dir); err != nil {
+		log.Warning("Failed to clean cache: %s", err)
+	}
+}
+
 func (cache *dirCache) Shutdown() {}
 
 func (cache *dirCache) getPath(target *core.BuildTarget, key []byte) string {

--- a/src/cache/http_cache.go
+++ b/src/cache/http_cache.go
@@ -164,6 +164,13 @@ func (cache *httpCache) Clean(target *core.BuildTarget) {
 	response.Body.Close()
 }
 
+func (cache *httpCache) CleanAll() {
+	req, _ := http.NewRequest("DELETE", cache.Url, nil)
+	if _, err := http.DefaultClient.Do(req); err != nil {
+		log.Warning("Failed to remove artifacts from http cache: %s", err)
+	}
+}
+
 func (cache *httpCache) Shutdown() {}
 
 func newHttpCache(config *core.Configuration) *httpCache {

--- a/src/cache/rpc_cache.go
+++ b/src/cache/rpc_cache.go
@@ -233,7 +233,11 @@ func (cache *rpcCache) Clean(target *core.BuildTarget) {
 }
 
 func (cache *rpcCache) CleanAll() {
-	if cache.isConnected() && cache.Writeable {
+	if !cache.isConnected() {
+		log.Error("RPC cache is not connected, cannot clean")
+	} else if !cache.Writeable {
+		log.Error("RPC cache is not writable, will not clean")
+	} else {
 		req := pb.DeleteRequest{Everything: true}
 		cache.runRpc(zeroKey, func(cache *rpcCache) (bool, []*pb.Artifact) {
 			if response, err := cache.client.Delete(context.Background(), &req); err != nil || !response.Success {

--- a/src/cache/rpc_cache.go
+++ b/src/cache/rpc_cache.go
@@ -238,6 +238,7 @@ func (cache *rpcCache) CleanAll() {
 	} else if !cache.Writeable {
 		log.Error("RPC cache is not writable, will not clean")
 	} else {
+		log.Debug("Cleaning entire RPC cache")
 		req := pb.DeleteRequest{Everything: true}
 		cache.runRpc(zeroKey, func(cache *rpcCache) (bool, []*pb.Artifact) {
 			if response, err := cache.client.Delete(context.Background(), &req); err != nil || !response.Success {

--- a/src/cache/rpc_cache.go
+++ b/src/cache/rpc_cache.go
@@ -231,6 +231,20 @@ func (cache *rpcCache) Clean(target *core.BuildTarget) {
 		})
 	}
 }
+
+func (cache *rpcCache) CleanAll() {
+	if cache.isConnected() && cache.Writeable {
+		req := pb.DeleteRequest{Everything: true}
+		cache.runRpc(zeroKey, func(cache *rpcCache) (bool, []*pb.Artifact) {
+			if response, err := cache.client.Delete(context.Background(), &req); err != nil || !response.Success {
+				log.Errorf("Failed to clean RPC cache: %s", err)
+				return false, nil
+			}
+			return true, nil
+		})
+	}
+}
+
 func (cache *rpcCache) Shutdown() {}
 
 func (cache *rpcCache) connect(url string, config *core.Configuration, isSubnode bool) {

--- a/src/cache/server/cache.go
+++ b/src/cache/server/cache.go
@@ -272,6 +272,7 @@ func (cache *Cache) DeleteArtifact(artPath string) error {
 // The function will return the first error found in the process, or nil if the process is successful.
 func (cache *Cache) DeleteAllArtifacts() error {
 	// Empty entire cache now.
+	log.Warning("Deleting entire cache")
 	cache.cachedFiles = cmap.New()
 	cache.totalSize = 0
 	return core.AsyncDeleteDir(cache.rootPath)

--- a/src/cache/server/cache.go
+++ b/src/cache/server/cache.go
@@ -274,12 +274,7 @@ func (cache *Cache) DeleteAllArtifacts() error {
 	// Empty entire cache now.
 	cache.cachedFiles = cmap.New()
 	cache.totalSize = 0
-	// Move directory somewhere else
-	tempPath := cache.rootPath + "_deleting"
-	if err := os.Rename(cache.rootPath, tempPath); err != nil {
-		return err
-	}
-	return os.RemoveAll(tempPath)
+	return core.AsyncDeleteDir(cache.rootPath)
 }
 
 // clean implements a periodic clean of the cache to remove old artifacts.

--- a/src/clean/clean.go
+++ b/src/clean/clean.go
@@ -3,13 +3,7 @@
 package clean
 
 import (
-	"encoding/hex"
-	"fmt"
-	"math/rand"
 	"os"
-	"os/exec"
-	"path"
-	"syscall"
 
 	"gopkg.in/op/go-logging.v1"
 
@@ -21,14 +15,14 @@ import (
 var log = logging.MustGetLogger("clean")
 
 // Clean cleans the entire output directory and optionally the cache as well.
-func Clean(config *core.Configuration, cleanCache, background bool) {
+func Clean(config *core.Configuration, cache core.Cache, background bool) {
+	if cache != nil {
+		cache.CleanAll()
+	}
 	if background {
-		if err := maybeFork(core.OutDir, config.Cache.Dir, cleanCache); err != nil {
+		if err := core.AsyncDeleteDir(core.OutDir); err != nil {
 			log.Warning("Couldn't run clean in background; will do it synchronously: %s", err)
 		}
-	}
-	if cleanCache {
-		clean(config.Cache.Dir)
 	}
 	clean(core.OutDir)
 }
@@ -69,48 +63,4 @@ func clean(path string) {
 			log.Fatalf("Failed to clean path %s: %s", path, err)
 		}
 	}
-}
-
-// maybeFork will fork & detach if background is true. First it will rename the out and
-// cache dirs so it's safe to run another plz in this repo, then fork & detach child
-// processes to do the actual cleaning.
-// The parent will then die quietly and the children will continue to actually remove the
-// directories.
-func maybeFork(outDir, cacheDir string, cleanCache bool) error {
-	rm, err := exec.LookPath("rm")
-	if err != nil {
-		return err
-	}
-	if !core.PathExists(outDir) || !core.PathExists(cacheDir) {
-		return nil
-	}
-	newOutDir, err := moveDir(outDir)
-	if err != nil {
-		return err
-	}
-	args := []string{rm, "-rf", newOutDir}
-	if cleanCache {
-		newCacheDir, err := moveDir(cacheDir)
-		if err != nil {
-			return err
-		}
-		args = append(args, newCacheDir)
-	}
-	// Note that we can't fork() directly and continue running Go code, but ForkExec() works okay.
-	_, err = syscall.ForkExec(rm, args, nil)
-	if err == nil {
-		// Success if we get here.
-		fmt.Println("Cleaning in background; you may continue to do pleasing things in this repo in the meantime.")
-		os.Exit(0)
-	}
-	return err
-}
-
-// moveDir moves a directory to a new location and returns that new location.
-func moveDir(dir string) (string, error) {
-	b := make([]byte, 16)
-	rand.Read(b)
-	name := path.Join(path.Dir(dir), ".plz_clean_"+hex.EncodeToString(b))
-	log.Notice("Moving %s to %s", dir, name)
-	return name, os.Rename(dir, name)
 }

--- a/src/clean/clean.go
+++ b/src/clean/clean.go
@@ -3,6 +3,7 @@
 package clean
 
 import (
+	"fmt"
 	"os"
 
 	"gopkg.in/op/go-logging.v1"
@@ -22,6 +23,9 @@ func Clean(config *core.Configuration, cache core.Cache, background bool) {
 	if background {
 		if err := core.AsyncDeleteDir(core.OutDir); err != nil {
 			log.Warning("Couldn't run clean in background; will do it synchronously: %s", err)
+		} else {
+			fmt.Println("Cleaning in background; you may continue to do pleasing things in this repo in the meantime.")
+			return
 		}
 	}
 	clean(core.OutDir)

--- a/src/core/cache.go
+++ b/src/core/cache.go
@@ -18,6 +18,8 @@ type Cache interface {
 	RetrieveExtra(target *BuildTarget, key []byte, file string) bool
 	// Cleans any artifacts associated with this target from the cache, for any possible key.
 	Clean(target *BuildTarget)
+	// Cleans the entire cache.
+	CleanAll()
 	// Shuts down the cache, blocking until any potentially pending requests are done.
 	Shutdown()
 }

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path"
@@ -578,4 +580,36 @@ func LookPath(filename string, paths []string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("%s not found in PATH %s", filename, strings.Join(paths, ":"))
+}
+
+// AsyncDeleteDir deletes a directory asynchronously.
+// First it renames the directory to something temporary and then forks to delete it.
+// The rename is done synchronously but the actual deletion is async (after fork) so
+// you don't have to wait for large directories to be removed.
+// Conversely there is obviously no guarantee about at what point it will actually cease to
+// be on disk any more.
+func AsyncDeleteDir(dir string) error {
+	rm, err := exec.LookPath("rm")
+	if err != nil {
+		return err
+	} else if !PathExists(dir) {
+		return nil // not an error, just don't need to do anything.
+	}
+	newDir, err := moveDir(dir)
+	if err != nil {
+		return err
+	}
+	// Note that we can't fork() directly and continue running Go code, but ForkExec() works okay.
+	// Hence why we're using rm rather than fork() + os.RemoveAll.
+	_, err = syscall.ForkExec(rm, []string{rm, "-rf", newDir}, nil)
+	return err
+}
+
+// moveDir moves a directory to a new location and returns that new location.
+func moveDir(dir string) (string, error) {
+	b := make([]byte, 16)
+	rand.Read(b)
+	name := path.Join(path.Dir(dir), ".plz_clean_"+hex.EncodeToString(b))
+	log.Notice("Moving %s to %s", dir, name)
+	return name, os.Rename(dir, name)
 }

--- a/src/core/utils_test.go
+++ b/src/core/utils_test.go
@@ -188,6 +188,20 @@ func TestExecWithTimeoutStderr(t *testing.T) {
 	assert.Equal(t, "hello\n", string(stderr))
 }
 
+func TestAsyncDeleteDir(t *testing.T) {
+	err := os.MkdirAll("test_dir/a/b/c", DirPermissions)
+	assert.NoError(t, err)
+	err = AsyncDeleteDir("test_dir")
+	assert.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		if !PathExists("test_dir") {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	assert.False(t, PathExists("test_dir"))
+}
+
 // buildGraph builds a test graph which we use to test IterSources etc.
 func buildGraph() *BuildGraph {
 	graph := NewGraph()

--- a/src/please.go
+++ b/src/please.go
@@ -150,6 +150,7 @@ var opts struct {
 
 	Clean struct {
 		NoBackground bool     `long:"nobackground" short:"f" description:"Don't fork & detach until clean is finished."`
+		Remote       bool     `long:"remote" description:"Clean entire remote cache when no targets are given (default is local only)"`
 		Args         struct { // Inner nesting is necessary to make positional-args work :(
 			Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to clean (default is to clean everything)"`
 		} `positional-args:"true"`
@@ -345,6 +346,9 @@ var buildFunctions = map[string]func() bool{
 		if len(opts.Clean.Args.Targets) == 0 {
 			if len(opts.BuildFlags.Include) == 0 && len(opts.BuildFlags.Exclude) == 0 {
 				// Clean everything, doesn't require parsing at all.
+				if !opts.FeatureFlags.NoCache && opts.Clean.Remote {
+					cache.NewRemoteCache(config).CleanAll()
+				}
 				clean.Clean(config, !opts.FeatureFlags.NoCache, !opts.Clean.NoBackground)
 				return true
 			}

--- a/src/please.go
+++ b/src/please.go
@@ -750,7 +750,10 @@ func main() {
 	}
 	// Reset this now we're at the repo root.
 	if opts.OutputFlags.LogFile != "" {
-		cli.InitFileLogging(path.Join(core.RepoRoot, opts.OutputFlags.LogFile), opts.OutputFlags.LogFileLevel)
+		if !path.IsAbs(opts.OutputFlags.LogFile) {
+			opts.OutputFlags.LogFile = path.Join(core.RepoRoot, opts.OutputFlags.LogFile)
+		}
+		cli.InitFileLogging(opts.OutputFlags.LogFile, opts.OutputFlags.LogFileLevel)
 	}
 
 	config = readConfig(command == "update")


### PR DESCRIPTION
It's gated by a `--remote` flag since it seems a little expensive to be doing by default.

Refactored things a bit so the logic in `clean` is limited to cleaning outputs, and cache cleaning is all done by the implementations in `cache`.
Fortunately the server side actually had this logic already, we just weren't calling it...

Should make the remote cache a little easier to administer.