### PR TITLE
Fix builds for Python3.6 on MacOS

### DIFF
--- a/src/parse/cffi/cffi_compiler.py
+++ b/src/parse/cffi/cffi_compiler.py
@@ -13,6 +13,12 @@ def main(defs_file, parser_file, verbose):
     # Support downloading portable PyPy on Linux.
     if platform.python_implementation() == 'PyPy' and platform.system() == 'Linux':
         ldflags = ['-Wl,-rpath=./plz-out/gen/_remote/_pypy/bin']
+    if platform.python_implementation() == 'CPython' and platform.system() == 'Darwin':
+        version = platform.python_version_tuple()
+        ldflags = [
+            '-L/usr/local/Cellar/python3/{}/Frameworks/Python.framework/Versions/{}/lib'
+            .format('{}.{}.{}'.format(*version), '{}.{}'.format(*version))
+        ]
     ffi.set_source('parser_interface', '#include "%s"' % defs_file,
                    extra_link_args=ldflags)
     with open(parser_file) as f:

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -39,7 +39,7 @@ maven_jar(
 
 maven_jar(
     name = 'protobuf',
-    id = 'com.google.protobuf:protobuf-java:3.0.0',
+    id = 'com.google.protobuf:protobuf-java:3.3.1',
     hash = '88d92d14d257f10971fbb734ffcdd290817045c0',
     sources = False,
 )

--- a/tools/misc/ci_lint.py
+++ b/tools/misc/ci_lint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """Implements a bunch of linters on the repo's source.
 
 Some specific things are run as plz tests (e.g. lint_builtin_rules_test)


### PR DESCRIPTION
  * Add python3.6 library to cffi flags
  * Update java-protobuf version to match protoc
  * Make shebang portable