### PR TITLE
python rules: switch test runner from unittest to pytest

### DIFF
--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -13,10 +13,10 @@ REPOS = [
 ]
 
 python_wheel(
-    name = 'xmlrunner',
-    package_name = 'unittest_xml_reporting',
-    version = '1.11.0',
-    hashes = ['sha1: 62e71134eb068413e40fe4d973451c0e4931db5a'],
+    name = 'pytest',
+    package_name = 'pytest',
+    version = '3.3.0',
+    hashes = ['md5: 334ee86af89c9811462b1b39bc2bfbca'],
     deps = [':six'],
 )
 

--- a/tools/please_pex/BUILD
+++ b/tools/please_pex/BUILD
@@ -24,8 +24,8 @@ genrule(
     name = 'please_pex',
     srcs = [
         ':pex_main',
+        '//third_party/python:pytest',
         '//third_party/python:six',
-        '//third_party/python:xmlrunner',
         '//third_party/python:coverage',
     ],
     outs = ['please_pex'],

--- a/tools/please_pex/test_main.py
+++ b/tools/please_pex/test_main.py
@@ -1,7 +1,7 @@
 """Customised test runner to output in JUnit-style XML."""
 
 import os
-import unittest
+import pytest
 import sys
 try:
     from builtins import __import__  # python3
@@ -10,23 +10,6 @@ except ImportError:
 
 # This will get templated in by the build rules.
 TEST_NAMES = '__TEST_NAMES__'.split(',')
-
-
-def list_classes(suite):
-    for test in suite:
-        if isinstance(test, unittest.suite.TestSuite):
-            for cls, name in list_classes(test):
-                yield cls, name
-        else:
-            yield test, test.__class__.__module__ + '.' + test.id()
-
-
-def filter_suite(suite, test_names):
-    """Reduces a test suite to just the tests matching the given names."""
-    new_suite = unittest.suite.TestSuite()
-    for name in test_names:
-        new_suite.addTests(cls for cls, class_name in list_classes(suite) if name in class_name)
-    return new_suite
 
 
 def initialise_coverage():
@@ -80,22 +63,12 @@ class TracerImport(object):
 
 
 def run_tests(test_names):
-    """Runs tests, returns the number of failures."""
-    import xmlrunner
-    # unittest's discovery produces very misleading errors in some cases; if it tries to import
-    # a module which imports other things that then fail, it reports 'module object has no
-    # attribute <test name>' and swallows the original exception. Try to import them all first
-    # so we get better error messages.
-    for test_name in TEST_NAMES:
-        __import__(test_name)
-    suite = unittest.defaultTestLoader.loadTestsFromNames(TEST_NAMES)
+    """Runs tests and returns exit code of pytest"""
+    ts = TEST_NAMES
     if test_names:
-        suite = filter_suite(suite, test_names)
-        if suite.countTestCases() == 0:
-            raise Exception('No matching tests found')
-    runner = xmlrunner.XMLTestRunner(output='test.results', outsuffix='')
-    results = runner.run(suite)
-    return len(results.errors) + len(results.failures)
+        ts = test_names
+    exitcode = pytest.main(['--junitxml', 'test.results'] + ts)
+    return exitcode
 
 
 def main():


### PR DESCRIPTION
This is WIP. I'm having trouble even going past declaring pytest a python wheel dependency. So none of this works. I'm sending this to get comments and help. Obviously I would prefer if you guys take over and just support pytest :-).

But this is sort of what I was thinking for switching test runner to pytest. pytest can run unittest TestCases natively and it can output junit-like xml reports.
