### PR TITLE
Interactive pytest debugging

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -160,6 +160,12 @@
 	  parse the results file to determine ultimate success / failure.</li>
 	<li><code>--test_results_file</code><br/>
 	  Specifies the location to write the combined test results to.</li>
+	<li><code>-d, --debug</code><br/>
+	  Turns on interactive debug mode for this test. You can only specify one test
+	  with this flag, because it attaches an interactive debugger to catch failures.<br/>
+	  It only works for some test types, currently python (with pytest as the test runner),
+	  C and C++.<br/>
+	  It implies <code>-c dbg</code> unless that flag is explicitly passed.</li>
       </ul>
     </p>
 
@@ -187,6 +193,12 @@
 	<li><code>--coverage_results_file</code><br/>
 	  Similar to <code>--test_results_file</code>, determines where to write
 	  the aggregated coverage results to.</li>
+	<li><code>-d, --debug</code><br/>
+	  Turns on interactive debug mode for this test. You can only specify one test
+	  with this flag, because it attaches an interactive debugger to catch failures.<br/>
+	  It only works for some test types, currently python (with pytest as the test runner),
+	  C and C++.<br/>
+	  It implies <code>-c dbg</code> unless that flag is explicitly passed.</li>
       </ul>
     </p>
 

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -144,6 +144,9 @@ func BuildEnvironment(state *BuildState, target *BuildTarget, test bool) BuildEn
 		if target.HasLabel("cc") {
 			env = append(env, "GCNO_DIR="+path.Join(RepoRoot, GenDir, target.Label.PackageName))
 		}
+		if state.DebugTests {
+			env = append(env, "DEBUG=true")
+		}
 	}
 	return env
 }

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -353,7 +353,7 @@ func (label BuildLabel) Complete(match string) []flags.Completion {
 	os.Setenv("PLZ_COMPLETE", match)
 	os.Unsetenv("GO_FLAGS_COMPLETION")
 	exec, _ := os.Executable()
-	out, _, err := ExecWithTimeout(nil, "", os.Environ(), 0, 0, false, append([]string{exec}, os.Args[1:]...))
+	out, _, err := ExecWithTimeout(nil, "", os.Environ(), 0, 0, false, false, append([]string{exec}, os.Args[1:]...))
 	if err != nil {
 		return nil
 	}

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -125,6 +125,8 @@ type BuildState struct {
 	ShowTestOutput bool
 	// True to print all output of all tasks to stderr.
 	ShowAllOutput bool
+	// True to attach a debugger on test failure.
+	DebugTests bool
 	// Number of running workers
 	numWorkers int
 	// Experimental directories

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -292,6 +292,8 @@ func ExecWithTimeout(target *BuildTarget, dir string, env []string, timeout time
 	}
 	if attachStdin {
 		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
 	}
 	if target != nil {
 		go logProgress(ctx, target.Label)

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -267,7 +267,7 @@ func logProgress(ctx context.Context, label BuildLabel) {
 // If the command times out the returned error will be a context.DeadlineExceeded error.
 // If showOutput is true then output will be printed to stderr as well as returned.
 // It returns the stdout only, combined stdout and stderr and any error that occurred.
-func ExecWithTimeout(target *BuildTarget, dir string, env []string, timeout time.Duration, defaultTimeout cli.Duration, showOutput bool, argv []string) ([]byte, []byte, error) {
+func ExecWithTimeout(target *BuildTarget, dir string, env []string, timeout time.Duration, defaultTimeout cli.Duration, showOutput, attachStdin bool, argv []string) ([]byte, []byte, error) {
 	if timeout == 0 {
 		if defaultTimeout == 0 {
 			timeout = 10 * time.Minute
@@ -289,6 +289,9 @@ func ExecWithTimeout(target *BuildTarget, dir string, env []string, timeout time
 	} else {
 		cmd.Stdout = io.MultiWriter(&out, &outerr)
 		cmd.Stderr = &outerr
+	}
+	if attachStdin {
+		cmd.Stdin = os.Stdin
 	}
 	if target != nil {
 		go logProgress(ctx, target.Label)
@@ -327,6 +330,11 @@ func runCommand(cmd *exec.Cmd, ch chan error) {
 // Other arguments are as ExecWithTimeout.
 // Note that the command is deliberately a single string.
 func ExecWithTimeoutShell(target *BuildTarget, dir string, env []string, timeout time.Duration, defaultTimeout cli.Duration, showOutput bool, cmd string, sandbox bool) ([]byte, []byte, error) {
+	return ExecWithTimeoutShellStdin(target, dir, env, timeout, defaultTimeout, showOutput, cmd, sandbox, false)
+}
+
+// ExecWithTimeoutShellStdin is as ExecWithTimeoutShell but optionally attaches stdin to the subprocess.
+func ExecWithTimeoutShellStdin(target *BuildTarget, dir string, env []string, timeout time.Duration, defaultTimeout cli.Duration, showOutput bool, cmd string, sandbox, attachStdin bool) ([]byte, []byte, error) {
 	c := append([]string{"bash", "-u", "-o", "pipefail", "-c"}, cmd)
 	// Runtime check is a little ugly, but we know this only works on Linux right now.
 	if sandbox && runtime.GOOS == "linux" {
@@ -336,13 +344,13 @@ func ExecWithTimeoutShell(target *BuildTarget, dir string, env []string, timeout
 		}
 		c = append([]string{tool}, c...)
 	}
-	return ExecWithTimeout(target, dir, env, timeout, defaultTimeout, showOutput, c)
+	return ExecWithTimeout(target, dir, env, timeout, defaultTimeout, showOutput, attachStdin, c)
 }
 
 // ExecWithTimeoutSimple runs an external command with a timeout.
 // It's a simpler version of ExecWithTimeout that gives less control.
 func ExecWithTimeoutSimple(timeout cli.Duration, cmd ...string) ([]byte, error) {
-	_, out, err := ExecWithTimeout(nil, "", nil, time.Duration(timeout), timeout, false, cmd)
+	_, out, err := ExecWithTimeout(nil, "", nil, time.Duration(timeout), timeout, false, false, cmd)
 	return out, err
 }
 

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -819,25 +819,25 @@ def _binary_transitive_labels(c, linker_flags, pkg_config_libs, shared=False):
 
 # C rules. These call straight through to the c++ versions and just set a flag.
 def c_library(**kwargs):
-    cc_library(_c=True, **kwargs)
+    return cc_library(_c=True, **kwargs)
 
 def c_object(**kwargs):
-    cc_object(_c=True, **kwargs)
+    return cc_object(_c=True, **kwargs)
 
 def c_static_library(**kwargs):
-    cc_static_library(_c=True, **kwargs)
+    return cc_static_library(_c=True, **kwargs)
 
 def c_shared_object(**kwargs):
-    cc_shared_object(_c=True, **kwargs)
+    return cc_shared_object(_c=True, **kwargs)
 
 def c_binary(**kwargs):
-    cc_binary(_c=True, **kwargs)
+    return cc_binary(_c=True, **kwargs)
 
 def c_test(write_main=False, **kwargs):
-    cc_test(_c=True, write_main=write_main, **kwargs)
+    return cc_test(_c=True, write_main=write_main, **kwargs)
 
 def c_embed_binary(**kwargs):
-    cc_embed_binary(**kwargs)
+    return cc_embed_binary(**kwargs)
 
 
 if CONFIG.BAZEL_COMPATIBILITY:

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -687,9 +687,17 @@ _CC_TEST_MAIN_CONTENTS = """
 #include <fstream>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+#include <vector>
 #include "UnitTest++/UnitTest++.h"
 #include "UnitTest++/XmlTestReporter.h"
-int main(int argc, char const *argv[]) {
+int main(int argc, const char** argv) {
+    if (getenv("DEBUG")) {
+        unsetenv("DEBUG");
+        std::vector<char*> v({strdup("gdb"), strdup("-ex"), strdup("run"), strdup("--args")});
+        v.insert(v.end(), const_cast<char**>(argv), const_cast<char**>(argv) + argc);
+        execvp("gdb", const_cast<char**>(&v[0]));
+    }
     auto run_named = [argc, argv](UnitTest::Test* test) {
         return argc <= 1 || std::any_of(argv + 1, argv + argc, [test](const char* name) {
             return strcmp(test->m_details.testName, name) == 0;

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -235,7 +235,7 @@ def cgo_library(name, srcs, go_srcs=None, c_srcs=None, hdrs=None, out=None, comp
     )
 
     # Compile the various bits
-    c_library(
+    c_rule = c_library(
         name = '_%s#c' % name,
         srcs = [cgo_rule + '|c'] + c_srcs,
         hdrs = [cgo_rule + '|h'] + hdrs,
@@ -246,20 +246,6 @@ def cgo_library(name, srcs, go_srcs=None, c_srcs=None, hdrs=None, out=None, comp
         pkg_config_libs = pkg_config,
         test_only = test_only,
         deps = deps,
-    )
-    # Recompile the output of the C rule into an object suitable for Go's linker.
-    ld_flag = '' if CONFIG.LINK_WITH_LD_TOOL else '-Wl,'
-    cgo_o_rule = build_rule(
-        name = name,
-        tag = 'cgo_o',
-        srcs = [':_%s#c' % name],
-        outs = [name + '_cgo.o'],
-        cmd = '$TOOLS_AR x $SRCS && $TOOLS_LD -o $OUT %s-r -nostdlib *.o' % ld_flag,
-        requires = ['cc'],
-        tools = {
-            'ld': [CONFIG.LD_TOOL if CONFIG.LINK_WITH_LD_TOOL else CONFIG.CC_TOOL],
-            'ar': [CONFIG.AR_TOOL],
-        },
     )
     go_rule = go_library(
         name = '_%s#go' % name,
@@ -272,7 +258,7 @@ def cgo_library(name, srcs, go_srcs=None, c_srcs=None, hdrs=None, out=None, comp
     return _merge_cgo_obj(
         name = name,
         a_rule = ':_%s#go' % name,
-        o_rule = cgo_o_rule,
+        o_rule = c_rule,
         visibility = visibility,
         test_only = test_only,
         linker_flags = linker_flags,
@@ -280,7 +266,7 @@ def cgo_library(name, srcs, go_srcs=None, c_srcs=None, hdrs=None, out=None, comp
         provides = {
             'go': ':' + name,
             'go_src': go_rule,
-            'cgo_obj': cgo_o_rule,
+            'cgo': c_rule,
         },
         deps = deps,
     )
@@ -289,6 +275,11 @@ def cgo_library(name, srcs, go_srcs=None, c_srcs=None, hdrs=None, out=None, comp
 def _merge_cgo_obj(name, a_rule, o_rule=None, visibility=None, test_only=False, tag=None,
                    linker_flags=None, deps=None, provides=None, out=None):
     """Defines a rule to merge a cgo object into a Go library."""
+    if o_rule:
+        cmd = 'cp $SRCS_A $OUT && chmod +w $OUT && $TOOLS_AR x $SRCS_O && $TOOLS_GO tool pack r $OUT *.o'
+    else:
+        cmd = 'cp $SRCS_A $OUT && chmod +w $OUT && $TOOLS_AR x $PKG/*#c.a && $TOOLS_GO tool pack r $OUT *.o'
+
     return build_rule(
         name = name,
         tag = tag,
@@ -297,12 +288,15 @@ def _merge_cgo_obj(name, a_rule, o_rule=None, visibility=None, test_only=False, 
             'o': [o_rule] if o_rule else [],
         },
         outs = [out or name + '.a'],
-        cmd = 'cp $SRCS_A $OUT && chmod +w $OUT && $TOOL tool pack r $OUT $PKG_DIR/*_cgo.o',
-        tools = [CONFIG.GO_TOOL],
+        cmd = cmd,
+        tools = {
+            'go': [CONFIG.GO_TOOL],
+            'ar': [CONFIG.AR_TOOL],
+        },
         visibility = visibility,
         test_only = test_only,
         labels = ['cc:ld:' + flag for flag in (linker_flags or [])],
-        requires = ['go', 'cgo_obj'],
+        requires = ['go', 'cgo'],
         provides = provides,
         deps = deps,
     )

--- a/src/please.go
+++ b/src/please.go
@@ -839,7 +839,7 @@ func main() {
 	} else if opts.OutputFlags.NoColour {
 		output.SetColouredOutput(false)
 	}
-	if opts.OutputFlags.ShowAllOutput || opts.Test.Debug || opts.Cover.Debug {
+	if opts.OutputFlags.ShowAllOutput {
 		opts.OutputFlags.PlainOutput = true
 	}
 	// Init logging, but don't do file output until we've chdir'd.

--- a/src/please.go
+++ b/src/please.go
@@ -645,8 +645,8 @@ func Please(targets []core.BuildLabel, config *core.Configuration, prettyOutput,
 	state.CleanWorkdirs = !opts.FeatureFlags.KeepWorkdirs
 	state.ForceRebuild = len(opts.Rebuild.Args.Targets) > 0
 	state.ShowTestOutput = opts.Test.ShowOutput || opts.Cover.ShowOutput
-	state.ShowAllOutput = opts.OutputFlags.ShowAllOutput
 	state.DebugTests = opts.Test.Debug || opts.Cover.Debug
+	state.ShowAllOutput = opts.OutputFlags.ShowAllOutput || state.DebugTests
 	state.SetIncludeAndExclude(opts.BuildFlags.Include, opts.BuildFlags.Exclude)
 	if config.Events.Port != 0 && shouldBuild {
 		shutdown := follow.InitialiseServer(state, config.Events.Port)
@@ -839,7 +839,7 @@ func main() {
 	} else if opts.OutputFlags.NoColour {
 		output.SetColouredOutput(false)
 	}
-	if opts.OutputFlags.ShowAllOutput {
+	if opts.OutputFlags.ShowAllOutput || opts.Test.Debug || opts.Cover.Debug {
 		opts.OutputFlags.PlainOutput = true
 	}
 	// Init logging, but don't do file output until we've chdir'd.

--- a/src/test/container.go
+++ b/src/test/container.go
@@ -45,7 +45,7 @@ func runContainerisedTest(state *core.BuildState, target *core.BuildTarget) ([]b
 	replacedCmd = "mkdir -p /tmp/test && cp -r /tmp/test_in/* /tmp/test && cd /tmp/test && " + replacedCmd
 	command = append(command, "-v", testDir+":/tmp/test_in", "-w", "/tmp/test_in", containerName, "bash", "-o", "pipefail", "-c", replacedCmd)
 	log.Debug("Running containerised test %s: %s", target.Label, strings.Join(command, " "))
-	_, out, err := core.ExecWithTimeout(target, target.TestDir(), nil, target.TestTimeout, state.Config.Test.Timeout, state.ShowAllOutput, command)
+	_, out, err := core.ExecWithTimeout(target, target.TestDir(), nil, target.TestTimeout, state.Config.Test.Timeout, state.ShowAllOutput, false, command)
 	retrieveResultsAndRemoveContainer(target, cidfile, err == nil)
 	return out, err
 }

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -287,7 +287,7 @@ func testCommandAndEnv(state *core.BuildState, target *core.BuildTarget) (string
 func runTest(state *core.BuildState, target *core.BuildTarget) ([]byte, error) {
 	replacedCmd, env := testCommandAndEnv(state, target)
 	log.Debug("Running test %s\nENVIRONMENT:\n%s\n%s", target.Label, strings.Join(env, "\n"), replacedCmd)
-	_, out, err := core.ExecWithTimeoutShellStdin(target, target.TestDir(), env, target.TestTimeout, state.Config.Test.Timeout, state.ShowAllOutput, replacedCmd, target.TestSandbox, state.DebugTests)
+	_, out, err := core.ExecWithTimeoutShellStdStreams(target, target.TestDir(), env, target.TestTimeout, state.Config.Test.Timeout, state.ShowAllOutput, replacedCmd, target.TestSandbox, state.DebugTests)
 	return out, err
 }
 

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -287,7 +287,7 @@ func testCommandAndEnv(state *core.BuildState, target *core.BuildTarget) (string
 func runTest(state *core.BuildState, target *core.BuildTarget) ([]byte, error) {
 	replacedCmd, env := testCommandAndEnv(state, target)
 	log.Debug("Running test %s\nENVIRONMENT:\n%s\n%s", target.Label, strings.Join(env, "\n"), replacedCmd)
-	_, out, err := core.ExecWithTimeoutShell(target, target.TestDir(), env, target.TestTimeout, state.Config.Test.Timeout, state.ShowAllOutput, replacedCmd, target.TestSandbox)
+	_, out, err := core.ExecWithTimeoutShellStdin(target, target.TestDir(), env, target.TestTimeout, state.Config.Test.Timeout, state.ShowAllOutput, replacedCmd, target.TestSandbox, state.DebugTests)
 	return out, err
 }
 

--- a/tools/images/ubuntu/Dockerfile
+++ b/tools/images/ubuntu/Dockerfile
@@ -1,29 +1,24 @@
-FROM ubuntu:xenial
+# We prefer Ubuntu 17.10 because it makes the installation of some packages simpler
+# and is more up-to-date than 16.04.
+# If you want to replicate this image on 16.04 the main difference is UnitTest++
+# which you'll need to compile your own copy of - their version is too old (we need v2)
+# and has some naming idiosyncrasies which are too hard to support).
+FROM ubuntu:artful
 MAINTAINER peter.ebden@gmail.com
 
-# Basic dependencies, Python and Java
+# Most dependencies; Python, Java, Clang and Ruby (only used for fpm)
 RUN apt-get update && \
     apt-get install -y python2.7 python3.5 python3-pip libpython2.7-dev openjdk-8-jdk-headless \
     curl unzip git locales pkg-config zlib1g-dev \
-    clang ruby ruby-dev rubygems
+    clang libunittest++-dev ruby ruby-dev rubygems golint && \
+    apt-get clean
 RUN pip3 install cffi
 
 # Go
-RUN curl -fsSL https://storage.googleapis.com/golang/go1.9.1.linux-amd64.tar.gz | tar -xzC /usr/local
+# We can't install this above because the latest available version for Artful is 1.8
+# and we require 1.9 for various minor features.
+RUN curl -fsSL https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
-
-# C++
-# Ubuntu's packaged version of UnitTest++ is older than we'd like and has some
-# idiosyncratic naming (unittest++ vs. UnitTest++ etc).
-# TODO(peterebden): Update this to 17.10 which fixes all the above.
-RUN curl -fsSL https://github.com/unittest-cpp/unittest-cpp/releases/download/v2.0.0/unittest-cpp-2.0.0.tar.gz | tar -xzC /tmp && \
-    cd /tmp/unittest-cpp-2.0.0 && ./configure --prefix=/usr && make -j4 && make install && \
-    rm -r /tmp/unittest-cpp-2.0.0
-
-# Protocol buffers
-RUN curl -fsSLo /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip && \
-    unzip /tmp/protoc.zip -x readme.txt -d /usr && \
-    rm /tmp/protoc.zip
 
 # Locale
 RUN locale-gen en_GB.UTF-8
@@ -34,7 +29,4 @@ RUN gem install --no-ri --no-rdoc fpm
 # Welcome message
 COPY /motd.txt /etc/motd
 RUN echo 'cat /etc/motd' >> /etc/bash.bashrc
-
-# Linters etc
 WORKDIR /tmp
-RUN go get github.com/golang/lint/golint && mv ~/go/bin/golint /usr/local/bin && rm -rf ~/go

--- a/tools/please_pex/pytest.py
+++ b/tools/please_pex/pytest.py
@@ -8,4 +8,6 @@ def run_tests(test_names):
     args = ['--junitxml', 'test.results'] + TEST_NAMES
     if test_names:
         args += ['-k', ' '.join(test_names)]
+    if os.environ.get('DEBUG'):
+        args.append('--pdb')
     return main(args)


### PR DESCRIPTION
Essentially you can now do `plz test -d //some/path:mytest` and, if the test runner supports it, it will break into a debugger on test failure. Works with pytest and C++, conceptually you could do the same with jdb but I feel like Java devs would generally want an attached GUI, and Go doesn't really have a clear answer here yet. What's here is certainly a useful foundation for those languages too though.

A special flag is needed in order to attach stdin, which we have to do before we know if the test will fail, and it wouldn't make any sense to attach it to more than one test simultaneously.

Also a little unsure if this should specify `-c dbg`, or be implied by it. That seems practical and useful but conceptually at least the two are orthogonal. Sometimes I think command-line flags are the hardest thing...

Fixes #246 , and hence might be of interest to @natpen 