### PR TITLE
Add option to read a config profile by flag.

### DIFF
--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -17,7 +17,7 @@ const size = 1000
 const numWorkers = 10
 
 func TestBuildLotsOfTargets(t *testing.T) {
-	config, _ := core.ReadConfigFiles(nil)
+	config, _ := core.ReadConfigFiles(nil, "")
 	state := core.NewBuildState(numWorkers, nil, 4, config)
 	state.Parser = &fakeParser{
 		PostBuildFunctions: buildFunctionMap{},

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -228,7 +228,7 @@ func TestLicenceEnforcement(t *testing.T) {
 }
 
 func newState(label string) (*core.BuildState, *core.BuildTarget) {
-	config, _ := core.ReadConfigFiles(nil)
+	config, _ := core.ReadConfigFiles(nil, "")
 	state := core.NewBuildState(1, nil, 4, config)
 	target := core.NewBuildTarget(core.ParseBuildLabel(label, ""))
 	target.Command = fmt.Sprintf("echo 'output of %s' > $OUT", target.Label)

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -32,7 +32,7 @@ go_library(
 go_test(
     name = 'config_test',
     srcs = ['config_test.go'],
-    data = glob(['test_data/*.plzconfig']),
+    data = glob(['test_data/*.plzconfig*']),
     deps = [
         ':core',
         '//src/cli',

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -63,11 +63,16 @@ func readConfigFile(config *Configuration, filename string) error {
 
 // ReadConfigFiles reads all the config locations, in order, and merges them into a config object.
 // Values are filled in by defaults initially and then overridden by each file in turn.
-func ReadConfigFiles(filenames []string) (*Configuration, error) {
+func ReadConfigFiles(filenames []string, profile string) (*Configuration, error) {
 	config := DefaultConfiguration()
 	for _, filename := range filenames {
 		if err := readConfigFile(config, filename); err != nil {
 			return config, err
+		}
+		if profile != "" {
+			if err := readConfigFile(config, filename+"."+profile); err != nil {
+				return config, err
+			}
 		}
 	}
 	// Set default values for slices. These add rather than overwriting so we can't set

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPlzConfigWorking(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/working.plzconfig"})
+	config, err := ReadConfigFiles([]string{"src/core/test_data/working.plzconfig"}, "")
 	assert.NoError(t, err)
 	assert.Equal(t, "pexmabob", config.Python.PexTool)
 	assert.Equal(t, "javac", config.Java.JavacTool)
@@ -19,22 +19,31 @@ func TestPlzConfigWorking(t *testing.T) {
 }
 
 func TestPlzConfigFailing(t *testing.T) {
-	_, err := ReadConfigFiles([]string{"src/core/test_data/failing.plzconfig"})
+	_, err := ReadConfigFiles([]string{"src/core/test_data/failing.plzconfig"}, "")
 	assert.Error(t, err)
+}
+
+func TestPlzConfigProfile(t *testing.T) {
+	config, err := ReadConfigFiles([]string{"src/core/test_data/working.plzconfig"}, "dev")
+	assert.NoError(t, err)
+	assert.Equal(t, "pexmabob", config.Python.PexTool)
+	assert.Equal(t, "/opt/java/bin/javac", config.Java.JavacTool)
+	assert.Equal(t, "8", config.Java.SourceLevel)
+	assert.Equal(t, "8", config.Java.TargetLevel)
 }
 
 func TestMultiplePlzConfigFiles(t *testing.T) {
 	config, err := ReadConfigFiles([]string{
 		"src/core/test_data/working.plzconfig",
 		"src/core/test_data/failing.plzconfig",
-	})
+	}, "")
 	assert.Error(t, err)
 	// Quick check of this - we should have still read the first config file correctly.
 	assert.Equal(t, "javac", config.Java.JavacTool)
 }
 
 func TestConfigSlicesOverwrite(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/slices.plzconfig"})
+	config, err := ReadConfigFiles([]string{"src/core/test_data/slices.plzconfig"}, "")
 	assert.NoError(t, err)
 	// This should be completely overwritten by the config file
 	assert.Equal(t, []string{"/sbin"}, config.Build.Path)
@@ -134,7 +143,7 @@ func TestConfigOverrideOptions(t *testing.T) {
 }
 
 func TestDynamicSection(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/aliases.plzconfig"})
+	config, err := ReadConfigFiles([]string{"src/core/test_data/aliases.plzconfig"}, "")
 	assert.NoError(t, err)
 	expected := map[string]string{
 		"deploy":      "run //deployment:deployer --",
@@ -145,7 +154,7 @@ func TestDynamicSection(t *testing.T) {
 }
 
 func TestDynamicSubsection(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/metrics.plzconfig"})
+	config, err := ReadConfigFiles([]string{"src/core/test_data/metrics.plzconfig"}, "")
 	assert.NoError(t, err)
 	assert.EqualValues(t, "http://localhost:9091", config.Metrics.PushGatewayURL)
 	expected := map[string]string{
@@ -155,37 +164,37 @@ func TestDynamicSubsection(t *testing.T) {
 }
 
 func TestReadSemver(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/version_good.plzconfig"})
+	config, err := ReadConfigFiles([]string{"src/core/test_data/version_good.plzconfig"}, "")
 	assert.NoError(t, err)
 	assert.EqualValues(t, 2, config.Please.Version.Major)
 	assert.EqualValues(t, 3, config.Please.Version.Minor)
 	assert.EqualValues(t, 4, config.Please.Version.Patch)
-	config, err = ReadConfigFiles([]string{"src/core/test_data/version_bad.plzconfig"})
+	config, err = ReadConfigFiles([]string{"src/core/test_data/version_bad.plzconfig"}, "")
 	assert.Error(t, err)
 }
 
 func TestReadDurations(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/duration_good.plzconfig"})
+	config, err := ReadConfigFiles([]string{"src/core/test_data/duration_good.plzconfig"}, "")
 	assert.NoError(t, err)
 	assert.EqualValues(t, 500*time.Millisecond, config.Metrics.PushTimeout)
 	assert.EqualValues(t, 5*time.Second, config.Metrics.PushFrequency)
-	config, err = ReadConfigFiles([]string{"src/core/test_data/duration_bad.plzconfig"})
+	config, err = ReadConfigFiles([]string{"src/core/test_data/duration_bad.plzconfig"}, "")
 	assert.Error(t, err)
 }
 
 func TestReadByteSizes(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/bytesize_good.plzconfig"})
+	config, err := ReadConfigFiles([]string{"src/core/test_data/bytesize_good.plzconfig"}, "")
 	assert.NoError(t, err)
 	assert.EqualValues(t, 500*1000*1000, config.Cache.RPCMaxMsgSize)
-	config, err = ReadConfigFiles([]string{"src/core/test_data/bytesize_bad.plzconfig"})
+	config, err = ReadConfigFiles([]string{"src/core/test_data/bytesize_bad.plzconfig"}, "")
 	assert.Error(t, err)
 }
 
 func TestReadContainers(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/container_good.plzconfig"})
+	config, err := ReadConfigFiles([]string{"src/core/test_data/container_good.plzconfig"}, "")
 	assert.NoError(t, err)
 	assert.EqualValues(t, ContainerImplementationDocker, config.Test.DefaultContainer)
-	config, err = ReadConfigFiles([]string{"src/core/test_data/container_bad.plzconfig"})
+	config, err = ReadConfigFiles([]string{"src/core/test_data/container_bad.plzconfig"}, "")
 	assert.Error(t, err)
 }
 
@@ -198,9 +207,9 @@ func TestCompletions(t *testing.T) {
 }
 
 func TestConfigVerifiesOptions(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/testrunner_good.plzconfig"})
+	config, err := ReadConfigFiles([]string{"src/core/test_data/testrunner_good.plzconfig"}, "")
 	assert.NoError(t, err)
 	assert.Equal(t, "pytest", config.Python.TestRunner)
-	_, err = ReadConfigFiles([]string{"src/core/test_data/testrunner_bad.plzconfig"})
+	_, err = ReadConfigFiles([]string{"src/core/test_data/testrunner_bad.plzconfig"}, "")
 	assert.Error(t, err)
 }

--- a/src/core/test_data/working.plzconfig.dev
+++ b/src/core/test_data/working.plzconfig.dev
@@ -1,0 +1,3 @@
+[java]
+javactool = /opt/java/bin/javac
+targetlevel = 8

--- a/src/please.go
+++ b/src/please.go
@@ -52,7 +52,7 @@ var opts struct {
 		Include    []string        `short:"i" long:"include" description:"Label of targets to include in automatic detection."`
 		Exclude    []string        `short:"e" long:"exclude" description:"Label of targets to exclude from automatic detection."`
 		Option     ConfigOverrides `short:"o" long:"override" env:"PLZ_OVERRIDES" env-delim:";" description:"Options to override from .plzconfig (e.g. -o please.selfupdate:false)"`
-		Profile    string          `long:"profile" env:"PLZ_CONFIG_PROFILE" description:"Configuration profie to load; e.g. --profile=dev will load .plzconfig.dev if it exists."`
+		Profile    string          `long:"profile" env:"PLZ_CONFIG_PROFILE" description:"Configuration profile to load; e.g. --profile=dev will load .plzconfig.dev if it exists."`
 	} `group:"Options controlling what to build & how to build it"`
 
 	OutputFlags struct {

--- a/src/please.go
+++ b/src/please.go
@@ -52,6 +52,7 @@ var opts struct {
 		Include    []string        `short:"i" long:"include" description:"Label of targets to include in automatic detection."`
 		Exclude    []string        `short:"e" long:"exclude" description:"Label of targets to exclude from automatic detection."`
 		Option     ConfigOverrides `short:"o" long:"override" env:"PLZ_OVERRIDES" env-delim:";" description:"Options to override from .plzconfig (e.g. -o please.selfupdate:false)"`
+		Profile    string          `long:"profile" env:"PLZ_CONFIG_PROFILE" description:"Configuration profie to load; e.g. --profile=dev will load .plzconfig.dev if it exists."`
 	} `group:"Options controlling what to build & how to build it"`
 
 	OutputFlags struct {
@@ -76,7 +77,7 @@ var opts struct {
 		KeepWorkdirs       bool `long:"keep_workdirs" description:"Don't clean directories in plz-out/tmp after successfully building targets."`
 	} `group:"Options that enable / disable certain features"`
 
-	Profile          string `long:"profile" hidden:"true" description:"Write profiling output to this file"`
+	Profile          string `long:"profile_file" hidden:"true" description:"Write profiling output to this file"`
 	ProfilePort      int    `long:"profile_port" hidden:"true" description:"Serve profiling info on this port."`
 	ParsePackageOnly bool   `description:"Parses a single package only. All that's necessary for some commands." no-flag:"true"`
 	Complete         string `long:"complete" hidden:"true" env:"PLZ_COMPLETE" description:"Provide completion options for this build target."`
@@ -736,7 +737,7 @@ func readConfig(forceUpdate bool) *core.Configuration {
 		path.Join(core.RepoRoot, core.ConfigFileName),
 		path.Join(core.RepoRoot, core.ArchConfigFileName),
 		path.Join(core.RepoRoot, core.LocalConfigFileName),
-	})
+	}, opts.BuildFlags.Profile)
 	if err != nil {
 		log.Fatalf("Error reading config file: %s", err)
 	} else if err := config.ApplyOverrides(opts.BuildFlags.Option); err != nil {

--- a/src/tool/tool_test.go
+++ b/src/tool/tool_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMatchingTools(t *testing.T) {
-	c, err := core.ReadConfigFiles(nil)
+	c, err := core.ReadConfigFiles(nil, "")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"pex": "~/.please/please_pex"}, matchingTools(c, "p"))
 	assert.Equal(t, map[string]string{"pex": "~/.please/please_pex"}, matchingTools(c, "pex"))
@@ -20,7 +20,7 @@ func TestMatchingTools(t *testing.T) {
 }
 
 func TestAllToolNames(t *testing.T) {
-	c, err := core.ReadConfigFiles(nil)
+	c, err := core.ReadConfigFiles(nil, "")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"jarcat", "javacworker"}, allToolNames(c, "ja"))
 }


### PR DESCRIPTION
As discussed in #256 and slightly more recently #250 with @natpen , adding a flag allowing a choice of config profile which can be checked in and thus version-controlled, but also easily accessed.


