### PR TITLE
Improve help text formatting

### DIFF
--- a/src/help/help.go
+++ b/src/help/help.go
@@ -39,7 +39,7 @@ func Help(topic string) bool {
 	fmt.Printf("Sorry OP, can't halp you with %s\n", topic)
 	if message := suggest(topic); message != "" {
 		printMessage(message)
-		fmt.Printf("Or have a look on the website: https://please.build\n")
+		fmt.Printf(" Or have a look on the website: https://please.build\n")
 	} else {
 		fmt.Printf("\nMaybe have a look on the website? https://please.build\n")
 	}

--- a/src/help/help_test.go
+++ b/src/help/help_test.go
@@ -23,6 +23,7 @@ func TestHelpDescription(t *testing.T) {
 
 func TestSuggestion(t *testing.T) {
 	assert.Equal(t, "\nMaybe you meant cc_embed_binary or c_embed_binary ?", suggest("cc_emdbed_binary"))
+	assert.Equal(t, "\nMaybe you meant godep , go , gc , gopath , goroot or gotool ?", suggest("godop"))
 	assert.Equal(t, "", suggest("blahdiblahdiblah"))
 }
 

--- a/src/parse/suggest_test.go
+++ b/src/parse/suggest_test.go
@@ -29,7 +29,7 @@ func TestSuggestTwoTargetsFromSamePackage(t *testing.T) {
 func TestSuggestSeveralTargetsFromSamePackage(t *testing.T) {
 	pkg := makePackage("src/core", "target1", "target21", "target_21", "wibble")
 	s := suggestTargets(pkg, bl("//src/core:target"), bl("//src/core:blibble"))
-	assert.Equal(t, s, "\nMaybe you meant :target1, :target21 or :target_21 ?")
+	assert.Equal(t, s, "\nMaybe you meant :target1 , :target21 or :target_21 ?")
 }
 
 func TestSuggestSingleTargetFromAnotherPackage(t *testing.T) {
@@ -47,7 +47,7 @@ func TestSuggestTwoTargetsFromAnotherPackage(t *testing.T) {
 func TestSuggestSeveralTargetsFromAnotherPackage(t *testing.T) {
 	pkg := makePackage("src/core", "target1", "target21", "target_21", "wibble")
 	s := suggestTargets(pkg, bl("//src/core:target"), bl("//src/parse:blibble"))
-	assert.Equal(t, s, "\nMaybe you meant //src/core:target1, //src/core:target21 or //src/core:target_21 ?")
+	assert.Equal(t, s, "\nMaybe you meant //src/core:target1 , //src/core:target21 or //src/core:target_21 ?")
 }
 
 func makePackage(name string, targets ...string) *core.Package {

--- a/src/utils/suggest.go
+++ b/src/utils/suggest.go
@@ -12,7 +12,7 @@ func Suggest(needle string, haystack []string, maxSuggestionDistance int) []stri
 	options := make(suggestions, 0, len(haystack))
 	for _, straw := range haystack {
 		distance := levenshtein.DistanceForStrings(r, []rune(straw), levenshtein.DefaultOptions)
-		if distance <= maxSuggestionDistance {
+		if len(straw) > 0 && distance <= maxSuggestionDistance {
 			options = append(options, suggestion{s: straw, dist: distance})
 		}
 	}
@@ -36,7 +36,7 @@ func PrettyPrintSuggestion(needle string, haystack []string, maxSuggestionDistan
 	for i, o := range options {
 		if i > 0 {
 			if i < len(options)-1 {
-				msg += ", "
+				msg += " , " // Leave a space before the comma so you can select them without getting the question mark
 			} else {
 				msg += " or "
 			}


### PR DESCRIPTION
This PR ensures that empty strings do not populate the list of
suggested help topics, and adds a few spaces for prettier formatting
and better selectability of help topics.

As an example, the previous output of `plz help godop` contained:
> Maybe you meant godep, go, , gc, gopath, goroot or gotool?

With this update, that becomes:
> Maybe you meant godep , go , gc , gopath , goroot or gotool ?