### PR TITLE
Open source the long-awaited SoImport code

### DIFF
--- a/tools/please_pex/pex_main.py
+++ b/tools/please_pex/pex_main.py
@@ -93,6 +93,7 @@ class SoImport(object):
         suffix = self.suffixes[ext]
         with tempfile.NamedTemporaryFile(suffix=ext, prefix=os.path.basename(prefix)) as f:
             f.write(self.zf.read(filename))
+            f.flush()
             mod = imp.load_module(fullname, None, f.name, suffix)
         # Make it look like module came from the original location for nicer tracebacks.
         mod.__file__ = filename

--- a/tools/please_pex/pex_main.py
+++ b/tools/please_pex/pex_main.py
@@ -73,7 +73,9 @@ class SoImport(object):
             for name in zf.namelist():
                 path, _ = self.splitext(name)
                 if path:
-                    self.modules[path.replace('/', '.')] = name
+                    if path.startswith('.bootstrap/'):
+                        path = path[len('.bootstrap/'):]
+                    self.modules.setdefault(path.replace('/', '.'), name)
             if self.modules:
                 self.zf = zf
 

--- a/tools/please_pex/pex_run.py
+++ b/tools/please_pex/pex_run.py
@@ -1,6 +1,7 @@
 def run():
     if MODULE_DIR:
         override_import(MODULE_DIR)
+        sys.meta_path.append(SoImport())
     clean_sys_path()
     if not ZIP_SAFE:
         with explode_zip()():


### PR DESCRIPTION
For non-TMers who aren't familiar with it, this means that Python binary modules can be transparently loaded from within a pex.

Removed TracerImport which was basically a less general version of the same thing.