### PR TITLE
Replace hyphen with underscore in [buildenv] plzconfig sections

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -252,7 +252,7 @@ type Configuration struct {
 		Nonce             string       `help:"This is an arbitrary string that is added to the hash of every build target. It provides a way to force a rebuild of everything when it's changed.\nWe will bump the default of this whenever we think it's required - although it's been a pretty long time now and we hope that'll continue."`
 	}
 	BuildConfig map[string]string `help:"A section of arbitrary key-value properties that are made available in the BUILD language. These are often useful for writing custom rules that need some configurable property.\n\n[buildconfig]\nandroid-tools-version = 23.0.2\n\nFor example, the above can be accessed as CONFIG.ANDROID_TOOLS_VERSION."`
-	BuildEnv    map[string]string `help:"A set of extra environment variables to define for build rules. For example:\n\n[buildenv]\nsecret-passphrase = 12345\n\nThis would become SECRET_PASSWORD for any rules. These can be useful for passing secrets into custom rules; any variables containing SECRET or PASSWORD won't be logged.\n\nIt's also useful if you'd like internal tools to honour some external variable."`
+	BuildEnv    map[string]string `help:"A set of extra environment variables to define for build rules. For example:\n\n[buildenv]\nsecret-passphrase = 12345\n\nThis would become SECRET_PASSPHRASE for any rules. These can be useful for passing secrets into custom rules; any variables containing SECRET or PASSWORD won't be logged.\n\nIt's also useful if you'd like internal tools to honour some external variable."`
 	Cache       struct {
 		Workers               int          `help:"Number of workers for uploading artifacts to remote caches, which is done asynchronously."`
 		Dir                   string       `help:"Sets the directory to use for the dir cache.\nThe default is .plz-cache, if set to the empty string the dir cache will be disabled."`
@@ -419,7 +419,8 @@ func (config *Configuration) GetBuildEnv() []string {
 	config.buildEnvOnce.Do(func() {
 		config.buildEnvStored = []string{}
 		for k, v := range config.BuildEnv {
-			config.buildEnvStored = append(config.buildEnvStored, strings.ToUpper(k)+"="+v)
+			pair := strings.Replace(strings.ToUpper(k), "-", "_", -1) + "=" + v
+			config.buildEnvStored = append(config.buildEnvStored, pair)
 		}
 		sort.Strings(config.buildEnvStored)
 	})

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -215,3 +215,10 @@ func TestConfigVerifiesOptions(t *testing.T) {
 	_, err = ReadConfigFiles([]string{"src/core/test_data/testrunner_bad.plzconfig"}, "")
 	assert.Error(t, err)
 }
+
+func TestBuildEnvSection(t *testing.T) {
+	config, err := ReadConfigFiles([]string{"src/core/test_data/buildenv.plzconfig"}, "")
+	assert.NoError(t, err)
+	expected := []string{"BAR_BAR=first", "FOO_BAR=second"}
+	assert.Equal(t, expected, config.GetBuildEnv())
+}

--- a/src/core/test_data/buildenv.plzconfig
+++ b/src/core/test_data/buildenv.plzconfig
@@ -1,0 +1,3 @@
+[buildenv]
+foo-bar = second
+bar-bar = first


### PR DESCRIPTION
Please was previously leaving the `-` from the config file key in the name used of the environment variable. This is not technically valid, nor desired, but apparently permitted by my system!