### PR TITLE
Add missing //third_party/go dependencies

### DIFF
--- a/src/follow/BUILD
+++ b/src/follow/BUILD
@@ -10,7 +10,7 @@ go_library(
         '//src/core',
         '//src/follow/proto:build_event',
         '//src/output',
-        '//third_party/go:context',
+        '//third_party/go:net',
         '//third_party/go:grpc',
         '//third_party/go:logging',
         '//third_party/go:psutil',

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -595,7 +595,8 @@ def go_get(name:str, get:str, outs:list=None, deps:list=None, exported_deps:list
         test_only=test_only,
         post_build=post_build,
         labels=['go_get:%s@%s' % (get, revision) if revision else 'go_get:%s' % get],
-        sandbox = False,
+        sandbox=False,
+        needs_transitive_deps=True,
     )
 
 

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -19,10 +19,24 @@ go_get(
 )
 
 go_get(
+    name = 'warnings',
+    get = 'gopkg.in/warnings.v0',
+    revision = 'v0.1.2',
+)
+
+go_get(
     name = 'gcfg',
     get = 'gopkg.in/gcfg.v1',
+    install = [
+        'gopkg.in/gcfg.v1/scanner',
+        'gopkg.in/gcfg.v1/token',
+        'gopkg.in/gcfg.v1/types',
+    ],
     patch = 'gcfg_dynamic_fields.patch',
     revision = '27e4946190b4a327b539185f2b5b1f7c84730728',
+    deps = [
+        ':warnings',
+    ],
 )
 
 go_get(
@@ -61,24 +75,66 @@ go_get(
 )
 
 go_get(
-    name = 'context',
-    get = 'golang.org/x/net/context',
-    revision = '57efc9c3d9f91fb3277f8da1cff370539c4d3dc5',
+    name = 'net',
+    get = 'golang.org/x/net/...',
+    revision = '136a25c244d3019482a795d728110278d6ba09a4',
+    deps = [
+        ':text',
+        ':terminal',
+    ],
+)
+
+go_get(
+    name = 'text',
+    get = 'golang.org/x/text/...',
+    revision = '4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1',
 )
 
 go_get(
     name = 'grpc',
-    exported_deps = [':context'],
+    exported_deps = [':net'],
     get = 'google.golang.org/grpc',
-    install = ['google.golang.org/grpc/health'],
+    install = [
+        'google.golang.org/grpc/balancer',
+        'google.golang.org/grpc/codes',
+        'google.golang.org/grpc/connectivity',
+        'google.golang.org/grpc/credentials',
+        'google.golang.org/grpc/grpclb/grpc_lb_v1/messages',
+        'google.golang.org/grpc/grpclog',
+        'google.golang.org/grpc/health',
+        'google.golang.org/grpc/health/grpc_health_v1',
+        'google.golang.org/grpc/internal',
+        'google.golang.org/grpc/keepalive',
+        'google.golang.org/grpc/metadata',
+        'google.golang.org/grpc/naming',
+        'google.golang.org/grpc/peer',
+        'google.golang.org/grpc/resolver',
+        'google.golang.org/grpc/stats',
+        'google.golang.org/grpc/status',
+        'google.golang.org/grpc/tap',
+        'google.golang.org/grpc/transport',
+    ],
     revision = 'v1.7.0',
+    deps = [
+        ':protobuf',
+        ':rpcstatus',
+    ],
+)
+
+#TODO: build from the actual proto.
+go_get(
+    name = 'rpcstatus',
+    get = 'google.golang.org/genproto/googleapis/rpc/status',
+    revision = '2b5a72b8730b0b16380010cfe5286c42108d88e7',
     deps = [':protobuf'],
 )
 
 go_get(
     name = 'protobuf',
-    get = 'github.com/golang/protobuf/ptypes',
-    install = ['github.com/golang/protobuf/protoc-gen-go/descriptor'],
+    get = 'github.com/golang/protobuf/...',
+    strip = [
+        'protoc-gen-go', # avoids conflict with :protoc-gen-go binary.
+    ],
     revision = '130e6b02ab059e7b717a096f397c5b60111cae74',
 )
 
@@ -102,9 +158,20 @@ go_get(
 go_get(
     name = 'testify',
     get = 'github.com/stretchr/testify',
-    install = ['github.com/stretchr/testify/require'],
+    install = [
+        'github.com/stretchr/testify/assert',
+        'github.com/stretchr/testify/require',
+        'github.com/stretchr/testify/vendor/github.com/davecgh/go-spew/spew',
+        'github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib',
+    ],
     revision = 'f390dcf405f7b83c997eac1b06768bb9f44dec18',
     deps = [':spew'],
+)
+
+go_get(
+    name = 'go-isatty',
+    get = 'github.com/mattn/go-isatty',
+    revision = '6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c',
 )
 
 go_get(
@@ -112,6 +179,7 @@ go_get(
     get = 'github.com/Songmu/prompter',
     revision = 'f49666b0047d12850875d771340e1d862d9e7a0c',
     deps = [
+        ':go-isatty',
         ':terminal',
     ],
 )
@@ -149,14 +217,34 @@ go_get(
 )
 
 go_get(
+    name = 'quantile',
+    get = 'github.com/beorn7/perks/quantile',
+    revision = '4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9',
+)
+
+go_get(
+    name = 'pbutil',
+    get = 'github.com/matttproud/golang_protobuf_extensions/pbutil',
+    revision = 'c12348ce28de40eed0136aa2b644d0ee0650e56c',
+    deps = [':protobuf'],
+)
+
+go_get(
     name = 'prometheus',
-    get = 'github.com/prometheus/client_golang/prometheus',
-    install = ['github.com/prometheus/client_golang/prometheus/push'],
+    get = 'github.com/prometheus/client_golang/prometheus/...',
+    install = [
+        'github.com/prometheus/client_model/go',
+        'github.com/prometheus/common/expfmt',
+        'github.com/prometheus/common/model',
+        'github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg',
+    ],
     revision = 'c5b7fccd204277076155f10851dad72b76a49317',
     deps = [
         ':grpc',
+        ':pbutil',
         ':procfs',
         ':protobuf',
+        ':quantile',
     ],
 )
 
@@ -182,11 +270,15 @@ go_get(
 go_get(
     name = 'grpc-middleware',
     get = 'github.com/grpc-ecosystem/go-grpc-middleware',
-    install = ['github.com/grpc-ecosystem/go-grpc-middleware/retry'],
+    install = [
+        'github.com/grpc-ecosystem/go-grpc-middleware/retry',
+        'github.com/grpc-ecosystem/go-grpc-middleware/util/metautils',
+        'github.com/grpc-ecosystem/go-grpc-middleware/util/backoffutils',
+    ],
     revision = 'fa8fef87dcecac0bda02d36abb3c790ab9e0030b',
     deps = [
-        ':context',
         ':grpc',
+        ':net',
         ':protobuf',
     ],
 )
@@ -207,12 +299,70 @@ go_get(
     name = 'memberlist',
     get = 'github.com/hashicorp/memberlist',
     revision = '7ad712f5f34ec40aebe6ca47756d07898486a8d2',
-    deps = [':dns'],
+    deps = [
+        ':dns',
+        ':go-metrics',
+        ':go-msgpack',
+        ':go-multierror',
+    ],
+)
+
+go_get(
+    name = 'go-msgpack',
+    get = 'github.com/hashicorp/go-msgpack/...',
+    revision = 'fa3f63826f7c23912c15263591e65d54d080b458',
+)
+
+go_get(
+    name = 'go-multierror',
+    get = 'github.com/hashicorp/go-multierror',
+    install = [
+        'github.com/hashicorp/go-multierror/vendor/github.com/hashicorp/errwrap',
+    ],
+    revision = 'b7773ae218740a7be65057fc60b366a49b538a44',
+)
+
+go_get(
+    name = 'go-metrics',
+    get = 'github.com/armon/go-metrics',
+    revision = '7aa49fde808223f8dadfdbfd3a20ff6c19e5f9ec',
+    deps = [
+        ':go-immutable-radix',
+        ':verify',
+    ],
+)
+
+go_get(
+    name = 'go-immutable-radix',
+    get = 'github.com/hashicorp/go-immutable-radix',
+    revision = '7f3cd4390caab3250a57f30efdb2a65dd7649ecf',
+    deps = [
+        ':simplelru',
+        ':go-uuid',
+    ],
+)
+
+go_get(
+    name = 'simplelru',
+    get = 'github.com/hashicorp/golang-lru/simplelru',
+    revision = '0fb14efe8c47ae851c0034ed7a448854d3d34cf3',
+)
+
+go_get(
+    name = 'go-uuid',
+    get = 'github.com/hashicorp/go-uuid',
+    revision = '64130c7a86d732268a38cb04cfbaf0cc987fda98',
+)
+
+go_get(
+    name = 'verify',
+    get = 'github.com/pascaldekloe/goe/verify',
+    revision = 'c580d16984352a427218a8e43232313d1c1c6f84',
 )
 
 go_get(
     name = 'dns',
-    get = 'github.com/miekg/dns',
+    get = 'github.com/miekg/dns/...',
     revision = 'be5ae6ca7ac994584d2e30167737687f1c1ded8e',
 )
 
@@ -226,13 +376,7 @@ go_get(
     name = 'errgroup',
     get = 'golang.org/x/sync/errgroup',
     revision = '457c5828408160d6a47e17645169cf8fa20218c4',
-    deps = [':context'],
-)
-
-go_get(
-    name = 'html',
-    get = 'golang.org/x/net/html',
-    revision = '66aacef3dd8a676686c7ae3716979581e8b03c47',
+    deps = [':net'],
 )
 
 go_get(
@@ -240,6 +384,7 @@ go_get(
     get = 'github.com/shirou/gopsutil',
     install = [
         'github.com/shirou/gopsutil/cpu',
+        'github.com/shirou/gopsutil/internal/common',
         'github.com/shirou/gopsutil/mem',
     ],
     revision = 'v2.17.09',
@@ -254,12 +399,27 @@ go_get(
 
 go_get(
     name = 'openpgp',
-    get = 'golang.org/x/crypto/openpgp',
+    get = 'golang.org/x/crypto/openpgp/...',
     revision = '077efaa604f994162e3307fafe5954640763fc08',
+    deps = [':cast5'],
+)
+
+go_get(
+    name = 'cast5',
+    get = 'golang.org/x/crypto/cast5',
+    revision = '077efaa604f994162e3307fafe5954640763fc08',
+)
+
+go_get(
+    name = 'ebnf',
+    get = 'golang.org/x/exp/ebnf',
+    revision = '83bc9a11ae1a00a79c4e59fc5d965d21fe14e6bb',
 )
 
 go_get(
     name = 'participle',
     get = 'github.com/alecthomas/participle',
+    install = ['github.com/alecthomas/participle/lexer'],
     revision = '48f3ab340563c5a91f83efdc0dc3f14f5d9364a2',
+    deps = [':ebnf'],
 )

--- a/tools/cache/cluster/BUILD
+++ b/tools/cache/cluster/BUILD
@@ -19,7 +19,7 @@ go_test(
         ':cluster',
         '//src/cache/proto:rpc_cache',
         '//src/cache/tools',
-        '//third_party/go:context',
+        '//third_party/go:net',
         '//third_party/go:grpc',
         '//third_party/go:testify',
     ],


### PR DESCRIPTION
Be more explicit about go_get deps to ensure compatibility with Go 1.10 which now will not fetch dependencies by default during 'go install'.

Where many sub-packages of one repo were in use, the go_get now imports the whole repo (e.g. golang.org/x/net/...) and the name of the build rule has changed to the name of the repo.

Enables needs_transitive_deps for all go_get rules to maintain compatibility with Go 1.9 and below, which now needs to ensure all of the correct deps (and their deps, and so on) are available during the go_get build, otherwise those deps will get automatically installed and packaged in the wrong build rule.

Fixes #277 

Tested on Go 1.9.4 and Go 1.10 linux/amd64.