### PR TITLE
go_get rewrite

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -173,7 +173,7 @@ func DefaultConfiguration() *Configuration {
 	config.Go.GoTool = "go"
 	config.Go.CgoCCTool = "gcc"
 	config.Go.GoVersion = "1.6"
-	config.Go.GoPath = "$TMP_DIR:$TMP_DIR/$PKG:$TMP_DIR/third_party/go:$TMP_DIR/third_party/"
+	config.Go.GoPath = "$TMP_DIR:$TMP_DIR/src:$TMP_DIR/$PKG:$TMP_DIR/third_party/go:$TMP_DIR/third_party/"
 	config.Python.PipTool = "pip"
 	config.Python.DefaultInterpreter = "python3"
 	config.Python.TestRunner = "unittest"

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -173,7 +173,7 @@ func DefaultConfiguration() *Configuration {
 	config.Go.GoTool = "go"
 	config.Go.CgoCCTool = "gcc"
 	config.Go.GoVersion = "1.6"
-	config.Go.GoPath = "$TMP_DIR:$TMP_DIR/src:$TMP_DIR/$PKG:$TMP_DIR/third_party/go:$TMP_DIR/third_party/"
+	config.Go.GoPath = "$TMP_DIR:$TMP_DIR/$PKG:$TMP_DIR/third_party/go:$TMP_DIR/third_party/"
 	config.Python.PipTool = "pip"
 	config.Python.DefaultInterpreter = "python3"
 	config.Python.TestRunner = "unittest"

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -512,7 +512,7 @@ def cgo_test(name:str, srcs:list, data:list=None, deps:list=None, visibility:lis
     )
 
 
-def go_get(name:str, get:str, deps:list=[], exported_deps:list=None,
+def go_get(name:str, get:str, repo:str='', deps:list=[], exported_deps:list=None,
            visibility:list=None, patch:str=None, binary:bool=False, test_only:bool&testonly=False,
            install:list=None, revision:str=None, strip:list=None, hashes:list=None):
     """Defines a dependency on a third-party Go library.
@@ -530,6 +530,7 @@ def go_get(name:str, get:str, deps:list=[], exported_deps:list=None,
     Args:
       name (str): Name of the rule
       get (str): Target to get (eg. "github.com/gorilla/mux")
+      repo (str): Location of a Git repository to fetch from.
       deps (list): Dependencies
       exported_deps (list): Dependencies to make available to anything using this rule.
       visibility (list): Visibility specification
@@ -549,23 +550,26 @@ def go_get(name:str, get:str, deps:list=[], exported_deps:list=None,
     getroot = get[:-4] if get.endswith('/...') else get
     subdir = 'src/' + getroot
 
+    # Some special optimisation for github, which lets us download zipfiles at a particular sha instead of
+    # cloning the whole repo. Obviously that is a lot faster than cloning entire repos.
     if get.startswith('github.com') and revision and get.count('/') >= 2:
-        # Optimisation for github, which lets us download zipfiles at a particular sha instead of
-        # cloning the whole repo. Obviously that is a lot faster than cloning entire repos.
-        parts = get.split('/')
-        repo = '/'.join(parts[:3])
-        cmd = [
-            'rm -rf src/' + repo,
-            'curl -fsSLo github.zip https://%s/archive/%s.zip' % (repo, revision),
-            'unzip -qq github.zip',
-            'mv %s* src/%s' % (parts[2], repo),
-        ]
+        cmd = _go_github_repo_cmd(getroot, getroot, revision)
+    elif get.startswith('golang.org/x/') and revision and not repo:
+        # We know about these guys...
+        cmd = _go_github_repo_cmd(getroot, 'github.com/golang/' + getroot[len('golang.org/x/'):], revision)
     else:
-        cmd = [
-            'rm -rf src pkg',
-            'export GOPATH="$TMP_DIR"',
-            '$TOOL get -d ' + get,
-        ]
+        if repo:
+            # we've been told exactly where to get the source from.
+            cmd = ['git clone %s %s' % (repo, getroot)]
+        else:
+            # Ultimate fallback to go get.
+            # This has some more restrictions than the above (e.g. go get won't fetch a directory
+            # with no Go files in it, even if passed -d).
+            cmd = [
+                'rm -rf src pkg',
+                'export GOPATH="$TMP_DIR"',
+                '$TOOL get -d ' + get,
+            ]
         if revision:
             # Annoyingly -C does not work on git checkout :(
             cmd.append('(cd %s && git checkout -q %s)' % (subdir, revision))
@@ -591,10 +595,15 @@ def go_get(name:str, get:str, deps:list=[], exported_deps:list=None,
         sandbox = False,
     )
 
+    if install:
+        install = [i if i.startswith(get) else (get + '/' + i) for i in install]
+    else:
+        install = [get]
+
     # Now compile it in a separate step.
     cmd = [
         'export GOPATH="$TMP_DIR:$TMP_DIR/$PKG"',
-        '$TOOL install -gcflags "-trimpath $TMP_DIR" ' + ' '.join([get] + (install or [])),
+        '$TOOL install -gcflags "-trimpath $TMP_DIR" ' + ' '.join(install),
         # The outputs tend to end up in subdirectories (Go seems to match them to the location the source came from)
         'rm -rf bin' if binary else 'rm -rf pkg',
         'mv $PKG/bin .' if binary else 'mv $PKG/pkg .',
@@ -619,6 +628,21 @@ def go_get(name:str, get:str, deps:list=[], exported_deps:list=None,
         sandbox = False,
         needs_transitive_deps = True,
     )
+
+
+def _go_github_repo_cmd(get, repo, revision):
+    """Returns a partial command to fetch a Go repo from Github."""
+    parts = get.split('/')
+    out = '/'.join(parts[:3])
+    if repo.count('/') > 2:
+        parts = repo.split('/')
+        repo = '/'.join(parts[:3])
+    return [
+        'rm -rf src/' + out,
+        'curl -fsSLo github.zip https://%s/archive/%s.zip' % (repo, revision),
+        'unzip -qq github.zip',
+        'mv %s* src/%s' % (parts[2], out),
+    ]
 
 
 def _replace_test_package(name, output, static):

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -512,19 +512,24 @@ def cgo_test(name:str, srcs:list, data:list=None, deps:list=None, visibility:lis
     )
 
 
-def go_get(name:str, get:str, outs:list=None, deps:list=None, exported_deps:list=None,
+def go_get(name:str, get:str, deps:list=[], exported_deps:list=None,
            visibility:list=None, patch:str=None, binary:bool=False, test_only:bool&testonly=False,
-           install:list=None, revision:str=None, strip:list=None):
+           install:list=None, revision:str=None, strip:list=None, hashes:list=None):
     """Defines a dependency on a third-party Go library.
 
     Note that unlike a normal `go get` call, this does *not* install transitive dependencies.
     You will need to add those as separate rules; `go list -f '{{.Deps}}' <package>` can be
     useful to discover what they should be.
 
+    Note also that while a single go_get is sufficient to compile all parts of a library,
+    one may also want separate ones for a binary. Since two rules can't both output the same
+    source files (and you only want to download them once anyway) you should handle that by
+    marking the non-binary rule as a dependency of the binary one - if you don't there may
+    be warnings issued about conflicting output files.
+
     Args:
       name (str): Name of the rule
       get (str): Target to get (eg. "github.com/gorilla/mux")
-      outs (list): Output files from the rule. Default autodetects.
       deps (list): Dependencies
       exported_deps (list): Dependencies to make available to anything using this rule.
       visibility (list): Visibility specification
@@ -536,55 +541,83 @@ def go_get(name:str, get:str, outs:list=None, deps:list=None, exported_deps:list
       revision (str): Git hash to check out before building. Only works for git at present,
                       not for other version control systems.
       strip (list): List of paths to strip from the installed target.
+      hashes (list): List of hashes to verify the downloaded sources against.
     """
-    if binary and outs and len(outs) != 1:
-        raise ValueError(name + ': Binary rules can only have a single output')
+    if hashes and not revision:
+        log.warning("You shouldn't specify hashes on go_get without specifying revision as well")
+    labels = ['go_get:%s@%s' % (get, revision) if revision else 'go_get:%s' % get]
     getroot = get[:-4] if get.endswith('/...') else get
     subdir = 'src/' + getroot
-    if not outs:
-        if binary:
-            outs = ['bin/' + name]
-        else:
-            outs = {
-                'src': ['src/' + getroot],
-                'pkg': ['pkg/%s_%s/%s' % (CONFIG.OS, CONFIG.ARCH, getroot)],
-            }
-    cmd = [
-        'rm -rf src pkg',
-        'export GOPATH="$TMP_DIR" DEST="%s"' % subdir,
-        '$TOOL get -d ' + get,
-    ]
-    if revision:
-        # Annoyingly -C does not work on git checkout :(
-        cmd.append('(cd $DEST && git checkout -q %s)' % revision)
-    if patch:
-        cmd.append('patch -s -d $DEST -p1 < ${TMP_DIR}/$SRCS')
-    cmd.append('$TOOL install -gcflags "-trimpath $TMP_DIR" ' + ' '.join([get] + (install or [])))
-    if not binary:
-        cmd += [
-            'find . -name .git | xargs rm -rf',
-            # Outputs are created one directory down from where we want them.
-            # For most it doesn't matter but the top-level one will get lost.
-            'if [ -f ${OUTS_PKG}.a ]; then mkdir -p $OUTS_PKG && mv ${OUTS_PKG}.a $OUTS_PKG; fi',
+
+    if get.startswith('github.com') and revision and get.count('/') >= 2:
+        # Optimisation for github, which lets us download zipfiles at a particular sha instead of
+        # cloning the whole repo. Obviously that is a lot faster than cloning entire repos.
+        parts = get.split('/')
+        repo = '/'.join(parts[:3])
+        cmd = [
+            'rm -rf src/' + repo,
+            'curl -fsSLo github.zip https://%s/archive/%s.zip' % (repo, revision),
+            'unzip -qq github.zip',
+            'mv %s* src/%s' % (parts[2], repo),
         ]
+    else:
+        cmd = [
+            'rm -rf src pkg',
+            'export GOPATH="$TMP_DIR"',
+            '$TOOL get -d ' + get,
+        ]
+        if revision:
+            # Annoyingly -C does not work on git checkout :(
+            cmd.append('(cd %s && git checkout -q %s)' % (subdir, revision))
+        cmd.append('find . -name .git | xargs rm -rf')
+    if patch:
+        cmd.append('patch -s -d %s -p1 < ${TMP_DIR}/$SRCS' % subdir)
     if strip:
         cmd += ['rm -rf %s/%s' % (subdir, s) for s in strip]
+    # This is an awkward case, as noted above one may want to build a binary from an existing library
+    # so we have to special case here to allow them both to use the same source download.
+    get_rule = None if binary and deps else build_rule(
+        name = name,
+        tag = 'get',
+        srcs = [patch] if patch else [],
+        outs = [subdir],
+        tools = [CONFIG.GO_TOOL],
+        visibility = visibility,
+        building_description = 'Fetching...',
+        cmd = ' && '.join(cmd),
+        requires = ['go'],
+        test_only = test_only,
+        labels = labels,
+        sandbox = False,
+    )
+
+    # Now compile it in a separate step.
+    cmd = [
+        'export GOPATH="$TMP_DIR:$TMP_DIR/$PKG"',
+        '$TOOL install -gcflags "-trimpath $TMP_DIR" ' + ' '.join([get] + (install or [])),
+        # The outputs tend to end up in subdirectories (Go seems to match them to the location the source came from)
+        'rm -rf bin' if binary else 'rm -rf pkg',
+        'mv $PKG/bin .' if binary else 'mv $PKG/pkg .',
+    ]
+    if not binary:
+        # Outputs are created one directory down from where we want them.
+        # For most it doesn't matter but the top-level one will get lost.
+        cmd.append(' if [ -f ${OUTS}.a ]; then mkdir -p $OUTS && mv ${OUTS}.a $OUTS; fi')
     build_rule(
-        name=name,
-        srcs=[patch] if patch else [],
-        outs=outs,
-        deps=deps,
-        exported_deps=exported_deps,
-        tools=[CONFIG.GO_TOOL],
-        visibility=visibility,
-        building_description='Fetching...',
-        cmd=' && '.join(cmd),
-        binary=binary,
-        requires=['go'],
-        test_only=test_only,
-        labels=['go_get:%s@%s' % (get, revision) if revision else 'go_get:%s' % get],
-        sandbox=False,
-        needs_transitive_deps=True,
+        name = name,
+        outs = [('bin/' + name) if binary else ('pkg/%s_%s/%s' % (CONFIG.OS, CONFIG.ARCH, getroot))],
+        deps = deps + [get_rule],
+        exported_deps = exported_deps,
+        tools = [CONFIG.GO_TOOL],
+        visibility = visibility,
+        building_description = 'Compiling...',
+        cmd = ' && '.join(cmd),
+        binary = binary,
+        requires = ['go'],
+        test_only = test_only,
+        labels = labels,
+        sandbox = False,
+        needs_transitive_deps = True,
     )
 
 

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -601,7 +601,7 @@ def go_get(name:str, get:str, repo:str='', deps:list=[], exported_deps:list=None
     )
 
     if install:
-        install = [i if i.startswith(get) else (get + '/' + i) for i in install]
+        install = [i if i.startswith(getroot) else (getroot + '/' + i) for i in install]
     else:
         install = [get]
 

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -607,12 +607,15 @@ def go_get(name:str, get:str, repo:str='', deps:list=[], exported_deps:list=None
 
     # Now compile it in a separate step.
     cmd = [
-        'export GOPATH="$TMP_DIR:$TMP_DIR/$PKG"',
+        'export GOPATH="$TMP_DIR:$TMP_DIR/$PKG_DIR"',
         '$TOOL install -gcflags "-trimpath $TMP_DIR" ' + ' '.join(install),
-        # The outputs tend to end up in subdirectories (Go seems to match them to the location the source came from)
-        'rm -rf bin' if binary else 'rm -rf pkg',
-        'mv $PKG/bin .' if binary else 'mv $PKG/pkg .',
     ]
+    if package_name():
+        cmd += [
+            # The outputs tend to end up in subdirectories (Go seems to match them to the location the source came from)
+            'rm -rf bin' if binary else 'rm -rf pkg',
+            'mv $PKG_DIR/bin .' if binary else 'mv $PKG_DIR/pkg .',
+        ]
     if not binary:
         # Outputs are created one directory down from where we want them.
         # For most it doesn't matter but the top-level one will get lost.

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -537,8 +537,10 @@ def go_get(name:str, get:str, repo:str='', deps:list=[], exported_deps:list=None
       patch (str): Patch file to apply
       binary (bool): True if the output of the rule is a binary.
       test_only (bool): If true this rule will only be visible to tests.
-      install (list): Allows specifying extra packages to install. Convenient in some cases where we
-                      want to go get something with an extra subpackage.
+      install (list): Allows specifying the exact list of packages to install. If this is not passed,
+                      the package passed to 'get' is installed. If you pass this for subpackages, you
+                      will need to explicitly add an empty string to the list if you want to install
+                      the root package from this repo.
       revision (str): Git hash to check out before building. Only works for git at present,
                       not for other version control systems.
       strip (list): List of paths to strip from the installed target.
@@ -592,6 +594,7 @@ def go_get(name:str, get:str, repo:str='', deps:list=[], exported_deps:list=None
         requires = ['go'],
         test_only = test_only,
         labels = labels,
+        hashes = hashes,
         sandbox = False,
     )
 

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -155,6 +155,7 @@ def go_generate(name:str, srcs:list, tools:list, deps:list=None, visibility:list
         # It's also essential that the compiled .a files are under this prefix, otherwise gcimporter won't find them.
         'mkdir pkg',
         'ln -s $TMP_DIR pkg/%s_%s' % (CONFIG.OS, CONFIG.ARCH),
+        'ln -s . src',
         'export PATH="$(echo "$TOOLS_GEN " | sed -E -e \'s|/[^/]+[ ]|:|g\')$PATH"',
         'GOPATH="$TMP_DIR$(echo ":$(%s)" | sed "s/:$//g")" $TOOLS_GO generate $SRCS' % gopath,
         'mv $PKG_DIR/*.go .',
@@ -172,6 +173,7 @@ def go_generate(name:str, srcs:list, tools:list, deps:list=None, visibility:list
         visibility=visibility,
         test_only=test_only,
         post_build=_post_build,
+        requires = ['go', 'go_src'],
     )
 
 

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -517,6 +517,10 @@ def go_get(name:str, get:str, outs:list=None, deps:list=None, exported_deps:list
            install:list=None, revision:str=None, strip:list=None):
     """Defines a dependency on a third-party Go library.
 
+    Note that unlike a normal `go get` call, this does *not* install transitive dependencies.
+    You will need to add those as separate rules; `go list -f '{{.Deps}}' <package>` can be
+    useful to discover what they should be.
+
     Args:
       name (str): Name of the rule
       get (str): Target to get (eg. "github.com/gorilla/mux")
@@ -533,60 +537,38 @@ def go_get(name:str, get:str, outs:list=None, deps:list=None, exported_deps:list
                       not for other version control systems.
       strip (list): List of paths to strip from the installed target.
     """
-    post_build = None
     if binary and outs and len(outs) != 1:
         raise ValueError(name + ': Binary rules can only have a single output')
     getroot = get[:-4] if get.endswith('/...') else get
     subdir = 'src/' + getroot
     if not outs:
-        outs = [('bin/' + name) if binary else ('src/' + getroot)]
-        if not binary:
-            post_build = _extra_outs(getroot)
+        if binary:
+            outs = ['bin/' + name]
+        else:
+            outs = {
+                'src': ['src/' + getroot],
+                'pkg': ['pkg/%s_%s/%s' % (CONFIG.OS, CONFIG.ARCH, getroot)],
+            }
     cmd = [
-        # the TMP_DIR contains all the compiled dependencies already. Later when
-        # we go install, it is difficult to seperate its outputs from the
-        # deps outputs, hence why we capture them here in advance
-        'export existing="$(find $TMP_DIR -name \"*.a\")"',
-
-        # go_get dependencies could be in different paths, make sure they are
-        # all available in the GOPATH by detecting their pkg/ folder and using its parent
-        'export GOPATH="$TMP_DIR"',
-        # loop done like this because the GOPATH export should not be in a SubShell
-        'while IFS= read -r dep_dir; do '
-        'if [ -n "$dep_dir" ]; then export GOPATH="${dep_dir}:${GOPATH}" ; fi ; done '
-        '< <(echo "$existing" | sed -e \'s|pkg/.*||g\' | sort -u)',
-
-        'export INSTALL_DIR=$(mktemp -d ${TMP_DIR}/tmp.XXXXX)',
-        'export GOPATH="$INSTALL_DIR:$GOPATH"',
-
-        'cd $INSTALL_DIR',
+        'rm -rf src pkg',
+        'export GOPATH="$TMP_DIR" DEST="%s"' % subdir,
         '$TOOL get -d ' + get,
     ]
     if revision:
         # Annoyingly -C does not work on git checkout :(
-        cmd.append('(cd %s && git checkout -q %s)' % (subdir, revision))
+        cmd.append('(cd $DEST && git checkout -q %s)' % revision)
     if patch:
-        cmd.append('patch -s -d %s -p1 < ${TMP_DIR}/$(location %s)' % (subdir, patch))
-    cmd.append('$TOOL install -gcflags "-trimpath $INSTALL_DIR" ' + ' '.join([get] + (install or [])))
-    # Remove anything that was there already.
-    cmd.extend([
-        # go_get built dependencies could be in different dirs so we strip the prefix
-        # leading up to `/pkg/`. These have been cached in the "$INSTALL_DIR/pkg/.."
-        # during the `go install`. So clean them up from this target's outputs
-        'echo "$existing" | while IFS= read -r pathname; do '
-        'if [ -n "$pathname" ]; then rm -f "$INSTALL_DIR/pkg/${pathname#*/pkg/}" ; fi ; done',
-        'cd $TMP_DIR',
-        # delete all other dirs with deps. Only src,pkg and maybe bin will remain
-        'ls | (grep -v $(basename $INSTALL_DIR) || true) | xargs rm -rf',
-        'mv $INSTALL_DIR/* $TMP_DIR/'
-    ])
+        cmd.append('patch -s -d $DEST -p1 < ${TMP_DIR}/$SRCS')
+    cmd.append('$TOOL install -gcflags "-trimpath $TMP_DIR" ' + ' '.join([get] + (install or [])))
     if not binary:
-        cmd.extend([
+        cmd += [
             'find . -name .git | xargs rm -rf',
-            'find pkg -name "*.a" | sort',
-        ])
+            # Outputs are created one directory down from where we want them.
+            # For most it doesn't matter but the top-level one will get lost.
+            'if [ -f ${OUTS_PKG}.a ]; then mkdir -p $OUTS_PKG && mv ${OUTS_PKG}.a $OUTS_PKG; fi',
+        ]
     if strip:
-        cmd.extend(['rm -rf %s/%s' % (subdir, s) for s in strip])
+        cmd += ['rm -rf %s/%s' % (subdir, s) for s in strip]
     build_rule(
         name=name,
         srcs=[patch] if patch else [],
@@ -600,26 +582,10 @@ def go_get(name:str, get:str, outs:list=None, deps:list=None, exported_deps:list
         binary=binary,
         requires=['go'],
         test_only=test_only,
-        post_build=post_build,
         labels=['go_get:%s@%s' % (get, revision) if revision else 'go_get:%s' % get],
         sandbox=False,
         needs_transitive_deps=True,
     )
-
-
-def _extra_outs(get):
-    """Attaches extra outputs to go_get rules."""
-    def _inner(name, output):
-        last = '<>'
-        for archive in output:
-            add_out(name, archive)
-            before, _, after = archive[6:-2].partition('/')
-            subpath = after or before
-            if ((not subpath.startswith(get)) and (not subpath.startswith(last)) and
-                (not get.startswith(subpath)) and (not last.startswith(subpath))):
-                    add_out(name, 'src/' + subpath)
-            last = subpath
-    return _inner
 
 
 def _replace_test_package(name, output, static):

--- a/src/test/BUILD
+++ b/src/test/BUILD
@@ -5,8 +5,8 @@ go_library(
         '//src/build',
         '//src/core',
         '//src/metrics',
-        '//third_party/go:cover',
         '//third_party/go:logging',
+        '//third_party/go:tools',
     ],
     visibility = ['PUBLIC'],
 )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -444,6 +444,7 @@ go_get(
     binary = True,
     get = 'github.com/dvyukov/go-fuzz/go-fuzz-build',
     revision = '445b00a1141b27425541ee8d7dc2f524faf202a9',
+    deps = [':go-fuzz-dep'],
 )
 
 go_get(
@@ -451,11 +452,15 @@ go_get(
     binary = True,
     get = 'github.com/dvyukov/go-fuzz/go-fuzz',
     revision = '445b00a1141b27425541ee8d7dc2f524faf202a9',
+    deps = [':go-fuzz-dep'],
 )
 
 go_get(
     name = 'go-fuzz-dep',
-    get = 'github.com/dvyukov/go-fuzz/go-fuzz-dep',
-    install = ['go-fuzz-defs'],
+    get = 'github.com/dvyukov/go-fuzz',
+    install = [
+        'go-fuzz-dep',
+        'go-fuzz-defs',
+    ],
     revision = '445b00a1141b27425541ee8d7dc2f524faf202a9',
 )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -44,6 +44,7 @@ go_get(
     binary = True,
     get = 'github.com/kevinburke/go-bindata/...',
     revision = '46eb4c183bfc1ebb527d9d19bcded39476302eb8',
+    strip = ['testdata'],
 )
 
 go_get(
@@ -133,9 +134,6 @@ go_get(
     name = 'protobuf',
     get = 'github.com/golang/protobuf/...',
     revision = '130e6b02ab059e7b717a096f397c5b60111cae74',
-    strip = [
-        'protoc-gen-go',  # avoids conflict with :protoc-gen-go binary.
-    ],
 )
 
 go_get(

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -299,9 +299,9 @@ go_get(
     name = 'grpc-middleware',
     get = 'github.com/grpc-ecosystem/go-grpc-middleware',
     install = [
-        'github.com/grpc-ecosystem/go-grpc-middleware/retry',
-        'github.com/grpc-ecosystem/go-grpc-middleware/util/metautils',
-        'github.com/grpc-ecosystem/go-grpc-middleware/util/backoffutils',
+        'retry',
+        'util/metautils',
+        'util/backoffutils',
     ],
     revision = 'fa8fef87dcecac0bda02d36abb3c790ab9e0030b',
     deps = [

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -103,24 +103,25 @@ go_get(
     exported_deps = [':net'],
     get = 'google.golang.org/grpc',
     install = [
-        'google.golang.org/grpc/balancer',
-        'google.golang.org/grpc/codes',
-        'google.golang.org/grpc/connectivity',
-        'google.golang.org/grpc/credentials',
-        'google.golang.org/grpc/grpclb/grpc_lb_v1/messages',
-        'google.golang.org/grpc/grpclog',
-        'google.golang.org/grpc/health',
-        'google.golang.org/grpc/health/grpc_health_v1',
-        'google.golang.org/grpc/internal',
-        'google.golang.org/grpc/keepalive',
-        'google.golang.org/grpc/metadata',
-        'google.golang.org/grpc/naming',
-        'google.golang.org/grpc/peer',
-        'google.golang.org/grpc/resolver',
-        'google.golang.org/grpc/stats',
-        'google.golang.org/grpc/status',
-        'google.golang.org/grpc/tap',
-        'google.golang.org/grpc/transport',
+        '',
+        'balancer',
+        'codes',
+        'connectivity',
+        'credentials',
+        'grpclb/grpc_lb_v1/messages',
+        'grpclog',
+        'health',
+        'health/grpc_health_v1',
+        'internal',
+        'keepalive',
+        'metadata',
+        'naming',
+        'peer',
+        'resolver',
+        'stats',
+        'status',
+        'tap',
+        'transport',
     ],
     revision = 'v1.7.0',
     deps = [
@@ -164,10 +165,10 @@ go_get(
     name = 'testify',
     get = 'github.com/stretchr/testify',
     install = [
-        'github.com/stretchr/testify/assert',
-        'github.com/stretchr/testify/require',
-        'github.com/stretchr/testify/vendor/github.com/davecgh/go-spew/spew',
-        'github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib',
+        'assert',
+        'require',
+        'vendor/github.com/davecgh/go-spew/spew',
+        'vendor/github.com/pmezard/go-difflib/difflib',
     ],
     revision = 'f390dcf405f7b83c997eac1b06768bb9f44dec18',
     deps = [':spew'],
@@ -238,19 +239,40 @@ go_get(
 go_get(
     name = 'prometheus',
     get = 'github.com/prometheus/client_golang/prometheus/...',
-    install = [
-        'github.com/prometheus/client_model/go',
-        'github.com/prometheus/common/expfmt',
-        'github.com/prometheus/common/model',
-        'github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg',
-    ],
     revision = 'c5b7fccd204277076155f10851dad72b76a49317',
     deps = [
         ':grpc',
         ':pbutil',
         ':procfs',
+        ':prometheus_client_model',
+        ':prometheus_common',
         ':protobuf',
         ':quantile',
+    ],
+)
+
+go_get(
+    name = 'prometheus_common',
+    get = 'github.com/prometheus/common',
+    install = [
+        'expfmt',
+        'model',
+        'internal/bitbucket.org/ww/goautoneg',
+    ],
+    revision = '89604d197083d4781071d3c65855d24ecfb0a563',
+    deps = [
+        ':pbutil',
+        ':prometheus_client_model',
+        ':protobuf',
+    ],
+)
+
+go_get(
+    name = 'prometheus_client_model',
+    get = 'github.com/prometheus/client_model/go',
+    revision = '99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c',
+    deps = [
+        ':protobuf',
     ],
 )
 
@@ -323,7 +345,8 @@ go_get(
     name = 'go-multierror',
     get = 'github.com/hashicorp/go-multierror',
     install = [
-        'github.com/hashicorp/go-multierror/vendor/github.com/hashicorp/errwrap',
+        '',
+        'vendor/github.com/hashicorp/errwrap',
     ],
     revision = 'b7773ae218740a7be65057fc60b366a49b538a44',
 )
@@ -389,9 +412,9 @@ go_get(
     name = 'psutil',
     get = 'github.com/shirou/gopsutil',
     install = [
-        'github.com/shirou/gopsutil/cpu',
-        'github.com/shirou/gopsutil/internal/common',
-        'github.com/shirou/gopsutil/mem',
+        'cpu',
+        'internal/common',
+        'mem',
     ],
     revision = 'v2.17.09',
     deps = [':unix'],
@@ -433,6 +456,6 @@ go_get(
 go_get(
     name = 'go-fuzz-dep',
     get = 'github.com/dvyukov/go-fuzz/go-fuzz-dep',
-    install = ['github.com/dvyukov/go-fuzz/go-fuzz-defs'],
+    install = ['go-fuzz-defs'],
     revision = '445b00a1141b27425541ee8d7dc2f524faf202a9',
 )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -13,12 +13,6 @@ go_get(
 )
 
 go_get(
-    name = 'cover',
-    get = 'golang.org/x/tools/cover',
-    revision = 'c0008c5889c0d5091cdfefd2bfb08bff96527879',
-)
-
-go_get(
     name = 'warnings',
     get = 'gopkg.in/warnings.v0',
     revision = 'v0.1.2',
@@ -28,9 +22,10 @@ go_get(
     name = 'gcfg',
     get = 'gopkg.in/gcfg.v1',
     install = [
-        'gopkg.in/gcfg.v1/scanner',
-        'gopkg.in/gcfg.v1/token',
-        'gopkg.in/gcfg.v1/types',
+        '',
+        'scanner',
+        'token',
+        'types',
     ],
     patch = 'gcfg_dynamic_fields.patch',
     revision = '27e4946190b4a327b539185f2b5b1f7c84730728',
@@ -89,6 +84,18 @@ go_get(
     name = 'text',
     get = 'golang.org/x/text/...',
     revision = '4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1',
+    deps = [
+        ':tools',
+    ],
+)
+
+go_get(
+    name = 'tools',
+    get = 'golang.org/x/tools',
+    install = [
+        'cover',
+    ],
+    revision = '2ae76fd1560b622911f444c1e66b70a857e1de67',
 )
 
 go_get(
@@ -187,6 +194,7 @@ go_get(
     binary = True,
     get = 'golang.org/x/tools/cmd/stringer',
     revision = 'f8ecfdb6b66ec67ca930b39806519a2b72d1eaca',
+    deps = [':tools'],
 )
 
 go_get(


### PR DESCRIPTION
Revisiting it yet again...

Post #280 we were specifying all transitive dependencies anyway; this takes advantage of that to simplify the rule by having it output just the specific package in question. It then regained a bit of complexity with some Github-specific optimisations :)

`install` now automatically prefixes with the repo name if not given, and you have to explicitly pass an empty string if you want the root (this is a bit awkward, but `install` is not the common case, and it allows more flexibility for cases when the repo root is not a valid `go install` target itself).

I've also broken it into two rules internally (one for fetching and one for compiling) since the former should now be hash verifiable.