### PR TITLE
Migrate filepath.Walk calls to godirwalk

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -28,6 +28,7 @@ go get github.com/texttheater/golang-levenshtein/levenshtein
 go get github.com/Workiva/go-datastructures/queue
 go get github.com/coreos/go-semver/semver
 go get github.com/djherbis/atime
+go get github.com/karrick/godirwalk
 
 # Clean out old artifacts.
 rm -rf plz-out src/parse/rules/builtin_rules.bindata.go src/parse/rules/builtin_data.bindata.go

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -224,10 +224,8 @@ func pathHashImpl(path string) ([]byte, error) {
 		return h.Sum(nil), err
 	}
 	if err == nil && info.IsDir() {
-		err = filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			} else if info.Mode()&os.ModeSymlink != 0 {
+		err = core.WalkMode(path, func(p string, isDir bool, mode os.FileMode) error {
+			if mode&os.ModeSymlink != 0 {
 				// Is a symlink, must verify that it's not a link outside the tmp dir.
 				deref, err := filepath.EvalSymlinks(p)
 				if err != nil {
@@ -242,7 +240,7 @@ func pathHashImpl(path string) ([]byte, error) {
 				// Just write something to the hash indicating that we found something here,
 				// otherwise rules might be marked as unchanged if they added additional symlinks.
 				h.Write(boolTrueHashValue)
-			} else if !info.IsDir() {
+			} else if !isDir {
 				return fileHash(&h, p)
 			}
 			return nil

--- a/src/cache/http_cache.go
+++ b/src/cache/http_cache.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"path/filepath"
 	"time"
 
 	"core"
@@ -28,10 +27,8 @@ func (cache *httpCache) Store(target *core.BuildTarget, key []byte, files ...str
 	if cache.Writeable {
 		for out := range cacheArtifacts(target, files...) {
 			if info, err := os.Stat(out); err == nil && info.IsDir() {
-				filepath.Walk(out, func(name string, info os.FileInfo, err error) error {
-					if err != nil {
-						return err
-					} else if !info.IsDir() {
+				core.Walk(out, func(name string, isDir bool) error {
+					if !isDir {
 						cache.StoreExtra(target, key, name)
 					}
 					return nil

--- a/src/cache/rpc_cache.go
+++ b/src/cache/rpc_cache.go
@@ -14,7 +14,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 	"runtime"
 	"sync/atomic"
 	"time"
@@ -101,10 +100,8 @@ func (cache *rpcCache) loadArtifacts(target *core.BuildTarget, file string) ([]*
 	outDir := target.OutDir()
 	root := path.Join(outDir, file)
 	totalSize := 1000 // Allow a little space for encoding overhead.
-	err := filepath.Walk(root, func(name string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		} else if !info.IsDir() {
+	err := core.Walk(root, func(name string, isDir bool) error {
+		if !isDir {
 			content, err := ioutil.ReadFile(name)
 			if err != nil {
 				return err

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -20,6 +20,7 @@ go_library(
         '//src/cli',
         '//third_party/go:gcfg',
         '//third_party/go:go-flags',
+        '//third_party/go:godirwalk',
         '//third_party/go:logging',
         '//third_party/go:queue',
         '//third_party/go:semver',

--- a/src/core/glob.go
+++ b/src/core/glob.go
@@ -1,12 +1,13 @@
 package core
 
 import (
-	"os"
 	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/karrick/godirwalk"
 )
 
 // Used to identify the fixed part at the start of a glob pattern.
@@ -93,10 +94,7 @@ func glob(state *BuildState, rootPath, pattern string, includeHidden bool, exclu
 		return matches, err
 	}
 
-	err = filepath.Walk(rootPath, func(name string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
+	err = godirwalk.Walk(rootPath, &godirwalk.Options{Callback: func(name string, info *godirwalk.Dirent) error {
 		if info.IsDir() {
 			if name != rootPath && IsPackage(state, name) {
 				return filepath.SkipDir // Can't glob past a package boundary
@@ -109,7 +107,7 @@ func glob(state *BuildState, rootPath, pattern string, includeHidden bool, exclu
 			matches = append(matches, name)
 		}
 		return nil
-	})
+	}})
 	return matches, err
 }
 

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -164,13 +164,11 @@ func WriteFile(fromFile io.Reader, to string, mode os.FileMode) error {
 // If 'fallback' is true then we'll fall back to a copy if linking fails.
 func RecursiveCopyFile(from string, to string, mode os.FileMode, link, fallback bool) error {
 	if info, err := os.Stat(from); err == nil && info.IsDir() {
-		return filepath.Walk(from, func(name string, info os.FileInfo, err error) error {
+		return WalkMode(from, func(name string, isDir bool, fileMode os.FileMode) error {
 			dest := path.Join(to, name[len(from):])
-			if err != nil {
-				return err
-			} else if info.IsDir() {
+			if isDir {
 				return os.MkdirAll(dest, DirPermissions)
-			} else if (info.Mode() & os.ModeSymlink) != 0 {
+			} else if (fileMode & os.ModeSymlink) != 0 {
 				fi, err := os.Stat(name)
 				if err != nil {
 					return err

--- a/src/test/results.go
+++ b/src/test/results.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"core"
 )
@@ -48,10 +47,8 @@ func parseTestResultsDir(outputDir string) (core.TestResults, error) {
 	if !core.PathExists(outputDir) {
 		return results, fmt.Errorf("Didn't find any test results in %s", outputDir)
 	}
-	err := filepath.Walk(outputDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		} else if !info.IsDir() {
+	err := core.Walk(outputDir, func(path string, isDir bool) error {
+		if !isDir {
 			fileResults, err := parseTestResultsImpl(path)
 			if err != nil {
 				return fmt.Errorf("Error parsing %s: %s", path, err)

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -123,10 +122,10 @@ func startWatching(watcher *fsnotify.Watcher, state *core.BuildState, labels []c
 func addSource(watcher *fsnotify.Watcher, state *core.BuildState, source core.BuildInput, dirs map[string]struct{}, files cmap.ConcurrentMap) {
 	if source.Label() == nil {
 		for _, src := range source.Paths(state.Graph) {
-			if err := filepath.Walk(src, func(src string, info os.FileInfo, err error) error {
+			if err := core.Walk(src, func(src string, isDir bool) error {
 				files.Set(src, struct{}{})
 				dir := src
-				if info, err := os.Stat(src); err == nil && !info.IsDir() {
+				if !isDir {
 					dir = path.Dir(src)
 				}
 				if _, present := dirs[dir]; !present {
@@ -136,7 +135,7 @@ func addSource(watcher *fsnotify.Watcher, state *core.BuildState, source core.Bu
 						log.Error("Failed to add watch on %s: %s", src, err)
 					}
 				}
-				return err
+				return nil
 			}); err != nil {
 				log.Error("Failed to add watch on %s: %s", src, err)
 			}

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -470,3 +470,21 @@ go_get(
     ],
     revision = '445b00a1141b27425541ee8d7dc2f524faf202a9',
 )
+
+go_get(
+    name = 'godirwalk',
+    get = 'github.com/karrick/godirwalk',
+    revision = '17c244300a0e2101858b851a8df1ae8e796a0bca',
+    strip = [
+        'examples',
+        'testdata',
+        'vendor',
+    ],
+    deps = [':errors'],
+)
+
+go_get(
+    name = 'errors',
+    get = 'github.com/pkg/errors',
+    revision = '30136e27e2ac8d167177e8a583aa4c3fea5be833',
+)

--- a/tools/cache/server/cache.go
+++ b/tools/cache/server/cache.go
@@ -195,10 +195,8 @@ func (cache *Cache) RetrieveArtifact(artPath string) (map[string][]byte, error) 
 	}
 	defer lock.RUnlock()
 
-	if err := filepath.Walk(fullPath, func(name string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		} else if !info.IsDir() {
+	if err := core.Walk(fullPath, func(name string, isDir bool) error {
+		if !isDir {
 			body, err := ioutil.ReadFile(name)
 			if err != nil {
 				return err
@@ -218,10 +216,8 @@ func (cache *Cache) retrieveDir(artPath string) (map[string][]byte, error) {
 	log.Debug("Searching dir %s for artifacts", artPath)
 	ret := map[string][]byte{}
 	fullPath := path.Join(cache.rootPath, artPath)
-	err := filepath.Walk(fullPath, func(name string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		} else if !info.IsDir() {
+	err := core.Walk(fullPath, func(name string, isDir bool) error {
+		if !isDir {
 			// Must strip cache path off the front of this.
 			m, err := cache.RetrieveArtifact(name[len(cache.rootPath)+1:])
 			if err != nil {

--- a/tools/cache/server/rpc_server.go
+++ b/tools/cache/server/rpc_server.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/signal"
 	"path"
-	"path/filepath"
 	"sync"
 	"syscall"
 
@@ -27,6 +26,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "cache/proto/rpc_cache"
+	"core"
 	"tools/cache/cluster"
 )
 
@@ -196,10 +196,8 @@ func extractAddress(ctx context.Context) string {
 
 func loadKeys(filename string) map[string]*x509.Certificate {
 	ret := map[string]*x509.Certificate{}
-	if err := filepath.Walk(filename, func(name string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		} else if !info.IsDir() {
+	if err := core.Walk(filename, func(name string, isDir bool) error {
+		if !isDir {
 			data, err := ioutil.ReadFile(name)
 			if err != nil {
 				log.Fatalf("Failed to read cert from %s: %s", name, err)

--- a/tools/jarcat/zip/BUILD
+++ b/tools/jarcat/zip/BUILD
@@ -2,6 +2,7 @@ go_library(
     name = 'zip',
     srcs = ['writer.go'],
     deps = [
+        '//src/core',
         '//third_party/go:logging',
         '//third_party/go:testify',
         '//third_party/go/zip',

--- a/tools/please_go_test/gotest/BUILD
+++ b/tools/please_go_test/gotest/BUILD
@@ -5,6 +5,7 @@ go_library(
         'write_test_main.go',
     ],
     deps = [
+        '//src/core',
         '//third_party/go:logging',
     ],
     visibility = ['//tools/please_go_test:all'],

--- a/tools/please_go_test/gotest/find_cover_vars.go
+++ b/tools/please_go_test/gotest/find_cover_vars.go
@@ -4,12 +4,13 @@ package gotest
 import (
 	"go/build"
 	"io/ioutil"
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
 	"gopkg.in/op/go-logging.v1"
+
+	"core"
 )
 
 var log = logging.MustGetLogger("buildgo")
@@ -31,11 +32,11 @@ func FindCoverVars(dir string, exclude, srcs []string) ([]CoverVar, error) {
 	}
 	ret := []CoverVar{}
 
-	err := filepath.Walk(dir, func(name string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		} else if _, present := excludeMap[name]; present {
-			return filepath.SkipDir
+	err := core.Walk(dir, func(name string, isDir bool) error {
+		if _, present := excludeMap[name]; present {
+			if isDir {
+				return filepath.SkipDir
+			}
 		} else if strings.HasSuffix(name, ".a") && !strings.ContainsRune(path.Base(name), '#') {
 			vars, err := findCoverVars(name, srcs)
 			if err != nil {


### PR DESCRIPTION
As mentioned in #273 and upstream, filepath.Walk could be faster. This swaps it out for a more optimal implementation which seems to preserve all the ordering that we require.

Resolves #273. I've still not done any real benchmarking of glob() but happy to assume that this is about as fast as it's going to get :)