### PR TITLE
Fix up self_executable jar expansion

### DIFF
--- a/src/parse/rules/java_rules.build_defs
+++ b/src/parse/rules/java_rules.build_defs
@@ -227,7 +227,7 @@ def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, dep
         )
         deps.append(lib_rule)
     if self_executable:
-        preamble = '#!/bin/sh\nexec java %s -jar $0 $@' % (jvm_args or '')
+        preamble = '#!/bin/sh\nexec java %s -jar $0 ${@}' % (jvm_args or '')
         cmd, tools = _jarcat_cmd(main_class, preamble, manifest=manifest)
     else:
         # This is essentially a hack to get past some Java things (notably Jersey) failing


### PR DESCRIPTION
If Bazel expansion rules are turned on, this gets expanded to $OUTS before being written to the shell file, meaning the script no longer accepts arguments.