### PR TITLE
Add config to pass in environment variables

### DIFF
--- a/docs/config.html
+++ b/docs/config.html
@@ -121,6 +121,11 @@
         The build config to use when one is chosen and a required target does not have
         one by the same name. Also defaults to <code>opt</code>.</li>
 
+      <li><b>PassEnv</b> (repeated string)<br/>
+        A list of environment variables to pass from the current environment to build rules. For example
+        <code>PassEnv = HTTP_PROXY</code>
+        would copy your HTTP_PROXY environment variable to the build env for any rules.</li>
+
     </ul>
 
     <h3>[Cache]</h3>

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -55,7 +55,9 @@ func GeneralBuildEnvironment(config *Configuration) BuildEnv {
 	if config.Cpp.PkgConfigPath != "" {
 		env = append(env, "PKG_CONFIG_PATH="+config.Cpp.PkgConfigPath)
 	}
-	return append(env, config.GetBuildEnv()...)
+	env = append(env, config.GetBuildEnv()...)
+	env = append(env, config.GetPassEnv()...)
+	return env
 }
 
 // BuildEnvironment creates the shell env vars to be passed

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -55,9 +55,7 @@ func GeneralBuildEnvironment(config *Configuration) BuildEnv {
 	if config.Cpp.PkgConfigPath != "" {
 		env = append(env, "PKG_CONFIG_PATH="+config.Cpp.PkgConfigPath)
 	}
-	env = append(env, config.GetBuildEnv()...)
-	env = append(env, config.GetPassEnv()...)
-	return env
+	return append(env, config.GetBuildEnv()...)
 }
 
 // BuildEnvironment creates the shell env vars to be passed

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -428,26 +428,24 @@ func (config *Configuration) ContainerisationHash() []byte {
 func (config *Configuration) GetBuildEnv() []string {
 	config.buildEnvOnce.Do(func() {
 		config.buildEnvStored = []string{}
+
+		// from the BuildEnv config keyword
 		for k, v := range config.BuildEnv {
 			pair := strings.Replace(strings.ToUpper(k), "-", "_", -1) + "=" + v
 			config.buildEnvStored = append(config.buildEnvStored, pair)
 		}
+
+		// from the user's environment based on the PassEnv config keyword
+		for _, k := range config.Build.PassEnv {
+			v, isSet := os.LookupEnv(k)
+			if isSet {
+				config.buildEnvStored = append(config.buildEnvStored, k+"="+v)
+			}
+		}
+
 		sort.Strings(config.buildEnvStored)
 	})
 	return config.buildEnvStored
-}
-
-// GetPassEnv returns environment variables from the user's shell.
-func (config *Configuration) GetPassEnv() []string {
-	envVars := []string{}
-	for _, k := range config.Build.PassEnv {
-		v, isSet := os.LookupEnv(k)
-		if isSet {
-			envVars = append(envVars, k+"="+v)
-		}
-	}
-	sort.Strings(envVars)
-	return envVars
 }
 
 // ApplyOverrides applies a set of overrides to the config.

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -221,4 +222,17 @@ func TestBuildEnvSection(t *testing.T) {
 	assert.NoError(t, err)
 	expected := []string{"BAR_BAR=first", "FOO_BAR=second"}
 	assert.Equal(t, expected, config.GetBuildEnv())
+}
+
+func TestPassEnvSection(t *testing.T) {
+	err := os.Setenv("FOO", "first")
+	assert.NoError(t, err)
+	err = os.Setenv("BAR", "second")
+	assert.NoError(t, err)
+	config, err := ReadConfigFiles([]string{"src/core/test_data/passenv.plzconfig"}, "")
+	assert.Contains(t, config.Build.PassEnv, "FOO")
+	assert.Contains(t, config.Build.PassEnv, "BAR")
+	assert.NoError(t, err)
+	expected := []string{"BAR=second", "FOO=first"}
+	assert.Equal(t, expected, config.GetPassEnv())
 }

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -224,15 +224,13 @@ func TestBuildEnvSection(t *testing.T) {
 	assert.Equal(t, expected, config.GetBuildEnv())
 }
 
-func TestPassEnvSection(t *testing.T) {
+func TestPassEnv(t *testing.T) {
 	err := os.Setenv("FOO", "first")
 	assert.NoError(t, err)
 	err = os.Setenv("BAR", "second")
 	assert.NoError(t, err)
 	config, err := ReadConfigFiles([]string{"src/core/test_data/passenv.plzconfig"}, "")
-	assert.Contains(t, config.Build.PassEnv, "FOO")
-	assert.Contains(t, config.Build.PassEnv, "BAR")
 	assert.NoError(t, err)
 	expected := []string{"BAR=second", "FOO=first"}
-	assert.Equal(t, expected, config.GetPassEnv())
+	assert.Equal(t, expected, config.GetBuildEnv())
 }

--- a/src/core/test_data/passenv.plzconfig
+++ b/src/core/test_data/passenv.plzconfig
@@ -1,0 +1,3 @@
+[Build]
+PassEnv = FOO
+PassEnv = BAR


### PR DESCRIPTION
This adds a config `Build.PassEnv` to copy environment variables from the user's current shell. Example:

```
[Build]
PassEnv = http_proxy
PassEnv = HTTP_PROXY
```

Should fix #205 in most cases, I think.