### PR TITLE
Implements `plz query changes`

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -37,6 +37,7 @@ go_get github.com/coreos/go-semver/semver
 go_get github.com/djherbis/atime
 go_get github.com/karrick/godirwalk
 go_get github.com/hashicorp/go-multierror
+go_get github.com/google/shlex
 notice ""
 
 # Detect javac presence and swap to compiling locally if we find it.

--- a/src/please.go
+++ b/src/please.go
@@ -314,7 +314,7 @@ var opts struct {
 			After           string `short:"a" long:"after" required:"true" description:"Revision to check out for the state after"`
 			CheckoutCommand string `long:"checkout_command" default:"git checkout %s" description:"Command to run to check out the before/after revisions."`
 			Args            struct {
-				Files []string `positional-arg-name:"files" description:"Files to consider changed"`
+				Files cli.StdinStrings `positional-arg-name:"files" description:"Files to consider changed"`
 			} `positional-args:"true"`
 		} `command:"changes" description:"Calculates the difference between two different states of the build graph"`
 	} `command:"query" description:"Queries information about the build graph"`
@@ -571,6 +571,7 @@ var buildFunctions = map[string]func() bool{
 	},
 	"changes": func() bool {
 		opts.OutputFlags.PlainOutput = true
+		files := opts.Query.Changes.Args.Files.Get()
 		if opts.Query.Changes.Before != "" {
 			query.MustCheckout(opts.Query.Changes.Before, opts.Query.Changes.CheckoutCommand)
 		}
@@ -583,7 +584,7 @@ var buildFunctions = map[string]func() bool{
 		if !success {
 			return false
 		}
-		for _, target := range query.DiffGraphs(before, after, opts.Query.Changes.Args.Files) {
+		for _, target := range query.DiffGraphs(before, after, files) {
 			fmt.Printf("%s\n", target)
 		}
 		return true

--- a/src/query/BUILD
+++ b/src/query/BUILD
@@ -6,6 +6,7 @@ go_library(
         '//src/core',
         '//src/utils',
         '//third_party/go:logging',
+        '//third_party/go:shlex',
     ],
     visibility = ['PUBLIC'],
 )
@@ -33,6 +34,16 @@ go_test(
 go_test(
     name = 'whatoutputs_test',
     srcs = ['whatoutputs_test.go'],
+    deps = [
+        ':query',
+        '//src/core',
+        '//third_party/go:testify',
+    ],
+)
+
+go_test(
+    name = 'changes_test',
+    srcs = ['changes_test.go'],
     deps = [
         ':query',
         '//src/core',

--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -1,0 +1,67 @@
+package query
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"sort"
+
+	"github.com/google/shlex"
+
+	"build"
+	"core"
+)
+
+// MustCheckout checks out the given revision.
+func MustCheckout(revision, command string) {
+	log.Notice("Checking out %s...", revision)
+	argv, err := shlex.Split(fmt.Sprintf(command, revision))
+	if err != nil {
+		log.Fatalf("Invalid checkout command: %s", err)
+	} else if out, err := exec.Command(argv[0], argv[1:]...).CombinedOutput(); err != nil {
+		log.Fatalf("Failed to check out %s: %s\n%s", revision, err, out)
+	}
+}
+
+// DiffGraphs calculates the difference between two build graphs.
+// Note that this is not symmetric; targets that have been removed from 'before' do not appear
+// (because this is designed to be fed into 'plz test' and we can't test targets that no longer exist).
+func DiffGraphs(before, after *core.BuildState, files []string) []core.BuildLabel {
+	log.Notice("Calculating difference...")
+	targets := after.Graph.AllTargets()
+	ret := make(core.BuildLabels, 0, len(targets))
+	done := make(map[*core.BuildTarget]struct{}, len(targets))
+	for _, t2 := range targets {
+		if t1 := before.Graph.Target(t2.Label); t1 == nil || changed(before, after, t1, t2, files) {
+			ret = append(ret, addRevdeps(after.Graph, t2, done)...)
+		}
+	}
+	sort.Sort(ret) // reverse dependencies aren't guaranteed to be consistent
+	return ret
+}
+
+// changed returns true if the given two targets are equivalent.
+func changed(s1, s2 *core.BuildState, t1, t2 *core.BuildTarget, files []string) bool {
+	for _, f := range files {
+		if t2.HasSource(f) {
+			return true
+		}
+	}
+	h1 := build.RuleHash(s1, t1, true, false)
+	h2 := build.RuleHash(s2, t2, true, false)
+	return !bytes.Equal(h1, h2)
+}
+
+// addRevdeps walks back up the reverse dependencies of a target, marking them all changed.
+// It returns the list of any that have, plus the target itself.
+func addRevdeps(graph *core.BuildGraph, target *core.BuildTarget, done map[*core.BuildTarget]struct{}) []core.BuildLabel {
+	if _, present := done[target]; present {
+		return nil
+	}
+	done[target] = struct{}{}
+	ret := []core.BuildLabel{target.Label}
+	for _, revdep := range graph.ReverseDependencies(target) {
+		ret = append(ret, addRevdeps(graph, revdep, done)...)
+	}
+	return ret
+}

--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -15,12 +15,25 @@ import (
 // MustCheckout checks out the given revision.
 func MustCheckout(revision, command string) {
 	log.Notice("Checking out %s...", revision)
-	argv, err := shlex.Split(fmt.Sprintf(command, revision))
-	if err != nil {
+	if argv, err := shlex.Split(fmt.Sprintf(command, revision)); err != nil {
 		log.Fatalf("Invalid checkout command: %s", err)
 	} else if out, err := exec.Command(argv[0], argv[1:]...).CombinedOutput(); err != nil {
 		log.Fatalf("Failed to check out %s: %s\n%s", revision, err, out)
 	}
+}
+
+// MustGetRevision runs a command to determine the current revision.
+func MustGetRevision(command string) string {
+	log.Notice("Determining current revision...")
+	argv, err := shlex.Split(command)
+	if err != nil {
+		log.Fatalf("Invalid revision command: %s", err)
+	}
+	out, err := exec.Command(argv[0], argv[1:]...).Output()
+	if err != nil {
+		log.Fatalf("Failed to determine current revision: %s\n%s", err, out)
+	}
+	return string(bytes.TrimSpace(out))
 }
 
 // DiffGraphs calculates the difference between two build graphs.

--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -28,11 +28,12 @@ func MustCheckout(revision, command string) {
 // (because this is designed to be fed into 'plz test' and we can't test targets that no longer exist).
 func DiffGraphs(before, after *core.BuildState, files []string) []core.BuildLabel {
 	log.Notice("Calculating difference...")
+	configChanged := !bytes.Equal(before.Hashes.Config, after.Hashes.Config)
 	targets := after.Graph.AllTargets()
 	ret := make(core.BuildLabels, 0, len(targets))
 	done := make(map[*core.BuildTarget]struct{}, len(targets))
 	for _, t2 := range targets {
-		if t1 := before.Graph.Target(t2.Label); t1 == nil || changed(before, after, t1, t2, files) {
+		if t1 := before.Graph.Target(t2.Label); t1 == nil || changed(before, after, t1, t2, files) || configChanged {
 			ret = append(ret, addRevdeps(after.Graph, t2, done)...)
 		}
 	}

--- a/src/query/changes_test.go
+++ b/src/query/changes_test.go
@@ -1,0 +1,38 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"core"
+)
+
+func TestTargetsChanged(t *testing.T) {
+	s1 := core.NewDefaultBuildState()
+	s2 := core.NewDefaultBuildState()
+	t1 := addTarget(s1, "//src/query:changes", nil, "src/query/changes.go")
+	t2 := addTarget(s2, "//src/query:changes", nil, "src/query/changes.go")
+	addTarget(s1, "//src/query:changes_test", t1, "src/query/changes_test.go")
+	t4 := addTarget(s2, "//src/query:changes_test", t2, "src/query/changes_test.go")
+	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil))
+
+	t2.Command = "nope nope nope"
+	assert.EqualValues(t, []core.BuildLabel{t2.Label, t4.Label}, DiffGraphs(s1, s2, nil))
+}
+
+func addTarget(state *core.BuildState, label string, dep *core.BuildTarget, sources ...string) *core.BuildTarget {
+	t := core.NewBuildTarget(core.ParseBuildLabel(label, ""))
+	for _, src := range sources {
+		t.AddSource(core.FileLabel{
+			File:    src,
+			Package: t.Label.PackageName,
+		})
+	}
+	state.Graph.AddTarget(t)
+	if dep != nil {
+		t.AddDependency(dep.Label)
+		state.Graph.AddDependency(t.Label, dep.Label)
+	}
+	return t
+}

--- a/tools/misc/plz_ci.sh
+++ b/tools/misc/plz_ci.sh
@@ -1,34 +1,14 @@
 #!/bin/bash
 #
-# This script implements an example CI flow using plz, which will run all affected tests
-# based on files that have changed vs. master.
-#
-# It performs a two-step test that both builds all possible targets and runs all tests;
-# this ensures that any targets that don't have tests are still at least buildable.
-#
-# It's a bit pessimistic, in that it runs all tests based on any file that has changed,
-# assuming all possible modifications (notably this means that if you change a BUILD file
-# it must rerun all reverse dependencies of all targets in that file).
-# A more advanced flow is possible using something along the lines of:
-#   git checkout master
-#   plz query graph > master.json
-#   git checkout mybranch
-#   plz query graph > branch.json
-#   git diff --name-only origin/master | \
-#       plz tool diff_graphs -- -b master.json -a branch.json - | \
-#       plz test -
-#
-# This performs an exhaustive diff of the build graph which runs all tests that have changed,
-# but is not affected by trivial changes to BUILD files and so forth.
-# It's a bit more involved though and for many cases this script is easier.
+# This script implements an example CI flow using plz, which will perform an exhaustive diff
+# of the build graph against master and run all targets that have changed
+# This is not affected by trivial changes (e.g. formatting changes to BUILD files).
 
 set -eu
 set -o pipefail
 
 # Set $ORIGIN to a branch or tag name if you want to build vs. something other than master.
 ORIGIN="${ORIGIN:-origin/master}"
-echo "\033[32mBuilding targets...\033[0m"
-plz query affectedtargets `git diff --name-only $ORIGIN` | plz build -
-echo "\033[32mBuilding targets...\033[0m"
-plz query affectedtargets --tests `git diff --name-only $ORIGIN` | plz test -
-echo "\033[32mDone!\033[0m"
+git diff --name-only "$ORIGIN" | \
+    plz query changes -b "$ORIGIN" -a "`git rev-parse HEAD`" - | \
+    plz test -

--- a/tools/misc/plz_ci.sh
+++ b/tools/misc/plz_ci.sh
@@ -10,5 +10,5 @@ set -o pipefail
 # Set $ORIGIN to a branch or tag name if you want to build vs. something other than master.
 ORIGIN="${ORIGIN:-origin/master}"
 git diff --name-only "$ORIGIN" | \
-    plz query changes -b "$ORIGIN" -a "`git rev-parse HEAD`" - | \
+    plz query changes --since "$ORIGIN" - | \
     plz test -

--- a/tools/please_diff_graphs/BUILD
+++ b/tools/please_diff_graphs/BUILD
@@ -3,6 +3,7 @@ go_binary(
     srcs = ['plz_diff_graphs_main.go'],
     deps = [
         '//src/cli',
+        '//third_party/go:logging',
         '//tools/please_diff_graphs/diff',
     ],
     visibility = ['PUBLIC'],

--- a/tools/please_diff_graphs/plz_diff_graphs_main.go
+++ b/tools/please_diff_graphs/plz_diff_graphs_main.go
@@ -14,9 +14,13 @@ import (
 	"os"
 	"strings"
 
+	"gopkg.in/op/go-logging.v1"
+
 	"cli"
 	"tools/please_diff_graphs/diff"
 )
+
+var log = logging.MustGetLogger("plz_diff_graphs")
 
 var opts = struct {
 	Usage        string

--- a/tools/please_diff_graphs/plz_diff_graphs_main.go
+++ b/tools/please_diff_graphs/plz_diff_graphs_main.go
@@ -69,6 +69,7 @@ func readStdin() []string {
 func main() {
 	cli.ParseFlagsOrDie("Please graph differ", "9.1.2", &opts)
 	cli.InitLogging(opts.Verbosity)
+	log.Warning("plz_diff_graphs has been deprecated in favour of 'plz query changes', consider using that instead")
 	before := diff.ParseGraphOrDie(opts.Before)
 	after := diff.ParseGraphOrDie(opts.After)
 	if len(opts.ChangedFiles.Files) == 1 && opts.ChangedFiles.Files[0] == "-" {


### PR DESCRIPTION
Replaces the previous multi-command dance with a single command (well, it's still a few to invoke the build properly, but it's not too hard). I don't think this was possible a year or two ago but things are a bit better factored now (especially the parser is a lot more cooperative).

The total runtime is rather faster; a large chunk of it now is the underlying git operations, which were previously dwarfed by all the other futzing about we were doing.

