### PR TITLE
fix MODULE_DIR for pandas

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -47,7 +47,7 @@ targetlevel = 7
 
 [proto]
 protoctool = //third_party/proto:protoc
-pythonpackage = third_party.python.google.protobuf
+pythonpackage = google.protobuf
 grpcjavaplugin = //third_party/java:protoc-gen-grpc-java
 protocgoplugin = //third_party/go:protoc-gen-go
 

--- a/test/python_rules/BUILD
+++ b/test/python_rules/BUILD
@@ -122,3 +122,13 @@ python_test(
     ],
     deps = ["//third_party/python:tensorflow"],
 )
+
+python_test(
+    name = "pandas_test",
+    srcs = ["pandas_test.py"],
+    labels = [
+        "py3",
+        "pip",
+    ],
+    deps = ["//third_party/python:pandas"],
+)

--- a/test/python_rules/pandas_test.py
+++ b/test/python_rules/pandas_test.py
@@ -1,0 +1,8 @@
+import unittest
+
+
+class PandasTest(unittest.TestCase):
+
+    def test_import(self):
+        import pandas as pd
+        pd.DataFrame()

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -131,3 +131,21 @@ pip_library(
         ":protobuf",
     ],
 )
+
+pip_library(
+    name = "pytz",
+    test_only = True,
+    version = "2018.4",
+)
+
+pip_library(
+    name = "pandas",
+    test_only = True,
+    version = "0.22.0",
+    deps = [
+        ":dateutil",
+        ":numpy",
+        ":pytz",
+        ":six",
+    ]
+)

--- a/tools/please_pex/pex_run.py
+++ b/tools/please_pex/pex_run.py
@@ -1,11 +1,13 @@
 def run():
-    if MODULE_DIR:
-        override_import(MODULE_DIR)
     clean_sys_path()
     if not ZIP_SAFE:
         with explode_zip()():
+            if MODULE_DIR:
+                sys.path = sys.path[:1] + [os.path.join(PEX_PATH, MODULE_DIR.replace('.', '/'))] + sys.path[1:]
             return interact(main)
     else:
+        if MODULE_DIR:
+            sys.path = sys.path[:1] + [os.path.join(sys.path[0], MODULE_DIR.replace('.', '/'))] + sys.path[1:]
         sys.meta_path.append(SoImport())
         return interact(main)
 


### PR DESCRIPTION
The pandas package does not work with the original method of allowing third_party.python to work.

Current method loads the module from third_party.python.pandas and then fixes sys.modules.
pandas refers to sys.modules expecting to find itself and it can not (see pandas.tools.plotting)

My proposed fix adds thrid_party/python to sys.path so it can be found as is.

I am not certain why I had to remove third_party.python from [proto].pythonpackage in .plzconfig, but the tests would not pass without it.