### PR TITLE
Close file manager when done.

### DIFF
--- a/tools/javac_worker/src/build/please/compile/JavaCompiler.java
+++ b/tools/javac_worker/src/build/please/compile/JavaCompiler.java
@@ -26,7 +26,7 @@ public class JavaCompiler {
      * run reads requests from stdin and sends them to stdout until they are closed.
      */
     public void run() {
-        ExecutorService executor = Executors.newFixedThreadPool(8);
+        ExecutorService executor = createExecutor();
         final Gson gson = new GsonBuilder()
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .create();
@@ -47,6 +47,13 @@ public class JavaCompiler {
                     }
                 });
         }
+    }
+
+    /**
+     * Overriding this allows customising the threadpool that is used.
+     */
+    protected ExecutorService createExecutor() {
+        return Executors.newFixedThreadPool(8);
     }
 
     /**

--- a/tools/javac_worker/src/build/please/compile/JavaCompiler.java
+++ b/tools/javac_worker/src/build/please/compile/JavaCompiler.java
@@ -53,7 +53,7 @@ public class JavaCompiler {
      * Overriding this allows customising the threadpool that is used.
      */
     protected ExecutorService createExecutor() {
-        return Executors.newFixedThreadPool(8);
+        return Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
     }
 
     /**

--- a/tools/javac_worker/src/build/please/compile/JavaCompiler.java
+++ b/tools/javac_worker/src/build/please/compile/JavaCompiler.java
@@ -26,7 +26,7 @@ public class JavaCompiler {
      * run reads requests from stdin and sends them to stdout until they are closed.
      */
     public void run() {
-        ExecutorService executor = createExecutor();
+        ExecutorService executor = Executors.newFixedThreadPool(8);
         final Gson gson = new GsonBuilder()
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .create();
@@ -47,13 +47,6 @@ public class JavaCompiler {
                     }
                 });
         }
-    }
-
-    /**
-     * Overriding this allows customising the threadpool that is used.
-     */
-    protected ExecutorService createExecutor() {
-        return Executors.newCachedThreadPool();
     }
 
     /**

--- a/tools/javac_worker/src/build/please/compile/JavaCompiler.java
+++ b/tools/javac_worker/src/build/please/compile/JavaCompiler.java
@@ -26,7 +26,7 @@ public class JavaCompiler {
      * run reads requests from stdin and sends them to stdout until they are closed.
      */
     public void run() {
-        ExecutorService executor = Executors.newFixedThreadPool(8);
+        ExecutorService executor = createExecutor();
         final Gson gson = new GsonBuilder()
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .create();
@@ -47,6 +47,13 @@ public class JavaCompiler {
                     }
                 });
         }
+    }
+
+    /**
+     * Overriding this allows customising the threadpool that is used.
+     */
+    protected ExecutorService createExecutor() {
+        return Executors.newCachedThreadPool();
     }
 
     /**

--- a/tools/javac_worker/src/build/please/compile/JavaCompiler.java
+++ b/tools/javac_worker/src/build/please/compile/JavaCompiler.java
@@ -125,6 +125,7 @@ public class JavaCompiler {
             }
             opts.add(finder.joinFiles(':'));
             response.success = compiler.getTask(writer, fileManager, reporter, opts, null, compilationUnits).call();
+            fileManager.close();
             return response.withMessage(writer.toString());
         }
     }


### PR DESCRIPTION
AFAICT this is not required, but it may help to close them when they are no longer needed rather than waiting for a GC. I wonder if Java 10 simply has a different GC strategy which is less aggressive about reclaiming them.
Anecdotally this seems to improve T14586.

Have also allowed customising the threadpool executor - don't think this worker should make a policy decision on it, but this way it's easier to experiment with outside this repo.