### PR TITLE
Upgrade jacoco to the latest version

### DIFF
--- a/third_party/java/jacoco/BUILD
+++ b/third_party/java/jacoco/BUILD
@@ -2,6 +2,10 @@ java_binary(
     name = "jacoco_all",
     deps = [
         ":asm",
+        ":asm-commons",
+        ":asm-tree",
+        ":asm-util",
+        ":asm-analysis",
         ":jacoco.agent",
         ":jacoco.core",
         ":jacoco.report",
@@ -23,23 +27,47 @@ genrule(
 maven_jar(
     name = "jacoco.core",
     hash = "5db0da8cb8905612df850d22c378912ead06c88f",
-    id = "org.jacoco:org.jacoco.core:0.7.7.201606060606",
+    id = "org.jacoco:org.jacoco.core:0.8.1",
 )
 
 maven_jar(
     name = "jacoco.report",
     hash = "be277d38f723a83e79304c9820df7655f8945d30",
-    id = "org.jacoco:org.jacoco.report:0.7.7.201606060606",
+    id = "org.jacoco:org.jacoco.report:0.8.1",
 )
 
 maven_jar(
     name = "jacoco.agent",
     hash = "7973f700eb8add2564871d1ed6d0ffad4e0ad9df",
-    id = "org.jacoco:org.jacoco.agent:0.7.7.201606060606",
+    id = "org.jacoco:org.jacoco.agent:0.8.1",
 )
 
 maven_jar(
     name = "asm",
     hash = "sha1: 079196a08a86094763068ac621ba90c73c2efa34",
-    id = "org.ow2.asm:asm-debug-all:5.0.4",
+    id = "org.ow2.asm:asm:6.0",
+)
+
+maven_jar(
+    name = "asm-commons",
+    hash = "sha1: 079196a08a86094763068ac621ba90c73c2efa34",
+    id = "org.ow2.asm:asm-commons:6.0",
+)
+
+maven_jar(
+    name = "asm-tree",
+    hash = "sha1: 079196a08a86094763068ac621ba90c73c2efa34",
+    id = "org.ow2.asm:asm-tree:6.0",
+)
+
+maven_jar(
+    name = "asm-analysis",
+    hash = "sha1: 079196a08a86094763068ac621ba90c73c2efa34",
+    id = "org.ow2.asm:asm-analysis:6.0",
+)
+
+maven_jar(
+    name = "asm-util",
+    hash = "sha1: 079196a08a86094763068ac621ba90c73c2efa34",
+    id = "org.ow2.asm:asm-util:6.0",
 )


### PR DESCRIPTION
This version is compatible with the latest versions of java.