### PR TITLE
Preliminary support for Python 3.7

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -3,6 +3,7 @@
 ; Other projects using Please wouldn't normally need to do anything like this.
 pextool = //tools/please_pex
 moduledir = third_party.python
+defaultinterpreter = python3.7
 
 [parse]
 ; This is a hack to handle operating systems with case-insensitive file systems.

--- a/.plzconfig
+++ b/.plzconfig
@@ -3,7 +3,6 @@
 ; Other projects using Please wouldn't normally need to do anything like this.
 pextool = //tools/please_pex
 moduledir = third_party.python
-defaultinterpreter = python3.7
 
 [parse]
 ; This is a hack to handle operating systems with case-insensitive file systems.

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -10,6 +10,7 @@ REPOS = [
     "https://get.please.build/third_party/python/py34",
     "https://get.please.build/third_party/python/py35",
     "https://get.please.build/third_party/python/py36",
+    "https://get.please.build/third_party/python/py37",
 ]
 
 python_wheel(

--- a/tools/jarcat/zip/writer.go
+++ b/tools/jarcat/zip/writer.go
@@ -484,7 +484,7 @@ func (f *File) isPy37(b []byte) bool {
 	// should probably convert this to a proper int...
 	if b[1] < 13 {
 		return false
-	} else if b[1] > 13 {
+	} else if b[1] > 13 && b[1] < 20 {
 		return true
 	}
 	// This corresponds to 3.7.0rc1; it's probably not quite accurate but unlikely to matter.

--- a/tools/jarcat/zip/writer.go
+++ b/tools/jarcat/zip/writer.go
@@ -455,7 +455,7 @@ func (f *File) WritePreamble(preamble []byte) error {
 // This is important so our output is deterministic.
 func (f *File) StripBytecodeTimestamp(filename string, contents []byte) error {
 	if strings.HasSuffix(filename, ".pyc") || strings.HasSuffix(filename, ".pyo") {
-		if len(contents) < 8 {
+		if len(contents) < 12 {
 			log.Warning("Invalid bytecode file, will not strip timestamp")
 		} else if f.isPy37(contents) {
 			// Check whether this is hash verified. This is probably unlikely since we don't

--- a/tools/jarcat/zip/writer.go
+++ b/tools/jarcat/zip/writer.go
@@ -481,14 +481,9 @@ func (f *File) StripBytecodeTimestamp(filename string, contents []byte) error {
 // isPy37 determines if the leading magic number in a .pyc corresponds to Python 3.7.
 // This is important to us because the structure changed (see PEP 552) and we have to handle that.
 func (f *File) isPy37(b []byte) bool {
-	// should probably convert this to a proper int...
-	if b[1] < 13 {
-		return false
-	} else if b[1] > 13 && b[1] < 20 {
-		return true
-	}
-	// This corresponds to 3.7.0rc1; it's probably not quite accurate but unlikely to matter.
-	return b[0] >= 66
+	i := (int(b[1]) << 8) + int(b[0])
+	// Python 2 versions use magic numbers in the 20-60,000 range. Ensure it's not one of them.
+	return i >= 3394 && i < 10000
 }
 
 // zeroPycTimestamp zeroes out a .pyc timestamp at a given offset.

--- a/tools/jarcat/zip/writer_test.go
+++ b/tools/jarcat/zip/writer_test.go
@@ -157,3 +157,11 @@ func TestIsSamePath(t *testing.T) {
 	assert.True(t, samePaths("/a", "/a"))
 	assert.False(t, samePaths("/a", "./a"))
 }
+
+func TestIsPy37(t *testing.T) {
+	f := NewFile("test_is_py37.zip", false)
+	assert.False(t, f.isPy37([]byte("\x03\xf3\r\n"))) // 2.7.15
+	assert.False(t, f.isPy37([]byte("\xee\x0c\r\n"))) // 3.4.3
+	assert.False(t, f.isPy37([]byte("3\r\r\n")))      // 3.6.2
+	assert.True(t, f.isPy37([]byte("B\r\r\n")))       // 3.7rc1
+}

--- a/tools/jarcat/zip/writer_test.go
+++ b/tools/jarcat/zip/writer_test.go
@@ -164,4 +164,6 @@ func TestIsPy37(t *testing.T) {
 	assert.False(t, f.isPy37([]byte("\xee\x0c\r\n"))) // 3.4.3
 	assert.False(t, f.isPy37([]byte("3\r\r\n")))      // 3.6.2
 	assert.True(t, f.isPy37([]byte("B\r\r\n")))       // 3.7rc1
+	assert.False(t, f.isPy37([]byte{0, 0, 0, 0}))
+	assert.False(t, f.isPy37([]byte{255, 255, 255, 255}))
 }


### PR DESCRIPTION
Adds the py37 version of coverage, but most of the change is adjusting how we handle .pyc files.

Background: pyc files traditionally have a timestamp in them which causes non-deterministic output, which has some negative effects on caching and so forth. PEP 552 proposes a new system for reproducible builds, but that alters their structure and we have to respect that correctly or they don't work.