### PR TITLE
Fix a potential deadlock

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -495,7 +495,7 @@ func (state *BuildState) ExpandVisibleOriginalTargets() BuildLabels {
 // WaitForPackage either returns the given package which is already parsed and available,
 // or returns nil if nothing's parsed it already, in which case everything else calling this
 // will wait for the caller to parse it themselves.
-func (state *BuildState) WaitForPackage(packageName string, register bool) *Package {
+func (state *BuildState) WaitForPackage(packageName string) *Package {
 	if p := state.Graph.Package(packageName); p != nil {
 		return p
 	}
@@ -506,9 +506,6 @@ func (state *BuildState) WaitForPackage(packageName string, register bool) *Pack
 		<-ch
 		state.ParsePool.StopWorker()
 		return state.Graph.Package(packageName)
-	} else if !register {
-		state.progress.pendingPackageMutex.Unlock()
-		return nil
 	}
 	// Nothing's registered this so we do it ourselves.
 	state.progress.pendingPackages[packageName] = make(chan struct{})

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -495,7 +495,7 @@ func (state *BuildState) ExpandVisibleOriginalTargets() BuildLabels {
 // WaitForPackage either returns the given package which is already parsed and available,
 // or returns nil if nothing's parsed it already, in which case everything else calling this
 // will wait for the caller to parse it themselves.
-func (state *BuildState) WaitForPackage(packageName string) *Package {
+func (state *BuildState) WaitForPackage(packageName string, register bool) *Package {
 	if p := state.Graph.Package(packageName); p != nil {
 		return p
 	}
@@ -506,6 +506,9 @@ func (state *BuildState) WaitForPackage(packageName string) *Package {
 		<-ch
 		state.ParsePool.StopWorker()
 		return state.Graph.Package(packageName)
+	} else if !register {
+		state.progress.pendingPackageMutex.Unlock()
+		return nil
 	}
 	// Nothing's registered this so we do it ourselves.
 	state.progress.pendingPackages[packageName] = make(chan struct{})

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -9,7 +9,6 @@ package parse
 import (
 	"fmt"
 	"path"
-	"time"
 
 	"gopkg.in/op/go-logging.v1"
 
@@ -42,7 +41,7 @@ func Parse(tid int, state *core.BuildState, label, dependor core.BuildLabel, noD
 
 func parse(tid int, state *core.BuildState, label, dependor core.BuildLabel, noDeps bool, include, exclude []string, forSubinclude bool) error {
 	// See if something else has parsed this package first.
-	pkg := state.WaitForPackage(label.PackageName, true)
+	pkg := state.WaitForPackage(label.PackageName)
 	if pkg != nil {
 		// Does exist, all we need to do is toggle on this target
 		return activateTarget(state, pkg, label, dependor, noDeps, forSubinclude, include, exclude)
@@ -114,13 +113,8 @@ func parsePackage(state *core.BuildState, label, dependor core.BuildLabel, subre
 		// Could indicate that we're looking for a subrepo that hasn't been loaded yet.
 		// TODO(peterebden): Ideally we'd like to be able to define these anywhere, so this is a bit of a hack for now.
 		if fs.IsPackage(state.Config.Parse.BuildFileName, core.RepoRoot) && state.Graph.Package("") == nil {
-			state.AddPendingParse(core.BuildLabel{PackageName: "", Name: "all"}, label, false)
-			// TODO(peterebden): This is an even more awkward hack than the one noted above. We
-			//                   need to wait until the parse we triggered above succeeds and are
-			//                   effectively polling to check it :(
-			var pkg *core.Package
-			for ; pkg == nil; pkg = state.WaitForPackage("", false) {
-				time.Sleep(5 * time.Millisecond)
+			if _, err := parsePackage(state, core.BuildLabel{PackageName: "", Name: "all"}, label, nil); err != nil {
+				return nil, err
 			}
 			return nil, errTryAgain
 		}


### PR DESCRIPTION
I think this will fix some of the hangs we've seen on circleci; the AddPendingParse / WaitForPackage pair was trying to cause a parse to happen asynchronously, but depending on ordering of things it might never complete. Doing it synchronously seems much easier...