### PR TITLE
Switching ~ for ${HOME} in .profile

### DIFF
--- a/tools/misc/get_plz.sh
+++ b/tools/misc/get_plz.sh
@@ -35,7 +35,7 @@ if ! hash plz 2>/dev/null; then
     if [ -d ~/.local/bin ]; then
         ln -s ~/.please/plz ~/.local/bin/plz
     elif [ -f ~/.profile ]; then
-        echo 'export PATH="${PATH}:~/.please"' >> ~/.profile
+        echo 'export PATH="${PATH}:${HOME}/.please"' >> ~/.profile
         echo "You may need to run 'source ~/.profile' to pick up the new PATH."
     else
         echo "Unsure how to add to PATH, not modifying anything."


### PR DESCRIPTION
This PR changes how the `$PATH` is updated in `~/.profile` by the install script. 

When trying to install on zsh, the tilde is not expanded in the same way as in bash. ([More info here.](https://unix.stackexchange.com/a/146697))  So far, the only way I can get the install script to work in zsh is to capture download of https://get.please.build and replace the `~` on line 38 with `${HOME}`. I think this change will simplify the install process. 