### PR TITLE
Fix errors reported in e2e tests

### DIFF
--- a/build_defs/plz_e2e_test.build_defs
+++ b/build_defs/plz_e2e_test.build_defs
@@ -19,9 +19,9 @@ def plz_e2e_test(name, cmd, pre_cmd=None, expected_output=None, expected_failure
         elif expected_output:
             test_cmd += 'diff -au output $(location %s)' % expected_output
         elif expect_output_contains:
-            test_cmd += 'if [ ! grep -v "%s" output; then cat output; exit 1 ]; fi' % expect_output_contains
+            test_cmd += 'if ! grep -q "%s" output; then cat output; exit 1; fi' % expect_output_contains
         elif expect_output_doesnt_contain:
-            test_cmd += 'if [ ! grep "%s" output; then cat output; exit 1 ]; fi' % expect_output_doesnt_contain
+            test_cmd += 'if grep -q "%s" output; then cat output; exit 1; fi' % expect_output_doesnt_contain
         elif expect_file_exists:
             test_cmd += 'if [ ! -f %s ]; then cat output; exit 1; fi' % expect_file_exists
         elif expect_file_doesnt_exist:

--- a/test/BUILD
+++ b/test/BUILD
@@ -334,7 +334,7 @@ plz_e2e_test(
 
 plz_e2e_test(
     name = "cyclic_dependency_test",
-    cmd = "plz test //plz-out/tmp/test/cyclic_dependency_test#.test/test/cycle:all",
+    cmd = "plz test //plz-out/tmp/test/cyclic_dependency_test._test/test/cycle:all",
     data = ["cycle/TEST_BUILD"],
     expect_output_contains = "Dependency cycle found",
     expected_failure = True,
@@ -360,7 +360,7 @@ plz_e2e_test(
 plz_e2e_test(
     name = "unknown_flag_test",
     cmd = "plz build --wibble",
-    expect_output_contains = "Unknown flag",
+    expect_output_contains = "unknown flag",
     expected_failure = True,
 )
 


### PR DESCRIPTION
The format of this test seems to be wrong, resulting in bash reporting errors when running e2e tests. This rewrite seems to retain the expected behaviour, with the added bonus of not causing error output.