### PR TITLE
Make subrepo an explicit part of BuildLabel

### DIFF
--- a/src/build/filegroup.go
+++ b/src/build/filegroup.go
@@ -86,7 +86,7 @@ func buildFilegroup(tid int, state *core.BuildState, target *core.BuildTarget) e
 		// It's a bit cheeky to do non-essential language-specific logic but this enables
 		// a lot of relatively normal Python workflows.
 		// Errors are deliberately ignored.
-		if pkg := state.Graph.Package(target.Label.PackageName); pkg == nil || !pkg.HasOutput("__init__.py") {
+		if pkg := state.Graph.PackageByLabel(target.Label); pkg == nil || !pkg.HasOutput("__init__.py") {
 			// Don't create this if someone else is going to create this in the package.
 			createInitPy(outDir)
 		}

--- a/src/clean/clean.go
+++ b/src/clean/clean.go
@@ -38,7 +38,7 @@ func Targets(state *core.BuildState, labels []core.BuildLabel, cleanCache bool) 
 		// This is not super efficient; we potentially repeat this walk multiple times if
 		// we have several targets to clean in a package. It's unlikely to be a big concern though
 		// unless we have lots of targets to clean and their packages are very large.
-		for _, target := range state.Graph.PackageOrDie(label.PackageName).AllChildren(state.Graph.TargetOrDie(label)) {
+		for _, target := range state.Graph.PackageOrDie(label).AllChildren(state.Graph.TargetOrDie(label)) {
 			if state.ShouldInclude(target) {
 				cleanTarget(state, target, cleanCache)
 			}

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -43,7 +43,7 @@ func GeneralBuildEnvironment(config *Configuration) BuildEnv {
 func buildEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 	return append(GeneralBuildEnvironment(state.Config),
 		"PKG="+target.Label.PackageName,
-		"PKG_DIR="+target.Subrepo.MakeRelativeName(target.Label.PackageDir()),
+		"PKG_DIR="+target.Label.PackageDir(),
 		"NAME="+target.Label.Name,
 		"CONFIG="+state.Config.Build.Config,
 	)

--- a/src/core/build_input.go
+++ b/src/core/build_input.go
@@ -219,14 +219,12 @@ func (label NamedOutputLabel) String() string {
 // MustParseNamedOutputLabel attempts to parse a build output label. It's allowed to just be
 // a normal build label as well.
 // The syntax is an extension of normal build labels: //package:target|output
-// If the label refers to a subrepo then that's returned separately.
-func MustParseNamedOutputLabel(target string, pkg *Package) (BuildInput, string) {
+func MustParseNamedOutputLabel(target string, pkg *Package) BuildInput {
 	if index := strings.IndexRune(target, '|'); index != -1 && index != len(target)-1 {
-		label, subrepo := ParseBuildLabelSubrepo(target[:index], pkg)
-		return NamedOutputLabel{BuildLabel: label.ForPackage(pkg), Output: target[index+1:]}, subrepo
+		label := ParseBuildLabelContext(target[:index], pkg)
+		return NamedOutputLabel{BuildLabel: label.ForPackage(pkg), Output: target[index+1:]}
 	}
-	label, subrepo := ParseBuildLabelSubrepo(target, pkg)
-	return label.ForPackage(pkg), subrepo
+	return ParseBuildLabelContext(target, pkg).ForPackage(pkg)
 }
 
 // A URLLabel represents a remote input that's defined by a URL.

--- a/src/core/build_input.go
+++ b/src/core/build_input.go
@@ -222,9 +222,9 @@ func (label NamedOutputLabel) String() string {
 func MustParseNamedOutputLabel(target string, pkg *Package) BuildInput {
 	if index := strings.IndexRune(target, '|'); index != -1 && index != len(target)-1 {
 		label := ParseBuildLabelContext(target[:index], pkg)
-		return NamedOutputLabel{BuildLabel: label.ForPackage(pkg), Output: target[index+1:]}
+		return NamedOutputLabel{BuildLabel: label, Output: target[index+1:]}
 	}
-	return ParseBuildLabelContext(target, pkg).ForPackage(pkg)
+	return ParseBuildLabelContext(target, pkg)
 }
 
 // A URLLabel represents a remote input that's defined by a URL.

--- a/src/core/build_input_test.go
+++ b/src/core/build_input_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestParseNamedOutputLabel(t *testing.T) {
 	pkg := NewPackage("")
-	input, _ := MustParseNamedOutputLabel("//src/core:target1|test", pkg)
+	input := MustParseNamedOutputLabel("//src/core:target1|test", pkg)
 	label, ok := input.(NamedOutputLabel)
 	assert.True(t, ok)
 	assert.Equal(t, "src/core", label.PackageName)
@@ -18,7 +18,7 @@ func TestParseNamedOutputLabel(t *testing.T) {
 
 func TestParseNamedOutputLabelRelative(t *testing.T) {
 	pkg := NewPackage("src/core")
-	input, _ := MustParseNamedOutputLabel(":target1|test", pkg)
+	input := MustParseNamedOutputLabel(":target1|test", pkg)
 	label, ok := input.(NamedOutputLabel)
 	assert.True(t, ok)
 	assert.Equal(t, "src/core", label.PackageName)
@@ -28,7 +28,7 @@ func TestParseNamedOutputLabelRelative(t *testing.T) {
 
 func TestParseNamedOutputLabelNoOutput(t *testing.T) {
 	pkg := NewPackage("")
-	input, _ := MustParseNamedOutputLabel("//src/core:target1", pkg)
+	input := MustParseNamedOutputLabel("//src/core:target1", pkg)
 	_, ok := input.(NamedOutputLabel)
 	assert.False(t, ok)
 	label, ok := input.(BuildLabel)

--- a/src/core/build_input_test.go
+++ b/src/core/build_input_test.go
@@ -43,3 +43,27 @@ func TestParseNamedOutputLabelEmptyOutput(t *testing.T) {
 		MustParseNamedOutputLabel("//src/core:target1|", pkg)
 	})
 }
+
+func TestParseNamedOutputLabelSubrepo(t *testing.T) {
+	pkg := NewPackage("")
+	input := MustParseNamedOutputLabel("@test_x86//src/core:target1", pkg)
+	_, ok := input.(NamedOutputLabel)
+	assert.False(t, ok)
+	label, ok := input.(BuildLabel)
+	assert.True(t, ok)
+	assert.Equal(t, "src/core", label.PackageName)
+	assert.Equal(t, "target1", label.Name)
+	assert.Equal(t, "test_x86", label.Subrepo)
+}
+
+func TestParseNamedOutputLabelRelativeSubrepo(t *testing.T) {
+	pkg := NewPackage("src/core")
+	input := MustParseNamedOutputLabel("@test_x86:target1", pkg)
+	_, ok := input.(NamedOutputLabel)
+	assert.False(t, ok)
+	label, ok := input.(BuildLabel)
+	assert.True(t, ok)
+	assert.Equal(t, "src/core", label.PackageName)
+	assert.Equal(t, "target1", label.Name)
+	assert.Equal(t, "test_x86", label.Subrepo)
+}

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -368,6 +368,20 @@ func (label BuildLabel) Complete(match string) []flags.Completion {
 	return ret
 }
 
+// A packageKey is a cut-down version of BuildLabel that only contains the package part.
+// It's used to key maps and so forth that don't care about the target name.
+type packageKey struct {
+	Name, Subrepo string
+}
+
+// String implements the traditional fmt.Stringer interface.
+func (key packageKey) String() string {
+	if key.Subrepo != "" {
+		return "@" + key.Subrepo + "//" + key.Name
+	}
+	return key.Name
+}
+
 // LooksLikeABuildLabel returns true if the string appears to be a build label, false if not.
 // Useful for cases like rule sources where sources can be a filename or a label.
 func LooksLikeABuildLabel(str string) bool {

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -113,7 +113,7 @@ func TryParseBuildLabel(target, currentPath string) (BuildLabel, error) {
 	return BuildLabel{}, fmt.Errorf("Invalid build label: %s", target)
 }
 
-// ParseBuildLabelSubrepo parses a build label in the context of a package.
+// ParseBuildLabelContext parses a build label in the context of a package.
 // It panics on error.
 func ParseBuildLabelContext(target string, pkg *Package) BuildLabel {
 	if p, name, subrepo := parseBuildLabelParts(target, pkg.Name, pkg.Subrepo); name != "" {
@@ -272,16 +272,6 @@ func (label BuildLabel) Label() *BuildLabel {
 
 func (label BuildLabel) nonOutputLabel() *BuildLabel {
 	return &label
-}
-
-// ForPackage converts this build label to one that's relative for the given package.
-func (label BuildLabel) ForPackage(pkg *Package) BuildLabel {
-	// TODO(peterebden): HasPrefix here is not super elegant. We should probably be able to avoid it
-	//                   if we were more selective about calling this.
-	if pkg.Subrepo != nil && !strings.HasPrefix(label.PackageName, pkg.Subrepo.Name) {
-		return BuildLabel{PackageName: path.Join(pkg.Subrepo.Name, label.PackageName), Name: label.Name}
-	}
-	return label
 }
 
 // UnmarshalFlag unmarshals a build label from a command line flag. Implementation of flags.Unmarshaler interface.

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -343,6 +343,15 @@ func (label BuildLabel) PackageDir() string {
 	return label.PackageName
 }
 
+// SubrepoLabel returns a build label corresponding to the subrepo part of this build label.
+func (label BuildLabel) SubrepoLabel() BuildLabel {
+	if idx := strings.LastIndexByte(label.Subrepo, '/'); idx != -1 {
+		return BuildLabel{PackageName: label.Subrepo[:idx], Name: label.Subrepo[idx+1:]}
+	}
+	// This is legit, the subrepo is defined at the root.
+	return BuildLabel{Name: label.Subrepo}
+}
+
 // Complete implements the flags.Completer interface, which is used for shell completion.
 // Unfortunately it's rather awkward to handle here; we need to do a proper parse in order
 // to find out what the possible build labels are, and we're not ready for that yet.

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -18,9 +18,12 @@ var log = logging.MustGetLogger("core")
 // like :ham are always parsed into an absolute form.
 // There is also implicit expansion of the final element of a target (ala Blaze)
 // so //spam/eggs is equivalent to //spam/eggs:eggs
+//
+// It can also be in a subrepo, in which case the syntax is @subrepo//spam/eggs:ham.
 type BuildLabel struct {
 	PackageName string
 	Name        string
+	Subrepo     string
 }
 
 // WholeGraph represents parsing the entire graph (i.e. //...).
@@ -35,10 +38,10 @@ var OriginalTarget = BuildLabel{PackageName: "", Name: "_ORIGINAL"}
 
 // String returns a string representation of this build label.
 func (label BuildLabel) String() string {
-	if label.Name != "" {
-		return "//" + label.PackageName + ":" + label.Name
+	if label.Subrepo != "" {
+		return "@" + "//" + label.PackageName + ":" + label.Name
 	}
-	return "//" + label.PackageName
+	return "//" + label.PackageName + ":" + label.Name
 }
 
 // NewBuildLabel constructs a new build label from the given components. Panics on failure.

--- a/src/core/build_label_test.go
+++ b/src/core/build_label_test.go
@@ -83,6 +83,17 @@ func TestCompleteError(t *testing.T) {
 	assert.Equal(t, 0, len(completions))
 }
 
+func TestSubrepoLabel(t *testing.T) {
+	label := BuildLabel{Subrepo: "test"}
+	assert.EqualValues(t, BuildLabel{PackageName: "", Name: "test"}, label.SubrepoLabel())
+	label.Subrepo = "package/test"
+	assert.EqualValues(t, BuildLabel{PackageName: "package", Name: "test"}, label.SubrepoLabel())
+	// This isn't really valid (the caller shouldn't need to call it in such a case)
+	// but we want to make sure it doesn't panic.
+	label.Subrepo = ""
+	assert.EqualValues(t, BuildLabel{PackageName: "", Name: ""}, label.SubrepoLabel())
+}
+
 func TestMain(m *testing.M) {
 	// Used to support TestComplete, the function it's testing re-execs
 	// itself thinking that it's actually plz.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -517,22 +517,12 @@ func (target *BuildTarget) CanSee(state *BuildState, dep *BuildTarget) bool {
 		return false
 	}
 	parent := target.Label.Parent()
-	// Visibility constraints currently do not include subrepos to handle cross-compiling nicely.
-	// This is a little dodgy (you can see into non-cross-compiled subrepos by duplicating their
-	// package names) but not the biggest concern right now.
-	if target.Subrepo != nil {
-		parent = target.Subrepo.MakeRelative(parent)
-	}
 	for _, vis := range dep.Visibility {
 		if vis.Includes(parent) {
 			return true
-		} else if dep.Subrepo != nil && dep.Subrepo.MakeRelative(vis).Includes(parent) {
-			return true
 		}
 	}
-	if dep.Subrepo != nil && dep.Subrepo.MakeRelative(dep.Label).PackageName == parent.PackageName {
-		return true
-	} else if dep.Label.PackageName == parent.PackageName {
+	if dep.Label.PackageName == parent.PackageName {
 		return true
 	}
 	if isExperimental(state, target) {

--- a/src/core/graph.go
+++ b/src/core/graph.go
@@ -6,7 +6,6 @@ package core
 
 import (
 	"sort"
-	"strings"
 	"sync"
 )
 
@@ -34,8 +33,7 @@ type BuildGraph struct {
 func (graph *BuildGraph) AddTarget(target *BuildTarget) *BuildTarget {
 	graph.mutex.Lock()
 	defer graph.mutex.Unlock()
-	_, present := graph.targets[target.Label]
-	if present {
+	if _, present := graph.targets[target.Label]; present {
 		panic("Attempted to re-add existing target to build graph: " + target.Label.String())
 	}
 	graph.targets[target.Label] = target
@@ -131,14 +129,6 @@ func (graph *BuildGraph) SubrepoOrDie(name string) *Subrepo {
 		log.Fatalf("No registered subrepo by the name %s", name)
 	}
 	return subrepo
-}
-
-// SubrepoFor returns the subrepo for the given package (which may be a subpackage inside the subrepo)
-func (graph *BuildGraph) SubrepoFor(name string) *Subrepo {
-	if idx := strings.IndexRune(name, '/'); idx != -1 {
-		return graph.Subrepo(name[:idx])
-	}
-	return graph.Subrepo(name)
 }
 
 // Len returns the number of targets currently in the graph.

--- a/src/core/graph.go
+++ b/src/core/graph.go
@@ -17,7 +17,7 @@ type BuildGraph struct {
 	// Map of all currently known targets by their label.
 	targets map[BuildLabel]*BuildTarget
 	// Map of all currently known packages.
-	packages map[string]*Package
+	packages map[packageKey]*Package
 	// Reverse dependencies that are pending on targets actually being added to the graph.
 	pendingRevDeps map[BuildLabel]map[BuildLabel]*BuildTarget
 	// Actual reverse dependencies
@@ -54,12 +54,13 @@ func (graph *BuildGraph) AddTarget(target *BuildTarget) *BuildTarget {
 
 // AddPackage adds a new package to the graph with given name.
 func (graph *BuildGraph) AddPackage(pkg *Package) {
+	key := packageKey{Name: pkg.Name, Subrepo: pkg.SubrepoName}
 	graph.mutex.Lock()
 	defer graph.mutex.Unlock()
-	if _, present := graph.packages[pkg.Name]; present {
-		panic("Attempt to readd existing package: " + pkg.Name)
+	if _, present := graph.packages[key]; present {
+		panic("Attempt to readd existing package: " + key.String())
 	}
-	graph.packages[pkg.Name] = pkg
+	graph.packages[key] = pkg
 }
 
 // Target retrieves a target from the graph by label
@@ -78,18 +79,27 @@ func (graph *BuildGraph) TargetOrDie(label BuildLabel) *BuildTarget {
 	return target
 }
 
-// Package retrieves a package from the graph by name
-func (graph *BuildGraph) Package(name string) *Package {
-	graph.mutex.RLock()
-	defer graph.mutex.RUnlock()
-	return graph.packages[name]
+// PackageByLabel retrieves a package from the graph using the appropriate parts of the given label.
+// The Name entry is ignored.
+func (graph *BuildGraph) PackageByLabel(label BuildLabel) *Package {
+	return graph.Package(label.PackageName, label.Subrepo)
 }
 
-// PackageOrDie retrieves a package by name, and dies if it can't be found.
-func (graph *BuildGraph) PackageOrDie(name string) *Package {
-	pkg := graph.Package(name)
+// Package retrieves a package from the graph by name & subrepo, or nil if it can't be found.
+func (graph *BuildGraph) Package(name, subrepo string) *Package {
+	graph.mutex.RLock()
+	defer graph.mutex.RUnlock()
+	return graph.packages[packageKey{Name: name, Subrepo: subrepo}]
+}
+
+// PackageOrDie retrieves a package by label, and dies if it can't be found.
+func (graph *BuildGraph) PackageOrDie(label BuildLabel) *Package {
+	pkg := graph.PackageByLabel(label)
 	if pkg == nil {
-		log.Fatalf("Package %s doesn't exist in graph", name)
+		if label.Subrepo != "" {
+			log.Fatalf("Package @%s//%s doesn't exist in graph", label.Subrepo, label.PackageName)
+		}
+		log.Fatalf("Package %s doesn't exist in graph", label.PackageName)
 	}
 	return pkg
 }
@@ -155,8 +165,8 @@ func (graph *BuildGraph) PackageMap() map[string]*Package {
 	graph.mutex.RLock()
 	defer graph.mutex.RUnlock()
 	packages := make(map[string]*Package, len(graph.packages))
-	for name, pkg := range graph.packages {
-		packages[name] = pkg
+	for k, v := range graph.packages {
+		packages[k.String()] = v
 	}
 	return packages
 }
@@ -186,7 +196,7 @@ func (graph *BuildGraph) AddDependency(from BuildLabel, to BuildLabel) {
 func NewGraph() *BuildGraph {
 	return &BuildGraph{
 		targets:        map[BuildLabel]*BuildTarget{},
-		packages:       map[string]*Package{},
+		packages:       map[packageKey]*Package{},
 		pendingRevDeps: map[BuildLabel]map[BuildLabel]*BuildTarget{},
 		revDeps:        map[BuildLabel][]*BuildTarget{},
 		subrepos:       map[string]*Subrepo{},

--- a/src/core/graph.go
+++ b/src/core/graph.go
@@ -96,10 +96,7 @@ func (graph *BuildGraph) Package(name, subrepo string) *Package {
 func (graph *BuildGraph) PackageOrDie(label BuildLabel) *Package {
 	pkg := graph.PackageByLabel(label)
 	if pkg == nil {
-		if label.Subrepo != "" {
-			log.Fatalf("Package @%s//%s doesn't exist in graph", label.Subrepo, label.PackageName)
-		}
-		log.Fatalf("Package %s doesn't exist in graph", label.PackageName)
+		log.Fatalf("Package %s doesn't exist in graph", packageKey{Name: label.PackageName, Subrepo: label.Subrepo})
 	}
 	return pkg
 }

--- a/src/core/graph_test.go
+++ b/src/core/graph_test.go
@@ -94,12 +94,6 @@ func TestSubrepo(t *testing.T) {
 	subrepo := graph.Subrepo("test")
 	assert.NotNil(t, subrepo)
 	assert.Equal(t, "plz-out/gen/test", subrepo.Root)
-	subrepo = graph.SubrepoFor("test/some/package")
-	assert.NotNil(t, subrepo)
-	assert.Equal(t, "plz-out/gen/test", subrepo.Root)
-	subrepo = graph.SubrepoFor("test")
-	assert.NotNil(t, subrepo)
-	assert.Equal(t, "plz-out/gen/test", subrepo.Root)
 }
 
 // makeTarget creates a new build target for us.

--- a/src/core/graph_test.go
+++ b/src/core/graph_test.go
@@ -17,7 +17,7 @@ func TestAddPackage(t *testing.T) {
 	graph := NewGraph()
 	pkg := NewPackage("src/core")
 	graph.AddPackage(pkg)
-	assert.Equal(t, pkg, graph.PackageOrDie("src/core"))
+	assert.Equal(t, pkg, graph.Package("src/core", ""))
 }
 
 func TestTarget(t *testing.T) {

--- a/src/core/label_parse_test.go
+++ b/src/core/label_parse_test.go
@@ -4,7 +4,7 @@ package core
 
 import "testing"
 
-func assertLabel(t *testing.T, in, pkg, name string) {
+func assertLabel(t *testing.T, in, pkg, name string) BuildLabel {
 	defer func() {
 		if r := recover(); r != nil {
 			t.Errorf("Failed to parse %s: %s", in, r)
@@ -16,6 +16,14 @@ func assertLabel(t *testing.T, in, pkg, name string) {
 	}
 	if label.Name != name {
 		t.Errorf("Incorrect parse of %s: target name should be %s, was %s", in, name, label.Name)
+	}
+	return label
+}
+
+func assertSubrepoLabel(t *testing.T, in, pkg, name, subrepo string) {
+	label := assertLabel(t, in, pkg, name)
+	if label.Subrepo != subrepo {
+		t.Errorf("Incorrect parse of %s: subrepo should be %s, was %s", in, subrepo, label.Subrepo)
 	}
 }
 
@@ -132,7 +140,7 @@ func TestPipesArentAccepted(t *testing.T) {
 }
 
 func TestSubrepos(t *testing.T) {
-	assertLabel(t, "@subrepo//pkg:target", "subrepo/pkg", "target")
-	assertLabel(t, "@com_google_googletest//:gtest_main", "com_google_googletest", "gtest_main")
-	assertLabel(t, "@test_x86:target", "test_x86/current_package", "target")
+	assertSubrepoLabel(t, "@subrepo//pkg:target", "pkg", "target", "subrepo")
+	assertSubrepoLabel(t, "@com_google_googletest//:gtest_main", "", "gtest_main", "com_google_googletest")
+	assertSubrepoLabel(t, "@test_x86:target", "current_package", "target", "test_x86")
 }

--- a/src/core/package.go
+++ b/src/core/package.go
@@ -15,6 +15,9 @@ import (
 type Package struct {
 	// Name of the package, ie. //spam/eggs
 	Name string
+	// If this package is in a subrepo, this is the name of the subrepo.
+	// Equivalent to Subrepo.Name but avoids NPEs.
+	SubrepoName string
 	// Filename of the build file that defined this package
 	Filename string
 	// Subincluded build defs files that this package imported

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -130,7 +130,7 @@ func addTarget(state *BuildState, name string, labels ...string) {
 	target := NewBuildTarget(ParseBuildLabel(name, ""))
 	target.Labels = labels
 	target.IsTest = strings.HasSuffix(name, "_test")
-	pkg := state.Graph.Package(target.Label.PackageName)
+	pkg := state.Graph.PackageByLabel(target.Label)
 	if pkg == nil {
 		pkg = NewPackage(target.Label.PackageName)
 		state.Graph.AddPackage(pkg)

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestExpandOriginalTargets(t *testing.T) {
 	state := NewBuildState(1, nil, 4, DefaultConfiguration())
-	state.OriginalTargets = []BuildLabel{{"src/core", "all"}, {"src/parse", "parse"}}
+	state.OriginalTargets = []BuildLabel{{PackageName: "src/core", Name: "all"}, {PackageName: "src/parse", Name: "parse"}}
 	state.Include = []string{"go"}
 	state.Exclude = []string{"py"}
 
@@ -27,14 +27,14 @@ func TestExpandOriginalTargets(t *testing.T) {
 	// //src/parse:parse doesn't have 'go' but was explicitly requested so will be
 	// added anyway.
 	assert.Equal(t, state.ExpandOriginalTargets(), BuildLabels{
-		{"src/core", "target1"},
-		{"src/parse", "parse"},
+		{PackageName: "src/core", Name: "target1"},
+		{PackageName: "src/parse", Name: "parse"},
 	})
 }
 
 func TestExpandOriginalTestTargets(t *testing.T) {
 	state := NewBuildState(1, nil, 4, DefaultConfiguration())
-	state.OriginalTargets = []BuildLabel{{"src/core", "all"}}
+	state.OriginalTargets = []BuildLabel{{PackageName: "src/core", Name: "all"}}
 	state.NeedTests = true
 	state.Include = []string{"go"}
 	state.Exclude = []string{"py"}
@@ -46,21 +46,21 @@ func TestExpandOriginalTestTargets(t *testing.T) {
 	addTarget(state, "//src/core:target4_test", "go", "manual")
 	// Only the one target comes out here; it must be a test and otherwise follows
 	// the same include / exclude logic as the previous test.
-	assert.Equal(t, state.ExpandOriginalTargets(), BuildLabels{{"src/core", "target1_test"}})
+	assert.Equal(t, state.ExpandOriginalTargets(), BuildLabels{{PackageName: "src/core", Name: "target1_test"}})
 }
 
 func TestExpandVisibleOriginalTargets(t *testing.T) {
 	state := NewBuildState(1, nil, 4, DefaultConfiguration())
-	state.OriginalTargets = []BuildLabel{{"src/core", "all"}}
+	state.OriginalTargets = []BuildLabel{{PackageName: "src/core", Name: "all"}}
 
 	addTarget(state, "//src/core:target1", "py")
 	addTarget(state, "//src/core:_target1#zip", "py")
-	assert.Equal(t, state.ExpandVisibleOriginalTargets(), BuildLabels{{"src/core", "target1"}})
+	assert.Equal(t, state.ExpandVisibleOriginalTargets(), BuildLabels{{PackageName: "src/core", Name: "target1"}})
 }
 
 func TestExpandOriginalSubTargets(t *testing.T) {
 	state := NewBuildState(1, nil, 4, DefaultConfiguration())
-	state.OriginalTargets = []BuildLabel{{"src/core", "..."}}
+	state.OriginalTargets = []BuildLabel{{PackageName: "src/core", Name: "..."}}
 	state.Include = []string{"go"}
 	state.Exclude = []string{"py"}
 	addTarget(state, "//src/core:target1", "go")
@@ -68,21 +68,28 @@ func TestExpandOriginalSubTargets(t *testing.T) {
 	addTarget(state, "//src/core/tests:target3", "go")
 	// Only the one target comes out here; it must be a test and otherwise follows
 	// the same include / exclude logic as the previous test.
-	assert.Equal(t, state.ExpandOriginalTargets(), BuildLabels{{"src/core", "target1"}, {"src/core/tests", "target3"}})
+	assert.Equal(t, state.ExpandOriginalTargets(), BuildLabels{
+		{PackageName: "src/core", Name: "target1"},
+		{PackageName: "src/core/tests", Name: "target3"},
+	})
 }
 
 func TestExpandOriginalTargetsOrdering(t *testing.T) {
 	state := NewBuildState(1, nil, 4, DefaultConfiguration())
-	state.OriginalTargets = []BuildLabel{{"src/parse", "parse"}, {"src/core", "..."}, {"src/build", "build"}}
+	state.OriginalTargets = []BuildLabel{
+		{PackageName: "src/parse", Name: "parse"},
+		{PackageName: "src/core", Name: "..."},
+		{PackageName: "src/build", Name: "build"},
+	}
 	addTarget(state, "//src/core:target1", "go")
 	addTarget(state, "//src/core:target2", "py")
 	addTarget(state, "//src/core/tests:target3", "go")
 	expected := BuildLabels{
-		{"src/parse", "parse"},
-		{"src/core", "target1"},
-		{"src/core", "target2"},
-		{"src/core/tests", "target3"},
-		{"src/build", "build"},
+		{PackageName: "src/parse", Name: "parse"},
+		{PackageName: "src/core", Name: "target1"},
+		{PackageName: "src/core", Name: "target2"},
+		{PackageName: "src/core/tests", Name: "target3"},
+		{PackageName: "src/build", Name: "build"},
 	}
 	assert.Equal(t, expected, state.ExpandOriginalTargets())
 }

--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -34,7 +34,7 @@ func SubrepoForArch(state *BuildState, arch cli.Arch) *Subrepo {
 // MakeRelative makes a build label that is within this subrepo relative to it (i.e. strips the leading name part).
 // The caller should already know that it is within this repo, otherwise this will panic.
 func (s *Subrepo) MakeRelative(label BuildLabel) BuildLabel {
-	return BuildLabel{s.MakeRelativeName(label.PackageName), label.Name}
+	return BuildLabel{PackageName: s.MakeRelativeName(label.PackageName), Name: label.Name}
 }
 
 // MakeRelativeName is as MakeRelative but operates only on the package name.

--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -2,9 +2,7 @@ package core
 
 import (
 	"cli"
-	"fmt"
 	"path"
-	"strings"
 )
 
 // A Subrepo stores information about a registered subrepository, typically one
@@ -31,24 +29,7 @@ func SubrepoForArch(state *BuildState, arch cli.Arch) *Subrepo {
 	}
 }
 
-// MakeRelative makes a build label that is within this subrepo relative to it (i.e. strips the leading name part).
-// The caller should already know that it is within this repo, otherwise this will panic.
-func (s *Subrepo) MakeRelative(label BuildLabel) BuildLabel {
-	return BuildLabel{PackageName: s.MakeRelativeName(label.PackageName), Name: label.Name}
-}
-
-// MakeRelativeName is as MakeRelative but operates only on the package name.
-func (s *Subrepo) MakeRelativeName(name string) string {
-	// Check for nil, makes it easier to call this without having so many conditionals.
-	if s == nil {
-		return name
-	} else if !strings.HasPrefix(name, s.Name) {
-		panic(fmt.Errorf("cannot make label %s relative, it is not within this subrepo (%s)", name, s.Name))
-	}
-	return strings.TrimPrefix(name[len(s.Name):], "/")
-}
-
 // Dir returns the directory for a package of this name.
 func (s *Subrepo) Dir(dir string) string {
-	return path.Join(s.Root, s.MakeRelativeName(dir))
+	return path.Join(s.Root, dir)
 }

--- a/src/core/subrepo_test.go
+++ b/src/core/subrepo_test.go
@@ -9,5 +9,4 @@ import (
 func TestDir(t *testing.T) {
 	s := &Subrepo{Name: "repo", Root: "plz-out/gen/repo"}
 	assert.Equal(t, "plz-out/gen/repo/package", s.Dir("package"))
-	assert.Panics(t, func() { s.Dir("other/package") })
 }

--- a/src/core/subrepo_test.go
+++ b/src/core/subrepo_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestDir(t *testing.T) {
 	s := &Subrepo{Name: "repo", Root: "plz-out/gen/repo"}
-	assert.Equal(t, "plz-out/gen/repo/package", s.Dir("repo/package"))
+	assert.Equal(t, "plz-out/gen/repo/package", s.Dir("package"))
 	assert.Panics(t, func() { s.Dir("other/package") })
 }

--- a/src/core/subrepo_test.go
+++ b/src/core/subrepo_test.go
@@ -6,18 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMakeRelative(t *testing.T) {
-	s := &Subrepo{Name: "repo"}
-	l := s.MakeRelative(NewBuildLabel("repo/package", "name"))
-	assert.Equal(t, NewBuildLabel("package", "name"), l)
-	assert.Panics(t, func() { s.MakeRelative(NewBuildLabel("other/package", "name")) })
-}
-
-func TestMakeRelativeName(t *testing.T) {
-	s := &Subrepo{Name: "com_google_googletest"}
-	assert.Equal(t, "googletest/include", s.MakeRelativeName("com_google_googletest/googletest/include"))
-}
-
 func TestDir(t *testing.T) {
 	s := &Subrepo{Name: "repo", Root: "plz-out/gen/repo"}
 	assert.Equal(t, "plz-out/gen/repo/package", s.Dir("repo/package"))

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -331,7 +331,7 @@ func IterSources(graph *BuildGraph, target *BuildTarget) <-chan SourcePair {
 			outDir := dependency.OutDir()
 			for _, dep := range dependency.Outputs() {
 				depPath := path.Join(outDir, dep)
-				pkgName := dependency.Subrepo.MakeRelativeName(dependency.Label.PackageName)
+				pkgName := dependency.Label.PackageName
 				tmpPath := path.Join(tmpDir, pkgName, dep)
 				if !donePaths[tmpPath] {
 					ch <- SourcePair{depPath, tmpPath}
@@ -444,16 +444,11 @@ func IterRuntimeFiles(graph *BuildGraph, target *BuildTarget, absoluteOuts bool)
 			pushOut(path.Join(outDir, out), out)
 		}
 		for _, data := range target.Data {
-			var subrepo *Subrepo
-			label := data.Label()
-			if label != nil {
-				subrepo = graph.TargetOrDie(*label).Subrepo
-			}
 			fullPaths := data.FullPaths(graph)
 			for i, dataPath := range data.Paths(graph) {
-				pushOut(fullPaths[i], subrepo.MakeRelativeName(dataPath))
+				pushOut(fullPaths[i], dataPath)
 			}
-			if label != nil {
+			if label := data.Label(); label != nil {
 				for _, dep := range graph.TargetOrDie(*label).ExportedDependencies() {
 					inner(graph.TargetOrDie(dep))
 				}

--- a/src/export/export.go
+++ b/src/export/export.go
@@ -27,7 +27,7 @@ func ToDir(state *core.BuildState, dir string, targets []core.BuildLabel) {
 	// Now write all the build files
 	packages := map[*core.Package]bool{}
 	for target := range done {
-		packages[state.Graph.PackageOrDie(target.Label.PackageName)] = true
+		packages[state.Graph.PackageOrDie(target.Label)] = true
 	}
 	for pkg := range packages {
 		dest := path.Join(dir, pkg.Filename)
@@ -71,7 +71,7 @@ func export(graph *core.BuildGraph, dir string, target *core.BuildTarget, done m
 			export(graph, dir, dep, done)
 		}
 	}
-	for _, subinclude := range graph.PackageOrDie(target.Label.PackageName).Subincludes {
+	for _, subinclude := range graph.PackageOrDie(target.Label).Subincludes {
 		export(graph, dir, graph.TargetOrDie(subinclude), done)
 	}
 }

--- a/src/gc/gc.go
+++ b/src/gc/gc.go
@@ -240,14 +240,14 @@ func RewriteFile(state *core.BuildState, filename string, targets []string) erro
 
 // removeTargets rewrites the given set of targets out of their BUILD files.
 func removeTargets(state *core.BuildState, labels core.BuildLabels) error {
-	byPackage := map[string][]string{}
+	byPackage := map[*core.Package][]string{}
 	for _, l := range labels {
-		byPackage[l.PackageName] = append(byPackage[l.PackageName], l.Name)
+		pkg := state.Graph.PackageOrDie(l)
+		byPackage[pkg] = append(byPackage[pkg], l.Name)
 	}
-	for pkgName, victims := range byPackage {
-		filename := state.Graph.PackageOrDie(pkgName).Filename
-		log.Notice("Rewriting %s to remove %s...\n", filename, strings.Join(victims, ", "))
-		if err := RewriteFile(state, filename, victims); err != nil {
+	for pkg, victims := range byPackage {
+		log.Notice("Rewriting %s to remove %s...\n", pkg.Filename, strings.Join(victims, ", "))
+		if err := RewriteFile(state, pkg.Filename, victims); err != nil {
 			return err
 		}
 	}

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -37,7 +37,7 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "int", intType)
 	setNativeCode(s, "str", strType)
 	setNativeCode(s, "join_path", joinPath).varargs = true
-	setNativeCode(s, "get_base_path", getBasePath)
+	setNativeCode(s, "get_base_path", packageName)
 	setNativeCode(s, "package_name", packageName)
 	setNativeCode(s, "canonicalise", canonicalise)
 	setNativeCode(s, "get_labels", getLabels)
@@ -498,14 +498,7 @@ func joinPath(s *scope, args []pyObject) pyObject {
 	return pyString(path.Join(l...))
 }
 
-func getBasePath(s *scope, args []pyObject) pyObject {
-	return pyString(s.pkg.Name)
-}
-
 func packageName(s *scope, args []pyObject) pyObject {
-	if s.pkg.Subrepo != nil {
-		return pyString(s.pkg.Subrepo.MakeRelativeName(s.pkg.Name))
-	}
 	return pyString(s.pkg.Name)
 }
 

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -338,7 +338,7 @@ func parseSource(s *scope, src string, systemAllowed, tool bool) core.BuildInput
 	if s.pkg.Subrepo != nil {
 		return core.SubrepoFileLabel{
 			File:        src,
-			Package:     s.pkg.Subrepo.MakeRelativeName(s.pkg.Name),
+			Package:     s.pkg.Name,
 			FullPackage: s.pkg.Subrepo.Dir(s.pkg.Name),
 		}
 	}

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -42,6 +42,7 @@ func createTarget(s *scope, args []pyObject) *core.BuildTarget {
 	}
 	label, err := core.TryNewBuildLabel(s.pkg.Name, name)
 	s.Assert(err == nil, "Invalid build target name %s", name)
+	label.Subrepo = s.pkg.SubrepoName
 
 	target := core.NewBuildTarget(label)
 	target.Subrepo = s.pkg.Subrepo
@@ -308,7 +309,7 @@ func parseSource(s *scope, src string, systemAllowed, tool bool) core.BuildInput
 			// TODO(peterebden): this should really use something involving named output labels;
 			//                   right now we don't have a package handy to call that but we
 			//                   don't use them for tools anywhere either...
-			return core.ParseBuildLabel(src, s.pkg.Subrepo.MakeRelativeName(s.pkg.Name))
+			return core.ParseBuildLabelContext(src, s.pkg)
 		}
 		label := core.MustParseNamedOutputLabel(src, s.pkg)
 		if l := label.Label(); l != nil && l.Subrepo != "" {

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -349,7 +349,7 @@ func parseSource(s *scope, src string, systemAllowed, tool bool) core.BuildInput
 func parseLabel(s *scope, label string) core.BuildLabel {
 	l := core.ParseBuildLabelContext(label, s.pkg)
 	verifyArchSubrepo(s, l.Subrepo)
-	return l.ForPackage(s.pkg)
+	return l
 }
 
 // verifyArchSubrepo creates a subrepo for the given architecture if one doesn't exist.

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -310,8 +310,10 @@ func parseSource(s *scope, src string, systemAllowed, tool bool) core.BuildInput
 			//                   don't use them for tools anywhere either...
 			return core.ParseBuildLabel(src, s.pkg.Subrepo.MakeRelativeName(s.pkg.Name))
 		}
-		label, subrepo := core.MustParseNamedOutputLabel(src, s.pkg)
-		verifyArchSubrepo(s, subrepo)
+		label := core.MustParseNamedOutputLabel(src, s.pkg)
+		if l := label.Label(); l != nil && l.Subrepo != "" {
+			verifyArchSubrepo(s, l.Subrepo)
+		}
 		return label
 	}
 	s.Assert(src != "", "Empty source path")
@@ -344,8 +346,8 @@ func parseSource(s *scope, src string, systemAllowed, tool bool) core.BuildInput
 
 // parseLabel parses a build label, handling potential cross-architecture labels.
 func parseLabel(s *scope, label string) core.BuildLabel {
-	l, subrepo := core.ParseBuildLabelSubrepo(label, s.pkg)
-	verifyArchSubrepo(s, subrepo)
+	l := core.ParseBuildLabelContext(label, s.pkg)
+	verifyArchSubrepo(s, l.Subrepo)
 	return l.ForPackage(s.pkg)
 }
 

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -380,7 +380,7 @@ type preBuildFunction struct {
 }
 
 func (f *preBuildFunction) Call(target *core.BuildTarget) error {
-	s := f.f.scope.NewPackagedScope(f.f.scope.state.Graph.PackageOrDie(target.Label.PackageName))
+	s := f.f.scope.NewPackagedScope(f.f.scope.state.Graph.PackageOrDie(target.Label))
 	s.Callback = true
 	s.Set(f.f.args[0], pyString(target.Label.Name))
 	return annotateCallbackError(s, target, s.interpreter.interpretStatements(s, f.f.code))
@@ -398,7 +398,7 @@ type postBuildFunction struct {
 
 func (f *postBuildFunction) Call(target *core.BuildTarget, output string) error {
 	log.Debug("Running post-build function for %s. Build output:\n%s", target.Label, output)
-	s := f.f.scope.NewPackagedScope(f.f.scope.state.Graph.PackageOrDie(target.Label.PackageName))
+	s := f.f.scope.NewPackagedScope(f.f.scope.state.Graph.PackageOrDie(target.Label))
 	s.Callback = true
 	s.Set(f.f.args[0], pyString(target.Label.Name))
 	s.Set(f.f.args[1], fromStringList(strings.Split(strings.TrimSpace(output), "\n")))
@@ -415,7 +415,7 @@ func annotateCallbackError(s *scope, target *core.BuildTarget, err error) error 
 		return nil
 	}
 	// Something went wrong, find the BUILD file and attach some info.
-	pkg := s.state.Graph.Package(target.Label.PackageName)
+	pkg := s.state.Graph.PackageByLabel(target.Label)
 	f, _ := os.Open(pkg.Filename)
 	return s.interpreter.parser.annotate(err, f)
 }

--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -64,7 +64,7 @@ func (p *aspParser) RunPostBuildFunction(threadID int, state *core.BuildState, t
 // runBuildFunction runs either the pre- or post-build function.
 func (p *aspParser) runBuildFunction(tid int, state *core.BuildState, target *core.BuildTarget, callbackType string, f func() error) error {
 	state.LogBuildResult(tid, target.Label, core.PackageParsing, fmt.Sprintf("Running %s-build function for %s", callbackType, target.Label))
-	pkg := state.Graph.Package(target.Label.PackageName)
+	pkg := state.Graph.PackageByLabel(target.Label)
 	changed, err := pkg.EnterBuildCallback(f)
 	if err != nil {
 		state.LogBuildError(tid, target.Label, core.ParseFailed, err, "Failed %s-build function for %s", callbackType, target.Label)

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -112,6 +112,9 @@ func parsePackage(state *core.BuildState, label, dependor core.BuildLabel, subre
 	packageName := label.PackageName
 	pkg := core.NewPackage(packageName)
 	pkg.Subrepo = subrepo
+	if subrepo != nil {
+		pkg.SubrepoName = subrepo.Name
+	}
 	if pkg.Filename = buildFileName(state, label.PackageName, label.Subrepo); pkg.Filename == "" {
 		// Could indicate that we're looking for a subrepo that hasn't been loaded yet.
 		// TODO(peterebden): Ideally we'd like to be able to define these anywhere, so this is a bit of a hack for now.

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -41,7 +41,7 @@ func Parse(tid int, state *core.BuildState, label, dependor core.BuildLabel, noD
 
 func parse(tid int, state *core.BuildState, label, dependor core.BuildLabel, noDeps bool, include, exclude []string, forSubinclude bool) error {
 	// See if something else has parsed this package first.
-	pkg := state.WaitForPackage(label.PackageName)
+	pkg := state.WaitForPackage(label)
 	if pkg != nil {
 		// Does exist, all we need to do is toggle on this target
 		return activateTarget(state, pkg, label, dependor, noDeps, forSubinclude, include, exclude)
@@ -118,7 +118,7 @@ func parsePackage(state *core.BuildState, label, dependor core.BuildLabel, subre
 	if pkg.Filename = buildFileName(state, label.PackageName, label.Subrepo); pkg.Filename == "" {
 		// Could indicate that we're looking for a subrepo that hasn't been loaded yet.
 		// TODO(peterebden): Ideally we'd like to be able to define these anywhere, so this is a bit of a hack for now.
-		if fs.IsPackage(state.Config.Parse.BuildFileName, core.RepoRoot) && state.Graph.Package("") == nil {
+		if fs.IsPackage(state.Config.Parse.BuildFileName, core.RepoRoot) && state.Graph.Package("", "") == nil {
 			if _, err := parsePackage(state, core.BuildLabel{PackageName: "", Name: "all"}, label, nil); err != nil {
 				return nil, err
 			}
@@ -196,7 +196,7 @@ func buildFileName(state *core.BuildState, pkgName, subrepo string) string {
 // Adds a single target to the build queue.
 func addDep(state *core.BuildState, label, dependor core.BuildLabel, rescan, forceBuild bool) {
 	// Stop at any package that's not loaded yet
-	if state.Graph.Package(label.PackageName) == nil {
+	if state.Graph.PackageByLabel(label) == nil {
 		if forceBuild {
 			log.Debug("Adding forced pending parse of %s", label)
 		}

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -74,7 +74,7 @@ func TestAddDepRescan(t *testing.T) {
 
 	// Add new target & dep to target1
 	target4 := makeTarget("//package1:target4")
-	state.Graph.Package("package1").AddTarget(target4)
+	state.Graph.Package("package1", "").AddTarget(target4)
 	state.Graph.AddTarget(target4)
 	target1 := state.Graph.TargetOrDie(buildLabel("//package1:target1"))
 	target1.AddDependency(buildLabel("//package1:target4"))

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -436,7 +436,8 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compil
 def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
             pkg_config_libs:list=[], deps:list=[], worker:str='', data:list=[], visibility:list=[], flags:str='',
             labels:list&features&tags=[], flaky:bool|int=0, test_outputs:list=[], size:str=None, timeout:int=0,
-            container:bool|dict=False, sandbox:bool=None, write_main:bool=not CONFIG.BAZEL_COMPATIBILITY, _c=False):
+            container:bool|dict=False, sandbox:bool=None, write_main:bool=not CONFIG.BAZEL_COMPATIBILITY,
+            linkstatic:bool=False, _c=False):
     """Defines a C++ test using UnitTest++.
 
     We template in a main file so you don't have to supply your own.
@@ -462,6 +463,8 @@ def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&cop
       container (bool | dict): If true the test is run in a container (eg. Docker).
       sandbox (bool): Sandbox the test on Linux to restrict access to namespaces such as network.
       write_main (bool): Whether or not to write a main() for these tests.
+      linkstatic (bool): Only provided for Bazel compatibility. Has no actual effect since we always
+                         link roughly equivalently to their "mostly-static" mode.
     """
     if CONFIG.BAZEL_COMPATIBILITY:
         linker_flags = ['-lpthread' if l == '-pthread' else l for l in linker_flags]

--- a/src/please.go
+++ b/src/please.go
@@ -779,7 +779,7 @@ func findOriginalTasks(state *core.BuildState, targets []core.BuildLabel) {
 
 func findOriginalTask(state *core.BuildState, target core.BuildLabel, addToList bool) {
 	if opts.BuildFlags.Arch.Arch != "" {
-		target.PackageName = path.Join(opts.BuildFlags.Arch.String(), target.PackageName)
+		target.Subrepo = opts.BuildFlags.Arch.String()
 	}
 	if target.IsAllSubpackages() {
 		for pkg := range utils.FindAllSubpackages(state.Config, target.PackageName, "") {

--- a/src/query/completions.go
+++ b/src/query/completions.go
@@ -75,7 +75,7 @@ func queryCompletionPackages(config *core.Configuration, query, repoRoot string)
 func Completions(graph *core.BuildGraph, labels []core.BuildLabel, binary, test, hidden bool) {
 	for _, label := range labels {
 		count := 0
-		for _, target := range graph.PackageOrDie(label.PackageName).AllTargets() {
+		for _, target := range graph.PackageOrDie(label).AllTargets() {
 			if !strings.HasPrefix(target.Label.Name, label.Name) {
 				continue
 			}

--- a/src/query/graph.go
+++ b/src/query/graph.go
@@ -92,7 +92,7 @@ func addJSONTarget(state *core.BuildState, ret *JSONGraph, label core.BuildLabel
 	}
 	done[label] = struct{}{}
 	if label.IsAllTargets() {
-		pkg := state.Graph.PackageOrDie(label.PackageName)
+		pkg := state.Graph.PackageOrDie(label)
 		for _, target := range pkg.AllTargets() {
 			addJSONTarget(state, ret, target.Label, done)
 		}

--- a/src/query/print_test.go
+++ b/src/query/print_test.go
@@ -161,8 +161,7 @@ func testPrintFields(target *core.BuildTarget, fields []string) string {
 func src(in string) core.BuildInput {
 	pkg := core.NewPackage("src/query")
 	if strings.HasPrefix(in, "//") || strings.HasPrefix(in, ":") {
-		src, _ := core.MustParseNamedOutputLabel(in, pkg)
-		return src
+		return core.MustParseNamedOutputLabel(in, pkg)
 	}
 	return core.FileLabel{File: in, Package: pkg.Name}
 }

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -13,7 +13,7 @@ func ReverseDeps(graph *core.BuildGraph, labels []core.BuildLabel) {
 	uniqueTargets := make(map[core.BuildLabel]struct{})
 
 	for _, label := range labels {
-		for _, child := range graph.PackageOrDie(label.PackageName).AllChildren(graph.TargetOrDie(label)) {
+		for _, child := range graph.PackageOrDie(label).AllChildren(graph.TargetOrDie(label)) {
 			for _, target := range graph.ReverseDependencies(child) {
 				if parent := target.Parent(graph); parent != nil {
 					uniqueTargets[parent.Label] = struct{}{}

--- a/src/query/somepath.go
+++ b/src/query/somepath.go
@@ -11,7 +11,7 @@ func SomePath(graph *core.BuildGraph, label1 core.BuildLabel, label2 core.BuildL
 	// trickiness is worth supporting.
 	// Of course this calculation is also quadratic but it's not very obvious how to avoid that.
 	if label1.IsAllTargets() {
-		for _, target := range graph.PackageOrDie(label1.PackageName).AllTargets() {
+		for _, target := range graph.PackageOrDie(label1).AllTargets() {
 			if querySomePath1(graph, target, label2, false) {
 				return
 			}
@@ -25,7 +25,7 @@ func SomePath(graph *core.BuildGraph, label1 core.BuildLabel, label2 core.BuildL
 func querySomePath1(graph *core.BuildGraph, target1 *core.BuildTarget, label2 core.BuildLabel, print bool) bool {
 	// Now we do the same for label2.
 	if label2.IsAllTargets() {
-		for _, target2 := range graph.PackageOrDie(label2.PackageName).AllTargets() {
+		for _, target2 := range graph.PackageOrDie(label2).AllTargets() {
 			if querySomePath2(graph, target1, target2, false) {
 				return true
 			}

--- a/src/query/whatoutputs_test.go
+++ b/src/query/whatoutputs_test.go
@@ -14,7 +14,7 @@ func makeTarget(g *core.BuildGraph, packageName string, labelName string, output
 	l := core.ParseBuildLabel(fmt.Sprintf("//%s:%s", packageName, labelName), "")
 	t := core.NewBuildTarget(l)
 
-	p := g.Package(packageName)
+	p := g.Package(packageName, "")
 	if p == nil {
 		p = core.NewPackage(packageName)
 		g.AddPackage(p)
@@ -52,8 +52,8 @@ func TestMapKeysContainFullPathFromProjectRoot(t *testing.T) {
 	label2 := core.ParseBuildLabel("//package1:target2", "")
 	label3 := core.ParseBuildLabel("//package2:target1", "")
 
-	p1 := graph.PackageOrDie("package1")
-	p2 := graph.PackageOrDie("package2")
+	p1 := graph.Package("package1", "")
+	p2 := graph.Package("package2", "")
 
 	assert.Equal(t, m[path.Join(p1.Target("target1").OutDir(), "out1")].String(), label1.String())
 	assert.Equal(t, m[path.Join(p1.Target("target1").OutDir(), "out2")].String(), label1.String())

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -113,7 +113,7 @@ func startWatching(watcher *fsnotify.Watcher, state *core.BuildState, labels []c
 		for _, dep := range target.Dependencies() {
 			startWatch(dep)
 		}
-		pkg := state.Graph.PackageOrDie(target.Label.PackageName)
+		pkg := state.Graph.PackageOrDie(target.Label)
 		if !files.Has(pkg.Filename) {
 			log.Notice("Adding watch on %s", pkg.Filename)
 			files.Set(pkg.Filename, struct{}{})


### PR DESCRIPTION
This makes things a lot cleaner versus the previous setup of mashing it into the package name and gets rid of a bunch of hackorama functions as a result. OTOH lots of knock-on changes throughout since a few core APIs need to change.

Unfortunately I still haven't persuaded it that it wants to deal with subrepos away from the root :(