### PR TITLE
added test case for custom defined userdata on behave

### DIFF
--- a/test/python_rules/behave/BUILD
+++ b/test/python_rules/behave/BUILD
@@ -5,4 +5,5 @@ python_test(
     srcs = glob([
         "features/*",
     ]),
+    flags= "-D test_value='this value should show up in my context'"
 )

--- a/test/python_rules/behave/features/behave_test.feature
+++ b/test/python_rules/behave/features/behave_test.feature
@@ -6,5 +6,6 @@ Feature: Please Integration with Behave
 
   Scenario: Run a dummy test
     Given we have behave installed
-      When we implement 6 tests
-      Then behave will test them for us!
+    And  we should see our custom flags in context
+    When we implement 6 tests
+    Then behave will test them for us!

--- a/test/python_rules/behave/features/steps/behave_test_steps.py
+++ b/test/python_rules/behave/features/steps/behave_test_steps.py
@@ -6,6 +6,11 @@ def step_impl(context):
     pass
 
 
+@given('we should see our custom flags in context')
+def step_impl(context):
+    assert context.config.userdata['test_value'] == 'this value should show up in my context'
+
+
 @when('we implement {number:d} tests')
 def step_impl(context, number):
     assert number > 1 or number == 0

--- a/tools/cache/server/cache_stress_test.go
+++ b/tools/cache/server/cache_stress_test.go
@@ -16,7 +16,7 @@ import (
 
 var cache *Cache
 
-const size = 1000
+const size = 100
 
 func init() {
 	logging.SetLevel(logging.NOTICE, "server")
@@ -24,7 +24,7 @@ func init() {
 }
 
 func TestStoreFiles(t *testing.T) {
-	// Store 1000 files in parallel
+	// Store 100 files in parallel
 	var wg sync.WaitGroup
 	wg.Add(size)
 	for _, i := range rand.Perm(size) {
@@ -38,7 +38,7 @@ func TestStoreFiles(t *testing.T) {
 }
 
 func TestRetrieveFiles(t *testing.T) {
-	// Store 1000 files in parallel
+	// Store 100 files in parallel
 	var wg sync.WaitGroup
 	wg.Add(size)
 	for _, i := range rand.Perm(size) {
@@ -59,7 +59,7 @@ func TestRetrieveFiles(t *testing.T) {
 }
 
 func TestDeleteFiles(t *testing.T) {
-	// Delete 1000 files in parallel
+	// Delete 100 files in parallel
 	var wg sync.WaitGroup
 	wg.Add(size)
 	for _, i := range rand.Perm(size) {


### PR DESCRIPTION
Testing to see if we can get userdata into our context object in behave test by passing in ```-D``` or ```--define``` flag
