### PR TITLE
Reorder repo check for `go_get`

### DIFF
--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -566,10 +566,10 @@ def _go_get_download(name:str, tag:str, get:str, repo:str='', patch:str=None, ha
 
     # Some special optimisation for github, which lets us download zipfiles at a particular sha instead of
     # cloning the whole repo. Obviously that is a lot faster than cloning entire repos.
-    if get.startswith('github.com') and revision:
+    if repo.startswith('github.com') and revision:
+            cmd, get_deps, tools = _go_github_repo_cmd(name, getroot, repo, revision)
+    elif get.startswith('github.com') and revision:
         cmd, get_deps, tools = _go_github_repo_cmd(name, getroot, getroot, revision)
-    elif repo.startswith('github.com') and revision:
-        cmd, get_deps, tools = _go_github_repo_cmd(name, getroot, repo, revision)
     elif get.startswith('golang.org/x/') and revision and not repo:
         # We know about these guys...
         cmd, get_deps, tools = _go_github_repo_cmd(name, getroot, 'github.com/golang/' + getroot[len('golang.org/x/'):], revision)


### PR DESCRIPTION
If you specify both a `get` and `repo` that are on `github.com`, the wrong one is chosen. For example, trying to `go_get` `github.com/docker/docker` with repo `github.com/moby/moby`.