### PR TITLE
More sensible defaults for num_runs and flakiness

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -149,8 +149,7 @@ type BuildTarget struct {
 	Tools []BuildInput
 	// Named tools, similar to named sources.
 	namedTools map[string][]BuildInput `name:"tools"`
-	// Flakiness of test, ie. number of times we will rerun it before giving up. 0 is the default and
-	// is interpreted the same way as 1 would be (ie. one run only).
+	// Flakiness of test, ie. number of times we will rerun it before giving up. 1 is the default.
 	Flakiness int `name:"flaky"`
 	// Timeouts for build/test actions
 	BuildTimeout time.Duration `name:"timeout"`

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -121,7 +121,7 @@ type BuildState struct {
 	PrepareOnly bool
 	// True if we're going to run a shell after builds are prepared.
 	PrepareShell bool
-	// Number of times to run each test target. 0 == once each, plus flakes if necessary.
+	// Number of times to run each test target. 1 == once each, plus flakes if necessary.
 	NumTestRuns int
 	// True to clean working directories after successful builds.
 	CleanWorkdirs bool

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -73,10 +73,18 @@ func createTarget(s *scope, args []pyObject) *core.BuildTarget {
 			if flaky == True {
 				target.Flakiness = 3
 				target.AddLabel("flaky") // Automatically label flaky tests
-			} else if i, ok := flaky.(pyInt); ok && i > 0 {
-				target.Flakiness = int(i)
-				target.AddLabel("flaky")
+			} else if flaky == False {
+				target.Flakiness = 1
+			} else if i, ok := flaky.(pyInt); ok {
+				if int(i) <= 1 {
+					target.Flakiness = 1
+				} else {
+					target.Flakiness = int(i)
+					target.AddLabel("flaky")
+				}
 			}
+		} else {
+			target.Flakiness = 1
 		}
 		// Automatically label containerised tests.
 		if target.Containerise {

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -379,15 +379,9 @@ func moveAndCacheOutputFile(state *core.BuildState, target *core.BuildTarget, ha
 
 // calcNumRuns works out how many total runs we should have for a test, and how many successes
 // are required for it to count as success.
+// numRuns and flakiness default to 1 which mean run once.
 func calcNumRuns(numRuns, flakiness int) (int, int) {
-	if numRuns > 0 && flakiness > 0 { // If flag is passed we run that many times * flakiness.
-		return numRuns * flakiness, numRuns
-	} else if numRuns > 0 {
-		return numRuns, numRuns
-	} else if flakiness > 0 { // Test is flaky, run that many times
-		return flakiness, 1
-	}
-	return 1, 1
+	return numRuns * flakiness, numRuns
 }
 
 // startTestWorkerIfNeeded starts a worker server if the test needs one.

--- a/src/test/test_step_test.go
+++ b/src/test/test_step_test.go
@@ -10,14 +10,7 @@ func TestCalcNumRuns(t *testing.T) {
 	// Helper for assert
 	nr := func(a, b int) []interface{} { return []interface{}{a, b} }
 
-	// Base case when no flags are passed
-	assert.Equal(t, nr(1, 1), nr(calcNumRuns(0, 0)))
-	// Trivially flaky test; run n times, one success is enough
-	assert.Equal(t, nr(3, 1), nr(calcNumRuns(0, 3)))
-	// Non-flaky test with multiple runs; run n times, must succeed every time
-	assert.Equal(t, nr(3, 3), nr(calcNumRuns(3, 0)))
-	// This is where it gets fiddly; when we pass both flags we should run
-	// until we get the requested number of passes.
+	// Check that multiplication works.
 	assert.Equal(t, nr(1, 1), nr(calcNumRuns(1, 1)))
 	assert.Equal(t, nr(3, 1), nr(calcNumRuns(1, 3)))
 	assert.Equal(t, nr(9, 3), nr(calcNumRuns(3, 3)))

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -60,3 +60,11 @@ func isABuildFile(name string, config *core.Configuration) bool {
 	}
 	return false
 }
+
+// Max is an incredibly complicated function, which is presumably why it didn't make it into the Go stdlib
+func Max(x, y int) int {
+	if x < y {
+		return y
+	}
+	return x
+}


### PR DESCRIPTION
As part of the work to improve reporting of flaky tests, it turned out to be useful to set the defaults for these values to `1` instead of `0`. It makes the calcNumRuns method a lot simpler too.