### PR TITLE
Re-enable pip tests on OSX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
       macos:
         xcode: "9.0"
       environment:
-        PLZ_ARGS: "-p --profile ci --exclude pip"
+        PLZ_ARGS: "-p --profile ci"
       steps:
        - checkout
        - restore_cache:


### PR DESCRIPTION
I *think* these might work again

This reverts commit 1dcc9f245ed5824f28baf9001e5300e3d361a2aa (PR #351)