### PR TITLE
Replace hash files with xattr tags

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,6 +38,7 @@ go_get github.com/djherbis/atime
 go_get github.com/karrick/godirwalk
 go_get github.com/hashicorp/go-multierror
 go_get github.com/google/shlex
+go_get github.com/pkg/xattr
 notice ""
 
 # Detect javac presence and swap to compiling locally if we find it.

--- a/src/build/BUILD
+++ b/src/build/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//third_party/go:logging",
         "//third_party/go:protobuf",
         "//third_party/go:shlex",
+        "//third_party/go:xattr",
     ],
 )
 

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -395,11 +395,6 @@ func moveOutput(state *core.BuildState, target *core.BuildTarget, tmpOutput, rea
 			return true, err
 		}
 	}
-	if target.IsBinary {
-		if err := os.Chmod(realOutput, target.OutMode()); err != nil {
-			return true, err
-		}
-	}
 	return true, nil
 }
 
@@ -450,6 +445,14 @@ func calculateAndCheckRuleHash(state *core.BuildState, target *core.BuildTarget)
 	}
 	if err := writeRuleHash(state, target); err != nil {
 		return nil, fmt.Errorf("Attempting to record rule hash: %s", err)
+	}
+	// Set appropriate permissions on outputs
+	if target.IsBinary {
+		for _, output := range target.FullOutputs() {
+			if err := os.Chmod(output, target.OutMode()); err != nil {
+				return nil, err
+			}
+		}
 	}
 	return hash, nil
 }

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -448,7 +448,7 @@ func calculateAndCheckRuleHash(state *core.BuildState, target *core.BuildTarget)
 			log.Warning("%s", err)
 		}
 	}
-	if err := writeRuleHashFile(state, target); err != nil {
+	if err := writeRuleHash(state, target); err != nil {
 		return nil, fmt.Errorf("Attempting to create hash file: %s", err)
 	}
 	return hash, nil

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -457,11 +457,10 @@ func calculateAndCheckRuleHash(state *core.BuildState, target *core.BuildTarget)
 // OutputHash calculates the hash of a target's outputs.
 func OutputHash(state *core.BuildState, target *core.BuildTarget) ([]byte, error) {
 	h := sha1.New()
-	for _, output := range target.Outputs() {
+	for _, filename := range target.FullOutputs() {
 		// NB. Always force a recalculation of the output hashes here. Memoisation is not
 		//     useful because by definition we are rebuilding a target, and can actively hurt
 		//     in cases where we compare the retrieved cache artifacts with what was there before.
-		filename := path.Join(target.OutDir(), output)
 		h2, err := state.PathHasher.Hash(filename, true)
 		if err != nil {
 			return nil, err

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -449,7 +449,7 @@ func calculateAndCheckRuleHash(state *core.BuildState, target *core.BuildTarget)
 		}
 	}
 	if err := writeRuleHash(state, target); err != nil {
-		return nil, fmt.Errorf("Attempting to create hash file: %s", err)
+		return nil, fmt.Errorf("Attempting to record rule hash: %s", err)
 	}
 	return hash, nil
 }

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -50,10 +50,10 @@ func TestBuildTargetWhichNeedsRebuilding(t *testing.T) {
 }
 
 func TestBuildTargetWhichDoesntNeedRebuilding(t *testing.T) {
-	// We write a rule hash file for this target before building it, so we don't need to build again.
+	// We write a rule hash for this target before building it, so we don't need to build again.
 	state, target := newState("//package1:target3")
 	target.AddOutput("file3")
-	assert.NoError(t, writeRuleHashFile(state, target))
+	assert.NoError(t, writeRuleHash(state, target))
 	err := buildTarget(1, state, target)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Reused, target.State())
@@ -64,7 +64,7 @@ func TestModifiedBuildTargetStillNeedsRebuilding(t *testing.T) {
 	// it should get rebuilt.
 	state, target := newState("//package1:target4")
 	target.AddOutput("file4")
-	assert.NoError(t, writeRuleHashFile(state, target))
+	assert.NoError(t, writeRuleHash(state, target))
 	target.Command = "echo 'wibble wibble wibble' > $OUT"
 	target.RuleHash = nil // Have to force a reset of this
 	err := buildTarget(1, state, target)

--- a/src/build/filegroup.go
+++ b/src/build/filegroup.go
@@ -70,9 +70,6 @@ func buildFilegroup(tid int, state *core.BuildState, target *core.BuildTarget) e
 	if err := prepareDirectory(target.OutDir(), false); err != nil {
 		return err
 	}
-	if err := os.RemoveAll(ruleHashFileName(target)); err != nil {
-		return err
-	}
 	outDir := target.OutDir()
 	localSources := target.AllLocalSourcePaths(state.Graph)
 	for i, source := range target.AllFullSourcePaths(state.Graph) {

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -328,7 +328,7 @@ func readRuleHashOnFile(target *core.BuildTarget, output string) []byte {
 		if fs.IsSymlink(output) {
 			// Symlinks can't take xattrs on Linux. We stash it on the fallback hash file instead.
 			return readRuleHashOnFile(target, fallbackRuleHashFileName(target))
-		} else if !os.IsNotExist(err.(*xattr.Error).Err) {
+		} else if e2 := err.(*xattr.Error).Err; !os.IsNotExist(e2) && e2 != xattr.ENOATTR {
 			log.Warning("Failed to read rule hash for %s: %s", target.Label, err)
 		}
 		return nil

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -32,6 +32,11 @@ import (
 
 const hashLength = sha1.Size
 
+// Tag that we attach for xattrs to store hashes against files.
+// Note that we are required to provide the user namespace; that seems to be set implicitly
+// by the attr utility, but that is not done for us here.
+const xattrName = "user.plz_build"
+
 // Length of the full hash we write, which has multiple parts.
 const fullHashLength = 5 * hashLength
 
@@ -318,12 +323,12 @@ func readRuleHash(target *core.BuildTarget, postBuild bool) ([]byte, []byte, []b
 
 // readRuleHashOnFile reads a rule hash from a single file. It returns an empty slice if it can't be read.
 func readRuleHashOnFile(target *core.BuildTarget, output string) []byte {
-	b, err := xattr.LGet(output, xattrName(target))
+	b, err := xattr.LGet(output, xattrName)
 	if err != nil {
 		if fs.IsSymlink(output) {
 			// Symlinks can't take xattrs on Linux. We stash it on the fallback hash file instead.
 			return readRuleHashOnFile(target, fallbackRuleHashFileName(target))
-		} else if xe := err.(*xattr.Error).Err; !os.IsNotExist(xe) && xe != xattr.ENOATTR {
+		} else if !os.IsNotExist(err.(*xattr.Error).Err) {
 			log.Warning("Failed to read rule hash for %s: %s", target.Label, err)
 		}
 		return nil
@@ -360,16 +365,14 @@ func writeRuleHash(state *core.BuildState, target *core.BuildTarget) error {
 
 // writeRuleHashOnFile sets a rule hash on a single file.
 func writeRuleHashOnFile(target *core.BuildTarget, output string, hash []byte) error {
-	if err := xattr.LSet(output, xattrName(target), hash); err != nil {
+	if err := xattr.LSet(output, xattrName, hash); err != nil {
 		if fs.IsSymlink(output) {
 			// As mentioned above, we have to put hashes for symlinks on the alternative hash file.
 			return writeFallbackRuleHashFile(target, hash)
 		} else if os.IsPermission(err.(*xattr.Error).Err) {
 			// Can't set xattrs without write permission... attempt to chmod it first.
-			if info, err := os.Lstat(output); err == nil {
-				if err := os.Chmod(output, info.Mode()|0200); err == nil {
-					return xattr.LSet(output, xattrName(target), hash)
-				}
+			if err := os.Chmod(output, target.OutMode()|0200); err == nil {
+				return xattr.LSet(output, xattrName, hash)
 			}
 		}
 		return err
@@ -386,14 +389,7 @@ func writeFallbackRuleHashFile(target *core.BuildTarget, hash []byte) error {
 	}
 	f.Close()
 	return writeRuleHashOnFile(target, fallbackFilename, hash)
-}
 
-// xattrName returns the name we'll use for xattrs on files.
-// It is currently per-rule to handle filegroups (which permit multiple per target).
-// Note that we are required to provide the user namespace; that seems to be set implicitly
-// by the attr utility, but that is not done for us here.
-func xattrName(target *core.BuildTarget) string {
-	return "user.plz_build:" + target.Label.Name
 }
 
 // fallbackRuleHashFile returns the filename we'll store the hashes for this file on if we have

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -371,7 +371,7 @@ func writeRuleHashOnFile(target *core.BuildTarget, output string, hash []byte) e
 			return writeFallbackRuleHashFile(target, hash)
 		} else if os.IsPermission(err.(*xattr.Error).Err) {
 			// Can't set xattrs without write permission... attempt to chmod it first.
-			if err := os.Chmod(output, target.OutMode()); err == nil {
+			if err := os.Chmod(output, target.OutMode()|0200); err == nil {
 				return xattr.LSet(output, xattrName, hash)
 			}
 		}

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//third_party/go:logging",
         "//third_party/go:queue",
         "//third_party/go:semver",
+        "//third_party/go:xattr",
     ],
 )
 

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1088,9 +1088,9 @@ func (target *BuildTarget) SetContainerSetting(name, value string) error {
 // OutMode returns the mode to set outputs of a target to.
 func (target *BuildTarget) OutMode() os.FileMode {
 	if target.IsBinary {
-		return 0755
+		return 0555
 	}
-	return 0644
+	return 0444
 }
 
 // PostBuildOutputFileName returns the post-build output file for this target.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -437,6 +437,16 @@ func (target *BuildTarget) Outputs() []string {
 	return ret
 }
 
+// FullOutputs returns a slice of all the outputs of this rule with the target's output directory prepended.
+func (target *BuildTarget) FullOutputs() []string {
+	outs := target.Outputs()
+	outDir := target.OutDir()
+	for i, out := range outs {
+		outs[i] = path.Join(outDir, out)
+	}
+	return outs
+}
+
 // NamedOutputs returns a slice of all the outputs of this rule with a given name.
 // If the name is not declared by this rule it panics.
 func (target *BuildTarget) NamedOutputs(name string) []string {

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1088,9 +1088,9 @@ func (target *BuildTarget) SetContainerSetting(name, value string) error {
 // OutMode returns the mode to set outputs of a target to.
 func (target *BuildTarget) OutMode() os.FileMode {
 	if target.IsBinary {
-		return 0555
+		return 0755
 	}
-	return 0444
+	return 0644
 }
 
 // PostBuildOutputFileName returns the post-build output file for this target.

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -192,6 +192,13 @@ func TestOutputs(t *testing.T) {
 	assert.Equal(t, []string{"file1.go", "file2.go", "file3.go", "file4.go"}, target3.Outputs())
 }
 
+func TestFullOutputs(t *testing.T) {
+	target := makeTarget("//src/core:target1", "PUBLIC")
+	target.AddOutput("file1.go")
+	target.AddOutput("file2.go")
+	assert.Equal(t, []string{"plz-out/gen/src/core/file1.go", "plz-out/gen/src/core/file2.go"}, target.FullOutputs())
+}
+
 func TestProvideFor(t *testing.T) {
 	// target1 is provided directly since they have a simple dependency
 	target1 := makeTarget("//src/core:target1", "PUBLIC")

--- a/src/core/lock.go
+++ b/src/core/lock.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"strings"
 	"syscall"
+
+	"github.com/pkg/xattr"
 )
 
 const lockFilePath = "plz-out/.lock"
@@ -47,6 +49,12 @@ func AcquireRepoLock() {
 		if n, err := lockFile.Write([]byte(strings.Join(os.Args[1:], " ") + "\n")); err == nil {
 			lockFile.Truncate(int64(n))
 		}
+	}
+
+	// Quick test of xattrs; everything will fail later if we can't write them, so make
+	// sure plz-out supports them now and give a clear error if not.
+	if err := xattr.Set(lockFilePath, "user.plz_build", []byte("lock")); err != nil {
+		log.Fatalf("Failed to set xattrs:%s\nMaybe plz-out is on a filesystem that doesn't support them?", err)
 	}
 }
 

--- a/src/fs/BUILD
+++ b/src/fs/BUILD
@@ -7,7 +7,10 @@ go_library(
         "home.go",
     ],
     visibility = ["PUBLIC"],
-    deps = ["//third_party/go:godirwalk"],
+    deps = [
+        "//third_party/go:godirwalk",
+        "//third_party/go:logging",
+    ],
 )
 
 go_test(

--- a/src/fs/fs.go
+++ b/src/fs/fs.go
@@ -47,6 +47,12 @@ func FileExists(filename string) bool {
 	return err == nil && !info.IsDir()
 }
 
+// IsSymlink returns true if the given path exists and is a symlink.
+func IsSymlink(filename string) bool {
+	info, err := os.Lstat(filename)
+	return err == nil && (info.Mode()&os.ModeSymlink) != 0
+}
+
 // IsSameFile returns true if two filenames describe the same underlying file (i.e. inode)
 func IsSameFile(a, b string) bool {
 	i1, err1 := getInode(a)

--- a/src/fs/fs.go
+++ b/src/fs/fs.go
@@ -9,14 +9,30 @@ import (
 	"path"
 	"runtime"
 	"syscall"
+
+	"gopkg.in/op/go-logging.v1"
 )
+
+var log = logging.MustGetLogger("fs")
 
 // DirPermissions are the default permission bits we apply to directories.
 const DirPermissions = os.ModeDir | 0775
 
 // EnsureDir ensures that the directory of the given file has been created.
 func EnsureDir(filename string) error {
-	return os.MkdirAll(path.Dir(filename), DirPermissions)
+	dir := path.Dir(filename)
+	err := os.MkdirAll(dir, DirPermissions)
+	if err != nil && FileExists(dir) {
+		// It looks like this is a file and not a directory. Attempt to remove it; this can
+		// happen in some cases if you change a rule from outputting a file to a directory.
+		log.Warning("Attempting to remove file %s; a subdirectory is required", dir)
+		if err2 := os.Remove(dir); err2 == nil {
+			err = os.MkdirAll(dir, DirPermissions)
+		} else {
+			log.Error("%s", err2)
+		}
+	}
+	return err
 }
 
 // PathExists returns true if the given path exists, as a file or a directory.

--- a/src/fs/fs_test.go
+++ b/src/fs/fs_test.go
@@ -19,3 +19,10 @@ func TestIsSameFile(t *testing.T) {
 	assert.False(t, IsSameFile("issamefile1.txt", "issamefile2.txt"))
 	assert.False(t, IsSameFile("issamefile1.txt", "doesntexist.txt"))
 }
+
+func TestEnsureDir(t *testing.T) {
+	err := ioutil.WriteFile("ensure_dir", []byte("hello"), 0644)
+	assert.NoError(t, err)
+	err = EnsureDir("ensure_dir/filename")
+	assert.NoError(t, err)
+}

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -38,6 +38,13 @@ go_get(
 )
 
 go_get(
+    name = "xattr",
+    get = "github.com/pkg/xattr",
+    revision = "d15dbc2bb0b5da267362b5e066e2c44c1fcff6c7",
+    deps = [":unix"],
+)
+
+go_get(
     name = "go-bindata",
     binary = True,
     get = "github.com/kevinburke/go-bindata/...",

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -433,7 +433,7 @@ go_get(
 go_get(
     name = "unix",
     get = "golang.org/x/sys/unix",
-    revision = "ebfc5b4631820b793c9010c87fd8fef0f39eb082",
+    revision = "1b2967e3c290b7c545b3db0deeda16e9be4f98a2",
 )
 
 go_get(


### PR DESCRIPTION
Turns out that it's possible to get incorrect builds due to stale hash files and (in)appropriate manipulations of BUILD files.

This resolves that by removing the separate file (in most cases) and instead recording hashes on output files using xattrs, which is less likely to get out of sync. I think this will work on most relevant systems (i.e. it should work by default on ext4 with no mount flags, and OSX 10.4+), don't *think* there will be Docker issues.