### PR TITLE
Fixed the deprecation warning related to `imp`

### DIFF
--- a/tools/please_pex/pex_main.py
+++ b/tools/please_pex/pex_main.py
@@ -1,6 +1,5 @@
 """Zipfile entry point which supports auto-extracting itself based on zip-safety."""
 
-# import imp
 from importlib import import_module
 import os
 import runpy

--- a/tools/please_pex/pex_main.py
+++ b/tools/please_pex/pex_main.py
@@ -34,7 +34,7 @@ class SoImport(object):
         if PY_VERSION < 3:
             self.suffixes = {x[0]: x for x in imp.get_suffixes() if x[2] == imp.C_EXTENSION}
         else:
-            self.suffixes = machinery.EXTENSION_SUFFIXES
+            self.suffixes = machinery.EXTENSION_SUFFIXES  # list, as importlib will not be using the file description
 
         self.suffixes_by_length = sorted(self.suffixes, key=lambda x: -len(x))
         # Identify all the possible modules we could handle.
@@ -64,14 +64,14 @@ class SoImport(object):
 
         filename = self.modules[fullname]
         prefix, ext = self.splitext(filename)
-        suffix = self.suffixes[ext]
         with tempfile.NamedTemporaryFile(suffix=ext, prefix=os.path.basename(prefix)) as f:
             f.write(self.zf.read(filename))
             f.flush()
             if PY_VERSION < 3:
+                suffix = self.suffixes[ext]
                 mod = imp.load_module(fullname, None, f.name, suffix)
             else:
-                mod = machinery.SourceFileLoader(fullname, f.name).load_module()
+                mod = machinery.ExtensionFileLoader(fullname, f.name).load_module()
         # Make it look like module came from the original location for nicer tracebacks.
         mod.__file__ = filename
         return mod

--- a/tools/please_pex/test_main.py
+++ b/tools/please_pex/test_main.py
@@ -7,7 +7,6 @@ import sys
 TEST_NAMES = '__TEST_NAMES__'.split(',')
 
 
-
 def initialise_coverage():
     """Imports & initialises the coverage module."""
     import coverage

--- a/tools/please_pex/unittest.py
+++ b/tools/please_pex/unittest.py
@@ -1,4 +1,3 @@
-import imp
 import os
 import sys
 import unittest
@@ -53,7 +52,11 @@ def import_tests():
             yield import_module(pkg_name)
         except ImportError:
             with open(filename, 'r') as f:
-                mod = imp.load_module(pkg_name, f, filename, ('.py', 'r', imp.PY_SOURCE))
+                if PY_VERSION < 3:
+                    mod = imp.load_module(pkg_name, f, filename, ('.py', 'r', imp.PY_SOURCE))
+                else:
+                    mod = machinery.SourceFileLoader(pkg_name, filename).load_module()
+
                 # Have to set the attribute on the parent module too otherwise some things
                 # can't find it.
                 parent, _, mod_name = pkg_name.rpartition('.')


### PR DESCRIPTION
- checking system python version in pex_main.py
- Still included imp for python2 support