### PR TITLE
Allow CONFIG.setdefault during subinclude

### DIFF
--- a/src/build/worker.go
+++ b/src/build/worker.go
@@ -129,10 +129,10 @@ func getOrStartWorker(state *core.BuildState, worker string) (*workerServer, err
 		process:   cmd,
 		stderr:    stderr,
 	}
+	workerMap[worker] = w
 	go w.sendRequests(stdin)
 	go w.readResponses(stdout)
 	go w.wait()
-	workerMap[worker] = w
 	state.Stats.NumWorkerProcesses = len(workerMap)
 	return w, nil
 }

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -124,6 +124,7 @@ func (i *interpreter) Subinclude(path string) pyDict {
 	}
 	stmts = i.parser.optimise(stmts)
 	s := i.scope.NewScope()
+	// Scope needs a local version of CONFIG
 	i.optimiseExpressions(reflect.ValueOf(stmts))
 	s.interpretStatements(stmts)
 	locals := s.Freeze()
@@ -281,6 +282,8 @@ func (s *scope) Freeze() pyDict {
 			s.locals[k] = d.Freeze()
 		} else if l, ok := v.(pyList); ok {
 			s.locals[k] = l.Freeze()
+		} else if c, ok := v.(pyConfig); ok {
+			s.locals[k] = c.Freeze()
 		}
 	}
 	return s.locals

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -278,12 +278,8 @@ func (s *scope) SetAll(d pyDict, publicOnly bool) {
 // It returns the newly frozen set of locals.
 func (s *scope) Freeze() pyDict {
 	for k, v := range s.locals {
-		if d, ok := v.(pyDict); ok {
-			s.locals[k] = d.Freeze()
-		} else if l, ok := v.(pyList); ok {
-			s.locals[k] = l.Freeze()
-		} else if c, ok := v.(pyConfig); ok {
-			s.locals[k] = c.Freeze()
+		if f, ok := v.(freezable); ok {
+			s.locals[k] = f.Freeze()
 		}
 	}
 	return s.locals

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -260,3 +260,10 @@ func TestFStrings(t *testing.T) {
 	assert.EqualValues(t, "a", s.Lookup("y"))
 	assert.EqualValues(t, "x: a y: a fin", s.Lookup("z"))
 }
+
+func TestSubincludeConfig(t *testing.T) {
+	s, err := parseFile("src/parse/asp/test_data/interpreter/partition.build")
+	assert.NoError(t, err)
+	s.SetAll(s.interpreter.Subinclude("src/parse/asp/test_data/interpreter/subinclude_config.build"), false)
+	assert.EqualValues(t, "test test", s.LookupConfig().Get("test", None))
+}

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -736,6 +736,17 @@ func (c *pyConfig) Freeze() pyObject {
 	return &pyFrozenConfig{pyConfig: *c}
 }
 
+// Merge merges the contents of the given config object into this one.
+func (c *pyConfig) Merge(other *pyFrozenConfig) {
+	if c.overlay == nil {
+		// N.B. We cannot directly copy since this might get mutated again later on.
+		c.overlay = make(pyDict, len(other.overlay))
+	}
+	for k, v := range other.overlay {
+		c.overlay[k] = v
+	}
+}
+
 // newConfig creates a new pyConfig object from the configuration.
 // This is typically only created once at global scope, other scopes copy it with .Copy()
 func newConfig(config *core.Configuration) *pyConfig {

--- a/src/parse/asp/test_data/interpreter/subinclude_config.build
+++ b/src/parse/asp/test_data/interpreter/subinclude_config.build
@@ -1,0 +1,1 @@
+CONFIG.setdefault("test", "test test")


### PR DESCRIPTION
This is done in several places in pleasings but hasn't worked for a little while. I thought about disallowing it but it seems nice for the subincluded rules to be able to set defaults (among other things it's not possible to call `package()` on a value that doesn't exist yet).

First thing is to fix a possible concurrent write where the `setdefault()` calls may have been affecting the same config object. That is no longer possible and we freeze the central config to be sure of it.

The process of  extracting changed config keys is a bit fiddly; requires some knowledge of the config object but c'est la vie.