### PR TITLE
#361 Support pkg-config for cflags only 

### DIFF
--- a/src/parse/rules/c_rules.build_defs
+++ b/src/parse/rules/c_rules.build_defs
@@ -10,7 +10,7 @@ you must pay attention to interoperability when needed (e.g. 'extern "C"' and so
 
 def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:list=[],
               visibility:list=None, test_only:bool&testonly=False, compiler_flags:list&cflags&copts=[],
-              linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[],
+              linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[], pkg_config_cflags:list=[],
               includes:list=[], defines:list|dict=[], alwayslink:bool=False):
     """Generate a C library target.
 
@@ -27,8 +27,10 @@ def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:l
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker; these will not be used here but will be
                            picked up by a c_binary or c_test rule.
-      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config. Again, the ldflags
-                              will be picked up by c_binary or c_test rules.
+      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`. Again, the ldflags
+                              will be picked up by cc_binary or cc_test rules.
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`. Again, the ldflags
+                              will be picked up by cc_binary or cc_test rules.
       includes (list): List of include directories to be added to the compiler's path.
       defines (list | dict): List of tokens to define in the preprocessor.
                              Alternatively can be a dict of name -> value to define, in which case
@@ -48,6 +50,7 @@ def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:l
         compiler_flags = compiler_flags,
         linker_flags = linker_flags,
         pkg_config_libs = pkg_config_libs,
+        pkg_config_cflags=pkg_config_cflags,
         includes = includes,
         defines = defines,
         alwayslink = alwayslink,
@@ -56,8 +59,9 @@ def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:l
 
 
 def c_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None, test_only:bool&testonly=False,
-             compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[], includes:list=[],
-             defines:list|dict=[], alwayslink:bool=False, visibility:list=None, deps:list=[]):
+             compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
+             pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[], defines:list|dict=[],
+             alwayslink:bool=False, visibility:list=None, deps:list=[]):
     """Generate a C object file from a single source.
 
     N.B. This is fairly low-level; for most use cases c_library should be preferred.
@@ -77,8 +81,10 @@ def c_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker; these will not be used here but will be
                            picked up by a c_binary or c_test rule.
-      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config. Again, the ldflags
-                              will be picked up by c_binary or c_test rules.
+      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`. Again, the ldflags
+                              will be picked up by cc_binary or cc_test rules.
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`. Again, the ldflags
+                              will be picked up by cc_binary or cc_test rules.
       includes (list): List of include directories to be added to the compiler's path.
       defines (list | dict): List of tokens to define in the preprocessor.
                              Alternatively can be a dict of name -> value to define, in which case
@@ -99,6 +105,7 @@ def c_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None
         compiler_flags = compiler_flags,
         linker_flags = linker_flags,
         pkg_config_libs = pkg_config_libs,
+        pkg_config_cflags=pkg_config_cflags,
         includes = includes,
         defines = defines,
         alwayslink = alwayslink,
@@ -107,7 +114,7 @@ def c_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None
 
 
 def c_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
-                     deps:list=[], visibility:list=None, test_only:bool&testonly=False, pkg_config_libs:list=[]):
+                     deps:list=[], visibility:list=None, test_only:bool&testonly=False, pkg_config_libs:list=[], pkg_config_cflags:list=[]):
     """Generates a C static library (.a).
 
     This is essentially just a collection of other c_library rules into a single archive.
@@ -123,7 +130,9 @@ def c_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&c
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
-      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config.
+      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
+
     """
     return cc_static_library(
         name = name,
@@ -135,13 +144,14 @@ def c_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&c
         compiler_flags = compiler_flags,
         linker_flags = linker_flags,
         pkg_config_libs = pkg_config_libs,
+        pkg_config_cflags = pkg_config_cflags,
         _c = True,
     )
 
 
 def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_flags:list&cflags&copts=[],
                     linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None, test_only:bool&testonly=False,
-                    pkg_config_libs:list=[], includes:list=[]):
+                    pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[]):
     """Generates a C shared object (.so) with its dependencies linked in.
 
     Args:
@@ -155,7 +165,8 @@ def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_f
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
-      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config.
+      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
       includes (list): Include directories to be added to the compiler's lookup path.
     """
     return cc_shared_object(
@@ -169,6 +180,7 @@ def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_f
         compiler_flags = compiler_flags,
         linker_flags = linker_flags,
         pkg_config_libs = pkg_config_libs,
+        pkg_config_cflags = pkg_config_cflags,
         includes = includes,
         _c = True,
     )
@@ -176,7 +188,7 @@ def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_f
 
 def c_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compiler_flags:list&cflags&copts=[],
              linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None, pkg_config_libs:list=[],
-             test_only:bool&testonly=False, static:bool=False):
+             pkg_config_cflags:list=[], test_only:bool&testonly=False, static:bool=False):
     """Builds a binary from a collection of C rules.
 
     Args:
@@ -189,7 +201,8 @@ def c_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compile
       linker_flags (list): Flags to pass to the linker.
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
-      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config.
+      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
       test_only (bool): If True, this rule can only be used by tests.
       static (bool): If True, the binary will be linked statically.
     """
@@ -204,13 +217,14 @@ def c_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compile
         compiler_flags = compiler_flags,
         linker_flags = linker_flags,
         pkg_config_libs = pkg_config_libs,
+        pkg_config_cflags = pkg_config_cflags,
         static = static,
         _c = True,
     )
 
 
 def c_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
-           pkg_config_libs:list=[], deps:list=[], worker:str='', data:list=[], visibility:list=None, flags:str='',
+           pkg_config_libs:list=[], pkg_config_cflags:list=[], deps:list=[], worker:str='', data:list=[], visibility:list=None, flags:str='',
            labels:list&features&tags=[], flaky:bool|int=0, test_outputs:list=None, size:str=None, timeout:int=0,
            container:bool|dict=False, sandbox:bool=None):
     """Defines a C test target.
@@ -224,7 +238,8 @@ def c_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copt
       hdrs (list): Header files.
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker.
-      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config.
+      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
       deps (list): Dependent rules.
       data (list): Runtime data files for this test.
       visibility (list): Visibility declaration for this rule.
@@ -247,6 +262,7 @@ def c_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copt
         compiler_flags = compiler_flags,
         linker_flags = linker_flags,
         pkg_config_libs = pkg_config_libs,
+        pkg_config_cflags = pkg_config_cflags,
         data = data,
         flags = flags,
         labels = labels,

--- a/src/parse/rules/c_rules.build_defs
+++ b/src/parse/rules/c_rules.build_defs
@@ -27,10 +27,9 @@ def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:l
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker; these will not be used here but will be
                            picked up by a c_binary or c_test rule.
-      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`. Again, the ldflags
+      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config. Again, the ldflags
                               will be picked up by cc_binary or cc_test rules.
-      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`. Again, the ldflags
-                              will be picked up by cc_binary or cc_test rules.
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`.
       includes (list): List of include directories to be added to the compiler's path.
       defines (list | dict): List of tokens to define in the preprocessor.
                              Alternatively can be a dict of name -> value to define, in which case

--- a/src/parse/rules/c_rules.build_defs
+++ b/src/parse/rules/c_rules.build_defs
@@ -80,7 +80,7 @@ def c_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker; these will not be used here but will be
                            picked up by a c_binary or c_test rule.
-      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`. Again, the ldflags
+      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config. Again, the ldflags
                               will be picked up by cc_binary or cc_test rules.
       pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`. Again, the ldflags
                               will be picked up by cc_binary or cc_test rules.
@@ -129,7 +129,7 @@ def c_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&c
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
-      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
+      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config
       pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
 
     """
@@ -164,7 +164,7 @@ def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_f
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
-      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
+      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config
       pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
       includes (list): Include directories to be added to the compiler's lookup path.
     """
@@ -200,7 +200,7 @@ def c_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compile
       linker_flags (list): Flags to pass to the linker.
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
-      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
+      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config
       pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
       test_only (bool): If True, this rule can only be used by tests.
       static (bool): If True, the binary will be linked statically.
@@ -237,7 +237,7 @@ def c_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copt
       hdrs (list): Header files.
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker.
-      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
+      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config
       pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
       deps (list): Dependent rules.
       data (list): Runtime data files for this test.

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -69,7 +69,6 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
               ['cc:inc:' + join_path(pkg_name, include) for include in includes] +
               ['cc:def:' + define for define in defines])
 
-
     if not srcs:
         # Header-only library, no compilation needed.
         return filegroup(

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -368,8 +368,6 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
             'cc': ':' + name,
         }
     cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, pkg_config_cflags, shared=True)
-
-    log.warning(cmds['opt'])
     return build_rule(
         name=name,
         srcs={'srcs': srcs, 'hdrs': hdrs},

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -48,9 +48,6 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
       linkstatic (bool): Only provided for Bazel compatibility. Has no actual effect.
       textual_hdrs (list): Also provided for Bazel compatibility. Effectively works the same as hdrs for now.
     """
-    # Make sure it is compatible with Mac systems, append additional linker_flags to the list
-    _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
-
     # Bazel suggests passing nonexported header files in 'srcs'. We however treat
     # srcs as things to actually compile and must mark a distinction.
     if CONFIG.BAZEL_COMPATIBILITY:
@@ -238,9 +235,6 @@ def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=Non
                          even if they don't directly reference them. This is useful for e.g. having
                          static members that register themselves at construction time.
     """
-    # Make sure it is compatible with Mac systems, append additional linker_flags to the list
-    _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
-
     # Handle defines being passed as a dict, as a nicety for the user.
     if isinstance(defines, dict):
         defines = [k if v is None else r'%s=\"%s\"' % (k, v) for k, v in sorted(defines.items())]
@@ -294,9 +288,6 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
       pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
       pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
     """
-    # Make sure it is compatible with Mac systems, append additional linker_flags to the list
-    _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
-
     provides = None
     if srcs:
         lib_rule = cc_library(
@@ -355,9 +346,6 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
       pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
       includes (list): Include directories to be added to the compiler's lookup path.
     """
-    # Make sure it is compatible with Mac systems, append additional linker_flags to the list
-    _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
-
     if CONFIG.DEFAULT_LDFLAGS:
         linker_flags.append(CONFIG.DEFAULT_LDFLAGS)
 
@@ -423,9 +411,6 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compil
       linkstatic (bool): Only provided for Bazel compatibility. Has no actual effect since we always
                          link roughly equivalently to their "mostly-static" mode.
     """
-    # Make sure it is compatible with Mac systems, append additional linker_flags to the list
-    _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
-
     if CONFIG.BAZEL_COMPATIBILITY:
         linker_flags = ['-lpthread' if l == '-pthread' else l for l in linker_flags]
     if CONFIG.DEFAULT_LDFLAGS:
@@ -500,8 +485,6 @@ def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&cop
       linkstatic (bool): Only provided for Bazel compatibility. Has no actual effect since we always
                          link roughly equivalently to their "mostly-static" mode.
     """
-    # Make sure it is compatible with Mac systems, append additional linker_flags to the list
-    _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
 
     if CONFIG.BAZEL_COMPATIBILITY:
         linker_flags = ['-lpthread' if l == '-pthread' else l for l in linker_flags]
@@ -896,18 +879,6 @@ def _binary_transitive_labels(c, linker_flags, pkg_config_libs, shared=False):
             for k, v in cmds.items():
                 set_command(name, k, v)
     return apply_transitive_labels
-
-
-def _append_mac_compatible_linker_flag(linker_flags:list, libs:list):
-    """
-    append '-undefined dynamic_lookup' to linker flag list if OS is mac and python is in pkg_config list
-
-    :param linker_flags: linker flag list
-    :param libs: pkg_config_libs or/and pkg_config_cflags
-    """
-    # Mac Compatible
-    if CONFIG.OS == 'darwin' and any([i for i in libs if 'python' in i]):
-        linker_flags.append("-bundle -undefined dynamic_lookup")
 
 
 if CONFIG.BAZEL_COMPATIBILITY:

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -249,7 +249,7 @@ def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=Non
     labels = (['cc:ld:' + flag for flag in linker_flags] +
               ['cc:pc:' + lib for lib in pkg_config_libs] +
               ['cc:pcc:' + cflag for cflag in pkg_config_cflags] +
-              ['cc:inc:{pkg}/{include}' for include in includes] +
+              [f'cc:inc:{pkg}/{include}' for include in includes] +
               ['cc:def:' + define for define in defines])
     if alwayslink:
         labels.append('cc:al:{pkg}/{name}.a')

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -367,7 +367,7 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
             'cc_hdrs': f':_{name}#lib_hdrs',
             'cc': ':' + name,
         }
-    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, pkg_config_cflags, shared=True)
+    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, shared=True)
     return build_rule(
         name=name,
         srcs={'srcs': srcs, 'hdrs': hdrs},
@@ -383,8 +383,7 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
         tools=tools,
         test_only=test_only,
         requires=['cc', 'cc_hdrs'],
-        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, pkg_config_cflags, shared=True)
-                  if deps else None,
+        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, shared=True) if deps else None,
     )
 
 
@@ -416,7 +415,7 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compil
         linker_flags.append(CONFIG.DEFAULT_LDFLAGS)
     if static:
         linker_flags.append('-static')
-    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, pkg_config_cflags)
+    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs)
     if srcs:
         if static:
             compiler_flags.append('-static -static-libgcc')
@@ -445,7 +444,7 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compil
         output_is_complete=True,
         requires=['cc'],
         tools=tools,
-        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, pkg_config_cflags),
+        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs),
         test_only=test_only,
     )
 
@@ -498,7 +497,7 @@ def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&cop
             test_only=True,
         )
         srcs.append(main_rule)
-    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, pkg_config_cflags)
+    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs)
 
     if srcs:
         lib_rule = cc_library(
@@ -543,7 +542,7 @@ def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&cop
         requires=['cc', 'cc_hdrs'],
         labels=labels,
         tools=tools,
-        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, pkg_config_cflags),
+        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs),
         flaky=flaky,
         test_outputs=test_outputs,
         test_timeout=timeout,
@@ -777,21 +776,14 @@ def _build_flags(compiler_flags:list, pkg_config_libs:list, pkg_config_cflags:li
     if defines:
         compiler_flags += ['-D' + define for define in defines]
 
-    pkg_config_list = pkg_config_libs or pkg_config_cflags or []
-    pkg_config_cmd = ' '.join([f'`pkg-config --cflags {x}`' for x in pkg_config_list])
+    pkg_config_cmd = ' '.join([f'`pkg-config --cflags {x}`' for x in pkg_config_cflags + pkg_config_libs])
 
     return ' '.join(compiler_flags) + ' ' + pkg_config_cmd
 
 
-def _binary_build_flags(linker_flags:list, pkg_config_libs:list, pkg_config_cflags:list, shared=False, alwayslink='', c=False, dbg=False):
+def _binary_build_flags(linker_flags:list, pkg_config_libs:list, shared=False, alwayslink='', c=False, dbg=False):
     """Builds flags that we'll pass to the linker invocation."""
-
-    if pkg_config_cflags:
-        pkg_config_cmd = ' '.join([f'`pkg-config --cflags {x}`' for x in pkg_config_cflags])
-    elif pkg_config_libs:
-        pkg_config_cmd = ' '.join([f'`pkg-config --libs {x}`' for x in pkg_config_libs])
-    else:
-        pkg_config_cmd = ' '
+    pkg_config_cmd = ' '.join([f'`pkg-config --libs {x}`' for x in pkg_config_libs])
 
     objs = '`find . -name "*.o" -or -name "*.a" | sort`'
     linker_prefix = '' if CONFIG.LINK_WITH_LD_TOOL else '-Wl,'
@@ -834,12 +826,10 @@ def _library_cmds(c, compiler_flags, pkg_config_libs, pkg_config_cflags, extra_f
     }
 
 
-def _binary_cmds(c, linker_flags, pkg_config_libs=[], pkg_config_cflags=[], extra_flags='', shared=False, alwayslink=''):
+def _binary_cmds(c, linker_flags, pkg_config_libs, extra_flags='', shared=False, alwayslink=''):
     """Returns the commands needed for a cc_binary, cc_test or cc_shared_object rule."""
-    dbg_flags = _binary_build_flags(linker_flags, pkg_config_libs, pkg_config_cflags,
-                                    shared, alwayslink, c=c, dbg=True)
-    opt_flags = _binary_build_flags(linker_flags, pkg_config_libs, pkg_config_cflags,
-                                    shared, alwayslink, c=c, dbg=False)
+    dbg_flags = _binary_build_flags(linker_flags, pkg_config_libs, shared, alwayslink, c=c, dbg=True)
+    opt_flags = _binary_build_flags(linker_flags, pkg_config_libs, shared, alwayslink, c=c, dbg=False)
     cmds = {
         'dbg': f'$TOOL -o $OUT {dbg_flags} {extra_flags}',
         'opt': f'$TOOL -o $OUT {opt_flags} {extra_flags}',
@@ -857,10 +847,8 @@ def _library_transitive_labels(c, compiler_flags, pkg_config_libs, pkg_config_cf
         flags = ['-isystem %s' % l[4:] for l in labels if l.startswith('inc:')]
         flags.extend(['-D' + l[4:] for l in labels if l.startswith('def:')])
 
-        if pkg_config_libs:
-            pkg_config_libs.extend([l[3:] for l in labels if l.startswith('pc:') and l[3:] not in pkg_config_libs])
-        elif pkg_config_cflags:
-            pkg_config_libs.extend([l[3:] for l in labels if l.startswith('pcc:') and l[4:] not in pkg_config_cflags])
+        pkg_config_libs.extend([l[3:] for l in labels if l.startswith('pc:') and l[3:] not in pkg_config_libs])
+        pkg_config_cflags.extend([l[4:] for l in labels if l.startswith('pcc:') and l[4:] not in pkg_config_cflags])
 
         if flags:  # Don't update if there aren't any relevant labels
             cmds, _ = _library_cmds(c, compiler_flags, pkg_config_libs, pkg_config_cflags, ' '.join(flags), archive=archive)
@@ -869,16 +857,14 @@ def _library_transitive_labels(c, compiler_flags, pkg_config_libs, pkg_config_cf
     return apply_transitive_labels
 
 
-def _binary_transitive_labels(c, linker_flags, pkg_config_libs=[], pkg_config_cflags=[], shared=False):
+def _binary_transitive_labels(c, linker_flags, pkg_config_libs, shared=False):
     """Applies commands from transitive labels to a cc_binary, cc_test or cc_shared_object rule."""
     def apply_transitive_labels(name):
         labels = get_labels(name, 'cc:')
         linker_prefix = '' if CONFIG.LINK_WITH_LD_TOOL else '-Wl,'
         flags = [linker_prefix + l[3:] for l in labels if l.startswith('ld:')]
-        if pkg_config_cflags:
-            flags.extend(['`pkg-config --cflags %s`' % l[4:] for l in labels if l.startswith('pcc:')])
-        elif pkg_config_libs:
-            flags.extend(['`pkg-config --libs %s`' % l[3:] for l in labels if l.startswith('pc:')])
+
+        flags.extend(['`pkg-config --libs %s`' % l[3:] for l in labels if l.startswith('pc:')])
 
         # ./ here because some weak linkers don't realise ./lib.a is the same file as lib.a
         # and report duplicate symbol errors as a result.
@@ -886,7 +872,7 @@ def _binary_transitive_labels(c, linker_flags, pkg_config_libs=[], pkg_config_cf
         # Probably a little optimistic to check this (most binaries are likely to have *some*
         # kind of linker flags to apply), but we might as well.
         if flags or alwayslink:
-            cmds, _ = _binary_cmds(c, linker_flags, pkg_config_libs, pkg_config_cflags, ' '.join(flags), shared, alwayslink)
+            cmds, _ = _binary_cmds(c, linker_flags, pkg_config_libs, ' '.join(flags), shared, alwayslink)
             for k, v in cmds.items():
                 set_command(name, k, v)
     return apply_transitive_labels

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -17,7 +17,7 @@ _NO_WHOLE_ARCHIVE = '-noall_load' if CONFIG.OS == 'darwin' else '--no-whole-arch
 
 def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:list=[],
                visibility:list=None, test_only:bool&testonly=False, compiler_flags:list&cflags&copts=[],
-               linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[], includes:list=[],
+               linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[],
                defines:list|dict=[], alwayslink:bool=False, linkstatic:bool=False, _c=False, textual_hdrs:list=[]):
     """Generate a C++ library target.
 
@@ -34,7 +34,9 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker; these will not be used here but will be
                            picked up by a cc_binary or cc_test rule.
-      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config. Again, the ldflags
+      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`. Again, the ldflags
+                              will be picked up by cc_binary or cc_test rules.
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`. Again, the ldflags
                               will be picked up by cc_binary or cc_test rules.
       includes (list): List of include directories to be added to the compiler's path.
       defines (list | dict): List of tokens to define in the preprocessor.
@@ -66,6 +68,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
     pkg_name = package_name()
     labels = (['cc:ld:' + flag for flag in linker_flags] +
               ['cc:pc:' + lib for lib in pkg_config_libs] +
+              ['cc:pcc:' + cflag for cflag in pkg_config_cflags] +
               ['cc:inc:' + join_path(pkg_name, include) for include in includes] +
               ['cc:def:' + define for define in defines])
 
@@ -93,9 +96,10 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
         output_is_complete=False,
     )
 
-    cmds, tools = _library_cmds(_c, compiler_flags, pkg_config_libs)
+    cmds, tools = _library_cmds(_c, compiler_flags, pkg_config_libs, pkg_config_cflags)
     # TODO(pebers): handle includes and defines in _library_cmds as well.
-    pre_build = _library_transitive_labels(_c, compiler_flags, pkg_config_libs) if (deps or includes or defines) else None
+    pre_build = _library_transitive_labels(_c, compiler_flags, pkg_config_libs, pkg_config_cflags) if (deps or includes or defines) else None
+
     pkg = package_name()
     if len(srcs) > 1:
         # Compile all the sources separately, this is much faster for large numbers of files
@@ -197,8 +201,8 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
 
 
 def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None, test_only:bool&testonly=False,
-              compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[], includes:list=[],
-              defines:list|dict=[], alwayslink:bool=False, _c=False, visibility:list=None, deps:list=[]):
+              compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[], pkg_config_cflags:list=[],
+              includes:list=[], defines:list|dict=[], alwayslink:bool=False, _c=False, visibility:list=None, deps:list=[]):
     """Generate a C or C++ object file from a single source.
 
     N.B. This is fairly low-level; for most use cases cc_library should be preferred.
@@ -218,7 +222,9 @@ def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=Non
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker; these will not be used here but will be
                            picked up by a cc_binary or cc_test rule.
-      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config. Again, the ldflags
+      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`. Again, the ldflags
+                              will be picked up by cc_binary or cc_test rules.
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`. Again, the ldflags
                               will be picked up by cc_binary or cc_test rules.
       includes (list): List of include directories to be added to the compiler's path.
       defines (list | dict): List of tokens to define in the preprocessor.
@@ -235,11 +241,12 @@ def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=Non
     pkg = package_name()
     labels = (['cc:ld:' + flag for flag in linker_flags] +
               ['cc:pc:' + lib for lib in pkg_config_libs] +
+              ['cc:pcc:' + cflag for cflag in pkg_config_cflags] +
               ['cc:inc:{pkg}/{include}' for include in includes] +
               ['cc:def:' + define for define in defines])
     if alwayslink:
         labels.append('cc:al:{pkg}/{name}.a')
-    cmds, tools = _library_cmds(_c, compiler_flags, pkg_config_libs, archive=False)
+    cmds, tools = _library_cmds(_c, compiler_flags, pkg_config_libs, pkg_config_cflags, archive=False)
 
     return build_rule(
         name=name,
@@ -253,14 +260,15 @@ def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=Non
         test_only=test_only,
         labels=labels,
         tools=tools,
-        pre_build=_library_transitive_labels(_c, compiler_flags, pkg_config_libs, archive=False)
+        pre_build=_library_transitive_labels(_c, compiler_flags, pkg_config_libs, pkg_config_cflags, archive=False)
                   if (deps or includes or defines) else None,
         needs_transitive_deps=True,
     )
 
 
-def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
-                      deps:list=[], visibility:list=None, test_only:bool&testonly=False, pkg_config_libs:list=[], _c=False):
+def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[],
+                      linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None,
+                      test_only:bool&testonly=False, pkg_config_libs:list=[], pkg_config_cflags:list=[],_c=False):
     """Generates a C++ static library (.a).
 
     This is essentially just a collection of other cc_library rules into a single archive.
@@ -276,7 +284,8 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
-      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config.
+      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
     """
     provides = None
     if srcs:
@@ -289,6 +298,7 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
             deps = deps,
             test_only = test_only,
             pkg_config_libs = pkg_config_libs,
+            pkg_config_cflags = pkg_config_cflags,
             _c=_c,
         )
         deps += [lib_rule, f':_{name}#lib_hdrs']
@@ -317,7 +327,7 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
 
 def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_flags:list&cflags&copts=[],
                      linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None, test_only:bool&testonly=False,
-                     pkg_config_libs:list=[], includes:list=[], _c=False):
+                     pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[], _c=False):
     """Generates a C++ shared object (.so) with its dependencies linked in.
 
     Args:
@@ -331,7 +341,8 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
       test_only (bool): If True, is only available to other test rules.
-      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config.
+      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
       includes (list): Include directories to be added to the compiler's lookup path.
     """
     if CONFIG.DEFAULT_LDFLAGS:
@@ -347,6 +358,7 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
             deps = deps,
             test_only = test_only,
             pkg_config_libs = pkg_config_libs,
+            pkg_config_cflags = pkg_config_cflags,
             includes = includes,
             _c=_c,
         )
@@ -355,7 +367,9 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
             'cc_hdrs': f':_{name}#lib_hdrs',
             'cc': ':' + name,
         }
-    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, shared=True)
+    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, pkg_config_cflags, shared=True)
+
+    log.warning(cmds['opt'])
     return build_rule(
         name=name,
         srcs={'srcs': srcs, 'hdrs': hdrs},
@@ -371,13 +385,14 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
         tools=tools,
         test_only=test_only,
         requires=['cc', 'cc_hdrs'],
-        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, shared=True) if deps else None,
+        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, pkg_config_cflags, shared=True)
+                  if deps else None,
     )
 
 
 def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compiler_flags:list&cflags&copts=[],
               linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None, pkg_config_libs:list=[],
-              test_only:bool&testonly=False, static:bool=False, _c=False, linkstatic:bool=False):
+              pkg_config_cflags:list=[], test_only:bool&testonly=False, static:bool=False, _c=False, linkstatic:bool=False):
     """Builds a binary from a collection of C++ rules.
 
     Args:
@@ -390,7 +405,8 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compil
       linker_flags (list): Flags to pass to the linker.
       deps (list): Dependent rules.
       visibility (list): Visibility declaration for this rule.
-      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config.
+      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
       test_only (bool): If True, this rule can only be used by tests.
       static (bool): If True, the binary will be linked statically.
       linkstatic (bool): Only provided for Bazel compatibility. Has no actual effect since we always
@@ -402,7 +418,7 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compil
         linker_flags.append(CONFIG.DEFAULT_LDFLAGS)
     if static:
         linker_flags.append('-static')
-    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs)
+    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, pkg_config_cflags)
     if srcs:
         if static:
             compiler_flags.append('-static -static-libgcc')
@@ -413,6 +429,7 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compil
             private_hdrs=private_hdrs,
             deps=deps,
             pkg_config_libs=pkg_config_libs,
+            pkg_config_cflags=pkg_config_cflags,
             compiler_flags=compiler_flags,
             test_only=test_only,
             _c=_c,
@@ -430,14 +447,14 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compil
         output_is_complete=True,
         requires=['cc'],
         tools=tools,
-        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs),
+        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, pkg_config_cflags),
         test_only=test_only,
     )
 
 
 def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
-            pkg_config_libs:list=[], deps:list=[], worker:str='', data:list=[], visibility:list=[], flags:str='',
-            labels:list&features&tags=[], flaky:bool|int=0, test_outputs:list=[], size:str=None, timeout:int=0,
+            pkg_config_libs:list=[], pkg_config_cflags:list=[], deps:list=[], worker:str='', data:list=[], visibility:list=[],
+            flags:str='', labels:list&features&tags=[], flaky:bool|int=0, test_outputs:list=[], size:str=None, timeout:int=0,
             container:bool|dict=False, sandbox:bool=None, write_main:bool=not CONFIG.BAZEL_COMPATIBILITY,
             linkstatic:bool=False, _c=False):
     """Defines a C++ test using UnitTest++.
@@ -451,7 +468,8 @@ def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&cop
       hdrs (list): Header files.
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker.
-      pkg_config_libs (list): Libraries to declare a dependency on using pkg-config.
+      pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
+      pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
       deps (list): Dependent rules.
       worker(str): Reference to worker script, A persistent worker process that is used to set up the test.
       data (list): Runtime data files for this test.
@@ -482,7 +500,7 @@ def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&cop
             test_only=True,
         )
         srcs.append(main_rule)
-    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs)
+    cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, pkg_config_cflags)
 
     if srcs:
         lib_rule = cc_library(
@@ -491,6 +509,7 @@ def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&cop
             hdrs=hdrs,
             deps=deps,
             pkg_config_libs=pkg_config_libs,
+            pkg_config_cflags=pkg_config_cflags,
             compiler_flags=compiler_flags,
             test_only=True,
             alwayslink=True,
@@ -526,7 +545,7 @@ def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&cop
         requires=['cc', 'cc_hdrs'],
         labels=labels,
         tools=tools,
-        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs),
+        pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, pkg_config_cflags),
         flaky=flaky,
         test_outputs=test_outputs,
         test_timeout=timeout,
@@ -754,18 +773,28 @@ def _default_cflags(c, dbg):
         return CONFIG.DEFAULT_DBG_CPPFLAGS if dbg else CONFIG.DEFAULT_OPT_CPPFLAGS
 
 
-def _build_flags(compiler_flags:list, pkg_config_libs:list, defines=None, c=False, dbg=False):
+def _build_flags(compiler_flags:list, pkg_config_libs:list, pkg_config_cflags:list, defines=None, c=False, dbg=False):
     """Builds flags that we'll pass to the compiler invocation."""
     compiler_flags = [_default_cflags(c, dbg), '-fPIC'] + compiler_flags  # N.B. order is important!
     if defines:
         compiler_flags += ['-D' + define for define in defines]
-    pkg_config_cmd = ' '.join([f'`pkg-config --cflags {x}`' for x in pkg_config_libs])
+
+    pkg_config_list = pkg_config_libs or pkg_config_cflags or []
+    pkg_config_cmd = ' '.join([f'`pkg-config --cflags {x}`' for x in pkg_config_list])
+
     return ' '.join(compiler_flags) + ' ' + pkg_config_cmd
 
 
-def _binary_build_flags(linker_flags:list, pkg_config_libs:list, shared=False, alwayslink='', c=False, dbg=False):
+def _binary_build_flags(linker_flags:list, pkg_config_libs:list, pkg_config_cflags:list, shared=False, alwayslink='', c=False, dbg=False):
     """Builds flags that we'll pass to the linker invocation."""
-    pkg_config_cmd = ' '.join([f'`pkg-config --libs {x}`' for x in pkg_config_libs])
+
+    if pkg_config_cflags:
+        pkg_config_cmd = ' '.join([f'`pkg-config --cflags {x}`' for x in pkg_config_cflags])
+    elif pkg_config_libs:
+        pkg_config_cmd = ' '.join([f'`pkg-config --libs {x}`' for x in pkg_config_libs])
+    else:
+        pkg_config_cmd = ' '
+
     objs = '`find . -name "*.o" -or -name "*.a" | sort`'
     linker_prefix = '' if CONFIG.LINK_WITH_LD_TOOL else '-Wl,'
     if (not shared) and alwayslink:
@@ -788,10 +817,10 @@ def _binary_build_flags(linker_flags:list, pkg_config_libs:list, shared=False, a
     return ' '.join([objs, build_id_flag, linker_flags, pkg_config_cmd])
 
 
-def _library_cmds(c, compiler_flags, pkg_config_libs, extra_flags='', archive=True):
+def _library_cmds(c, compiler_flags, pkg_config_libs, pkg_config_cflags, extra_flags='', archive=True):
     """Returns the commands needed for a cc_library rule."""
-    dbg_flags = _build_flags(compiler_flags, pkg_config_libs, c=c, dbg=True)
-    opt_flags = _build_flags(compiler_flags, pkg_config_libs, c=c)
+    dbg_flags = _build_flags(compiler_flags, pkg_config_libs, pkg_config_cflags, c=c, dbg=True)
+    opt_flags = _build_flags(compiler_flags, pkg_config_libs, pkg_config_cflags, c=c)
     cmd_template = '$TOOLS_CC -c -I . ${SRCS_SRCS} %s %s'
     if archive:
         cmd_template += ' && $TOOLS_AR rcs $OUT *.o'
@@ -807,10 +836,12 @@ def _library_cmds(c, compiler_flags, pkg_config_libs, extra_flags='', archive=Tr
     }
 
 
-def _binary_cmds(c, linker_flags, pkg_config_libs, extra_flags='', shared=False, alwayslink=''):
+def _binary_cmds(c, linker_flags, pkg_config_libs=[], pkg_config_cflags=[], extra_flags='', shared=False, alwayslink=''):
     """Returns the commands needed for a cc_binary, cc_test or cc_shared_object rule."""
-    dbg_flags = _binary_build_flags(linker_flags, pkg_config_libs, shared, alwayslink, c=c, dbg=True)
-    opt_flags = _binary_build_flags(linker_flags, pkg_config_libs, shared, alwayslink, c=c, dbg=False)
+    dbg_flags = _binary_build_flags(linker_flags, pkg_config_libs, pkg_config_cflags,
+                                    shared, alwayslink, c=c, dbg=True)
+    opt_flags = _binary_build_flags(linker_flags, pkg_config_libs, pkg_config_cflags,
+                                    shared, alwayslink, c=c, dbg=False)
     cmds = {
         'dbg': f'$TOOL -o $OUT {dbg_flags} {extra_flags}',
         'opt': f'$TOOL -o $OUT {opt_flags} {extra_flags}',
@@ -821,34 +852,43 @@ def _binary_cmds(c, linker_flags, pkg_config_libs, extra_flags='', shared=False,
                   CONFIG.CC_TOOL if c else CONFIG.CPP_TOOL]
 
 
-def _library_transitive_labels(c, compiler_flags, pkg_config_libs, archive=True):
+def _library_transitive_labels(c, compiler_flags, pkg_config_libs, pkg_config_cflags, archive=True):
     """Applies commands from transitive labels to a cc_library rule."""
     def apply_transitive_labels(name):
         labels = get_labels(name, 'cc:')
         flags = ['-isystem %s' % l[4:] for l in labels if l.startswith('inc:')]
         flags.extend(['-D' + l[4:] for l in labels if l.startswith('def:')])
-        pkg_config_libs.extend([l[3:] for l in labels if l.startswith('pc:') and l[3:] not in pkg_config_libs])
+
+        if pkg_config_libs:
+            pkg_config_libs.extend([l[3:] for l in labels if l.startswith('pc:') and l[3:] not in pkg_config_libs])
+        elif pkg_config_cflags:
+            pkg_config_libs.extend([l[3:] for l in labels if l.startswith('pcc:') and l[4:] not in pkg_config_cflags])
+
         if flags:  # Don't update if there aren't any relevant labels
-            cmds, _ = _library_cmds(c, compiler_flags, pkg_config_libs, ' '.join(flags), archive=archive)
+            cmds, _ = _library_cmds(c, compiler_flags, pkg_config_libs, pkg_config_cflags, ' '.join(flags), archive=archive)
             for k, v in cmds.items():
                 set_command(name, k, v)
     return apply_transitive_labels
 
 
-def _binary_transitive_labels(c, linker_flags, pkg_config_libs, shared=False):
+def _binary_transitive_labels(c, linker_flags, pkg_config_libs=[], pkg_config_cflags=[], shared=False):
     """Applies commands from transitive labels to a cc_binary, cc_test or cc_shared_object rule."""
     def apply_transitive_labels(name):
         labels = get_labels(name, 'cc:')
         linker_prefix = '' if CONFIG.LINK_WITH_LD_TOOL else '-Wl,'
         flags = [linker_prefix + l[3:] for l in labels if l.startswith('ld:')]
-        flags.extend(['`pkg-config --libs %s`' % l[3:] for l in labels if l.startswith('pc:')])
+        if pkg_config_cflags:
+            flags.extend(['`pkg-config --cflags %s`' % l[4:] for l in labels if l.startswith('pcc:')])
+        elif pkg_config_libs:
+            flags.extend(['`pkg-config --libs %s`' % l[3:] for l in labels if l.startswith('pc:')])
+
         # ./ here because some weak linkers don't realise ./lib.a is the same file as lib.a
         # and report duplicate symbol errors as a result.
         alwayslink = ' '.join(['./' + l[3:] for l in labels if l.startswith('al:')])
         # Probably a little optimistic to check this (most binaries are likely to have *some*
         # kind of linker flags to apply), but we might as well.
         if flags or alwayslink:
-            cmds, _ = _binary_cmds(c, linker_flags, pkg_config_libs, ' '.join(flags), shared, alwayslink)
+            cmds, _ = _binary_cmds(c, linker_flags, pkg_config_libs, pkg_config_cflags, ' '.join(flags), shared, alwayslink)
             for k, v in cmds.items():
                 set_command(name, k, v)
     return apply_transitive_labels

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -48,6 +48,9 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
       linkstatic (bool): Only provided for Bazel compatibility. Has no actual effect.
       textual_hdrs (list): Also provided for Bazel compatibility. Effectively works the same as hdrs for now.
     """
+    # Make sure it is compatible with Mac systems, append additional linker_flags to the list
+    _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
+
     # Bazel suggests passing nonexported header files in 'srcs'. We however treat
     # srcs as things to actually compile and must mark a distinction.
     if CONFIG.BAZEL_COMPATIBILITY:
@@ -97,6 +100,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
     )
 
     cmds, tools = _library_cmds(_c, compiler_flags, pkg_config_libs, pkg_config_cflags)
+
     # TODO(pebers): handle includes and defines in _library_cmds as well.
     pre_build = _library_transitive_labels(_c, compiler_flags, pkg_config_libs, pkg_config_cflags) if (deps or includes or defines) else None
 
@@ -234,6 +238,9 @@ def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=Non
                          even if they don't directly reference them. This is useful for e.g. having
                          static members that register themselves at construction time.
     """
+    # Make sure it is compatible with Mac systems, append additional linker_flags to the list
+    _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
+
     # Handle defines being passed as a dict, as a nicety for the user.
     if isinstance(defines, dict):
         defines = [k if v is None else r'%s=\"%s\"' % (k, v) for k, v in sorted(defines.items())]
@@ -287,6 +294,9 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
       pkg_config_libs (list): Libraries to declare a dependency on using `pkg-config --libs`
       pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
     """
+    # Make sure it is compatible with Mac systems, append additional linker_flags to the list
+    _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
+
     provides = None
     if srcs:
         lib_rule = cc_library(
@@ -345,8 +355,12 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
       pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
       includes (list): Include directories to be added to the compiler's lookup path.
     """
+    # Make sure it is compatible with Mac systems, append additional linker_flags to the list
+    _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
+
     if CONFIG.DEFAULT_LDFLAGS:
         linker_flags.append(CONFIG.DEFAULT_LDFLAGS)
+
     provides = None
     if srcs:
         lib_rule = cc_library(
@@ -409,6 +423,9 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compil
       linkstatic (bool): Only provided for Bazel compatibility. Has no actual effect since we always
                          link roughly equivalently to their "mostly-static" mode.
     """
+    # Make sure it is compatible with Mac systems, append additional linker_flags to the list
+    _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
+
     if CONFIG.BAZEL_COMPATIBILITY:
         linker_flags = ['-lpthread' if l == '-pthread' else l for l in linker_flags]
     if CONFIG.DEFAULT_LDFLAGS:
@@ -483,6 +500,9 @@ def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&cop
       linkstatic (bool): Only provided for Bazel compatibility. Has no actual effect since we always
                          link roughly equivalently to their "mostly-static" mode.
     """
+    # Make sure it is compatible with Mac systems, append additional linker_flags to the list
+    _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
+    
     if CONFIG.BAZEL_COMPATIBILITY:
         linker_flags = ['-lpthread' if l == '-pthread' else l for l in linker_flags]
     timeout, labels = _test_size_and_timeout(size, timeout, labels)
@@ -877,6 +897,17 @@ def _binary_transitive_labels(c, linker_flags, pkg_config_libs, shared=False):
                 set_command(name, k, v)
     return apply_transitive_labels
 
+
+def _append_mac_compatible_linker_flag(linker_flags:list, libs:list):
+    """
+    append '-undefined dynamic_lookup' to linker flag list if OS is mac and python is in pkg_config list
+
+    :param linker_flags: linker flag list
+    :param libs: pkg_config_libs or/and pkg_config_cflags
+    """
+    # Mac Compatible
+    if CONFIG.OS == 'darwin' and any([i for i in libs if 'python' in i]):
+        linker_flags.append("-undefined dynamic_lookup")
 
 if CONFIG.BAZEL_COMPATIBILITY:
     # For nominal Buck compatibility. The cc_ forms are preferred.

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -502,7 +502,7 @@ def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&cop
     """
     # Make sure it is compatible with Mac systems, append additional linker_flags to the list
     _append_mac_compatible_linker_flag(linker_flags, pkg_config_libs + pkg_config_cflags)
-    
+
     if CONFIG.BAZEL_COMPATIBILITY:
         linker_flags = ['-lpthread' if l == '-pthread' else l for l in linker_flags]
     timeout, labels = _test_size_and_timeout(size, timeout, labels)
@@ -907,7 +907,8 @@ def _append_mac_compatible_linker_flag(linker_flags:list, libs:list):
     """
     # Mac Compatible
     if CONFIG.OS == 'darwin' and any([i for i in libs if 'python' in i]):
-        linker_flags.append("-undefined dynamic_lookup")
+        linker_flags.append("-bundle -undefined dynamic_lookup")
+
 
 if CONFIG.BAZEL_COMPATIBILITY:
     # For nominal Buck compatibility. The cc_ forms are preferred.

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -12,7 +12,7 @@ that on every single cc_binary / cc_test that transitively depends on that libra
 _COVERAGE_FLAGS = ' -ftest-coverage -fprofile-arcs -fprofile-dir=.'
 # OSX's ld uses --all_load / --noall_load instead of --whole-archive.
 _WHOLE_ARCHIVE = '-all_load' if CONFIG.OS == 'darwin' else '--whole-archive'
-_NO_WHOLE_ARCHIVE = '-noall_load' if CONFIG.OS == 'darwin' else '--no-whole-archive'
+_NO_WHOLE_ARCHIVE = '-force_load' if CONFIG.OS == 'darwin' else '--no-whole-archive'
 
 
 def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:list=[],

--- a/src/parse/rules/cc_rules.build_defs
+++ b/src/parse/rules/cc_rules.build_defs
@@ -12,7 +12,7 @@ that on every single cc_binary / cc_test that transitively depends on that libra
 _COVERAGE_FLAGS = ' -ftest-coverage -fprofile-arcs -fprofile-dir=.'
 # OSX's ld uses --all_load / --noall_load instead of --whole-archive.
 _WHOLE_ARCHIVE = '-all_load' if CONFIG.OS == 'darwin' else '--whole-archive'
-_NO_WHOLE_ARCHIVE = '-force_load' if CONFIG.OS == 'darwin' else '--no-whole-archive'
+_NO_WHOLE_ARCHIVE = '-noall_load' if CONFIG.OS == 'darwin' else '--no-whole-archive'
 
 
 def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:list=[],

--- a/test/cc_rules/clang/BUILD
+++ b/test/cc_rules/clang/BUILD
@@ -53,6 +53,7 @@ cc_shared_object(
     name = "so_test",
     srcs = ["so_test.cc"],
     pkg_config_cflags = ["python3"],
+    linker_flags = ["-bundle -undefined dynamic_lookup"] if CONFIG.OS == 'darwin' else [],
     deps = [
         ":embedded_files",
     ],

--- a/test/cc_rules/clang/BUILD
+++ b/test/cc_rules/clang/BUILD
@@ -52,7 +52,7 @@ cc_library(
 cc_shared_object(
     name = "so_test",
     srcs = ["so_test.cc"],
-    pkg_config_libs = ["python3"],
+    pkg_config_cflags = ["python3"],
     deps = [
         ":embedded_files",
     ],

--- a/test/cc_rules/gcc/BUILD
+++ b/test/cc_rules/gcc/BUILD
@@ -41,6 +41,7 @@ cc_shared_object(
     name = "so_test",
     srcs = ["so_test.cc"],
     pkg_config_cflags = ["python3"],
+    linker_flags = ["-bundle -undefined dynamic_lookup"] if CONFIG.OS == 'darwin',
     deps = [
         ":embedded_files",
     ],

--- a/test/cc_rules/gcc/BUILD
+++ b/test/cc_rules/gcc/BUILD
@@ -41,7 +41,6 @@ cc_shared_object(
     name = "so_test",
     srcs = ["so_test.cc"],
     pkg_config_cflags = ["python3"],
-    linker_flags = ['-v'],
     deps = [
         ":embedded_files",
     ],

--- a/test/cc_rules/gcc/BUILD
+++ b/test/cc_rules/gcc/BUILD
@@ -41,6 +41,7 @@ cc_shared_object(
     name = "so_test",
     srcs = ["so_test.cc"],
     pkg_config_cflags = ["python3"],
+    linker_flags = ['-v'],
     deps = [
         ":embedded_files",
     ],

--- a/test/cc_rules/gcc/BUILD
+++ b/test/cc_rules/gcc/BUILD
@@ -41,7 +41,7 @@ cc_shared_object(
     name = "so_test",
     srcs = ["so_test.cc"],
     pkg_config_cflags = ["python3"],
-    linker_flags = ["-bundle -undefined dynamic_lookup"] if CONFIG.OS == 'darwin',
+    linker_flags = ["-bundle -undefined dynamic_lookup"] if CONFIG.OS == 'darwin' else [],
     deps = [
         ":embedded_files",
     ],

--- a/test/cc_rules/gcc/BUILD
+++ b/test/cc_rules/gcc/BUILD
@@ -40,7 +40,7 @@ cc_library(
 cc_shared_object(
     name = "so_test",
     srcs = ["so_test.cc"],
-    pkg_config_libs = ["python3"],
+    pkg_config_cflags = ["python3"],
     deps = [
         ":embedded_files",
     ],


### PR DESCRIPTION
- Added pkg_config_cflags option in cc related build rules in  `/src/parse/rules/cc_rules.build_defs` and `/src/parse/rules/c_rules.build_defs` 