### PR TITLE
Allowing xml coverage report, and added new flag --coverage_xml_report

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -135,6 +135,7 @@ var opts struct {
 		TestResultsFile     cli.Filepath `long:"test_results_file" default:"plz-out/log/test_results.xml" description:"File to write combined test results to."`
 		SurefireDir         cli.Filepath `long:"surefire_dir" default:"plz-out/surefire-reports" description:"Directory to copy XML test results to."`
 		CoverageResultsFile cli.Filepath `long:"coverage_results_file" default:"plz-out/log/coverage.json" description:"File to write combined coverage results to."`
+		CoverageXmlReport	cli.FilePath `long:"coverage_xml_report" default:"plz-out/log/coverage.xml" description:"XML File to write combined coverage results to."`
 		ShowOutput          bool         `short:"s" long:"show_output" description:"Always show output of tests, even on success."`
 		Debug               bool         `short:"d" long:"debug" description:"Allows starting an interactive debugger on test failure. Does not work with all test types (currently only python/pytest, C and C++). Implies -c dbg unless otherwise set."`
 		Failed              bool         `short:"f" long:"failed" description:"Runs just the test cases that failed from the immediately previous run."`

--- a/src/please.go
+++ b/src/please.go
@@ -368,6 +368,7 @@ var buildFunctions = map[string]func() bool{
 		success, state := doTest(targets, opts.Cover.SurefireDir, opts.Cover.TestResultsFile)
 		test.AddOriginalTargetsToCoverage(state, opts.Cover.IncludeAllFiles)
 		test.RemoveFilesFromCoverage(state.Coverage, state.Config.Cover.ExcludeExtension)
+
 		test.WriteCoverageToFileOrDie(state.Coverage, string(opts.Cover.CoverageResultsFile))
 		test.WriteXMLCoverageToFileOrDie(targets, state.Coverage, string(opts.Cover.CoverageXMLReport))
 

--- a/src/please.go
+++ b/src/please.go
@@ -135,7 +135,7 @@ var opts struct {
 		TestResultsFile     cli.Filepath `long:"test_results_file" default:"plz-out/log/test_results.xml" description:"File to write combined test results to."`
 		SurefireDir         cli.Filepath `long:"surefire_dir" default:"plz-out/surefire-reports" description:"Directory to copy XML test results to."`
 		CoverageResultsFile cli.Filepath `long:"coverage_results_file" default:"plz-out/log/coverage.json" description:"File to write combined coverage results to."`
-		CoverageXmlReport	cli.FilePath `long:"coverage_xml_report" default:"plz-out/log/coverage.xml" description:"XML File to write combined coverage results to."`
+		CoverageXMLReport	cli.Filepath `long:"coverage_xml_report" default:"plz-out/log/coverage.xml" description:"XML File to write combined coverage results to."`
 		ShowOutput          bool         `short:"s" long:"show_output" description:"Always show output of tests, even on success."`
 		Debug               bool         `short:"d" long:"debug" description:"Allows starting an interactive debugger on test failure. Does not work with all test types (currently only python/pytest, C and C++). Implies -c dbg unless otherwise set."`
 		Failed              bool         `short:"f" long:"failed" description:"Runs just the test cases that failed from the immediately previous run."`
@@ -369,6 +369,7 @@ var buildFunctions = map[string]func() bool{
 		test.AddOriginalTargetsToCoverage(state, opts.Cover.IncludeAllFiles)
 		test.RemoveFilesFromCoverage(state.Coverage, state.Config.Cover.ExcludeExtension)
 		test.WriteCoverageToFileOrDie(state.Coverage, string(opts.Cover.CoverageResultsFile))
+		test.WriteXMLCoverageToFileOrDie(targets, state.Coverage, string(opts.Cover.CoverageXMLReport))
 
 		if opts.Cover.LineCoverageReport {
 			output.PrintLineCoverageReport(state, opts.Cover.IncludeFile)

--- a/src/test/BUILD
+++ b/src/test/BUILD
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//src/build",
         "//src/core",
+        "//src/cli",
         "//src/fs",
         "//src/metrics",
         "//src/utils",

--- a/src/test/coverage.go
+++ b/src/test/coverage.go
@@ -147,6 +147,15 @@ func WriteCoverageToFileOrDie(coverage core.TestCoverage, filename string) {
 	}
 }
 
+// WriteXMLCoverageToFileOrDie writes the collected coverage data to a file in XML format. Dies on failure.
+func WriteXMLCoverageToFileOrDie(sources []core.BuildLabel, coverage core.TestCoverage, filename string) {
+	data := CoverageResultToXML(sources, coverage)
+
+	if err := ioutil.WriteFile(filename, data, 0644); err != nil {
+		log.Fatalf("Failed to write coverage results to %s: %s", filename, err)
+	}
+}
+
 // CountCoverage counts the number of lines covered and the total number coverable in a single file.
 func CountCoverage(lines []core.LineCoverage) (int, int) {
 	covered := 0

--- a/src/test/coverage.go
+++ b/src/test/coverage.go
@@ -153,7 +153,7 @@ func WriteCoverageToFileOrDie(coverage core.TestCoverage, filename string) {
 
 // WriteXMLCoverageToFileOrDie writes the collected coverage data to a file in XML format. Dies on failure.
 func WriteXMLCoverageToFileOrDie(sources []core.BuildLabel, coverage core.TestCoverage, filename string) {
-	data := CoverageResultToXML(sources, coverage)
+	data := coverageResultToXML(sources, coverage)
 
 	if err := ioutil.WriteFile(filename, data, 0644); err != nil {
 		log.Fatalf("Failed to write coverage results to %s: %s", filename, err)

--- a/src/test/coverage.go
+++ b/src/test/coverage.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"core"
+	"cli"
 )
 
 // Parses test coverage for a single target from its output file.
@@ -195,10 +196,9 @@ func getStats(coverage core.TestCoverage) stats {
 func convertCoverage(in map[string][]core.LineCoverage, allowedFiles []string) map[string]string {
 	ret := map[string]string{}
 	for k, v := range in {
-		if !shouldInclude(k, allowedFiles) {
-			continue
+		if cli.ContainsString(k, allowedFiles) {
+			ret[k] = core.TestCoverageString(v)
 		}
-		ret[k] = core.TestCoverageString(v)
 	}
 	return ret
 }

--- a/src/test/xml_coverage.go
+++ b/src/test/xml_coverage.go
@@ -5,7 +5,12 @@ package test
 import "encoding/xml"
 import "strings"
 
-import "core"
+import (
+	"core"
+	"fmt"
+	"strconv"
+	"time"
+)
 
 func parseXMLCoverageResults(target *core.BuildTarget, coverage *core.TestCoverage, data []byte) error {
 	xcoverage := xmlCoverage{}
@@ -38,6 +43,99 @@ func parseXMLLines(lines []xmlCoverageLine) []core.LineCoverage {
 	return ret
 }
 
+
+// Covert the Coverage result to XML bytes, ready to be write to file
+func CoverageResultToXML(sources []core.BuildLabel, coverage core.TestCoverage) []byte {
+	linesValid := 0
+	linesCovered := 0
+
+	// get the string representative of sources
+	var sourcesAsStr []string
+	for _, source := range sources {
+		sourcesAsStr = append(sourcesAsStr, source.PackageName + ":" + source.Name)
+	}
+
+	// Get the list of packages for <package> tag in the coverage xml file
+	var packages []Package
+	for label, coverage := range coverage.Tests {
+		packageName := strings.Replace(label.String(), ":", "/", -1)
+
+		// Get the list of classes for <class> tag in the coverage xml file
+		var classes []Class
+		classLineRateTotal := float32(0)
+		for className, lineCover := range coverage {
+
+			lines, covered, total := GetLineCoverageInfo(lineCover)
+			classLineRate := float32(covered) / float32(total)
+
+			cls := Class{Name:className, Filename: className,
+						 Lines:lines, LineRate:formatFloatPrecision(classLineRate, 4)}
+
+		    classes = append(classes, cls)
+		    classLineRateTotal += classLineRate
+			linesValid += total
+			linesCovered += covered
+		}
+
+		pkgLineRate := float32(classLineRateTotal) / float32(len(classes))
+
+		pkg := Package{Name:packageName, Classes:classes, LineRate:formatFloatPrecision(pkgLineRate, 4)}
+		packages = append(packages, pkg)
+	}
+
+	topLevelLineRate := float32(linesCovered) / float32(linesValid)
+
+	// Create the coverage object based on the data collected
+	coverageObj := Coverage{Packages:packages, LineRate:formatFloatPrecision(topLevelLineRate, 4),
+						    LinesCovered:int64(linesCovered), LinesValid: int64(linesValid),
+						    Timestamp: time.Now().UnixNano() / int64(time.Millisecond),
+							Sources:sourcesAsStr}
+
+    // Parse struct to xml bytes
+	xmlBytes, err := xml.MarshalIndent(coverageObj, "", "	")
+    if err != nil {
+		log.Fatalf("Failed to parse to xml: %s", err)
+	}
+	covReport := []byte(xml.Header + string(xmlBytes))
+	return covReport
+}
+
+// Get the line coverage info, returns: list of lines covered, num of covered lines, and total valid lines
+func GetLineCoverageInfo(lineCover []core.LineCoverage) ([]Line, int, int) {
+	var lines []Line
+	covered := 0
+	total := 0
+
+	for index, status := range lineCover {
+		if status == 3 {
+			line := Line{Hits:1, Number:index}
+			lines = append(lines, line)
+			covered += 1
+			total += 1
+		} else if status == 2 {
+			line := Line{Hits:0, Number:index}
+			lines = append(lines, line)
+			total += 1
+		}
+	}
+
+	return lines, covered, total
+}
+
+// format the float32 numbers to a specific precision
+func formatFloatPrecision(val float32, precision int) float32 {
+	precString := fmt.Sprintf("%v", precision)
+	strVal := fmt.Sprintf("%." + precString + "f", val)
+
+	i, err := strconv.ParseFloat(strVal, 32)
+
+	if err != nil {
+		log.Fatalf("Failed to parse float: %s", err)
+	}
+
+	return float32(i)
+}
+
 // Note that this is based off coverage.py's format, which is originally a Java format
 // so some of the structures are a little awkward (eg. 'classes' actually refer to Python modules, not classes).
 type xmlCoverage struct {
@@ -60,4 +158,57 @@ type xmlCoverage struct {
 type xmlCoverageLine struct {
 	Hits   int `xml:"hits,attr"`
 	Number int `xml:"number,attr"`
+}
+
+
+// Coverage struct for writing to xml file
+type Coverage struct {
+	XMLName         xml.Name  `xml:"coverage"`
+	LineRate        float32   `xml:"line-rate,attr"`
+	BranchRate      float32   `xml:"branch-rate,attr"`
+	LinesCovered    int64     `xml:"lines-covered,attr"`
+	LinesValid      int64     `xml:"lines-valid,attr"`
+	BranchesCovered int64     `xml:"branches-covered,attr"`
+	BranchesValid   int64     `xml:"branches-valid,attr"`
+	Complexity      float32   `xml:"complexity,attr"`
+	Version         string    `xml:"version,attr"`
+	Timestamp       int64     `xml:"timestamp,attr"`
+	Sources         []string   `xml:"sources>source"`
+	Packages        []Package `xml:"packages>package"`
+}
+
+type Package struct {
+	Name       string  `xml:"name,attr"`
+	LineRate   float32 `xml:"line-rate,attr"`
+	BranchRate float32 `xml:"branch-rate,attr"`
+	Complexity float32 `xml:"complexity,attr"`
+	Classes    []Class `xml:"classes>class"`
+	LineCount  int64   `xml:"line-count,attr"`
+	LineHits   int64   `xml:"line-hits,attr"`
+}
+
+type Class struct {
+	Name       string   `xml:"name,attr"`
+	Filename   string   `xml:"filename,attr"`
+	LineRate   float32  `xml:"line-rate,attr"`
+	BranchRate float32  `xml:"branch-rate,attr"`
+	Complexity float32  `xml:"complexity,attr"`
+	Methods    []Method `xml:"methods>method"`
+	Lines      []Line   `xml:"lines>line"`
+}
+
+type Method struct {
+	Name       string  `xml:"name,attr"`
+	Signature  string  `xml:"signature,attr"`
+	LineRate   float32 `xml:"line-rate,attr"`
+	BranchRate float32 `xml:"branch-rate,attr"`
+	Complexity float32 `xml:"complexity,attr"`
+	Lines      []Line  `xml:"lines>line"`
+	LineCount  int64   `xml:"line-count,attr"`
+	LineHits   int64   `xml:"line-hits,attr"`
+}
+
+type Line struct {
+	Number int   `xml:"number,attr"`
+	Hits   int64 `xml:"hits,attr"`
 }

--- a/src/test/xml_coverage.go
+++ b/src/test/xml_coverage.go
@@ -190,7 +190,7 @@ type Coverage struct {
 	Complexity      float32   `xml:"complexity,attr"`
 	Version         string    `xml:"version,attr"`
 	Timestamp       int64     `xml:"timestamp,attr"`
-	Sources         []string   `xml:"sources>source"`
+	Sources         []string  `xml:"sources>source"`
 	Packages        []Package `xml:"packages>package"`
 }
 

--- a/src/test/xml_coverage.go
+++ b/src/test/xml_coverage.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 	"math"
-	"fmt"
 )
 
 func parseXMLCoverageResults(target *core.BuildTarget, coverage *core.TestCoverage, data []byte) error {

--- a/src/test/xml_coverage.go
+++ b/src/test/xml_coverage.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 	"math"
+	"fmt"
 )
 
 func parseXMLCoverageResults(target *core.BuildTarget, coverage *core.TestCoverage, data []byte) error {
@@ -51,7 +52,7 @@ func coverageResultToXML(sources []core.BuildLabel, coverage core.TestCoverage) 
 	// get the string representative of sources
 	var sourcesAsStr []string
 	for _, source := range sources {
-		sourcesAsStr = append(sourcesAsStr, source.PackageName+":"+source.Name)
+		sourcesAsStr = append(sourcesAsStr, source.String())
 	}
 
 	// Get the list of packages for <package> tag in the coverage xml file


### PR DESCRIPTION
- xml coverage report will now be able to be output to `plz-out/log/coverage.xml`
- To specify xml coverage report path, use the flag  `--coverage_xml_report` with custom path specified, like so  `--coverage_xml_report=/tmp/coverage.xml`
