### PR TITLE
Structured alias subsections

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -52,7 +52,7 @@ fi
 rm -rf plz-out src/parse/rules/builtin_rules.bindata.go src/parse/rules/builtin_data.bindata.go
 # Compile the builtin rules
 notice "Compiling built-in rules..."
-go run src/parse/asp/main/compiler.go -o plz-out/tmp/src/parse/rules src/parse/rules/*.build_defs
+go run -tags bootstrap src/parse/asp/main/compiler.go -o plz-out/tmp/src/parse/rules src/parse/rules/*.build_defs
 # Embed them into Go
 .bootstrap/bin/go-bindata -o src/parse/rules/builtin_data.bindata.go -pkg rules -prefix plz-out/tmp/src/parse/rules plz-out/tmp/src/parse/rules
 

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -40,6 +40,7 @@ go_test(
     deps = [
         ":core",
         "//src/cli",
+        "//third_party/go:go-flags",
         "//third_party/go:testify",
     ],
 )

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -585,7 +585,7 @@ func (config *Configuration) UpdateArgsWithAliases(args []string) []string {
 		if arg == "--" {
 			break
 		}
-		for k, v := range config.Aliases {
+		for k, v := range config.AllAliases() {
 			if arg == k {
 				// We could insert every token in v into os.Args at this point and then we could have
 				// aliases defined in terms of other aliases but that seems rather like overkill so just
@@ -596,4 +596,16 @@ func (config *Configuration) UpdateArgsWithAliases(args []string) []string {
 		}
 	}
 	return args
+}
+
+// AllAliases returns all the aliases defined in this config
+func (config *Configuration) AllAliases() map[string]string {
+	ret := map[string]string{}
+	for k, v := range config.Aliases {
+		ret[k] = v
+	}
+	for k, v := range config.Alias {
+		ret[k] = v.Cmd
+	}
+	return ret
 }

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -388,17 +388,23 @@ type Configuration struct {
 		Reject []string `help:"Licences that are explicitly rejected in this repository.\nAn astute observer will notice that this is not very different to just not adding it to the accept section, but it does have the advantage of explicitly documenting things that the team aren't allowed to use."`
 	} `help:"Please has some limited support for declaring acceptable licences and detecting them from some libraries. You should not rely on this for complete licence compliance, but it can be a useful check to try to ensure that unacceptable licences do not slip in."`
 	Aliases map[string]string `help:"It is possible to define aliases for new commands in your .plzconfig file. These are essentially string-string replacements of the command line, for example 'deploy = run //tools:deployer --' makes 'plz deploy' run a particular tool."`
-	Alias   map[string]*struct {
-		Cmd        string   `help:"Command to run for this alias."`
-		Subcommand []string `help:"Known subcommands of this command"`
-		Flag       []string `help:"Known flags of this command"`
-	} `help:"Allows defining alias replacements with more detail than the [aliases] section. Otherwise follows the same process, i.e. performs replacements of command strings."`
-	Bazel struct {
+	Alias   map[string]*Alias `help:"Allows defining alias replacements with more detail than the [aliases] section. Otherwise follows the same process, i.e. performs replacements of command strings."`
+	Bazel   struct {
 		Compatibility bool `help:"Activates limited Bazel compatibility mode. When this is active several rule arguments are available under different names (e.g. compiler_flags -> copts etc), the WORKSPACE file is interpreted, Makefile-style replacements like $< and $@ are made in genrule commands, etc.\nNote that Skylark is not generally supported and many aspects of compatibility are fairly superficial; it's unlikely this will work for complex setups of either tool." var:"BAZEL_COMPATIBILITY"`
 	} `help:"Bazel is an open-sourced version of Google's internal build tool. Please draws a lot of inspiration from the original tool although the two have now diverged in various ways.\nNonetheless, if you've used Bazel, you will likely find Please familiar."`
 
 	// buildEnvStored is a cached form of BuildEnv.
 	buildEnvStored *storedBuildEnv
+}
+
+// An Alias represents aliases in the config.
+type Alias struct {
+	Cmd        string   `help:"Command to run for this alias."`
+	Desc       string   `help:"Description of this alias"`
+	Subcommand []string `help:"Known subcommands of this command"`
+	// TODO(peterebden): Looks like we can't dynamically add these right now. Can probably
+	//                   figure out some kind of patch to do it later.
+	// Flag       []string `help:"Known flags of this command"`
 }
 
 type storedBuildEnv struct {
@@ -591,7 +597,7 @@ func (config *Configuration) UpdateArgsWithAliases(args []string) []string {
 				// aliases defined in terms of other aliases but that seems rather like overkill so just
 				// stick the replacement in wholesale instead.
 				// Do not ask about the inner append and the empty slice.
-				return append(append(append([]string{}, args[:idx+1]...), strings.Fields(v)...), args[idx+2:]...)
+				return append(append(append([]string{}, args[:idx+1]...), strings.Fields(v.Cmd)...), args[idx+2:]...)
 			}
 		}
 	}
@@ -599,13 +605,36 @@ func (config *Configuration) UpdateArgsWithAliases(args []string) []string {
 }
 
 // AllAliases returns all the aliases defined in this config
-func (config *Configuration) AllAliases() map[string]string {
-	ret := map[string]string{}
+func (config *Configuration) AllAliases() map[string]*Alias {
+	ret := map[string]*Alias{}
 	for k, v := range config.Aliases {
-		ret[k] = v
+		ret[k] = &Alias{Cmd: v}
 	}
 	for k, v := range config.Alias {
-		ret[k] = v.Cmd
+		ret[k] = v
 	}
 	return ret
+}
+
+// AttachAliasFlags attaches the alias flags to the given flag parser.
+// It returns true if any modifications were made.
+func (config *Configuration) AttachAliasFlags(parser *flags.Parser) bool {
+	for name, alias := range config.AllAliases() {
+		cmd, _ := parser.AddCommand(name, alias.Desc, alias.Desc, &struct{}{})
+		for _, subcommand := range alias.Subcommand {
+			addSubcommands(cmd, strings.Fields(subcommand))
+		}
+	}
+	return len(config.Aliases) > 0 || len(config.Alias) > 0
+}
+
+// addSubcommands attaches a series of subcommands to the given command.
+func addSubcommands(cmd *flags.Command, subcommand []string) {
+	if len(subcommand) > 0 && cmd != nil {
+		cmd2 := cmd.Find(subcommand[0])
+		if cmd2 == nil {
+			cmd2, _ = cmd.AddCommand(subcommand[0], "", "", &struct{}{})
+		}
+		addSubcommands(cmd2, subcommand[1:])
+	}
 }

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -388,10 +388,10 @@ type Configuration struct {
 		Reject []string `help:"Licences that are explicitly rejected in this repository.\nAn astute observer will notice that this is not very different to just not adding it to the accept section, but it does have the advantage of explicitly documenting things that the team aren't allowed to use."`
 	} `help:"Please has some limited support for declaring acceptable licences and detecting them from some libraries. You should not rely on this for complete licence compliance, but it can be a useful check to try to ensure that unacceptable licences do not slip in."`
 	Aliases map[string]string `help:"It is possible to define aliases for new commands in your .plzconfig file. These are essentially string-string replacements of the command line, for example 'deploy = run //tools:deployer --' makes 'plz deploy' run a particular tool."`
-	Alias   map[string]struct {
-		Cmd        string `help:"Command to run for this alias."`
-		Subcommand string `help:"Known subcommands of this command"`
-		Flag       string `help:"Known flags of this command"`
+	Alias   map[string]*struct {
+		Cmd        string   `help:"Command to run for this alias."`
+		Subcommand []string `help:"Known subcommands of this command"`
+		Flag       []string `help:"Known flags of this command"`
 	} `help:"Allows defining alias replacements with more detail than the [aliases] section. Otherwise follows the same process, i.e. performs replacements of command strings."`
 	Bazel struct {
 		Compatibility bool `help:"Activates limited Bazel compatibility mode. When this is active several rule arguments are available under different names (e.g. compiler_flags -> copts etc), the WORKSPACE file is interpreted, Makefile-style replacements like $< and $@ are made in genrule commands, etc.\nNote that Skylark is not generally supported and many aspects of compatibility are fairly superficial; it's unlikely this will work for complex setups of either tool." var:"BAZEL_COMPATIBILITY"`

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -402,9 +402,7 @@ type Alias struct {
 	Cmd        string   `help:"Command to run for this alias."`
 	Desc       string   `help:"Description of this alias"`
 	Subcommand []string `help:"Known subcommands of this command"`
-	// TODO(peterebden): Looks like we can't dynamically add these right now. Can probably
-	//                   figure out some kind of patch to do it later.
-	// Flag       []string `help:"Known flags of this command"`
+	Flag       []string `help:"Known flags of this command"`
 }
 
 type storedBuildEnv struct {
@@ -614,27 +612,4 @@ func (config *Configuration) AllAliases() map[string]*Alias {
 		ret[k] = v
 	}
 	return ret
-}
-
-// AttachAliasFlags attaches the alias flags to the given flag parser.
-// It returns true if any modifications were made.
-func (config *Configuration) AttachAliasFlags(parser *flags.Parser) bool {
-	for name, alias := range config.AllAliases() {
-		cmd, _ := parser.AddCommand(name, alias.Desc, alias.Desc, &struct{}{})
-		for _, subcommand := range alias.Subcommand {
-			addSubcommands(cmd, strings.Fields(subcommand))
-		}
-	}
-	return len(config.Aliases) > 0 || len(config.Alias) > 0
-}
-
-// addSubcommands attaches a series of subcommands to the given command.
-func addSubcommands(cmd *flags.Command, subcommand []string) {
-	if len(subcommand) > 0 && cmd != nil {
-		cmd2 := cmd.Find(subcommand[0])
-		if cmd2 == nil {
-			cmd2, _ = cmd.AddCommand(subcommand[0], "", "", &struct{}{})
-		}
-		addSubcommands(cmd2, subcommand[1:])
-	}
 }

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -388,7 +388,12 @@ type Configuration struct {
 		Reject []string `help:"Licences that are explicitly rejected in this repository.\nAn astute observer will notice that this is not very different to just not adding it to the accept section, but it does have the advantage of explicitly documenting things that the team aren't allowed to use."`
 	} `help:"Please has some limited support for declaring acceptable licences and detecting them from some libraries. You should not rely on this for complete licence compliance, but it can be a useful check to try to ensure that unacceptable licences do not slip in."`
 	Aliases map[string]string `help:"It is possible to define aliases for new commands in your .plzconfig file. These are essentially string-string replacements of the command line, for example 'deploy = run //tools:deployer --' makes 'plz deploy' run a particular tool."`
-	Bazel   struct {
+	Alias   map[string]struct {
+		Cmd        string `help:"Command to run for this alias."`
+		Subcommand string `help:"Known subcommands of this command"`
+		Flag       string `help:"Known flags of this command"`
+	} `help:"Allows defining alias replacements with more detail than the [aliases] section. Otherwise follows the same process, i.e. performs replacements of command strings."`
+	Bazel struct {
 		Compatibility bool `help:"Activates limited Bazel compatibility mode. When this is active several rule arguments are available under different names (e.g. compiler_flags -> copts etc), the WORKSPACE file is interpreted, Makefile-style replacements like $< and $@ are made in genrule commands, etc.\nNote that Skylark is not generally supported and many aspects of compatibility are fairly superficial; it's unlikely this will work for complex setups of either tool." var:"BAZEL_COMPATIBILITY"`
 	} `help:"Bazel is an open-sourced version of Google's internal build tool. Please draws a lot of inspiration from the original tool although the two have now diverged in various ways.\nNonetheless, if you've used Bazel, you will likely find Please familiar."`
 

--- a/src/core/config_flags.go
+++ b/src/core/config_flags.go
@@ -1,0 +1,51 @@
+// +build !bootstrap
+
+package core
+
+import (
+	"github.com/jessevdk/go-flags"
+
+	"strings"
+)
+
+// AttachAliasFlags attaches the alias flags to the given flag parser.
+// It returns true if any modifications were made.
+func (config *Configuration) AttachAliasFlags(parser *flags.Parser) bool {
+	for name, alias := range config.AllAliases() {
+		cmd, _ := parser.AddCommand(name, alias.Desc, alias.Desc, &struct{}{})
+		for _, subcommand := range alias.Subcommand {
+			addSubcommands(cmd, strings.Fields(subcommand))
+		}
+		for _, flag := range alias.Flag {
+			// This is unavailable during bootstrap due to being a local modification.
+			cmd.AddOption(getOption(flag))
+		}
+	}
+	return len(config.Aliases) > 0 || len(config.Alias) > 0
+}
+
+// addSubcommands attaches a series of subcommands to the given command.
+func addSubcommands(cmd *flags.Command, subcommand []string) {
+	if len(subcommand) > 0 && cmd != nil {
+		cmd2 := cmd.Find(subcommand[0])
+		if cmd2 == nil {
+			cmd2, _ = cmd.AddCommand(subcommand[0], "", "", &struct{}{})
+		}
+		addSubcommands(cmd2, subcommand[1:])
+	}
+}
+
+// getOption creates a new flags.Option.
+// This is a fiddle since it doesn't really expose a direct way of doing this programmatically.
+func getOption(name string) *flags.Option {
+	data := struct {
+		Opt string `long:"option"`
+	}{}
+	p := flags.NewParser(&data, 0)
+	opt := p.FindOptionByLongName("option")
+	opt.LongName = strings.TrimLeft(name, "-")
+	if len(name) == 2 && name[0] == '-' {
+		opt.ShortName = rune(name[1])
+	}
+	return opt
+}

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -280,3 +280,13 @@ func TestUpdateArgsWithAliases(t *testing.T) {
 	args = c.UpdateArgsWithAliases([]string{"plz", "mytool", "deploy", "something"})
 	assert.EqualValues(t, []string{"plz", "run", "//mytool:tool", "--", "deploy", "something"}, args)
 }
+
+func TestParseNewFormatAliases(t *testing.T) {
+	c, err := ReadConfigFiles([]string{"src/core/test_data/alias.plzconfig"}, "")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(c.Alias))
+	a := c.Alias["auth"]
+	assert.Equal(t, "run //infra:auth --", a.Cmd)
+	assert.EqualValues(t, []string{"gcp", "aws k8s", "aws ecr"}, a.Subcommand)
+	assert.EqualValues(t, []string{"--host", "--repo"}, a.Flag)
+}

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -289,7 +289,7 @@ func TestParseNewFormatAliases(t *testing.T) {
 	a := c.Alias["auth"]
 	assert.Equal(t, "run //infra:auth --", a.Cmd)
 	assert.EqualValues(t, []string{"gcp", "aws k8s", "aws ecr"}, a.Subcommand)
-	// assert.EqualValues(t, []string{"--host", "--repo"}, a.Flag)
+	assert.EqualValues(t, []string{"--host", "--repo"}, a.Flag)
 }
 
 func TestAttachAliasFlags(t *testing.T) {
@@ -318,4 +318,8 @@ func TestAttachAliasFlags(t *testing.T) {
 	_, err = p.ParseArgs([]string{"plz", "auth", "aws", "e"})
 	assert.NoError(t, err)
 	assert.EqualValues(t, []string{"ecr"}, completions)
+
+	_, err = p.ParseArgs([]string{"plz", "auth", "aws", "--h"})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []string{"--host"}, completions)
 }

--- a/src/core/stub.go
+++ b/src/core/stub.go
@@ -1,0 +1,10 @@
+// +build bootstrap
+
+package core
+
+import "github.com/jessevdk/go-flags"
+
+// AttachAliasFlags is disabled during initial bootstrap.
+func (config *Configuration) AttachAliasFlags(parser *flags.Parser) bool {
+	return false
+}

--- a/src/core/test_data/alias.plzconfig
+++ b/src/core/test_data/alias.plzconfig
@@ -1,0 +1,7 @@
+[alias "auth"]
+cmd = run //infra:auth --
+subcommand = gcp
+subcommand = aws k8s
+subcommand = aws ecr
+flag = --host
+flag = --repo

--- a/src/parse/BUILD
+++ b/src/parse/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//src/parse/asp",
         "//src/parse/rules",
         "//src/utils",
-        "//third_party/go:gcfg",
         "//third_party/go:logging",
     ],
 )

--- a/src/please.go
+++ b/src/please.go
@@ -890,10 +890,7 @@ func handleCompletions(parser *flags.Parser, items []flags.Completion) {
 		cli.InitLogging(0)                // Ensure this is quiet
 		opts.FeatureFlags.NoUpdate = true // Ensure we don't try to update
 		config := readConfigAndSetRoot(false)
-		if len(config.Aliases) > 0 {
-			for k, v := range config.Aliases {
-				parser.AddCommand(k, v, v, &struct{}{})
-			}
+		if config.AttachAliasFlags(parser) {
 			// Run again without this registered as a completion handler
 			parser.CompletionHandler = nil
 			parser.ParseArgs(os.Args[1:])

--- a/src/please.go
+++ b/src/please.go
@@ -884,17 +884,15 @@ func readConfigAndSetRoot(forceUpdate bool) *core.Configuration {
 // handleCompletions handles shell completion. Typically it just prints to stdout but
 // may do a little more if we think we need to handle aliases.
 func handleCompletions(parser *flags.Parser, items []flags.Completion) {
-	if len(items) > 0 {
-		cli.PrintCompletions(items)
+	cli.InitLogging(0)                // Ensure this is quiet
+	opts.FeatureFlags.NoUpdate = true // Ensure we don't try to update
+	config := readConfigAndSetRoot(false)
+	if config.AttachAliasFlags(parser) {
+		// Run again without this registered as a completion handler
+		parser.CompletionHandler = nil
+		parser.ParseArgs(os.Args[1:])
 	} else {
-		cli.InitLogging(0)                // Ensure this is quiet
-		opts.FeatureFlags.NoUpdate = true // Ensure we don't try to update
-		config := readConfigAndSetRoot(false)
-		if config.AttachAliasFlags(parser) {
-			// Run again without this registered as a completion handler
-			parser.CompletionHandler = nil
-			parser.ParseArgs(os.Args[1:])
-		}
+		cli.PrintCompletions(items)
 	}
 	// Regardless of what happened, always exit with 0 at this point.
 	os.Exit(0)

--- a/third_party/go/flags_subcommand.patch
+++ b/third_party/go/flags_subcommand.patch
@@ -24,3 +24,19 @@ index fd2fd5f..3af2af9 100644
  	if (p.Options & PassAfterNonOption) != None {
  		// If PassAfterNonOption is set then all remaining arguments
  		// are considered positional
+diff --git a/group.go b/group.go
+index 9341d23..7f269b2 100644
+--- a/group.go
++++ b/group.go
+@@ -128,6 +128,11 @@ func (g *Group) FindOptionByShortName(shortName rune) *Option {
+ 	})
+ }
+ 
++// AddOption adds a new option to this group.
++func (g *Group) AddOption(option *Option) {
++	g.options = append(g.options, option)
++}
++
+ func newGroup(shortDescription string, longDescription string, data interface{}) *Group {
+ 	return &Group{
+ 		ShortDescription: shortDescription,


### PR DESCRIPTION
This allows having a more complex set of data against each alias, and hence doing some form of tab completion for them with subcommands and so forth. For example:

```
[alias "auth"]
cmd = run //infra:auth --
subcommand = gcp
subcommand = aws k8s
subcommand = aws ecr
flag = --host
flag = --repo
```

which will tab-complete all the way out through `plz auth aws ecr --host blah --repo somewhere`