### PR TITLE
Make scipy work

### DIFF
--- a/test/python_rules/BUILD
+++ b/test/python_rules/BUILD
@@ -137,3 +137,13 @@ python_test(
     ],
     deps = ["//third_party/python:pandas"],
 )
+
+python_test(
+    name = "scipy_test",
+    srcs = ["scipy_test.py"],
+    labels = [
+        "py3",
+        "pip",
+    ],
+    deps = ["//third_party/python:scipy"],
+)

--- a/test/python_rules/scipy_test.py
+++ b/test/python_rules/scipy_test.py
@@ -1,0 +1,8 @@
+import unittest
+
+
+class SciPyTest(unittest.TestCase):
+
+    def test_can_import(self):
+        # This fails to import if we put an __init__.py in the wrong place.
+        from third_party.python.scipy import stats

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -210,3 +210,11 @@ pip_library(
         ":six",
     ],
 )
+
+pip_library(
+    name = "scipy",
+    test_only = True,
+    version = "1.1.0",
+    zip_safe = False,
+    deps = [":numpy"],
+)


### PR DESCRIPTION
Turns out that we are adding slightly too many `__init__.py` files, as discussed on the mailing list. Skip adding them in inappropriate cases.

cc @jeffols , this should fix your issue. Sorry it took a while for me to figure it out...