### PR TITLE
Added function to check output dir does not contain a BUILD file

### DIFF
--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -423,8 +423,6 @@ func asDict(obj pyObject) (pyDict, bool) {
 	return nil, false
 }
 
-
-
 // Target is in a subdirectory, check nobody else owns that.
 func checkSubDir(s *scope, src string) {
 	if strings.Contains(src, "/") {


### PR DESCRIPTION
- This is related to issue [#213](https://github.com/thought-machine/please/issues/213)
- Added `checkSubDir` function in `src/parse/asp/targets.go` to check if src or out  directory contains a build file
