### PR TITLE
Fix protos in plz-out/go

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -576,11 +576,14 @@ func checkLicences(state *core.BuildState, target *core.BuildTarget) {
 // buildLinks builds links from the given target if it's labelled appropriately.
 // For example, Go targets may link themselves into plz-out/go/src etc.
 func buildLinks(state *core.BuildState, target *core.BuildTarget) {
-	for _, dest := range target.PrefixedLabels("link:") {
-		destDir := path.Join(core.RepoRoot, dest, target.Label.PackageName)
-		srcDir := path.Join(core.RepoRoot, target.OutDir())
-		for _, out := range target.Outputs() {
-			symlinkIfNotExists(path.Join(srcDir, out), path.Join(destDir, out))
+	if labels := target.PrefixedLabels("link:"); len(labels) > 0 {
+		env := core.BuildEnvironment(state, target)
+		for _, dest := range labels {
+			destDir := path.Join(core.RepoRoot, os.Expand(dest, env.ReplaceEnvironment))
+			srcDir := path.Join(core.RepoRoot, target.OutDir())
+			for _, out := range target.Outputs() {
+				symlinkIfNotExists(path.Join(srcDir, out), path.Join(destDir, out))
+			}
 		}
 	}
 }

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -184,11 +184,11 @@ func TestRecursiveInitPyCreation(t *testing.T) {
 
 func TestCreatePlzOutGo(t *testing.T) {
 	state, target := newState("//gopkg:target")
-	target.AddLabel("link:plz-out/go/src")
+	target.AddLabel("link:plz-out/go/${PKG}/src")
 	target.AddOutput("file1.go")
 	assert.False(t, fs.PathExists("plz-out/go"))
 	assert.NoError(t, buildTarget(1, state, target))
-	assert.True(t, fs.PathExists("plz-out/go/src/gopkg/file1.go"))
+	assert.True(t, fs.PathExists("plz-out/go/gopkg/src/file1.go"))
 }
 
 func TestLicenceEnforcement(t *testing.T) {

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -36,7 +36,9 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
                     code that you never want to be instrumented.
       filter_srcs (bool): If True, filters source files through Go's standard build constraints.
     """
-    private = name.startswith('_')
+    out = out or name + '.a'
+    private = out.startswith('_')
+    labels = [] if private else ['link:plz-out/go/pkg/%s_%s' % (CONFIG.OS, CONFIG.ARCH)]
     if asm_srcs:
         lib_rule = go_library(
             name = f'_{name}#lib',
@@ -67,13 +69,13 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
                 'lib': [lib_rule],
                 'asm': [asm_rule],
             },
-            outs=[out or name + '.a'],
+            outs=[out],
             tools=[CONFIG.GO_TOOL],
             cmd = 'cp $SRCS_LIB $OUT && chmod +w $OUT && $TOOL tool pack r $OUT $SRCS_ASM',
             visibility = visibility,
             building_description = 'Packing...',
             requires = ['go'],
-            labels = [] if private else ['link:plz-out/go/pkg/%s_%s' % (CONFIG.OS, CONFIG.ARCH)],
+            labels = labels,
             provides = {'go': ':' + name, 'go_src': lib_rule},
             test_only = test_only,
         )
@@ -98,13 +100,13 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
         name=name,
         srcs=srcs,
         deps=deps + [src_rule],
-        outs=[out or name + '.a'],
+        outs=[out],
         cmd=_go_library_cmds(complete=complete, all_srcs=_all_srcs, cover=cover, filter_srcs=filter_srcs),
         visibility=visibility,
         building_description="Compiling...",
         requires=['go', 'go_src'] if _all_srcs else ['go'],
         provides={'go': ':' + name, 'go_src': src_rule},
-        labels = [] if private else ['link:plz-out/go/pkg/%s_%s' % (CONFIG.OS, CONFIG.ARCH)],
+        labels = labels,
         test_only=test_only,
         tools=tools,
         needs_transitive_deps=_needs_transitive_deps,

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -15,8 +15,7 @@ _LINK_PKGS_CMD = ' '.join([
 
 def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=None, deps:list=[],
                visibility:list=None, test_only:bool&testonly=False, complete:bool=True,
-               _needs_transitive_deps=False, _all_srcs=False, cover:bool=True,
-               filter_srcs:bool=True, labels:list=[]):
+               _needs_transitive_deps=False, _all_srcs=False, cover:bool=True, filter_srcs:bool=True):
     """Generates a Go library which can be reused by other rules.
 
     Args:
@@ -36,11 +35,16 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
                     but if this is false they never will be. Can be useful for e.g. third-party
                     code that you never want to be instrumented.
       filter_srcs (bool): If True, filters source files through Go's standard build constraints.
-      labels (list): Additional labels to attach to this rule.
     """
     out = out or name + '.a'
     private = out.startswith('_')
-    labels += [] if private else ['link:plz-out/go/pkg/${OS}_${ARCH}/${PKG}']
+    labels = [] if private else ['link:plz-out/go/pkg/${OS}_${ARCH}/${PKG}']
+    src_labels = [] if private else ['link:plz-out/go/src/${PKG}']
+    libname = out[:-2] if len(out) > 2 else out
+    if libname != basename(package_name()) and not private:
+        # Libraries that are in a directory not of their own name will need the sources in
+        # a subdirectory for go to be able to transparently import them.
+        src_labels += [f'link:plz-out/go/src/$PKG/{libname}']
     if asm_srcs:
         lib_rule = go_library(
             name = f'_{name}#lib',
@@ -90,7 +94,7 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
         exported_deps=deps,
         visibility=visibility,
         requires=['go'],
-        labels = labels + ([] if private else ['link:plz-out/go/src/${PKG}']),
+        labels = src_labels,
         test_only=test_only,
     )
 
@@ -556,6 +560,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
         binary = binary,
         requires = ['go'],
         test_only = test_only,
+        labels = ['link:plz-out/go'],
         sandbox = False,
         needs_transitive_deps = True,
         provides = provides,
@@ -616,7 +621,7 @@ def _go_get_download(name:str, tag:str, get:str, repo:str='', patch:str=None, ha
         cmd = ' && '.join(cmd),
         requires = ['go'],
         test_only = test_only,
-        labels = labels + ['link:plz-out/go/vendor'],
+        labels = labels + ['link:plz-out/go'],
         hashes = hashes,
         sandbox = False,
     ), getroot

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -15,7 +15,8 @@ _LINK_PKGS_CMD = ' '.join([
 
 def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=None, deps:list=[],
                visibility:list=None, test_only:bool&testonly=False, complete:bool=True,
-               _needs_transitive_deps=False, _all_srcs=False, cover:bool=True, filter_srcs:bool=True):
+               _needs_transitive_deps=False, _all_srcs=False, cover:bool=True,
+               filter_srcs:bool=True, labels:list=[]):
     """Generates a Go library which can be reused by other rules.
 
     Args:
@@ -35,10 +36,11 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
                     but if this is false they never will be. Can be useful for e.g. third-party
                     code that you never want to be instrumented.
       filter_srcs (bool): If True, filters source files through Go's standard build constraints.
+      labels (list): Additional labels to attach to this rule.
     """
     out = out or name + '.a'
     private = out.startswith('_')
-    labels = [] if private else ['link:plz-out/go/pkg/%s_%s' % (CONFIG.OS, CONFIG.ARCH)]
+    labels += [] if private else ['link:plz-out/go/pkg/${OS}_${ARCH}/${PKG}']
     if asm_srcs:
         lib_rule = go_library(
             name = f'_{name}#lib',
@@ -88,7 +90,7 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
         exported_deps=deps,
         visibility=visibility,
         requires=['go'],
-        labels = [] if private else ['link:plz-out/go/src'],
+        labels = labels + ([] if private else ['link:plz-out/go/src/${PKG}']),
         test_only=test_only,
     )
 


### PR DESCRIPTION
They aren't getting output because the target is private, but it should be decided by the output filename instead.

Also extend the `link:` pseudo-magic labels to use shell var expansions so we can control them a bit more.

Ditch `vendor` from `go_get` since it isn't in the right place - it should be `plz-out/go/src/vendor/github.com/...` but that isn't easy to do since the output is `src/github.com/...` so we can't put the `vendor` in the right place.