### PR TITLE
Enabled abbreviation syntax for subrepos, ticket 386

### DIFF
--- a/docs/subrepos.html
+++ b/docs/subrepos.html
@@ -51,3 +51,17 @@ cc_test(
 <p>Subrepos also underpin <a href="cross_compiling.html">cross-compiling</a> and share the same
   syntax; you can use that to reference architectures as well. There is currently some ambiguity
   here and so it is best not to define subrepo names that match cross-compile architectures.</p>
+
+<p>If the subrepo and the package names are the same, for example, <code>@unittest_cpp//:unittest_cpp</code>,
+    the build label reference to the target can be abbreviated, like so:</p>
+
+<pre><code>subinclude("@pleasings//go:go_bindata")
+
+cc_test(
+    name = "my_test",
+    ...
+    deps = [
+        "@unittest_cpp",
+    ],
+)
+</code></pre>

--- a/docs/subrepos.html
+++ b/docs/subrepos.html
@@ -55,8 +55,7 @@ cc_test(
 <p>If the subrepo and the package names are the same, for example, <code>@unittest_cpp//:unittest_cpp</code>,
     the build label reference to the target can be abbreviated, like so:</p>
 
-<pre><code>subinclude("@pleasings//go:go_bindata")
-
+<pre><code>
 cc_test(
     name = "my_test",
     ...

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -140,8 +140,9 @@ func parseBuildLabelParts(target, currentPath string, subrepo *Subrepo) (string,
 		// @subrepo//pkg:target or @subrepo:target syntax
 		idx := strings.Index(target, "//")
 		if idx == -1 {
+			// if subrepo and target are the same name, then @subrepo syntax will also suffice
 			if idx = strings.IndexRune(target, ':'); idx == -1 {
-				return "", "", ""
+				return "", target[1:], target[1:]
 			}
 		}
 		pkg, name, _ := parseBuildLabelParts(target[idx:], currentPath, subrepo)

--- a/src/core/build_label_test.go
+++ b/src/core/build_label_test.go
@@ -100,11 +100,11 @@ func TestParseBuildLabelParts(t *testing.T) {
 	pkg, name, subrepo := parseBuildLabelParts(target1, "/", nil)
 	pkg2, name2, subrepo2 := parseBuildLabelParts(targetNewSyntax, "/", nil)
 	assert.Equal(t, pkg, "")
-	assert.Equal(t, pkg, pkg2)
+	assert.Equal(t, pkg2, "")
 	assert.Equal(t, name, "unittest_cpp")
-	assert.Equal(t, name, name2)
+	assert.Equal(t, name2, "unittest_cpp")
 	assert.Equal(t, subrepo, "unittest_cpp")
-	assert.Equal(t, subrepo, subrepo2)
+	assert.Equal(t, subrepo2, "unittest_cpp")
 }
 
 func TestMain(m *testing.M) {

--- a/src/core/build_label_test.go
+++ b/src/core/build_label_test.go
@@ -94,6 +94,16 @@ func TestSubrepoLabel(t *testing.T) {
 	assert.EqualValues(t, BuildLabel{PackageName: "", Name: ""}, label.SubrepoLabel())
 }
 
+func TestParseBuildLabelParts(t *testing.T) {
+	target1 := "@unittest_cpp//:unittest_cpp"
+	targetNewSyntax := "@unittest_cpp"
+	pkg, name, subrepo := parseBuildLabelParts(target1, "/", nil)
+	pkg2, name2, subrepo2 := parseBuildLabelParts(targetNewSyntax, "/", nil)
+	assert.Equal(t, pkg, pkg2)
+	assert.Equal(t, name, name2)
+	assert.Equal(t, subrepo, subrepo2)
+}
+
 func TestMain(m *testing.M) {
 	// Used to support TestComplete, the function it's testing re-execs
 	// itself thinking that it's actually plz.

--- a/src/core/build_label_test.go
+++ b/src/core/build_label_test.go
@@ -99,8 +99,11 @@ func TestParseBuildLabelParts(t *testing.T) {
 	targetNewSyntax := "@unittest_cpp"
 	pkg, name, subrepo := parseBuildLabelParts(target1, "/", nil)
 	pkg2, name2, subrepo2 := parseBuildLabelParts(targetNewSyntax, "/", nil)
+	assert.Equal(t, pkg, "")
 	assert.Equal(t, pkg, pkg2)
+	assert.Equal(t, name, "unittest_cpp")
 	assert.Equal(t, name, name2)
+	assert.Equal(t, subrepo, "unittest_cpp")
 	assert.Equal(t, subrepo, subrepo2)
 }
 


### PR DESCRIPTION
- now supports abbreviation syntax for build target with the same subrepo and package name. for example: `@unittest_cpp//:unittest_cpp` can be shortened to `@unittest_cpp`
- Also added documentation in `subrepo` section