### PR TITLE
Fix for #405

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -329,8 +329,8 @@ func moveOutputs(state *core.BuildState, target *core.BuildTarget) ([]string, bo
 	changed := false
 	tmpDir := target.TmpDir()
 	outDir := target.OutDir()
-	for tmp, output := range target.GetOutputsMapping(target.Outputs()) {
-		tmpOutput := path.Join(tmpDir, tmp)
+	for _, output := range target.Outputs() {
+		tmpOutput := path.Join(tmpDir, target.GetTmpOutput(output))
 		realOutput := path.Join(outDir, output)
 		if !core.PathExists(tmpOutput) {
 			return nil, true, fmt.Errorf("Rule %s failed to create output %s", target.Label, tmpOutput)

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -329,13 +329,8 @@ func moveOutputs(state *core.BuildState, target *core.BuildTarget) ([]string, bo
 	changed := false
 	tmpDir := target.TmpDir()
 	outDir := target.OutDir()
-	for _, output := range target.Outputs() {
-		var tmpOutput string
-		if output == target.Label.PackageName {
-			tmpOutput = path.Join(tmpDir, fmt.Sprintf(core.TmpOutputFormat, output))
-		} else {
-			tmpOutput = path.Join(tmpDir, output)
-		}
+	for tmp, output := range target.GetOutPutsMapping(target.Outputs()) {
+		tmpOutput := path.Join(tmpDir, tmp)
 		realOutput := path.Join(outDir, output)
 		if !core.PathExists(tmpOutput) {
 			return nil, true, fmt.Errorf("Rule %s failed to create output %s", target.Label, tmpOutput)

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -332,7 +332,7 @@ func moveOutputs(state *core.BuildState, target *core.BuildTarget) ([]string, bo
 	for _, output := range target.Outputs() {
 		var tmpOutput string
 		if output == target.Label.PackageName {
-			tmpOutput = path.Join(tmpDir, fmt.Sprintf("%s.out", output))
+			tmpOutput = path.Join(tmpDir, fmt.Sprintf(core.TmpOutputFormat, output))
 		} else {
 			tmpOutput = path.Join(tmpDir, output)
 		}

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -330,7 +330,12 @@ func moveOutputs(state *core.BuildState, target *core.BuildTarget) ([]string, bo
 	tmpDir := target.TmpDir()
 	outDir := target.OutDir()
 	for _, output := range target.Outputs() {
-		tmpOutput := path.Join(tmpDir, output)
+		var tmpOutput string
+		if output == target.Label.PackageName {
+			tmpOutput = path.Join(tmpDir, fmt.Sprintf("%s.out", output))
+		} else {
+			tmpOutput = path.Join(tmpDir, output)
+		}
 		realOutput := path.Join(outDir, output)
 		if !core.PathExists(tmpOutput) {
 			return nil, true, fmt.Errorf("Rule %s failed to create output %s", target.Label, tmpOutput)

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -329,7 +329,7 @@ func moveOutputs(state *core.BuildState, target *core.BuildTarget) ([]string, bo
 	changed := false
 	tmpDir := target.TmpDir()
 	outDir := target.OutDir()
-	for tmp, output := range target.GetOutPutsMapping(target.Outputs()) {
+	for tmp, output := range target.GetOutputsMapping(target.Outputs()) {
 		tmpOutput := path.Join(tmpDir, tmp)
 		realOutput := path.Join(outDir, output)
 		if !core.PathExists(tmpOutput) {

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -15,7 +15,8 @@ var ExpandHomePath func(string) string = fs.ExpandHomePath
 // A BuildEnv is a representation of the build environment that also knows how to log itself.
 type BuildEnv []string
 
-// Temporary formatting for outputs, this is used to avoid name conflicts when packageName and output are the same
+// TmpOutputFormat is a Temporary formatting for outputs, this is used to avoid name conflicts
+// when package directory name and output are the same
 var TmpOutputFormat = "%s.out"
 
 // GeneralBuildEnvironment creates the shell env vars used for a command, not based

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -5,8 +5,7 @@ import (
 	"path"
 	"strings"
 
-	"fmt"
-	"fs"
+		"fs"
 )
 
 // ExpandHomePath is an alias to the function in fs for compatibility.
@@ -14,10 +13,6 @@ var ExpandHomePath func(string) string = fs.ExpandHomePath
 
 // A BuildEnv is a representation of the build environment that also knows how to log itself.
 type BuildEnv []string
-
-// TmpOutputFormat is a Temporary formatting for outputs, this is used to avoid name conflicts
-// when package directory name and output are the same
-var TmpOutputFormat = "%s.out"
 
 // GeneralBuildEnvironment creates the shell env vars used for a command, not based
 // on any specific target etc.
@@ -61,7 +56,7 @@ func BuildEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 	env := buildEnvironment(state, target)
 	sources := target.AllSourcePaths(state.Graph)
 	tmpDir := path.Join(RepoRoot, target.TmpDir())
-	outEnv := getOutPuts(target, target.Outputs())
+	outEnv := target.GetTmpOutput(target.Outputs())
 
 	env = append(env,
 		"TMP_DIR="+tmpDir,
@@ -92,7 +87,7 @@ func BuildEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 	}
 	// Named output groups similarly.
 	for name, outs := range target.DeclaredNamedOutputs() {
-		outs = getOutPuts(target, outs)
+		outs = target.GetTmpOutput(outs)
 		env = append(env, "OUTS_"+strings.ToUpper(name)+"="+strings.Join(outs, " "))
 	}
 	// Named tools as well.
@@ -114,19 +109,19 @@ func BuildEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 	return env
 }
 
-// Get the outputs for the environment variable
-// Check if each output has the same name as the package, this avoids the name conflict issue with go link tool
-func getOutPuts(target *BuildTarget, outputsFromTarget []string) []string {
-	var newOuts []string
-	for _, out := range outputsFromTarget {
-		if out == target.Label.PackageName {
-			newOuts = append(newOuts, fmt.Sprintf(TmpOutputFormat, out))
-		} else {
-			newOuts = append(newOuts, out)
-		}
-	}
-	return newOuts
-}
+//// Get the outputs for the environment variable
+//// Check if each output has the same name as the package, this avoids the name conflict issue with go link tool
+//func getOutPuts(target *BuildTarget, outputsFromTarget []string) []string {
+//	var newOuts []string
+//	for _, out := range outputsFromTarget {
+//		if out == target.Label.PackageName {
+//			newOuts = append(newOuts, fmt.Sprintf(TmpOutputFormat, out))
+//		} else {
+//			newOuts = append(newOuts, out)
+//		}
+//	}
+//	return newOuts
+//}
 
 // TestEnvironment creates the environment variables for a test.
 func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) BuildEnv {

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"strings"
 
-		"fs"
+	"fs"
 )
 
 // ExpandHomePath is an alias to the function in fs for compatibility.
@@ -108,20 +108,6 @@ func BuildEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 	}
 	return env
 }
-
-//// Get the outputs for the environment variable
-//// Check if each output has the same name as the package, this avoids the name conflict issue with go link tool
-//func getOutPuts(target *BuildTarget, outputsFromTarget []string) []string {
-//	var newOuts []string
-//	for _, out := range outputsFromTarget {
-//		if out == target.Label.PackageName {
-//			newOuts = append(newOuts, fmt.Sprintf(TmpOutputFormat, out))
-//		} else {
-//			newOuts = append(newOuts, out)
-//		}
-//	}
-//	return newOuts
-//}
 
 // TestEnvironment creates the environment variables for a test.
 func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) BuildEnv {

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -56,7 +56,7 @@ func BuildEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 	env := buildEnvironment(state, target)
 	sources := target.AllSourcePaths(state.Graph)
 	tmpDir := path.Join(RepoRoot, target.TmpDir())
-	outEnv := target.GetTmpOutput(target.Outputs())
+	outEnv := target.GetTmpOutputAll(target.Outputs())
 
 	env = append(env,
 		"TMP_DIR="+tmpDir,
@@ -87,7 +87,7 @@ func BuildEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 	}
 	// Named output groups similarly.
 	for name, outs := range target.DeclaredNamedOutputs() {
-		outs = target.GetTmpOutput(outs)
+		outs = target.GetTmpOutputAll(outs)
 		env = append(env, "OUTS_"+strings.ToUpper(name)+"="+strings.Join(outs, " "))
 	}
 	// Named tools as well.

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -96,7 +96,15 @@ func BuildEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 	}
 	// Named output groups similarly.
 	for name, outs := range target.DeclaredNamedOutputs() {
-		env = append(env, "OUTS_"+strings.ToUpper(name)+"="+strings.Join(outs, " "))
+		var newOuts []string
+		for _, out := range outs {
+			if out == target.Label.PackageName {
+				newOuts = append(outEnv, fmt.Sprintf("%s.out", out))
+			} else {
+				newOuts = append(outEnv, out)
+			}
+		}
+		env = append(env, "OUTS_"+strings.ToUpper(name)+"="+strings.Join(newOuts, " "))
 	}
 	// Named tools as well.
 	for name, tools := range target.namedTools {

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -5,8 +5,8 @@ import (
 	"path"
 	"strings"
 
-	"fs"
 	"fmt"
+	"fs"
 )
 
 // ExpandHomePath is an alias to the function in fs for compatibility.
@@ -15,8 +15,7 @@ var ExpandHomePath func(string) string = fs.ExpandHomePath
 // A BuildEnv is a representation of the build environment that also knows how to log itself.
 type BuildEnv []string
 
-// Temporary formatting for outputs, this is used to avoid name conflicts
-// when the package name and output are the same
+// Temporary formatting for outputs, this is used to avoid name conflicts when packageName and output are the same
 var TmpOutputFormat = "%s.out"
 
 // GeneralBuildEnvironment creates the shell env vars used for a command, not based
@@ -116,7 +115,7 @@ func BuildEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 
 // Get the outputs for the environment variable
 // Check if each output has the same name as the package, this avoids the name conflict issue with go link tool
-func getOutPuts(target *BuildTarget, outputsFromTarget []string) []string{
+func getOutPuts(target *BuildTarget, outputsFromTarget []string) []string {
 	var newOuts []string
 	for _, out := range outputsFromTarget {
 		if out == target.Label.PackageName {

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -15,6 +15,10 @@ var ExpandHomePath func(string) string = fs.ExpandHomePath
 // A BuildEnv is a representation of the build environment that also knows how to log itself.
 type BuildEnv []string
 
+// Temporary formatting for outputs, this is used to avoid name conflicts
+// when the package name and output are the same
+var TmpOutputFormat = "%s.out"
+
 // GeneralBuildEnvironment creates the shell env vars used for a command, not based
 // on any specific target etc.
 func GeneralBuildEnvironment(config *Configuration) BuildEnv {
@@ -116,7 +120,7 @@ func getOutPuts(target *BuildTarget, outputsFromTarget []string) []string{
 	var newOuts []string
 	for _, out := range outputsFromTarget {
 		if out == target.Label.PackageName {
-			newOuts = append(newOuts, fmt.Sprintf("%s.out", out))
+			newOuts = append(newOuts, fmt.Sprintf(TmpOutputFormat, out))
 		} else {
 			newOuts = append(newOuts, out)
 		}

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -31,10 +31,6 @@ const DefaultBuildingDescription = "Building..."
 const buildDirSuffix = "._build"
 const testDirSuffix = "._test"
 
-// TmpOutputFormat is a Temporary formatting for outputs, this is used to avoid name conflicts
-// when package directory name and output are the same
-const tmpOutputFormat = "%s.out"
-
 // A BuildTarget is a representation of a build target and all information about it;
 // its name, dependencies, build commands, etc.
 type BuildTarget struct {
@@ -463,19 +459,16 @@ func (target *BuildTarget) NamedOutputs(name string) []string {
 	return nil
 }
 
-// GetOutPutsMapping returns a mapping of temporary output(plz-out/tmp/) to real output(plz-out/bin/)
+// GetOutputsMapping returns a mapping of temporary output(plz-out/tmp/) to real output(plz-out/bin/)
 // Check if each output has the same name as the package, this avoids the name conflict issue
-func (target *BuildTarget) GetOutPutsMapping(parseOutputs []string) map[string]string {
+func (target *BuildTarget) GetOutputsMapping(parseOutputs []string) map[string]string {
 	var outputMapping = make(map[string]string, len(parseOutputs))
-	var tmpOutput []string
 
 	for _, out := range parseOutputs {
 		if out == target.Label.PackageName {
-			outputMapping[fmt.Sprintf(tmpOutputFormat, out)] = out
-			tmpOutput = append(tmpOutput, fmt.Sprintf(tmpOutputFormat, out))
+			outputMapping[fmt.Sprintf("%s.out", out)] = out
 		} else {
 			outputMapping[out] = out
-			tmpOutput = append(tmpOutput, out)
 		}
 	}
 
@@ -485,7 +478,7 @@ func (target *BuildTarget) GetOutPutsMapping(parseOutputs []string) map[string]s
 // GetTmpOutput returns a slice of temporary output only, this is used in setting up environment for outputs,
 // e.g: OUTS, OUT
 func (target *BuildTarget) GetTmpOutput(parseOutputs []string) []string {
-	outputMap := target.GetOutPutsMapping(parseOutputs)
+	outputMap := target.GetOutputsMapping(parseOutputs)
 	var tmpOutput []string
 
 	for tmp := range outputMap {

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -475,17 +475,26 @@ func (target *BuildTarget) GetOutputsMapping(parseOutputs []string) map[string]s
 	return outputMapping
 }
 
-// GetTmpOutput returns a slice of temporary output only, this is used in setting up environment for outputs,
-// e.g: OUTS, OUT
-func (target *BuildTarget) GetTmpOutput(parseOutputs []string) []string {
-	outputMap := target.GetOutputsMapping(parseOutputs)
-	var tmpOutput []string
 
-	for tmp := range outputMap {
-		tmpOutput = append(tmpOutput, tmp)
+// GetTmpOutput takes the original output filename as an argument, and returns a temporary output
+// filename(plz-out/tmp/) if output has the same name as the package, this avoids the name conflict issue
+func (target *BuildTarget) GetTmpOutput(parseOutput string) string {
+	if parseOutput == target.Label.PackageName {
+		return fmt.Sprintf("%s.out", parseOutput)
+	}
+	return parseOutput
+}
+
+// GetTmpOutputAll returns a slice of all the temporary outputs this is used in setting up environment for outputs,
+// e.g: OUTS, OUT
+func (target *BuildTarget) GetTmpOutputAll(parseOutputs []string) []string {
+	var tmpOutputs []string
+
+	for _, out := range parseOutputs {
+		tmpOutputs = append(tmpOutputs, target.GetTmpOutput(out))
 	}
 
-	return tmpOutput
+	return tmpOutputs
 }
 
 // SourcePaths returns the source paths for a given set of sources.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -463,7 +463,7 @@ func (target *BuildTarget) NamedOutputs(name string) []string {
 // filename(plz-out/tmp/) if output has the same name as the package, this avoids the name conflict issue
 func (target *BuildTarget) GetTmpOutput(parseOutput string) string {
 	if parseOutput == target.Label.PackageName {
-		return fmt.Sprintf("%s.out", parseOutput)
+		return parseOutput + ".out"
 	}
 	return parseOutput
 }

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -463,7 +463,7 @@ func (target *BuildTarget) NamedOutputs(name string) []string {
 	return nil
 }
 
-// Get a mapping of temporary output(plz-out/tmp/) to real output(plz-out/bin/)
+// GetOutPutsMapping returns a mapping of temporary output(plz-out/tmp/) to real output(plz-out/bin/)
 // Check if each output has the same name as the package, this avoids the name conflict issue
 func (target *BuildTarget) GetOutPutsMapping(parseOutputs []string) map[string]string {
 	var outputMapping = make(map[string]string, len(parseOutputs))
@@ -482,7 +482,8 @@ func (target *BuildTarget) GetOutPutsMapping(parseOutputs []string) map[string]s
 	return outputMapping
 }
 
-// Get the temporary output only, this is used in setting up environment for outputs, e.g: OUTS, OUT
+// GetTmpOutput returns a slice of temporary output only, this is used in setting up environment for outputs,
+// e.g: OUTS, OUT
 func (target *BuildTarget) GetTmpOutput(parseOutputs []string) []string {
 	outputMap := target.GetOutPutsMapping(parseOutputs)
 	var tmpOutput []string

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -459,23 +459,6 @@ func (target *BuildTarget) NamedOutputs(name string) []string {
 	return nil
 }
 
-// GetOutputsMapping returns a mapping of temporary output(plz-out/tmp/) to real output(plz-out/bin/)
-// Check if each output has the same name as the package, this avoids the name conflict issue
-func (target *BuildTarget) GetOutputsMapping(parseOutputs []string) map[string]string {
-	var outputMapping = make(map[string]string, len(parseOutputs))
-
-	for _, out := range parseOutputs {
-		if out == target.Label.PackageName {
-			outputMapping[fmt.Sprintf("%s.out", out)] = out
-		} else {
-			outputMapping[out] = out
-		}
-	}
-
-	return outputMapping
-}
-
-
 // GetTmpOutput takes the original output filename as an argument, and returns a temporary output
 // filename(plz-out/tmp/) if output has the same name as the package, this avoids the name conflict issue
 func (target *BuildTarget) GetTmpOutput(parseOutput string) string {

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1006,11 +1006,7 @@ func (target *BuildTarget) toolPath() string {
 
 // AddOutput adds a new output to the target if it's not already there.
 func (target *BuildTarget) AddOutput(output string) {
-	if output == target.Label.PackageName {
-		target.outputs = target.insert(target.outputs, fmt.Sprintf("%s.out", output))
-	} else {
-		target.outputs = target.insert(target.outputs, output)
-	}
+	target.outputs = target.insert(target.outputs, output)
 }
 
 // AddOptionalOutput adds a new optional output to the target if it's not already there.

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -272,7 +272,7 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
                      (including net/http DNS lookup code potentially).
       filter_srcs (bool): If True, filters source files through Go's standard build constraints.
     """
-    go_library(
+    lib = go_library(
         name=f'_{name}#lib',
         srcs=srcs or [name + '.go'],
         filter_srcs=filter_srcs,
@@ -283,7 +283,7 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
     cmds, tools = _go_binary_cmds(static=static)
     return build_rule(
         name=name,
-        srcs=[f':_{name}#lib'],
+        srcs=[lib],
         deps=deps,
         outs=[out or name],
         cmd=cmds,

--- a/test/BUILD
+++ b/test/BUILD
@@ -424,6 +424,12 @@ python_test(
     labels = ["manual"],
 )
 
+go_binary(
+    name='test',
+    srcs=['name_conflict.go'],
+)
+
+
 # Test that it's not possible to glob the BUILD file at parse time.
 if 'BUILD' in glob(['*']):
     raise ParseError('should not be able to glob the BUILD file')

--- a/test/name_conflict.go
+++ b/test/name_conflict.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
Fixed the issue for the name conflicts when the output name is the same as the package name.
This is because the `go_library` created as a dependency for `go_binary` would generate a directory in plz-out/tmp/, then the `go tool link` tries to generate a binary output file under the same name, thus the conflict. 

To test it, do this command:
`plz run //test:test`