### PR TITLE
Some go linking fixes

### DIFF
--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -15,7 +15,8 @@ _LINK_PKGS_CMD = ' '.join([
 
 def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=None, deps:list=[],
                visibility:list=None, test_only:bool&testonly=False, complete:bool=True,
-               _needs_transitive_deps=False, _all_srcs=False, cover:bool=True, filter_srcs:bool=True):
+               _needs_transitive_deps=False, _all_srcs=False, cover:bool=True,
+               filter_srcs:bool=True, _test:bool=False):
     """Generates a Go library which can be reused by other rules.
 
     Args:
@@ -41,7 +42,7 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
     labels = [] if private else ['link:plz-out/go/pkg/${OS}_${ARCH}/${PKG}']
     src_labels = [] if private else ['link:plz-out/go/src/${PKG}']
     libname = out[:-2] if len(out) > 2 else out
-    if libname != basename(package_name()) and not private:
+    if libname != basename(package_name()) and not private and not _test:
         # Libraries that are in a directory not of their own name will need the sources in
         # a subdirectory for go to be able to transparently import them.
         src_labels += [f'link:plz-out/go/src/$PKG/{libname}']
@@ -339,6 +340,7 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
         deps = deps,
         test_only = True,
         _all_srcs = not external,
+        _test = True,
         complete = False,
     )
     if cgo:
@@ -351,7 +353,7 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
             test_only = True,
             deps = deps,
         )
-    build_rule(
+    main_rule = build_rule(
         name='_%s#main' % name,
         srcs=srcs,
         outs=[name + '_main.go'],
@@ -371,9 +373,9 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
         post_build=lambda name, output: _replace_test_package(name, output, static),
     )
     deps.append(lib_rule)
-    go_library(
+    lib_rule = go_library(
         name='_%s#main_lib' % name,
-        srcs=[':_%s#main' % name],
+        srcs=[main_rule],
         deps=deps,
         _needs_transitive_deps=True,  # Rather annoyingly this is only needed for coverage
         test_only=True,
@@ -385,9 +387,9 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
         test_cmd = '$(worker %s) && %s ' % (worker, test_cmd)
         deps += [worker]
 
-    build_rule(
+    return build_rule(
         name=name,
-        srcs=[':_%s#main_lib' % name],
+        srcs=[lib_rule],
         data=data,
         deps=deps,
         outs=[name],
@@ -440,7 +442,7 @@ def cgo_test(name:str, srcs:list, data:list=None, deps:list=None, visibility:lis
                      It may not be easy to make cgo tests work when linked statically; depending
                      on your toolchain it may not be possible or may fail.
     """
-    go_test(
+    return go_test(
         name = name,
         srcs = srcs,
         data = data,

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -16,7 +16,7 @@ _LINK_PKGS_CMD = ' '.join([
 def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=None, deps:list=[],
                visibility:list=None, test_only:bool&testonly=False, complete:bool=True,
                _needs_transitive_deps=False, _all_srcs=False, cover:bool=True,
-               filter_srcs:bool=True, _test:bool=False):
+               filter_srcs:bool=True, _link_private:bool=False, _link_extra:bool=True):
     """Generates a Go library which can be reused by other rules.
 
     Args:
@@ -38,14 +38,18 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
       filter_srcs (bool): If True, filters source files through Go's standard build constraints.
     """
     out = out or name + '.a'
+    labels = []
+    src_labels = []
     private = out.startswith('_')
-    labels = [] if private else ['link:plz-out/go/pkg/${OS}_${ARCH}/${PKG}']
-    src_labels = [] if private else ['link:plz-out/go/src/${PKG}']
-    libname = out[:-2] if len(out) > 2 else out
-    if libname != basename(package_name()) and not private and not _test:
-        # Libraries that are in a directory not of their own name will need the sources in
-        # a subdirectory for go to be able to transparently import them.
-        src_labels += [f'link:plz-out/go/src/$PKG/{libname}']
+    if _link_private or not private:
+        src_labels = ['link:plz-out/go/src/${PKG}']
+        if not private:
+            labels = ['link:plz-out/go/pkg/${OS}_${ARCH}/${PKG}']
+        libname = out[:-2] if len(out) > 2 else out
+        if libname != basename(package_name()) and _link_extra:
+            # Libraries that are in a directory not of their own name will need the sources in
+            # a subdirectory for go to be able to transparently import them.
+            src_labels += [f'link:plz-out/go/src/$PKG/{libname}']
     if asm_srcs:
         lib_rule = go_library(
             name = f'_{name}#lib',
@@ -280,6 +284,8 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
         asm_srcs=asm_srcs,
         deps=deps,
         test_only=test_only,
+        _link_private = True,
+        _link_extra = False,
     )
     cmds, tools = _go_binary_cmds(static=static)
     return build_rule(
@@ -340,7 +346,7 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
         deps = deps,
         test_only = True,
         _all_srcs = not external,
-        _test = True,
+        _link_extra = False,
         complete = False,
     )
     if cgo:

--- a/test/BUILD
+++ b/test/BUILD
@@ -425,10 +425,9 @@ python_test(
 )
 
 go_binary(
-    name='test',
-    srcs=['name_conflict.go'],
+    name = "test",
+    srcs = ["name_conflict.go"],
 )
-
 
 # Test that it's not possible to glob the BUILD file at parse time.
 if 'BUILD' in glob(['*']):


### PR DESCRIPTION
Should fix #409. It's a bit fiddly but can't see a good way of simplifying really, they're just exceptions to the "standard" rules.