### PR TITLE
Add `plz query changed`

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -92,11 +92,10 @@ var opts struct {
 	VisibilityParse  bool   `description:"Parse all targets that the original targets are visible to. Used for some query steps." no-flag:"true"`
 
 	Build struct {
-		Prepare    bool `long:"prepare" description:"Prepare build directory for these targets but don't build them."`
-		Shell      bool `long:"shell" description:"Like --prepare, but opens a shell in the build directory with the appropriate environment variables."`
-		ShowStatus bool `long:"show_status" hidden:"true" description:"Show status of each target in output after build"`
-		Args       struct {
-			// Inner nesting is necessary to make positional-args work :(
+		Prepare    bool     `long:"prepare" description:"Prepare build directory for these targets but don't build them."`
+		Shell      bool     `long:"shell" description:"Like --prepare, but opens a shell in the build directory with the appropriate environment variables."`
+		ShowStatus bool     `long:"show_status" hidden:"true" description:"Show status of each target in output after build"`
+		Args       struct { // Inner nesting is necessary to make positional-args work :(
 			Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to build"`
 		} `positional-args:"true" required:"true"`
 	} `command:"build" description:"Builds one or more targets"`
@@ -603,8 +602,8 @@ var buildFunctions = map[string]func() bool{
 		for _, label := range query.ChangedLabels(
 			state,
 			query.ChangedRequest{
-				Since: opts.Query.Changed.Since,
-				DiffSpec: opts.Query.Changed.DiffSpec,
+				Since:            opts.Query.Changed.Since,
+				DiffSpec:         opts.Query.Changed.DiffSpec,
 				IncludeDependees: opts.Query.Changed.IncludeDependees,
 			}) {
 			fmt.Printf("%s\n", label)

--- a/src/please.go
+++ b/src/please.go
@@ -342,7 +342,7 @@ var opts struct {
 		Changed struct {
 			Since            string `long:"since" description:"Calculate changes since this tree-ish/scm ref (defaults to current HEAD/tip)."`
 			DiffSpec         string `long:"diffspec" description:"Calculate changes contained within given scm spec (commit range/sha/ref/etc)."`
-			IncludeDependees string `long:"include-dependees" default:"none" description:"Include direct or transitive dependees of changed targets."`
+			IncludeDependees string `long:"include-dependees" default:"none" choice:"none" choice:"direct" choice:"transitive" description:"Include direct or transitive dependees of changed targets."`
 		} `command:"changed" description:"Show changed targets since some diffspec."`
 	} `command:"query" description:"Queries information about the build graph"`
 }

--- a/src/please.go
+++ b/src/please.go
@@ -596,10 +596,20 @@ var buildFunctions = map[string]func() bool{
 		return success
 	},
 	"changed": func() bool {
-		for _, target := range query.ChangedTargetAddresses(query.ChangedRequest{opts.Query.Changed.Since, opts.Query.Changed.DiffSpec, opts.Query.Changed.IncludeDependees}) {
-			fmt.Printf("%s\n", target)
+		success, state := runBuild(opts.Watch.Args.Targets, false, false)
+		if !success {
+			return false
 		}
-		return true;
+		for _, label := range query.ChangedLabels(
+			state,
+			query.ChangedRequest{
+				Since: opts.Query.Changed.Since,
+				DiffSpec: opts.Query.Changed.DiffSpec,
+				IncludeDependees: opts.Query.Changed.IncludeDependees,
+			}) {
+			fmt.Printf("%s\n", label)
+		}
+		return true
 	},
 	"changes": func() bool {
 		// Temporarily set this flag on to avoid fatal errors from the first parse.

--- a/src/please.go
+++ b/src/please.go
@@ -177,10 +177,9 @@ var opts struct {
 	} `command:"run" subcommands-optional:"true" description:"Builds and runs a single target"`
 
 	Clean struct {
-		NoBackground bool `long:"nobackground" short:"f" description:"Don't fork & detach until clean is finished."`
-		Remote       bool `long:"remote" description:"Clean entire remote cache when no targets are given (default is local only)"`
-		Args         struct {
-			// Inner nesting is necessary to make positional-args work :(
+		NoBackground bool     `long:"nobackground" short:"f" description:"Don't fork & detach until clean is finished."`
+		Remote       bool     `long:"remote" description:"Clean entire remote cache when no targets are given (default is local only)"`
+		Args         struct { // Inner nesting is necessary to make positional-args work :(
 			Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to clean (default is to clean everything)"`
 		} `positional-args:"true"`
 	} `command:"clean" description:"Cleans build artifacts" subcommands-optional:"true"`
@@ -595,7 +594,7 @@ var buildFunctions = map[string]func() bool{
 		return success
 	},
 	"changed": func() bool {
-		success, state := runBuild(opts.Watch.Args.Targets, false, false)
+		success, state := runBuild(core.WholeGraph, false, false)
 		if !success {
 			return false
 		}

--- a/src/query/BUILD
+++ b/src/query/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//src/build",
         "//src/cli",
         "//src/core",
+        "//src/scm",
         "//src/utils",
         "//third_party/go:logging",
         "//third_party/go:shlex",

--- a/src/query/changed.go
+++ b/src/query/changed.go
@@ -5,12 +5,14 @@ import (
 	"scm"
 )
 
+// ChangedRequest is a simple parameter object
 type ChangedRequest struct {
 	Since            string
 	DiffSpec         string
 	IncludeDependees string
 }
 
+// ChangedLabels returns all BuildLabels that have changed according to the given request.
 func ChangedLabels(state *core.BuildState, request ChangedRequest) []core.BuildLabel {
 	workspaceChangedFiles := changedFiles(request.Since, request.DiffSpec)
 	if len(workspaceChangedFiles) == 0 {
@@ -18,7 +20,7 @@ func ChangedLabels(state *core.BuildState, request ChangedRequest) []core.BuildL
 	}
 
 	labels := make([]core.BuildLabel, 0)
-	targets := TargetsForChangedFiles(state.Graph, workspaceChangedFiles, request.IncludeDependees)
+	targets := targetsForChangedFiles(state.Graph, workspaceChangedFiles, request.IncludeDependees)
 	for _, t := range targets {
 		if state.ShouldInclude(t) {
 			labels = append(labels, t.Label)
@@ -40,7 +42,7 @@ func changedFiles(since string, diffSpec string) []string {
 	return scm.ChangedFiles(since, true, "")
 }
 
-func TargetsForChangedFiles(graph *core.BuildGraph, files []string, includeDependees string) []*core.BuildTarget {
+func targetsForChangedFiles(graph *core.BuildGraph, files []string, includeDependees string) []*core.BuildTarget {
 	addresses := make([]*core.BuildTarget, 0)
 	for _, target := range graph.AllTargets() {
 		for _, source := range target.Sources {

--- a/src/query/changed.go
+++ b/src/query/changed.go
@@ -6,8 +6,8 @@ import (
 )
 
 type ChangedRequest struct {
-	Since string
-	DiffSpec string
+	Since            string
+	DiffSpec         string
 	IncludeDependees string
 }
 

--- a/src/query/changed.go
+++ b/src/query/changed.go
@@ -1,0 +1,56 @@
+package query
+
+import (
+	"core"
+	"scm"
+)
+
+type ChangedRequest struct {
+	Since string
+	DiffSpec string
+	IncludeDependees string
+}
+
+func ChangedTargetAddresses(graph *core.BuildGraph, request ChangedRequest) []core.BuildLabel {
+	workspaceChangedFiles := changedFiles(request.Since, request.DiffSpec)
+	if len(workspaceChangedFiles) == 0 {
+		return []core.BuildLabel{}
+	}
+
+	return TargetAddressesForChangedFiles(graph, workspaceChangedFiles, request.IncludeDependees)
+}
+
+func changedFiles(since string, diffSpec string) []string {
+	if diffSpec != "" {
+		return scm.ChangesIn(diffSpec, "")
+	}
+
+	if since == "" {
+		since = scm.CurrentRevIdentifier()
+	}
+
+	return scm.ChangedFiles(since, true, "")
+}
+
+func TargetAddressesForChangedFiles(graph *core.BuildGraph, files []string, includeDependees string) []core.BuildLabel {
+	addresses := make([]core.BuildLabel, 0)
+	for _, target := range graph.AllTargets() {
+		for _, source := range target.Sources {
+			if source.Label() == nil {
+				for path := range source.Paths(graph) {
+					for file := range files {
+						if path == file {
+							addresses = append(addresses, target.Label)
+						}
+					}
+				}
+			}
+		}
+	}
+	if includeDependees == "" {
+		return addresses
+	}
+
+	// Find dependees
+	return addresses
+}

--- a/src/query/changed.go
+++ b/src/query/changed.go
@@ -20,7 +20,7 @@ func ChangedLabels(state *core.BuildState, request ChangedRequest) []core.BuildL
 	labels := make([]core.BuildLabel, 0)
 	targets := TargetsForChangedFiles(state.Graph, workspaceChangedFiles, request.IncludeDependees)
 	for _, t := range targets {
-		if state.ShouldInclude(&t) {
+		if state.ShouldInclude(t) {
 			labels = append(labels, t.Label)
 		}
 	}
@@ -40,25 +40,53 @@ func changedFiles(since string, diffSpec string) []string {
 	return scm.ChangedFiles(since, true, "")
 }
 
-func TargetsForChangedFiles(graph *core.BuildGraph, files []string, includeDependees string) []core.BuildTarget {
-	addresses := make([]core.BuildTarget, 0)
+func TargetsForChangedFiles(graph *core.BuildGraph, files []string, includeDependees string) []*core.BuildTarget {
+	addresses := make([]*core.BuildTarget, 0)
 	for _, target := range graph.AllTargets() {
 		for _, source := range target.Sources {
 			if source.Label() == nil {
 				for _, path := range source.Paths(graph) {
 					for _, file := range files {
 						if path == file {
-							addresses = append(addresses, *target)
+							addresses = append(addresses, target)
 						}
 					}
 				}
 			}
 		}
 	}
-	if includeDependees == "" {
+	if includeDependees != "direct" && includeDependees != "transitive" {
 		return addresses
 	}
 
-	// Find dependees - either `direct` or `transitive`
-	return addresses
+	dependents := make(map[*core.BuildTarget]struct{})
+	if includeDependees == "direct" {
+		for _, target := range addresses {
+			dependents[target] = struct{}{}
+
+			for _, dep := range graph.ReverseDependencies(target) {
+				dependents[dep] = struct{}{}
+			}
+		}
+	} else {
+		for _, target := range addresses {
+			visit(dependents, target, graph.ReverseDependencies)
+		}
+	}
+	keys := make([]*core.BuildTarget, len(dependents))
+
+	i := 0
+	for k := range dependents {
+		keys[i] = k
+		i++
+	}
+
+	return keys
+}
+
+func visit(dependents map[*core.BuildTarget]struct{}, target *core.BuildTarget, f func(*core.BuildTarget) []*core.BuildTarget) {
+	for _, dep := range f(target) {
+		dependents[dep] = struct{}{}
+		visit(dependents, dep, f)
+	}
 }

--- a/src/query/changed.go
+++ b/src/query/changed.go
@@ -11,13 +11,21 @@ type ChangedRequest struct {
 	IncludeDependees string
 }
 
-func ChangedTargetAddresses(graph *core.BuildGraph, request ChangedRequest) []core.BuildLabel {
+func ChangedLabels(state *core.BuildState, request ChangedRequest) []core.BuildLabel {
 	workspaceChangedFiles := changedFiles(request.Since, request.DiffSpec)
 	if len(workspaceChangedFiles) == 0 {
 		return []core.BuildLabel{}
 	}
 
-	return TargetAddressesForChangedFiles(graph, workspaceChangedFiles, request.IncludeDependees)
+	labels := make([]core.BuildLabel, 0)
+	targets := TargetsForChangedFiles(state.Graph, workspaceChangedFiles, request.IncludeDependees)
+	for _, t := range targets {
+		if state.ShouldInclude(&t) {
+			labels = append(labels, t.Label)
+		}
+	}
+
+	return labels
 }
 
 func changedFiles(since string, diffSpec string) []string {
@@ -32,15 +40,15 @@ func changedFiles(since string, diffSpec string) []string {
 	return scm.ChangedFiles(since, true, "")
 }
 
-func TargetAddressesForChangedFiles(graph *core.BuildGraph, files []string, includeDependees string) []core.BuildLabel {
-	addresses := make([]core.BuildLabel, 0)
+func TargetsForChangedFiles(graph *core.BuildGraph, files []string, includeDependees string) []core.BuildTarget {
+	addresses := make([]core.BuildTarget, 0)
 	for _, target := range graph.AllTargets() {
 		for _, source := range target.Sources {
 			if source.Label() == nil {
-				for path := range source.Paths(graph) {
-					for file := range files {
+				for _, path := range source.Paths(graph) {
+					for _, file := range files {
 						if path == file {
-							addresses = append(addresses, target.Label)
+							addresses = append(addresses, *target)
 						}
 					}
 				}
@@ -51,6 +59,6 @@ func TargetAddressesForChangedFiles(graph *core.BuildGraph, files []string, incl
 		return addresses
 	}
 
-	// Find dependees
+	// Find dependees - either `direct` or `transitive`
 	return addresses
 }

--- a/src/scm/BUILD
+++ b/src/scm/BUILD
@@ -1,6 +1,11 @@
 go_library(
-    srcs=globs(['*.go'],
+    name="scm",
+    srcs=glob(['*.go'],
                exclude = ["*_test.go"],
     ),
+    deps=[
+        "//src/core",
+        "//third_party/go:logging",
+    ],
     visibility = ["PUBLIC"],
 )

--- a/src/scm/BUILD
+++ b/src/scm/BUILD
@@ -1,0 +1,6 @@
+go_library(
+    srcs=globs(['*.go'],
+               exclude = ["*_test.go"],
+    ),
+    visibility = ["PUBLIC"],
+)

--- a/src/scm/BUILD
+++ b/src/scm/BUILD
@@ -1,11 +1,12 @@
 go_library(
-    name="scm",
-    srcs=glob(['*.go'],
-               exclude = ["*_test.go"],
+    name = "scm",
+    srcs = glob(
+        ["*.go"],
+        exclude = ["*_test.go"],
     ),
-    deps=[
+    visibility = ["PUBLIC"],
+    deps = [
         "//src/core",
         "//third_party/go:logging",
     ],
-    visibility = ["PUBLIC"],
 )

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -1,6 +1,5 @@
 // Package scm abstracts operations on various tools like git
 // Currently, only git
-
 package scm
 
 import (
@@ -15,10 +14,12 @@ import (
 
 var log = logging.MustGetLogger("scm")
 
+// CurrentRevIdentifier returns the string that specifies what the current revision is.
 func CurrentRevIdentifier() string {
 	return "HEAD"
 }
 
+// ChangesIn returns a list of modified files in the given diffSpec.
 func ChangesIn(diffSpec string, relativeTo string) []string {
 	if relativeTo == "" {
 		relativeTo = core.RepoRoot
@@ -31,11 +32,12 @@ func ChangesIn(diffSpec string, relativeTo string) []string {
 	}
 	output := strings.Split(string(out), "\n")
 	for _, o := range output {
-		files = append(files, FixGitRelativePath(strings.TrimSpace(o), relativeTo))
+		files = append(files, fixGitRelativePath(strings.TrimSpace(o), relativeTo))
 	}
 	return files
 }
 
+// ChangedFiles returns a list of modified files since the given commit, optionally including untracked files.
 func ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) []string {
 	if relativeTo == "" {
 		relativeTo = core.RepoRoot
@@ -72,12 +74,12 @@ func ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) [
 	// git will report changed files relative to the worktree: re-relativize to relativeTo
 	normalized := make([]string, 0)
 	for _, f := range files {
-		normalized = append(normalized, FixGitRelativePath(strings.TrimSpace(f), relativeTo))
+		normalized = append(normalized, fixGitRelativePath(strings.TrimSpace(f), relativeTo))
 	}
 	return normalized
 }
 
-func FixGitRelativePath(worktreePath, relativeTo string) string {
+func fixGitRelativePath(worktreePath, relativeTo string) string {
 	p, err := filepath.Rel(relativeTo, path.Join(core.RepoRoot, worktreePath))
 	if err != nil {
 		log.Fatalf("unable to determine relative path for %s and %s", core.RepoRoot, relativeTo)

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -24,7 +24,7 @@ func ChangesIn(diffSpec string, relativeTo string) []string {
 		relativeTo = core.RepoRoot
 	}
 	files := make([]string, 0)
-	command := []string{"diff-tree", "--no-commit-id", "--name-only", "-r", diffSpec }
+	command := []string{"diff-tree", "--no-commit-id", "--name-only", "-r", diffSpec}
 	out, err := exec.Command("git", command...).CombinedOutput()
 	if err != nil {
 		log.Fatalf("unable to determine changes: %s", err)
@@ -52,7 +52,7 @@ func ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) [
 	if fromCommit != "" {
 		// Grab the diff from the merge-base to HEAD using ... syntax.  This ensures we have just
 		// the changes that have occurred on the current branch.
-		command = []string{"diff", "--name-only", fromCommit+"...HEAD"}
+		command = []string{"diff", "--name-only", fromCommit + "...HEAD"}
 		out, err = exec.Command("git", append(command, relSuffix...)...).CombinedOutput()
 		if err != nil {
 			log.Fatalf("unable to check current branch: %s", err)

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -1,0 +1,86 @@
+// Package scm abstracts operations on various tools like git
+// Currently, only git
+
+package scm
+
+import (
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/op/go-logging.v1"
+)
+
+var log = logging.MustGetLogger("scm")
+var worktree = ""
+
+func CurrentRevIdentifier() string {
+	return "HEAD"
+}
+
+func ChangesIn(diffSpec string, relativeTo string) []string {
+	if relativeTo == "" {
+		relativeTo = worktree
+	}
+	files := make([]string, 0)
+	command := []string{"diff-tree", "--no-commit-id", "--name-only", "-r", diffSpec }
+	out, err := exec.Command("git", command...).CombinedOutput()
+	if err != nil {
+		log.Fatalf("unable to determine changes: %s", err)
+	}
+	output := strings.Split(string(out), "\n")
+	for _, o := range output {
+		files = append(files, FixGitRelativePath(strings.TrimSpace(o), relativeTo))
+	}
+	return files
+}
+
+func ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) []string {
+	if relativeTo == "" {
+		relativeTo = worktree
+	}
+	relSuffix := []string{"--", relativeTo}
+	command := []string{"diff", "--name-only", "HEAD"}
+
+	out, err := exec.Command("git", append(command, relSuffix...)...).CombinedOutput()
+	if err != nil {
+		log.Fatalf("unable to find changes: %s", err)
+	}
+	files := strings.Split(string(out), "\n")
+
+	if fromCommit != "" {
+		// Grab the diff from the merge-base to HEAD using ... syntax.  This ensures we have just
+		// the changes that have occurred on the current branch.
+		command = []string{"diff", "--name-only", fromCommit+"...HEAD"}
+		out, err = exec.Command("git", append(command, relSuffix...)...).CombinedOutput()
+		if err != nil {
+			log.Fatalf("unable to check current branch: %s", err)
+		}
+		committedChanges := strings.Split(string(out), "\n")
+		files = append(files, committedChanges...)
+	}
+	if includeUntracked {
+		command = []string{"ls-files", "--other", "--exclude-standard"}
+		out, err = exec.Command("git", append(command, relSuffix...)...).CombinedOutput()
+		if err != nil {
+			log.Fatalf("unable to determine untracked files: %s", err)
+		}
+		untracked := strings.Split(string(out), "\n")
+		files = append(files, untracked...)
+	}
+	// git will report changed files relative to the worktree: re-relativize to relative_to
+	normalized := make([]string, 0)
+	for _, f := range files {
+		normalized = append(normalized, FixGitRelativePath(strings.TrimSpace(f), relativeTo))
+	}
+	return normalized
+}
+
+func FixGitRelativePath(worktreePath, relativeTo string) string {
+	p, err := filepath.Rel(relativeTo, path.Join(worktree, worktreePath))
+	if err != nil {
+		log.Fatalf("unable to determine relative path for %s and %s", worktree, relativeTo)
+	}
+	return p
+}

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -4,6 +4,7 @@
 package scm
 
 import (
+	"core"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 )
 
 var log = logging.MustGetLogger("scm")
-var worktree = ""
 
 func CurrentRevIdentifier() string {
 	return "HEAD"
@@ -21,7 +21,7 @@ func CurrentRevIdentifier() string {
 
 func ChangesIn(diffSpec string, relativeTo string) []string {
 	if relativeTo == "" {
-		relativeTo = worktree
+		relativeTo = core.RepoRoot
 	}
 	files := make([]string, 0)
 	command := []string{"diff-tree", "--no-commit-id", "--name-only", "-r", diffSpec }
@@ -38,7 +38,7 @@ func ChangesIn(diffSpec string, relativeTo string) []string {
 
 func ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) []string {
 	if relativeTo == "" {
-		relativeTo = worktree
+		relativeTo = core.RepoRoot
 	}
 	relSuffix := []string{"--", relativeTo}
 	command := []string{"diff", "--name-only", "HEAD"}
@@ -69,7 +69,7 @@ func ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) [
 		untracked := strings.Split(string(out), "\n")
 		files = append(files, untracked...)
 	}
-	// git will report changed files relative to the worktree: re-relativize to relative_to
+	// git will report changed files relative to the worktree: re-relativize to relativeTo
 	normalized := make([]string, 0)
 	for _, f := range files {
 		normalized = append(normalized, FixGitRelativePath(strings.TrimSpace(f), relativeTo))
@@ -78,9 +78,9 @@ func ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) [
 }
 
 func FixGitRelativePath(worktreePath, relativeTo string) string {
-	p, err := filepath.Rel(relativeTo, path.Join(worktree, worktreePath))
+	p, err := filepath.Rel(relativeTo, path.Join(core.RepoRoot, worktreePath))
 	if err != nil {
-		log.Fatalf("unable to determine relative path for %s and %s", worktree, relativeTo)
+		log.Fatalf("unable to determine relative path for %s and %s", core.RepoRoot, relativeTo)
 	}
 	return p
 }


### PR DESCRIPTION
`plz query changes` is a powerful tool that requires performing multiple builds and changing the state of the workspace - `plz query changed` is a fairly direct port from PantsBuild of a similar but less accurate change detector that does not require extra builds or mutating the directory state.

It will not pick up all changes (such as adding existing files to existing targets) but I intend this to be useful as a best-effort "what have my local changes modified, and what tests should I run?" step