### PR TITLE
Improve surefire reporting in cases where only a few tests are run

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -444,7 +444,14 @@ func (state *BuildState) SetTaskNumbers(active, done int64) {
 
 // ExpandOriginalTargets expands any pseudo-targets (ie. :all, ... has already been resolved to a bunch :all targets)
 // from the set of original targets.
+// Deprecated: Callers should use ExpandOriginalLabels instead.
 func (state *BuildState) ExpandOriginalTargets() BuildLabels {
+	return state.ExpandOriginalLabels()
+}
+
+// ExpandOriginalLabels expands any pseudo-labels (ie. :all, ... has already been resolved to a bunch :all targets)
+// from the set of original labels.
+func (state *BuildState) ExpandOriginalLabels() BuildLabels {
 	ret := BuildLabels{}
 	for _, label := range state.OriginalTargets {
 		if label.IsAllTargets() || label.IsAllSubpackages() {

--- a/src/test/surefire.go
+++ b/src/test/surefire.go
@@ -11,7 +11,8 @@ import (
 // CopySurefireXmlFilesToDir copies all the XML test results files into the given directory.
 func CopySurefireXmlFilesToDir(state *core.BuildState, surefireDir string) {
 	outputDirs := make(map[string]struct{})
-	for _, target := range state.Graph.AllTargets() {
+	for _, label := range state.ExpandOriginalLabels() {
+		target := state.Graph.TargetOrDie(label)
 		if state.ShouldInclude(target) && target.IsTest && !target.NoTestOutput {
 			outputDir := target.OutDir()
 			if !core.PathExists(outputDir) {

--- a/src/test/surefire.go
+++ b/src/test/surefire.go
@@ -9,10 +9,10 @@ import (
 )
 
 // CopySurefireXmlFilesToDir copies all the XML test results files into the given directory.
-func CopySurefireXmlFilesToDir(graph *core.BuildGraph, surefireDir string) {
+func CopySurefireXmlFilesToDir(state *core.BuildState, surefireDir string) {
 	outputDirs := make(map[string]struct{})
-	for _, target := range graph.AllTargets() {
-		if target.IsTest && !target.NoTestOutput {
+	for _, target := range state.Graph.AllTargets() {
+		if state.ShouldInclude(target) && target.IsTest && !target.NoTestOutput {
 			outputDir := target.OutDir()
 			if !core.PathExists(outputDir) {
 				// Unable to find tests


### PR DESCRIPTION
We also fix the profiling at the same time as this was currently not closing the file correctly. It should now work even in the case of please exiting with failure (from the top level)