### PR TITLE
Remade how cancellation works

### DIFF
--- a/tools/build_langserver/langserver/handler.go
+++ b/tools/build_langserver/langserver/handler.go
@@ -123,11 +123,11 @@ func (h *LsHandler) handleInit(ctx context.Context, req *jsonrpc2.Request) (resu
 	}, nil
 }
 
-func (h *LsHandler) handleInitialized(ctx context.Context, request *jsonrpc2.Request) (result interface{}, err error) {
+func (h *LsHandler) handleInitialized(ctx context.Context, req *jsonrpc2.Request) (result interface{}, err error) {
 	return nil, nil
 }
 
-func (h *LsHandler) handleShutDown(ctx context.Context, request *jsonrpc2.Request) (result interface{}, err error) {
+func (h *LsHandler) handleShutDown(ctx context.Context, req *jsonrpc2.Request) (result interface{}, err error) {
 	h.mu.Lock()
 	if h.IsServerDown {
 		log.Warning("Server is already down!")
@@ -137,23 +137,23 @@ func (h *LsHandler) handleShutDown(ctx context.Context, request *jsonrpc2.Reques
 	return nil, nil
 }
 
-func (h *LsHandler) handleExit(ctx context.Context, request *jsonrpc2.Request) (result interface{}, err error) {
-	h.handleShutDown(ctx, request)
+func (h *LsHandler) handleExit(ctx context.Context, req *jsonrpc2.Request) (result interface{}, err error) {
+	h.handleShutDown(ctx, req)
 	h.conn.Close()
 	return nil, nil
 }
 
-func (h *LsHandler) handleCancel(ctx context.Context, request *jsonrpc2.Request) (result interface{}, err error) {
+func (h *LsHandler) handleCancel(ctx context.Context, req *jsonrpc2.Request) (result interface{}, err error) {
 	// Is there is no param with Id, or if there is no requests stored currently, return nothing
-	if request.Params == nil || h.requestStore.IsEmpty() {
+	if req.Params == nil || h.requestStore.IsEmpty() {
 		return nil, nil
 	}
 
 	var params lsp.CancelParams
-	if err := json.Unmarshal(*request.Params, &params); err != nil {
+	if err := json.Unmarshal(*req.Params, &params); err != nil {
 		return nil, &jsonrpc2.Error{
 			Code:    lsp.RequestCancelled,
-			Message: fmt.Sprintf("Cancellation of request(id: %s) failed", request.ID),
+			Message: fmt.Sprintf("Cancellation of request(id: %s) failed", req.ID),
 		}
 	}
 

--- a/tools/build_langserver/langserver/handler.go
+++ b/tools/build_langserver/langserver/handler.go
@@ -5,11 +5,12 @@ import (
 	"core"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 
-	"fmt"
 	"github.com/sourcegraph/jsonrpc2"
 	"gopkg.in/op/go-logging.v1"
+
 	"tools/build_langserver/lsp"
 )
 

--- a/tools/build_langserver/langserver/handler.go
+++ b/tools/build_langserver/langserver/handler.go
@@ -86,7 +86,7 @@ func (h *LsHandler) handleInit(ctx context.Context, req *jsonrpc2.Request) (resu
 	h.init = &params
 
 	// Reset the requestStore, and get sub-context based on request ID
-	reqStore := NewRequestStore()
+	reqStore := newRequestStore()
 	h.requestStore = reqStore
 	ctx = h.requestStore.Store(ctx, req)
 

--- a/tools/build_langserver/langserver/handler.go
+++ b/tools/build_langserver/langserver/handler.go
@@ -84,7 +84,9 @@ func (h *LsHandler) handleInit(ctx context.Context, request *jsonrpc2.Request) (
 	params.EnsureRoot()
 	h.init = &params
 
-	// Get sub-context based on request ID
+	// Reset the requestStore, and get sub-context based on request ID
+	var reqStore requestStore
+	h.requestStore = &reqStore
 	ctx = h.requestStore.Store(ctx, request)
 
 	h.mu.Unlock()

--- a/tools/build_langserver/langserver/handler.go
+++ b/tools/build_langserver/langserver/handler.go
@@ -147,7 +147,7 @@ func (h *LsHandler) handleExit(ctx context.Context, request *jsonrpc2.Request) (
 
 func (h *LsHandler) handleCancel(ctx context.Context, request *jsonrpc2.Request) (result interface{}, err error) {
 	// Is there is no param with Id, or if there is no requests stored currently, return nothing
-	if request.Params == nil || h.requestStore.requests == nil {
+	if request.Params == nil || len(h.requestStore.requests) == 0 {
 		return nil, nil
 	}
 

--- a/tools/build_langserver/langserver/handler.go
+++ b/tools/build_langserver/langserver/handler.go
@@ -7,10 +7,10 @@ import (
 	"errors"
 	"sync"
 
+	"fmt"
 	"github.com/sourcegraph/jsonrpc2"
 	"gopkg.in/op/go-logging.v1"
 	"tools/build_langserver/lsp"
-	"fmt"
 )
 
 var log = logging.MustGetLogger("lsp")
@@ -29,12 +29,12 @@ type handler struct {
 
 // LsHandler is the main handler struct of the language server handler
 type LsHandler struct {
-	init     			*lsp.InitializeParams
-	mu       			sync.Mutex
-	conn     			*jsonrpc2.Conn
+	init *lsp.InitializeParams
+	mu   sync.Mutex
+	conn *jsonrpc2.Conn
 
-	repoRoot 			string
-	requestStore 		*requestStore
+	repoRoot     string
+	requestStore *requestStore
 
 	IsServerDown         bool
 	supportedCompletions []lsp.CompletionItemKind
@@ -153,7 +153,7 @@ func (h *LsHandler) handleCancel(ctx context.Context, request *jsonrpc2.Request)
 	var params lsp.CancelParams
 	if err := json.Unmarshal(*request.Params, &params); err != nil {
 		return nil, &jsonrpc2.Error{
-			Code: lsp.RequestCancelled,
+			Code:    lsp.RequestCancelled,
 			Message: fmt.Sprintf("Cancellation of request(id: %s) failed", request.ID),
 		}
 	}

--- a/tools/build_langserver/langserver/handler.go
+++ b/tools/build_langserver/langserver/handler.go
@@ -86,10 +86,8 @@ func (h *LsHandler) handleInit(ctx context.Context, req *jsonrpc2.Request) (resu
 	h.init = &params
 
 	// Reset the requestStore, and get sub-context based on request ID
-	reqStore := requestStore{
-		requests: make(map[jsonrpc2.ID]request),
-	}
-	h.requestStore = &reqStore
+	reqStore := NewRequestStore()
+	h.requestStore = reqStore
 	ctx = h.requestStore.Store(ctx, req)
 
 	h.mu.Unlock()
@@ -147,7 +145,7 @@ func (h *LsHandler) handleExit(ctx context.Context, request *jsonrpc2.Request) (
 
 func (h *LsHandler) handleCancel(ctx context.Context, request *jsonrpc2.Request) (result interface{}, err error) {
 	// Is there is no param with Id, or if there is no requests stored currently, return nothing
-	if request.Params == nil || len(h.requestStore.requests) == 0 {
+	if request.Params == nil || h.requestStore.IsEmpty() {
 		return nil, nil
 	}
 

--- a/tools/build_langserver/langserver/hover.go
+++ b/tools/build_langserver/langserver/hover.go
@@ -10,13 +10,13 @@ import (
 
 const hoverMethod = "textDocument/hover"
 
-func (h *LsHandler) handleHover(ctx context.Context, request *jsonrpc2.Request) (result interface{}, err error) {
-	if request.Params == nil {
+func (h *LsHandler) handleHover(ctx context.Context, req *jsonrpc2.Request) (result interface{}, err error) {
+	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}
 
 	var params lsp.TextDocumentPositionParams
-	if err := json.Unmarshal(*request.Params, &params); err != nil {
+	if err := json.Unmarshal(*req.Params, &params); err != nil {
 		return nil, err
 	}
 	documentURI, err := EnsureURL(params.TextDocument.URL, "file")

--- a/tools/build_langserver/langserver/request_store.go
+++ b/tools/build_langserver/langserver/request_store.go
@@ -1,0 +1,58 @@
+package langserver
+
+import (
+	"context"
+	"github.com/sourcegraph/jsonrpc2"
+	"sync"
+)
+
+type requestStore struct {
+	mu sync.Mutex
+	requests map[jsonrpc2.ID]request
+}
+
+// Perhaps later we can store more things in the request we might want to use
+type request struct {
+	id 	   string
+	cancel func()
+}
+
+func (rs *requestStore) Store(ctx context.Context, req *jsonrpc2.Request) context.Context {
+	ctx, cancel := context.WithCancel(ctx)
+	rs.mu.Lock()
+	if rs.requests == nil {
+		rs.requests = make(map[jsonrpc2.ID]request)
+	}
+	rs.mu.Unlock()
+
+	rs.mu.Lock()
+
+	// Cancellation function definition,
+	// calling both cancel and delete id from the requests map
+	cancelFunc := func () {
+		rs.mu.Lock()
+		cancel()
+		delete(rs.requests, req.ID)
+		rs.mu.Unlock()
+	}
+
+	rs.requests[req.ID] = request{
+		id: req.ID.String(),
+		cancel: cancelFunc,
+	}
+
+	rs.mu.Unlock()
+
+	// returns the sub-context for the specific request.ID
+	return ctx
+}
+
+
+func (rs *requestStore) Cancel(id jsonrpc2.ID) {
+	rs.mu.Lock()
+	if rs.requests != nil {
+		req := rs.requests[id]
+		req.cancel()
+	}
+	rs.mu.Unlock()
+}

--- a/tools/build_langserver/langserver/request_store.go
+++ b/tools/build_langserver/langserver/request_store.go
@@ -19,8 +19,8 @@ type request struct {
 	cancel func()
 }
 
-// NewRequestsStore constructs a new requestStore with an empty requests map
-func NewRequestStore() *requestStore {
+// newRequestStore constructs a new requestStore with an empty requests map
+func newRequestStore() *requestStore {
 	return &requestStore{
 		requests:make(map[jsonrpc2.ID]request),
 	}
@@ -34,6 +34,8 @@ func (rs *requestStore) IsEmpty() bool {
 	return false
 }
 
+// Store method takes a context and request object and stores the request.ID and cancellation function
+// into requestStore.requests
 func (rs *requestStore) Store(ctx context.Context, req *jsonrpc2.Request) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/tools/build_langserver/langserver/request_store.go
+++ b/tools/build_langserver/langserver/request_store.go
@@ -19,6 +19,21 @@ type request struct {
 	cancel func()
 }
 
+// NewRequestsStore constructs a new requestStore with an empty requests map
+func NewRequestStore() *requestStore {
+	return &requestStore{
+		requests:make(map[jsonrpc2.ID]request),
+	}
+}
+
+// IsEmpty checks if requestStore.requests is empty
+func (rs *requestStore) IsEmpty() bool {
+	if len(rs.requests) == 0  {
+		return true
+	}
+	return false
+}
+
 func (rs *requestStore) Store(ctx context.Context, req *jsonrpc2.Request) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/tools/build_langserver/lsp/specs.go
+++ b/tools/build_langserver/lsp/specs.go
@@ -6,6 +6,10 @@ var EOL = []string{"\n", "\r\n", "\r"}
 // DocumentURI is the uri representation of the filepath, usually prefixed with "files://"
 type DocumentURI string
 
+// RequestCancelled is an error code specific to language server protocol
+// it is been used when the requests returns an error response on cancellation
+const RequestCancelled	int64 = -32800
+
 // Position is the position in a text document expressed as zero-based line and zero-based character offset
 type Position struct {
 	/**


### PR DESCRIPTION
- Added a requestStore object in handler, this struct will handle storing the requestID mapped to the cancellation function.
- Request inside of requestStore is a struct, we can also use this later on if we were to store anything related to this specific request.

p.s. Sub contexts are awesome!