### PR TITLE
HTML-encode the lexicon content.

### DIFF
--- a/docs/template_lexicon.go
+++ b/docs/template_lexicon.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	htmltemplate "html/template"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -47,7 +48,7 @@ func main() {
 	tmpl, err := template.New("lexicon.html").Funcs(template.FuncMap{
 		"join": strings.Join,
 		"newlines": func(s string) string {
-			return strings.Replace(s, "\n", "<br/>", -1)
+			return strings.Replace(htmltemplate.HTMLEscapeString(s), "\n", "<br/>", -1)
 		},
 	}).ParseFiles(
 		"docs/lexicon.html", "docs/lexicon_entry.html")


### PR DESCRIPTION
Fixes the website docs:
<img width="641" alt="screenshot" src="https://user-images.githubusercontent.com/1479315/46571177-47039900-c968-11e8-854f-9077442a0d2e.png">
