### PR TITLE
Clear the cache for badly cached test targets properly

### DIFF
--- a/src/clean/clean.go
+++ b/src/clean/clean.go
@@ -51,7 +51,7 @@ func cleanTarget(state *core.BuildState, target *core.BuildTarget, cleanCache bo
 		log.Fatalf("Failed to remove output: %s", err)
 	}
 	if target.IsTest {
-		if err := test.RemoveCachedTestFiles(target); err != nil {
+		if err := test.RemoveTestOutputs(target); err != nil {
 			log.Fatalf("Failed to remove file: %s", err)
 		}
 	}

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -77,7 +77,7 @@ func test(tid int, state *core.BuildState, label core.BuildLabel, target *core.B
 			state.LogBuildError(tid, label, core.TargetTestFailed, err, "Failed to parse cached test file %s", cachedOutputFile)
 		} else if results.Failures() > 0 {
 			log.Warning("Test results (for %s) with failures shouldn't be cached - ignoring.", label)
-			RemoveCachedTestFiles(target)
+			state.Cache.Clean(target)
 			return nil
 		} else {
 			logTestSuccess(state, tid, label, &results, &coverage)
@@ -166,8 +166,8 @@ func test(tid int, state *core.BuildState, label core.BuildLabel, target *core.B
 	}
 
 	// Remove any cached test result file.
-	if err := RemoveCachedTestFiles(target); err != nil {
-		state.LogBuildError(tid, label, core.TargetTestFailed, err, "Failed to remove cached test files")
+	if err := RemoveTestOutputs(target); err != nil {
+		state.LogBuildError(tid, label, core.TargetTestFailed, err, "Failed to remove test output files")
 		return
 	}
 	if worker, err := startTestWorkerIfNeeded(tid, state, target); err != nil {
@@ -516,8 +516,8 @@ func parseCoverageFile(target *core.BuildTarget, coverageFile string) core.TestC
 	return coverage
 }
 
-// RemoveCachedTestFiles removes any cached test or coverage result files for a target.
-func RemoveCachedTestFiles(target *core.BuildTarget) error {
+// RemoveTestOutputs removes any cached test or coverage result files for a target.
+func RemoveTestOutputs(target *core.BuildTarget) error {
 	if err := os.RemoveAll(target.TestResultsFile()); err != nil {
 		return err
 	} else if err := os.RemoveAll(target.CoverageFile()); err != nil {


### PR DESCRIPTION
Also rename the slightly confusing RemoveCachedTestFiles method to make it clear it's not removing cached test files.