### PR TITLE
Added functionalities for Call type hoverring

### DIFF
--- a/src/parse/asp/grammar.go
+++ b/src/parse/asp/grammar.go
@@ -166,6 +166,8 @@ type IdentStatementAction struct {
 // An IdentExpr implements parts of an expression that begin with an identifier (i.e. anything
 // that might be a variable name).
 type IdentExpr struct {
+	Pos Position
+	EndPos Position
 	Name   string `@Ident`
 	Action []struct {
 		Property *IdentExpr `  "." @@`

--- a/src/parse/asp/grammar_parse.go
+++ b/src/parse/asp/grammar_parse.go
@@ -438,12 +438,14 @@ func (p *parser) parseValueExpression() *ValueExpression {
 	} else if tok.Value == "lambda" {
 		ve.Lambda = p.parseLambda()
 	} else if tok.Type == Ident {
-		ve.Ident, p.endPos = p.parseIdentExpr()
+		ve.Ident = p.parseIdentExpr()
+		p.endPos = ve.Ident.EndPos
 
-		// In case the Ident is a variable name, we assign the endPos to the end of current token.
-		// see test_data/unary_op.build
+		//In case the Ident is a variable name, we assign the endPos to the end of current token.
+		//see test_data/unary_op.build
 		if p.endPos.Column == 0 {
 			p.endPos = tok.EndPos()
+			ve.Ident.EndPos = p.endPos
 		}
 	} else {
 		p.fail(tok, "Unexpected token %s", tok)
@@ -455,7 +457,8 @@ func (p *parser) parseValueExpression() *ValueExpression {
 		tok = p.l.Peek()
 	}
 	if p.optional('.') {
-		ve.Property, p.endPos = p.parseIdentExpr()
+		ve.Property = p.parseIdentExpr()
+		p.endPos = ve.Property.EndPos
 	} else if p.optional('(') {
 		ve.Call = p.parseCall()
 	}
@@ -487,7 +490,8 @@ func (p *parser) parseIdentStatement() *IdentStatement {
 		}
 	case '.':
 		p.initField(&i.Action)
-		i.Action.Property, p.endPos = p.parseIdentExpr()
+		i.Action.Property = p.parseIdentExpr()
+		p.endPos = i.Action.Property.EndPos
 	case '(':
 		p.initField(&i.Action)
 		i.Action.Call = p.parseCall()
@@ -502,20 +506,25 @@ func (p *parser) parseIdentStatement() *IdentStatement {
 	return i
 }
 
-func (p *parser) parseIdentExpr() (*IdentExpr, Position) {
-	var endPos Position
-	ie := &IdentExpr{Name: p.next(Ident).Value}
+func (p *parser) parseIdentExpr() *IdentExpr {
+	//var endPos Position
+	identTok := p.next(Ident)
+	ie := &IdentExpr{
+		Name: identTok.Value,
+		Pos: identTok.Pos,
+	}
 	for tok := p.l.Peek(); tok.Type == '.' || tok.Type == '('; tok = p.l.Peek() {
 		tok := p.l.Next()
 		action := &ie.Action[p.newElement(&ie.Action)]
 		if tok.Type == '.' {
-			action.Property, endPos = p.parseIdentExpr()
+			action.Property = p.parseIdentExpr()
+			ie.EndPos = action.Property.EndPos
 		} else {
 			action.Call = p.parseCall()
-			endPos = p.endPos
+			ie.EndPos = p.endPos
 		}
 	}
-	return ie, endPos
+	return ie
 }
 
 func (p *parser) parseCall() *Call {

--- a/src/parse/asp/parser_test.go
+++ b/src/parse/asp/parser_test.go
@@ -169,7 +169,7 @@ func TestOperators(t *testing.T) {
 func TestIndexing(t *testing.T) {
 	statements, err := newParser().parse("src/parse/asp/test_data/indexing.build")
 	assert.NoError(t, err)
-	assert.Equal(t, 6, len(statements))
+	assert.Equal(t, 7, len(statements))
 
 	assert.Equal(t, "x", statements[0].Ident.Name)
 	assert.NotNil(t, statements[0].Ident.Action.Assign)
@@ -540,6 +540,13 @@ func TestExample3(t *testing.T) {
 	// Test for Endpos
 	assert.Equal(t, 2, stmts[0].EndPos.Column)
 	assert.Equal(t, 4, stmts[0].EndPos.Line)
+
+	// Test for IdentExpr.Endpos
+	property := stmts[0].Ident.Action.Assign.Val.Ident.Action[0].Property
+	assert.Equal(t, 1, property.Pos.Line)
+	assert.Equal(t, 16, property.Pos.Column)
+	assert.Equal(t, 4, property.EndPos.Line)
+	assert.Equal(t, 2, property.EndPos.Column)
 }
 
 func TestExample4(t *testing.T) {
@@ -568,6 +575,19 @@ func TestExample6(t *testing.T) {
 	// Test for Endpos
 	assert.Equal(t, 1, stmts[0].EndPos.Line)
 	assert.Equal(t, 80, stmts[0].EndPos.Column)
+
+	// Test for IdentExpr.Endpos
+	property := stmts[0].Ident.Action.Assign.Val.Property
+	assert.Equal(t, 1, property.Pos.Line)
+	assert.Equal(t, 15, property.Pos.Column)
+	assert.Equal(t, 1, property.EndPos.Line)
+	assert.Equal(t, 60, property.EndPos.Column)
+
+	property = stmts[1].Ident.Action.Call.Arguments[0].Value.Val.Property
+	assert.Equal(t, 4, property.Pos.Line)
+	assert.Equal(t, 31, property.Pos.Column)
+	assert.Equal(t, 4, property.EndPos.Line)
+	assert.Equal(t, 66, property.EndPos.Column)
 }
 
 func TestPrecedence(t *testing.T) {

--- a/src/parse/asp/test_data/example_6.build
+++ b/src/parse/asp/test_data/example_6.build
@@ -1,1 +1,5 @@
 options = ' '.join(['-o ' + option for option in optional]) if optional else ''
+
+Myfunc(
+    name = "{time}-{message}".format(time='today', message='msg')
+)

--- a/src/parse/asp/test_data/indexing.build
+++ b/src/parse/asp/test_data/indexing.build
@@ -9,3 +9,5 @@ a = x[2:]
 b = x[:2]
 
 c = x[y]
+
+b = x[0].startswith('hello')

--- a/tools/build_langserver/langserver/handler.go
+++ b/tools/build_langserver/langserver/handler.go
@@ -77,7 +77,7 @@ func (h *LsHandler) handleInit(ctx context.Context, req *jsonrpc2.Request) (resu
 
 	// Set the Init state of the handler
 	h.mu.Lock()
-	// TODO(bnmetrics): Ideas: this could essentially  be a bit fragile.
+	// TODO(bnmetrics): Ideas: this could essentially be a bit fragile.
 	// maybe we can defer until user send a request with first file URL
 	core.FindRepoRoot()
 

--- a/tools/build_langserver/langserver/hover.go
+++ b/tools/build_langserver/langserver/hover.go
@@ -2,11 +2,11 @@ package langserver
 
 import (
 	"context"
+	"core"
 	"encoding/json"
 	"fmt"
-	"strings"
-
 	"parse/asp"
+	"strings"
 	"tools/build_langserver/lsp"
 
 	"github.com/sourcegraph/jsonrpc2"
@@ -45,8 +45,10 @@ func (h *LsHandler) handleHover(ctx context.Context, req *jsonrpc2.Request) (res
 	}, nil
 }
 
-func getHoverContent(ctx context.Context, analyzer *Analyzer, uri lsp.DocumentURI, position lsp.Position) (content *lsp.MarkupContent, err error) {
+func getHoverContent(ctx context.Context, analyzer *Analyzer,
+					 uri lsp.DocumentURI, position lsp.Position) (content *lsp.MarkupContent, err error) {
 	// Read file, and get a list of strings from the file
+	// TODO: Try using GetLineContent instead
 	fileContent, err := ReadFile(ctx, uri)
 	if err != nil {
 		return nil, &jsonrpc2.Error{
@@ -70,13 +72,17 @@ func getHoverContent(ctx context.Context, analyzer *Analyzer, uri lsp.DocumentUR
 
 	switch ident.Type {
 	case "call":
-		contentString = getCallContent(lineContent, ident, analyzer, position)
+		identArgs := ident.Action.Call.Arguments
+		contentString = getCallContent(ctx, analyzer, identArgs, ident.Name,
+			lineContent, position, uri)
 	case "property":
-		//TODO
+		//TODO(bnmetrics)
 	case "assign":
-		//TODO
+		//TODO(bnmetrics)
+		//identAssign := ident.Action.Assign
+		fmt.Println(ident.IdentStatement.Action.Assign)
 	case "augAssign":
-		//TODO
+		//TODO(bnmetrics)
 	default:
 		//TODO(bnmetrics): handle cases when ident.Action is nil
 	}
@@ -87,104 +93,178 @@ func getHoverContent(ctx context.Context, analyzer *Analyzer, uri lsp.DocumentUR
 	}, nil
 }
 
-func getCallContent(lineContent string, ident *Identifier, analyzer *Analyzer, position lsp.Position) string {
-	var contentString string
+func getCallContent(ctx context.Context, analyzer *Analyzer, args []asp.CallArgument,
+					identName string, lineContent string, pos lsp.Position, uri lsp.DocumentURI) string {
 
+	// Return empty string if the hovered content is blank
+	if isEmpty(lineContent, pos) {
+		return ""
+	}
 	// check if the hovered line is the first line of the function call
-	if strings.Contains(lineContent, ident.Name) {
-		return getRuleDefContent(analyzer, ident.Name)
+	if strings.Contains(lineContent, identName) {
+		return contentFromRuleDef(analyzer, identName)
 	}
 
-	identArgs := ident.Action.Call.Arguments
-	for _, identArg := range identArgs {
-		if content := contentFromNestedCall(analyzer, identArg, lineContent, position); content != "" {
-			return content
-		}
-
-		if content := getArgContent(analyzer, identArg, ident.Name, lineContent, position); content != "" {
-			return content
-		}
-
+	// Return the content for the BuildLabel if the line content is a buildLabel
+	if content, err := contentFromBuildLabel(ctx, analyzer, lineContent, uri);
+		err == nil && content != "" {
+		return content
 	}
 
-	//// check if the hovered line is an argument to the Identifier
-	//// TODO(bnmetrics): revamp!!
-	//if strings.Contains(lineContent, "=") {
-	//	EqualIndex := strings.Index(lineContent, "=")
-	//	// Check if the hover column is the argument definition
-	//	if position.Character < EqualIndex {
-	//
-	//		arg := strings.TrimSpace(lineContent[:EqualIndex])
-	//		identArgs := ident.Action.Call.Arguments
-	//
-	//		for _, identArg := range identArgs {
-	//			// Ensure we are not getting the arguments from nested calls
-	//			if identArg.Name == arg {
-	//				contentString = analyzer.BuiltIns[ident.Name].ArgMap[arg].definition
-	//				break
-	//			} else {
-	//				//TODO(bnmetrics): get the content from nested called, do something with the ident.Call.Arguments
-	//				contentString = ContentFromNestedCall(analyzer, identArg, position)
-	//
-	//				//nestedIdent := identArg.Value.Val.Ident
-	//				//withInRange := bool(position.Line >= identArg.Value.Pos.Line - 1 && position.Line <= (identArg.Value.EndPos.Line - 1))
-	//				//if nestedIdent != nil {
-	//				//	fmt.Println(lineContent, nestedIdent.Name, position.Line, identArg.Value.EndPos.Line - 1)
-	//				//}
-	//				//if nestedIdent != nil && withInRange && nestedIdent.Action != nil {
-	//				//	contentstring := analyzer.BuiltIns[nestedIdent.Name].ArgMap
-	//				//	fmt.Println(contentstring)
-	//				//}
-	//			}
-	//		}
-	//	} else {
-	//
-	//	}
-	//}
-
-	return contentString
-}
-
-func contentFromNestedCall(analyzer *Analyzer, identArg asp.CallArgument, lineContent string, position lsp.Position) string {
-	nestedIdent := identArg.Value.Val.Ident
-	withInRange := position.Line >= identArg.Value.Pos.Line-1 && position.Line <= identArg.Value.EndPos.Line-1
-
-	if nestedIdent != nil && withInRange && nestedIdent.Action != nil {
-		for _, action := range nestedIdent.Action {
-			if action.Call != nil {
-				for _, arg := range action.Call.Arguments {
-					if content := getArgContent(analyzer, arg, nestedIdent.Name, lineContent, position); content != "" {
-						return content
-					}
-				}
-			}
-		}
-		content := getRuleDefContent(analyzer, nestedIdent.Name)
+	if content, err := contentFromIdentArgs(ctx, analyzer, args, identName,
+		lineContent, pos, uri); err == nil && content != "" {
 		return content
 	}
 
 	return ""
 }
 
-// getRuleDefContent returns a string contains the header and the docstring of a build rule
-func getRuleDefContent(analyzer *Analyzer, name string) string {
-	header := analyzer.BuiltIns[name].Header
-	docString := analyzer.BuiltIns[name].Docstring
+func contentFromIdentArgs(ctx context.Context, analyzer *Analyzer, args []asp.CallArgument,
+					 identName string, lineContent string, pos lsp.Position, uri lsp.DocumentURI) (string, error) {
+	builtinRule := analyzer.BuiltIns[identName]
+	for i, identArg := range args {
 
-	return header + "\n\n" + docString
+		// check if the lineContent contains "=", as it could be a keyword argument
+		if strings.Contains(lineContent, "=") {
+
+			EqualIndex := strings.Index(lineContent, "=")
+			hoveredArgName := strings.TrimSpace(lineContent[:EqualIndex])
+
+			if identArg.Name == hoveredArgName {
+				// Return the definition of the argument if the hovering is on the argument name
+				if pos.Character <= EqualIndex {
+					return analyzer.BuiltIns[identName].ArgMap[hoveredArgName].definition, nil
+				}
+
+				if identArg.Value.Val.Property != nil {
+					if content := contentFromProperty(ctx, analyzer, identArg.Value.Val.Property,
+						lineContent, pos, uri); content != "" {
+						return content,nil
+					}
+				}
+				if identArg.Value.Val.String != "" {
+					return contentFromBuildLabel(ctx, analyzer,lineContent, uri)
+				}
+				if identArg.Value.Val.List != nil {
+					return contentFromList(ctx, analyzer, identArg.Value.Val.List, lineContent, pos, uri)
+				}
+				if identArg.Value.Val.Tuple != nil {
+					return contentFromList(ctx, analyzer, identArg.Value.Val.Tuple, lineContent, pos, uri)
+				}
+
+			}
+		// Return definition if the hoverred content is a positional argument
+		} else if identArg.Name == "" {
+			return builtinRule.ArgMap[builtinRule.Arguments[i].Name].definition, nil
+		}
+
+		// Check if each identStatement argument are assigned to a call,
+		// this applies to both keyword and positional arguments
+		if identArg.Value.Val.Ident != nil {
+			if content := contentFromIdent(ctx, analyzer, identArg.Value.Val.Ident,
+				lineContent, pos, uri); content != "" {
+				return content,nil
+			}
+		}
+
+	}
+	return "", nil
 }
 
-func getArgContent(analyzer *Analyzer, identArg asp.CallArgument, name string, lineContent string, position lsp.Position) string {
-	if strings.Contains(lineContent, "=") {
-		EqualIndex := strings.Index(lineContent, "=")
-		if position.Character < EqualIndex {
-			arg := strings.TrimSpace(lineContent[:EqualIndex])
+func contentFromIdent(ctx context.Context, analyzer *Analyzer, IdentValExpr *asp.IdentExpr,
+	lineContent string, pos lsp.Position, uri lsp.DocumentURI) string {
 
-			if identArg.Name == arg {
-				return analyzer.BuiltIns[name].ArgMap[arg].definition
+	// Check if each identStatement argument are assigned to a call
+	withInRange := pos.Line >= IdentValExpr.Pos.Line - 1 &&
+				   pos.Line <= IdentValExpr.EndPos.Line - 1
+
+	if withInRange {
+		return contentFromIdentExpr(ctx, analyzer, IdentValExpr,
+									lineContent, pos, uri)
+	}
+	return ""
+}
+
+func contentFromProperty(ctx context.Context, analyzer *Analyzer, propertyVal *asp.IdentExpr,
+	lineContent string, pos lsp.Position, uri lsp.DocumentURI) string {
+
+	withInRange := pos.Character >= propertyVal.Pos.Column - 1 &&
+				   pos.Character <= propertyVal.EndPos.Column - 1
+
+	if withInRange {
+		return contentFromIdentExpr(ctx, analyzer, propertyVal,
+									lineContent, pos, uri)
+	}
+
+	return ""
+}
+
+
+func contentFromIdentExpr(ctx context.Context, analyzer *Analyzer, identExpr *asp.IdentExpr,
+	lineContent string, pos lsp.Position, uri lsp.DocumentURI) string {
+
+	if identExpr.Action != nil {
+		for _, action := range identExpr.Action {
+			if action.Call != nil {
+				content := getCallContent(ctx, analyzer, action.Call.Arguments,
+					identExpr.Name, lineContent, pos, uri)
+				if content != "" {
+					return content
+				}
 			}
 		}
 	}
 
 	return ""
+}
+
+
+func contentFromList(ctx context.Context, analyzer *Analyzer, listVal *asp.List,
+					 lineContent string, pos lsp.Position, uri lsp.DocumentURI) (string, error) {
+	for _, expr := range listVal.Values {
+		withInRange := pos.Character >= expr.Pos.Column - 1 &&
+					   pos.Character <= expr.EndPos.Column - 1
+
+		if withInRange && expr.Val.String != "" {
+			return contentFromBuildLabel(ctx, analyzer, expr.Val.String, uri)
+		}
+
+		if expr.Val.List != nil {
+			return contentFromList(ctx, analyzer, expr.Val.List, lineContent, pos, uri)
+		}
+		if expr.Val.Tuple != nil {
+			return contentFromList(ctx, analyzer, expr.Val.Tuple, lineContent, pos, uri)
+		}
+	}
+
+	return "", nil
+}
+
+func isEmpty(lineContent string, pos lsp.Position) bool {
+	return len(lineContent) < pos.Character + 1 || strings.TrimSpace(lineContent[:pos.Character]) == ""
+}
+
+func contentFromBuildLabel(ctx context.Context, analyzer *Analyzer,
+	  					   lineContent string, uri lsp.DocumentURI) (string, error) {
+	trimed := TrimQoutes(lineContent)
+	if core.LooksLikeABuildLabel(trimed) {
+		buildLabel, err := analyzer.BuildLabelFromString(ctx, core.RepoRoot, uri, trimed)
+		if err != nil {
+			return "", err
+		}
+		return buildLabel.BuildDefContent, nil
+	}
+
+	return "", nil
+}
+
+// contentFromRuleDef returns a string contains the header and the docstring of a build rule
+func contentFromRuleDef(analyzer *Analyzer, name string) string {
+	header := analyzer.BuiltIns[name].Header
+	docString := analyzer.BuiltIns[name].Docstring
+
+	if docString != "" {
+		return header + "\n\n" + docString
+	}
+	return header
 }

--- a/tools/build_langserver/langserver/hover_test.go
+++ b/tools/build_langserver/langserver/hover_test.go
@@ -3,41 +3,140 @@ package langserver
 import (
 	"context"
 	"core"
+	"os"
 	"path"
+	"strings"
 	"testing"
 	"tools/build_langserver/lsp"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetHoverContent(t *testing.T) {
+func TestMain(m *testing.M) {
 	core.FindRepoRoot()
-	ctx := context.Background()
-	filepath := path.Join(core.RepoRoot, "tools/build_langserver/langserver/test_data/example.build")
-	uri := lsp.DocumentURI("file://" + filepath)
+	retCode := m.Run()
+	os.Exit(retCode)
+}
 
-	analyzer := newAnalyzer()
-	// Test hovering on the function call
-	content, err := getHoverContent(ctx, analyzer, uri, lsp.Position{Line: 0, Character: 3})
-	expected := analyzer.BuiltIns["go_library"].Header + "\n\n"  + analyzer.BuiltIns["go_library"].Docstring
+var ctx = context.Background()
+var filePath = path.Join(core.RepoRoot, "tools/build_langserver/langserver/test_data/example.build")
+var exampleBuildUri = lsp.DocumentURI("file://" + filePath)
+var analyzer = newAnalyzer()
+
+func TestGetHoverContentOnBuildDefName(t *testing.T) {
+	content, err := getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line: 0, Character: 3})
+	expected := analyzer.BuiltIns["go_library"].Header + "\n\n" + analyzer.BuiltIns["go_library"].Docstring
 
 	assert.Equal(t, nil, err)
 	assert.Equal(t, expected, content.Value)
+}
 
-	// Test hovering over arguments
-	content, err = getHoverContent(ctx, analyzer, uri, lsp.Position{Line:7, Character:7})
+func TestGetHoverContentOnArgument(t *testing.T) {
+	// Test hovering over argument name
+	content, err := getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line:7, Character:7})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "deps required:false, type:list", content.Value)
 
-	// Test hovering over nexted call
-	content, err = getHoverContent(ctx, analyzer, uri, lsp.Position{Line:5, Character:10})
+	// Test hovering over argument name with nested call
+	content, err = getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line: 2, Character: 7})
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "def glob(include:list, exclude:list&excludes=[], hidden:bool=False)\n\n",
+	assert.Equal(t, "srcs required:true, type:list",
 		content.Value)
 
-	// Test hovering over argument of nexted call
-	content, err = getHoverContent(ctx, analyzer, uri, lsp.Position{Line:4, Character:15})
+	// Test hovering over argument content
+
+	// when build label is a label for including all sub packages
+	content, err = getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line:6, Character:21})
+	assert.Equal(t, nil, err)
+	expected := "BuildLabel includes all subpackages in path: " +
+		core.RepoRoot + "/tools/build_langserver"
+	assert.Equal(t, expected, content.Value)
+
+	// When build label is definitive, e.g. "//src/core" or "//src/core:core"
+	content, err = getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line:6, Character:57})
+	expectedContent := []string{"go_library(", "    name = \"core\",", "    srcs = glob("}
+	assert.Equal(t, nil, err)
+	// Checking only the first 3 line
+	splited := strings.Split(content.Value, "\n")
+	assert.Equal(t, expectedContent, splited[:3])
+}
+
+func TestGetHoverContentOnNestedCall(t *testing.T) {
+	// Test hovering over nested call on definition, e.g. glob(
+	content, err := getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line: 2, Character: 15})
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "def glob(include:list, exclude:list&excludes=[], hidden:bool=False)",
+		content.Value)
+
+	// Test hovering over nested call on ending parenthese
+	content, err = getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line: 5, Character: 6})
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "", content.Value)
+
+	// Test hovering over argument assignment of nested call
+	content, err = getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line:4, Character:15})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "exclude required:false, type:list",
 		content.Value)
+
+	content, err = getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line:3, Character:15})
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "include required:true, type:list",
+		content.Value)
+	t.Log(content.Value)
 }
+
+func TestGetHoverContentOnEmptyContent(t *testing.T) {
+	content, err := getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line: 1, Character: 3})
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "", content.Value)
+
+	content, err = getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line: 2, Character: 30})
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "", content.Value)
+}
+
+
+func TestGetHoverContentOnBuildLabels(t *testing.T) {
+	// Test hovering over buildlabels
+	content, err := getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line:13, Character:15})
+	expected := "go_get(\n" +
+		"    name = \"jsonrpc2\",\n"+
+		"    get = \"github.com/sourcegraph/jsonrpc2\",\n" +
+		"    revision = \"549eb959f029d014d623104d40ab966d159a92de\",\n" +
+		")"
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expected, content.Value)
+}
+
+
+func TestGetHoverContentOnNoneBuildLabelString(t *testing.T) {
+	content, err := getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line:20, Character: 18})
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "", content.Value)
+}
+
+func TestGetHoverContentOnArgumentWithProperty(t *testing.T) {
+	// Hover on argument name
+	content, err := getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line:34, Character: 6})
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "name required:true, type:str", content.Value)
+
+	// Hover on property name
+	content, err = getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line:34, Character: 20})
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "", content.Value)
+
+	// Hover on property call
+	content, err = getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line:34, Character: 34})
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "str.format()", content.Value)
+}
+
+// TODO(bnm): make this work, and this should go in the assign part of Ident.Type, line 81
+func TestGetHoverContentOnPropertyAssignment(t *testing.T) {
+	content, err := getHoverContent(ctx, analyzer, exampleBuildUri, lsp.Position{Line:42, Character: 30})
+	assert.Equal(t, nil, err)
+	t.Log(content.Value)
+}
+

--- a/tools/build_langserver/langserver/test_data/example.build
+++ b/tools/build_langserver/langserver/test_data/example.build
@@ -4,7 +4,7 @@ go_library(
         ["*.go"],
         exclude = ["*_test.go"],
     ),
-    visibility = ["//tools/build_langserver/..."],
+    visibility = ["//tools/build_langserver/...", "//src/core"],
     deps = [
         "//src/core",
         "//src/fs",
@@ -32,10 +32,12 @@ go_test(
 )
 
 go_test(
-    name = "utils_test",
+    name ="{time}-{message}".format(time='today', message='msg'),
     srcs = ["utils_test.go"],
     deps = [
         ":langserver",
         "//third_party/go:testify",
     ],
 )
+
+mystr = "{time}-{message}".format(time='today', message='msg')

--- a/tools/build_langserver/langserver/utils.go
+++ b/tools/build_langserver/langserver/utils.go
@@ -8,6 +8,7 @@ import (
 	"fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"tools/build_langserver/lsp"
@@ -126,4 +127,19 @@ func doIOScan(uri lsp.DocumentURI, callback func(scanner *bufio.Scanner) ([]stri
 	scanner := bufio.NewScanner(file)
 
 	return callback(scanner)
+}
+
+// TrimQoutes is used to trim the qouted string
+// this will also work for string with any extra characters outside of qoutes
+// like so: "//src/core",
+func TrimQoutes(str string) string {
+	// Regex match the string starts with qoute("),
+	// this is so that strings like this(visibility = ["//tools/build_langserver/...", "//src/core"]) won't be matched
+	re := regexp.MustCompile(`(^("|')([^"]|"")*("|'))`)
+	matched := re.FindString(strings.TrimSpace(str))
+	if matched != "" {
+		return matched[1:len(matched)-1]
+	}
+
+	return ""
 }

--- a/tools/build_langserver/langserver/utils_test.go
+++ b/tools/build_langserver/langserver/utils_test.go
@@ -119,8 +119,25 @@ func TestGetLineContent(t *testing.T) {
 	assert.Equal(t, strings.TrimSpace(line[0]), "go_library(")
 }
 
+func TestTrimQoutes(t *testing.T) {
+	trimed := TrimQoutes("\"blah\"")
+	assert.Equal(t, trimed, "blah")
+
+	trimed= TrimQoutes("\"//src/core\",")
+	assert.Equal(t, "//src/core", trimed)
+
+	trimed= TrimQoutes("'blah")
+	assert.Equal(t, "", trimed)
+
+
+	// this is to make sure our regex works,
+	// so it doesn't just match anything with a build label
+	trimed= TrimQoutes("visibility = [\"//tools/build_langserver/...\", \"//src/core\"]")
+	assert.Equal(t, "", trimed)
+}
+
 /*
- * Utilities for tests in this file
+ * Utilities function for tests in this file
  */
 func getFileinCwd(name string) (lsp.DocumentURI, error) {
 	core.FindRepoRoot()

--- a/tools/build_langserver/outline.txt
+++ b/tools/build_langserver/outline.txt
@@ -49,7 +49,7 @@ Completion
 - build labels
 - build_def functions,
 - arg suggestions
--
+- ******plz query completion******
 
 
 BINARY


### PR DESCRIPTION
- I needed the `Pos` and `EndPos` for the `IdentExpr` as well, so I added them on to the `grammar.go`. Not so surprisingly, it cleaned up that function `parseIdentExpr`.
- Most of the puzzle pieces for hovering should be done. I have used that in function call type of `IdentStatement`. The rest of it should be only fitting the pieces together. (Unless I changed my mind again)

- Added functionality in `analyzer.go` for obtaining info on `BuildLabels`(Analyzer.BuildLabelFromString()).