### PR TITLE
Small cleanup on hover

### DIFF
--- a/tools/build_langserver/langserver/analyzer.go
+++ b/tools/build_langserver/langserver/analyzer.go
@@ -199,7 +199,7 @@ func (a *Analyzer) AspStatementFromFile(uri lsp.DocumentURI) ([]*asp.Statement, 
 
 	stmts, err := a.parser.ParseData(bytecontent, filepath)
 	if err != nil {
-		log.Warning("parsing failure: %s ", err)
+		log.Warning("reading only partial of the file due to parsing failure: %s ", err)
 	}
 
 	return stmts, nil

--- a/tools/build_langserver/langserver/completion_test.go
+++ b/tools/build_langserver/langserver/completion_test.go
@@ -118,6 +118,7 @@ func TestCompletionWithDictMethods(t *testing.T) {
 
 func TestCompletionWithBuildLabels(t *testing.T) {
 	ctx := context.Background()
+
 	err := storeFile(ctx, completionLabelURI)
 	assert.Equal(t, nil, err)
 
@@ -140,6 +141,14 @@ func TestCompletionWithBuildLabels(t *testing.T) {
 	assert.Equal(t, 1, len(items))
 	assert.Equal(t, "query", items[0].Label)
 	t.Log(items[0].Label)
+}
+
+func TestCompletionWithBuildLabels2(t *testing.T) {
+	ctx := context.Background()
+
+	items, err := handler.getCompletionItemsList(ctx, completionLabelURI, lsp.Position{Line: 4, Character: 7})
+	assert.Equal(t, nil, err)
+	t.Log(items)
 }
 
 func TestCompletionIncompleteFile(t *testing.T) {

--- a/tools/build_langserver/langserver/completion_test.go
+++ b/tools/build_langserver/langserver/completion_test.go
@@ -154,9 +154,10 @@ func TestCompletionWithBuildLabels2(t *testing.T) {
 func TestCompletionIncompleteFile(t *testing.T) {
 	//TODO(BNM)
 	t.Log(core.LooksLikeABuildLabel("//bkag//bh"))
-	stmt, err := analyzer.AspStatementFromFile(completionURI)
-	t.Log(stmt)
-	t.Log(err)
+	//stmt, err := analyzer.AspStatementFromFile(completionURI)
+	//t.Log(stmt)
+	//t.Log(err)
+	t.Log(analyzer.BuildFileURIFromPackage(""))
 }
 
 /***************************************

--- a/tools/build_langserver/langserver/handler.go
+++ b/tools/build_langserver/langserver/handler.go
@@ -125,7 +125,7 @@ func (h *LsHandler) handleInit(ctx context.Context, req *jsonrpc2.Request) (resu
 	TDsync := lsp.SyncIncremental
 	completeOps := &lsp.CompletionOptions{
 		ResolveProvider:   false,
-		TriggerCharacters: []string{".", "//", ":"},
+		TriggerCharacters: []string{".", ":"},
 	}
 
 	sigHelpOps := &lsp.SignatureHelpOptions{

--- a/tools/build_langserver/langserver/hover.go
+++ b/tools/build_langserver/langserver/hover.go
@@ -294,17 +294,13 @@ func contentFromList(ctx context.Context, analyzer *Analyzer, listVal *asp.List,
 			continue
 		}
 
-		if expr.Val.String != "" {
-			return contentFromBuildLabel(ctx, analyzer, expr.Val.String, uri)
-		} else {
-			content, err := contentFromValueExpression(ctx, analyzer, expr.Val,
-				lineContent, uri, pos)
-			if err != nil {
-				return "", err
-			}
-			if content != "" {
-				return content, nil
-			}
+		content, err := contentFromValueExpression(ctx, analyzer, expr.Val,
+			lineContent, uri, pos)
+		if err != nil {
+			return "", err
+		}
+		if content != "" {
+			return content, nil
 		}
 	}
 

--- a/tools/build_langserver/langserver/hover.go
+++ b/tools/build_langserver/langserver/hover.go
@@ -312,9 +312,9 @@ func contentFromList(ctx context.Context, analyzer *Analyzer, listVal *asp.List,
 }
 
 func contentFromBuildLabel(ctx context.Context, analyzer *Analyzer,
-	lineContent string, uri lsp.DocumentURI) (string, error) {
+	buildLabelstr string, uri lsp.DocumentURI) (string, error) {
 
-	trimed := TrimQuotes(strings.TrimSpace(lineContent))
+	trimed := TrimQuotes(buildLabelstr)
 
 	if core.LooksLikeABuildLabel(trimed) {
 		buildLabel, err := analyzer.BuildLabelFromString(ctx, uri, trimed)

--- a/tools/build_langserver/langserver/hover.go
+++ b/tools/build_langserver/langserver/hover.go
@@ -41,8 +41,6 @@ func (h *LsHandler) handleHover(ctx context.Context, req *jsonrpc2.Request) (res
 		return nil, err
 	}
 
-	// TODO(bnm): reconsider the content, because right now everything is on one line.....:(
-
 	markedString := lsp.MarkedString{
 		Language: "build",
 		Value:    content,

--- a/tools/build_langserver/langserver/hover_test.go
+++ b/tools/build_langserver/langserver/hover_test.go
@@ -183,6 +183,14 @@ func TestGetHoverContentOnPropertyAssignment(t *testing.T) {
 	assert.Equal(t, "def subinclude(target:str, hash:str=None)", content)
 }
 
+func TestGetHoverAssignmentBuildLabel(t *testing.T) {
+	var ctx = context.Background()
+
+	content, err := handler.getHoverContent(ctx, assignBuildURI, lsp.Position{Line: 25, Character: 13})
+	assert.Equal(t, nil, err)
+	t.Log("LUNA" + content)
+}
+
 func TestGetHoverContentOnUnaryAssignment(t *testing.T) {
 	var ctx = context.Background()
 

--- a/tools/build_langserver/langserver/hover_test.go
+++ b/tools/build_langserver/langserver/hover_test.go
@@ -187,8 +187,10 @@ func TestGetHoverAssignmentBuildLabel(t *testing.T) {
 	var ctx = context.Background()
 
 	content, err := handler.getHoverContent(ctx, assignBuildURI, lsp.Position{Line: 25, Character: 13})
+	expected := []string{"go_library(", "    name = \"fs\",", "    srcs = ["}
+
 	assert.Equal(t, nil, err)
-	t.Log("LUNA" + content)
+	assert.Equal(t, strings.Split(content, "\n")[:3], expected)
 }
 
 func TestGetHoverContentOnUnaryAssignment(t *testing.T) {

--- a/tools/build_langserver/langserver/test_data/assignment.build
+++ b/tools/build_langserver/langserver/test_data/assignment.build
@@ -22,3 +22,5 @@ label_list_single = ["//src/fs", "//src/core"]
 if_assign = "hello" if len("") else subinclude("//build_defs:fpm")
 
 augassign += len(replace_str)
+
+target = "//src/fs"

--- a/tools/build_langserver/langserver/test_data/completion_buildlabels.build
+++ b/tools/build_langserver/langserver/test_data/completion_buildlabels.build
@@ -1,3 +1,5 @@
 "//src"
 "//src/query:"
 "//src/query:q"
+
+"//src/"

--- a/tools/build_langserver/langserver/utils.go
+++ b/tools/build_langserver/langserver/utils.go
@@ -66,7 +66,6 @@ func GetPathFromURL(uri lsp.DocumentURI, pathType string) (documentPath string, 
 
 // PackageLabelFromURI returns a build label of a package
 func PackageLabelFromURI(uri lsp.DocumentURI) (string, error) {
-	// TODO(bnm): need to check if the build file matches the build file name set in config
 	filePath, err := GetPathFromURL(uri, "file")
 	if err != nil {
 		return "", err

--- a/tools/build_langserver/langserver/utils_test.go
+++ b/tools/build_langserver/langserver/utils_test.go
@@ -132,7 +132,10 @@ func TestTrimQoutes(t *testing.T) {
 	trimed := TrimQuotes("\"blah\"")
 	assert.Equal(t, trimed, "blah")
 
-	trimed = TrimQuotes("\"//src/core\",")
+	trimed = TrimQuotes(`"//src/core",`)
+	assert.Equal(t, "//src/core", trimed)
+
+	trimed = TrimQuotes(`     "//src/core",`)
 	assert.Equal(t, "//src/core", trimed)
 
 	trimed = TrimQuotes("'blah")
@@ -140,10 +143,10 @@ func TestTrimQoutes(t *testing.T) {
 
 	// this is to make sure our regex works,
 	// so it doesn't just match anything with a build label
-	trimed = TrimQuotes("visibility = [\"//tools/build_langserver/...\", \"//src/core\"]")
-	assert.Equal(t, "visibility = [\"//tools/build_langserver/...\", \"//src/core\"]", trimed)
+	trimed = TrimQuotes(`visibility = ["//tools/build_langserver/...", "//src/core"]`)
+	assert.Equal(t, `visibility = ["//tools/build_langserver/...", "//src/core"]`, trimed)
 
-	trimed = TrimQuotes("\"//src/core")
+	trimed = TrimQuotes(`"//src/core`)
 	assert.Equal(t, "//src/core", trimed)
 }
 


### PR DESCRIPTION
I noticed a bug in the hover that prevents assignment of buildlabels from displaying the content.
I think this could be included in our next release with the LPS
