### PR TITLE
Fix having multiple .tar.xz targets

### DIFF
--- a/src/parse/rules/misc_rules.build_defs
+++ b/src/parse/rules/misc_rules.build_defs
@@ -371,7 +371,7 @@ def tarball(name:str, srcs:list, out:str=None, deps:list=None, subdir:str=None, 
     tar_name = name
     if xzip:
         tar_out = name + '.tar'
-        tar_name = f'_name#tar'
+        tar_name = f'_{name}#tar'
     elif gzip:
         cmd += ' -z'
     if subdir:


### PR DESCRIPTION
Otherwise you get:
```
$ plz build --nocolour
15:46:41.167 WARNING: in CheckAndUpdate
15:46:41.201   ERROR: //src/update:all failed:
Duplicate build target in src/update: _name#tar
Build stopped after 60ms. 1 target failed:
    //src/update:all
src/parse/rules/misc_rules.build_defs:380:16: error: Duplicate build target in src/update: _name#tar

    tar_rule = build_rule(
               ^
        name = tar_name,

Traceback:
src/parse/rules/misc_rules.build_defs:380:16:       tar_rule = build_rule(

                     src/update/BUILD: 83: 1:   tarball(
```