### PR TITLE
Added handler for textDocument/formatting

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,12 +1,19 @@
 deps = []
 
-for src in glob(['*.html'], exclude=['template.html', 'lexicon*.html', 'language.html']):
+for src in glob(
+    ["*.html"],
+    exclude = [
+        "template.html",
+        "lexicon*.html",
+        "language.html",
+    ],
+):
     templated_rule = genrule(
-        name = src.replace('.', '_'),
-        srcs = ['template.html', src],
-        tools = [':templater'],
+        name = src.replace(".", "_"),
+        srcs = ["template.html", src],
         outs = [src],
-        cmd = '$TOOL $SRCS > $OUT',
+        cmd = "$TOOL $SRCS > $OUT",
+        tools = [":templater"],
     )
     deps += [templated_rule]
 
@@ -44,14 +51,17 @@ genrule(
 )
 
 # Downscale images from original resolution
-for colour, scale in [('teal', '50%'), ('white', '20%')]:
-    for src in glob(['images/%s*.png' % colour]):
+for colour, scale in [
+    ("teal", "50%"),
+    ("white", "20%"),
+]:
+    for src in glob(["images/%s*.png" % colour]):
         image_rule = genrule(
-            name = src.replace('.', '_').replace('/', '_'),
+            name = src.replace(".", "_").replace("/", "_"),
             srcs = [src],
             outs = [src],
-            cmd = 'mkdir -p images && $TOOL $SRC -crop 500x510+230+30 -resize %s $OUT' % scale,
-            tools = ['convert'],
+            cmd = "mkdir -p images && $TOOL $SRC -crop 500x510+230+30 -resize %s $OUT" % scale,
+            tools = ["convert"],
         )
         deps += [image_rule]
 

--- a/test/filegroup/many/BUILD
+++ b/test/filegroup/many/BUILD
@@ -1,5 +1,5 @@
 for i in range(100):
     filegroup(
-        name = 'f%02d' % i,
-        srcs = ['//test/filegroup:gen'],
+        name = "f%02d" % i,
+        srcs = ["//test/filegroup:gen"],
     )

--- a/test/workers/BUILD
+++ b/test/workers/BUILD
@@ -18,10 +18,10 @@ go_binary(
 
 for i in range(1, 6):
     gentest(
-        name = 'worker_test_%d' % i,
-        data = [':test_bin'],
+        name = "worker_test_%d" % i,
+        data = [":test_bin"],
         no_test_output = True,
-        test_cmd = '$(worker :worker) && $DATA',
-        tools = [':worker'],
         sandbox = False,
+        test_cmd = "$(worker :worker) && $DATA",
+        tools = [":worker"],
     )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -606,8 +606,8 @@ go_get(
     revision = "264ccecd4f2715cd5a37ce3dc987459ac2fb9d20",
     deps = [
         ":protobuf",
-        ":skylark"
-    ]
+        ":skylark",
+    ],
 )
 
 go_get(

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -603,7 +603,7 @@ go_get(
 go_get(
     name = "buildtools",
     get = "github.com/bazelbuild/buildtools/...",
-    revision = "v0.19.2",
+    revision = "0.19.2",
     deps = [
         ":protobuf",
         ":skylark",

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -603,7 +603,7 @@ go_get(
 go_get(
     name = "buildtools",
     get = "github.com/bazelbuild/buildtools/...",
-    revision = "264ccecd4f2715cd5a37ce3dc987459ac2fb9d20",
+    revision = "v0.19.2",
     deps = [
         ":protobuf",
         ":skylark",

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -643,11 +643,8 @@ go_get(
     revision = "a0ae3a11a518fb9559c95ed151ec07865b31980b",
 )
 
-#go_get(
-#    name = "build",
-#    get = "github.com/bazelbuild/buildtools/build",
-#    revision = "264ccecd4f2715cd5a37ce3dc987459ac2fb9d20",
-#    deps = [
-#        ":buildifier",
-#    ],
-#)
+go_get(
+    name = "difflib",
+    get = "github.com/pmezard/go-difflib/difflib",
+    revision = "792786c7400a136282c1664665ae0a8db921c6c2",
+)

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -595,11 +595,29 @@ go_get(
 )
 
 go_get(
+    name = "skylark",
+    get = "github.com/google/skylark/syntax",
+    revision = "a5f7082aabed29c0e429c722292c66ec8ecf9591",
+)
+
+go_get(
+    name = "buildtools",
+    get = "github.com/bazelbuild/buildtools/...",
+    revision = "264ccecd4f2715cd5a37ce3dc987459ac2fb9d20",
+    deps = [
+        ":protobuf",
+        ":skylark"
+    ]
+)
+
+go_get(
     name = "buildifier",
     binary = True,
-    get = "github.com/bazelbuild/buildtools",
-    install = ["buildifier"],
-    revision = "0.11.1",
+    get = [],
+    install = ["github.com/bazelbuild/buildtools/buildifier"],
+    deps = [
+        ":buildtools",
+    ],
 )
 
 go_get(
@@ -624,3 +642,12 @@ go_get(
     get = "github.com/peterebden/ar",
     revision = "a0ae3a11a518fb9559c95ed151ec07865b31980b",
 )
+
+#go_get(
+#    name = "build",
+#    get = "github.com/bazelbuild/buildtools/build",
+#    revision = "264ccecd4f2715cd5a37ce3dc987459ac2fb9d20",
+#    deps = [
+#        ":buildifier",
+#    ],
+#)

--- a/tools/build_langserver/langserver/BUILD
+++ b/tools/build_langserver/langserver/BUILD
@@ -12,11 +12,11 @@ go_library(
         "//src/parse/asp",
         "//src/parse/rules",
         "//src/query",
+        "//third_party/go:buildtools",
+        "//third_party/go:difflib",
         "//third_party/go:jsonrpc2",
         "//third_party/go:logging",
-        "//third_party/go:difflib",
         "//third_party/go:queue",
-        "//third_party/go:buildtools",
         "//tools/build_langserver/lsp",
     ],
 )

--- a/tools/build_langserver/langserver/BUILD
+++ b/tools/build_langserver/langserver/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//third_party/go:jsonrpc2",
         "//third_party/go:logging",
         "//third_party/go:queue",
+        "//third_party/go:buildtools",
         "//tools/build_langserver/lsp",
     ],
 )

--- a/tools/build_langserver/langserver/BUILD
+++ b/tools/build_langserver/langserver/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//src/query",
         "//third_party/go:jsonrpc2",
         "//third_party/go:logging",
+        "//third_party/go:difflib",
         "//third_party/go:queue",
         "//third_party/go:buildtools",
         "//tools/build_langserver/lsp",

--- a/tools/build_langserver/langserver/definition_test.go
+++ b/tools/build_langserver/langserver/definition_test.go
@@ -30,8 +30,8 @@ func TestGetDefinitionLocationOnBuildDefs(t *testing.T) {
 	loc = handler.getDefinitionLocation(ctx, exampleBuildURI, lsp.Position{Line: 13, Character: 21})
 	expectedURI = lsp.DocumentURI("file://" + path.Join(core.RepoRoot, "third_party/go/BUILD"))
 	expectedRange = lsp.Range{
-		Start: lsp.Position{Line: 604, Character: 0},
-		End:   lsp.Position{Line: 608, Character: 1},
+		Start: lsp.Position{Line: 622, Character: 0},
+		End:   lsp.Position{Line: 626, Character: 1},
 	}
 	assert.Equal(t, 1, len(loc))
 	assert.Equal(t, expectedURI, loc[0].URI)

--- a/tools/build_langserver/langserver/handler.go
+++ b/tools/build_langserver/langserver/handler.go
@@ -64,6 +64,7 @@ func (h *LsHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrp
 		"textDocument/completion":    h.handleCompletion,
 		"textDocument/signatureHelp": h.handleSignature,
 		"textDocument/definition":    h.handleDefinition,
+		"textDocument/formatting":    h.handleReformatting,
 	}
 
 	if req.Method != "initialize" && req.Method != "exit" &&

--- a/tools/build_langserver/langserver/reformat.go
+++ b/tools/build_langserver/langserver/reformat.go
@@ -1,0 +1,65 @@
+package langserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"io/ioutil"
+
+	"tools/build_langserver/lsp"
+
+	"github.com/bazelbuild/buildtools/build"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+const reformatMethod = "textDocument/formatting"
+
+func (h *LsHandler) handleReformatting(ctx context.Context, req *jsonrpc2.Request) (result interface{}, err error) {
+	if req.Params == nil {
+		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
+	}
+
+	var params lsp.DocumentFormattingParams
+	if err := json.Unmarshal(*req.Params, &params); err != nil {
+		return nil, err
+	}
+
+	documentURI, err := getURIAndHandleErrors(params.TextDocument.URI, reformatMethod)
+	if err != nil {
+		return nil, err
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	edits, err := h.getFormatEdits(documentURI)
+	if err != nil {
+		log.Warning("error occurred when formatting file: %s, skipping", err)
+	}
+
+	return edits, err
+}
+
+func (h *LsHandler) getFormatEdits(uri lsp.DocumentURI) ([]*lsp.TextEdit, error) {
+
+	filePath, err := GetPathFromURL(uri, "file")
+	if err != nil {
+		return nil, err
+	}
+
+	bytecontent, err := ioutil.ReadFile(filePath)
+	f, err := build.ParseBuild(filePath, bytecontent)
+
+	if err != nil {
+		return nil, err
+	}
+
+	reformatted := build.Format(f)
+
+	fmt.Println(f)
+	fmt.Println(string(reformatted))
+
+	// TODO(bnm): make them into edits
+	return nil, nil
+}

--- a/tools/build_langserver/langserver/reformat.go
+++ b/tools/build_langserver/langserver/reformat.go
@@ -56,9 +56,17 @@ func (h *LsHandler) getFormatEdits(uri lsp.DocumentURI) ([]*lsp.TextEdit, error)
 	content := JoinLines(doc.textInEdit, true)
 	bytecontent := []byte(content)
 
-	f, err := build.ParseBuild(filePath, bytecontent)
-	if err != nil {
-		return nil, err
+	var f *build.File
+	if h.analyzer.IsBuildFile(uri) {
+		f, err = build.ParseBuild(filePath, bytecontent)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		f, err = build.ParseDefault(filePath, bytecontent)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	reformatted := build.Format(f)

--- a/tools/build_langserver/langserver/reformat_test.go
+++ b/tools/build_langserver/langserver/reformat_test.go
@@ -1,0 +1,13 @@
+package langserver
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetFormatEdits(t *testing.T) {
+
+	edited, err := handler.getFormatEdits(exampleBuildURI)
+	assert.NoError(t, err)
+	t.Log(edited)
+}

--- a/tools/build_langserver/langserver/reformat_test.go
+++ b/tools/build_langserver/langserver/reformat_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestGetFormatEdits(t *testing.T) {
+	analyzer.State.Config.Parse.BuildFileName = append(analyzer.State.Config.Parse.BuildFileName,
+		[]string{"reformat.build", "example.build"}...)
 	edits, err := handler.getFormatEdits(reformatURI)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(edits))

--- a/tools/build_langserver/langserver/reformat_test.go
+++ b/tools/build_langserver/langserver/reformat_test.go
@@ -1,13 +1,61 @@
 package langserver
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"tools/build_langserver/lsp"
 )
 
 func TestGetFormatEdits(t *testing.T) {
-
-	edited, err := handler.getFormatEdits(exampleBuildURI)
+	edits, err := handler.getFormatEdits(reformatURI)
 	assert.NoError(t, err)
-	t.Log(edited)
+	assert.Equal(t, 1, len(edits))
+
+	expected := `python_library(
+    name = "test",
+    srcs = ["utils_test.go"],
+)
+`
+	assert.Equal(t, expected, edits[0].NewText)
+
+	edits, err = handler.getFormatEdits(exampleBuildURI)
+	assert.NoError(t, err)
+	expected = `blah = "blah"` + "\n"
+	assert.Equal(t, expected, edits[len(edits)-1].NewText)
+
+	expected = `
+subinclude({
+    "foo": "bar",
+    "blah": 1,
+})
+`
+	t.Log(edits[7].Range)
+	assert.Equal(t, expected, edits[7].NewText)
+}
+
+func TestGetEdits(t *testing.T) {
+	edits := getEdits(`blah="hello"`, `blah = "blah"`+"\n")
+	expectedRange := lsp.Range{
+		Start: lsp.Position{
+			Line:      0,
+			Character: 0,
+		},
+		End: lsp.Position{
+			Line:      1,
+			Character: 0,
+		},
+	}
+
+	assert.Equal(t, expectedRange, edits[0].Range)
+
+	after := `subinclude({
+    "foo": "bar",
+    "blah": 1,
+})
+`
+	edits = getEdits(`subinclude({"foo": "bar", "blah":1})`, after)
+	assert.Equal(t, expectedRange, edits[0].Range)
+	assert.Equal(t, after, edits[0].NewText)
+	t.Log(edits[0].NewText)
 }

--- a/tools/build_langserver/langserver/test_data/example.build
+++ b/tools/build_langserver/langserver/test_data/example.build
@@ -65,3 +65,5 @@ add_dep("blah")
 python_library(name = "hello".foo(), interpreter = CONFIG.DEFAULT_PYTHON_INTERPRETER)
 
 baz = CONFIG.BLAH
+
+blah='blah'

--- a/tools/build_langserver/langserver/test_data/example.build
+++ b/tools/build_langserver/langserver/test_data/example.build
@@ -29,7 +29,7 @@ go_test(
         "//src/parse/rules",
         "//third_party/go:testify",
         "//dummy/buildlabels:foo",
-    ],
+        ],
 )
 
 go_test(

--- a/tools/build_langserver/langserver/test_data/reformat.build
+++ b/tools/build_langserver/langserver/test_data/reformat.build
@@ -1,0 +1,1 @@
+python_library(name = "test", srcs = ["utils_test.go"])

--- a/tools/build_langserver/langserver/workspace_store.go
+++ b/tools/build_langserver/langserver/workspace_store.go
@@ -137,11 +137,12 @@ func SplitLines(content string, keepEnds bool) []string {
 
 	for i := range splited {
 		// Do not add endline character on the last empty line
-		if i == len(splited)-1 {
+		if (i == len(splited)-1 && splited[i] == "") || len(splited) <= 1 {
 			continue
 		}
 		splited[i] += "\n"
 	}
+
 	return splited
 }
 
@@ -154,7 +155,12 @@ func JoinLines(text []string, hasEnds bool) string {
 
 	newText := make([]string, len(text))
 	for i := range text {
+		if i == len(text)-1 && text[i] == "" {
+			newText[i] = text[i]
+			continue
+		}
 		newText[i] = strings.TrimSuffix(text[i], "\n")
 	}
+
 	return strings.Join(newText, "\n")
 }

--- a/tools/build_langserver/langserver/workspace_store_test.go
+++ b/tools/build_langserver/langserver/workspace_store_test.go
@@ -57,7 +57,8 @@ func TestWorkspaceStore_TrackEdit(t *testing.T) {
 		"    name = \"\",\n",
 		"    srcs =[],\n",
 		"    \"//src\"\n",
-		")",
+		")\n",
+		"",
 	}
 	assert.Equal(t, expected, ws.documents[completionURI].textInEdit[6:])
 }
@@ -130,6 +131,7 @@ func TestWorkspaceStore_applyChangeAddChar(t *testing.T) {
 	outText, err = ws.applyChange([]string{""}, change)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "yh", outText[0])
+	assert.Equal(t, 1, len(outText))
 }
 
 func TestWorkspaceStore_applyChangeDelete(t *testing.T) {

--- a/tools/build_langserver/lsp/service.go
+++ b/tools/build_langserver/lsp/service.go
@@ -159,11 +159,13 @@ type PublishDiagnosticsParams struct {
 	Diagnostics []*Diagnostic `json:"diagnostics"`
 }
 
+// DocumentFormattingParams is the params sent from the client for textDocument/formatting request
 type DocumentFormattingParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	Options      FormattingOptions      `json:"options"`
 }
 
+// FormattingOptions represent Value-object describing what options formatting should use.
 type FormattingOptions struct {
 	TabSize      int    `json:"tabSize"`
 	InsertSpaces bool   `json:"insertSpaces"`

--- a/tools/build_langserver/lsp/service.go
+++ b/tools/build_langserver/lsp/service.go
@@ -158,3 +158,14 @@ type PublishDiagnosticsParams struct {
 	URI         DocumentURI   `json:"uri"`
 	Diagnostics []*Diagnostic `json:"diagnostics"`
 }
+
+type DocumentFormattingParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	Options      FormattingOptions      `json:"options"`
+}
+
+type FormattingOptions struct {
+	TabSize      int    `json:"tabSize"`
+	InsertSpaces bool   `json:"insertSpaces"`
+	Key          string `json:"key"`
+}


### PR DESCRIPTION
Utilizing the `github.com/bazelbuild/buildtools/build` methods to reformat files, and `github.com/pmezard/go-difflib/difflib` to calculate diffs