### PR TITLE
issue fix regarding #461

### DIFF
--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -653,8 +653,8 @@ def _go_github_repo_cmd(name, get, repo, revision):
     )
     return [
         'rm -rf src/' + out,
-        '$TOOL x $SRCS_GET',
-        f'mv {dest}* src/{out}',
+        f'$TOOL x $SRCS_GET -o={dest}',
+        f'mv {dest}/{dest}* src/{out}',
     ], [remote_rule], [CONFIG.JARCAT_TOOL]
 
 


### PR DESCRIPTION
This fails at the step `_go_get_download` in `go_get` rules, when trying to move the unpackaged zip files from `plz-out/tmp/_pkgname#get._build` to `plz-out/tmp/_pkgname#get._build/src/github.com/vendor/pkgname`.

Apparently `mv` command fails when you do `pkgname*`, i suspect it has to do with the parent package having an unconventional name. A work around I found is to put that in a directory(`-o` on jarcat), with that everything seemed to worked fine, and it doesn't interfere with other `go_get`s either.