### PR TITLE
Fix termination of subdir walking.

### DIFF
--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -439,7 +439,7 @@ func asDict(obj pyObject) (pyDict, bool) {
 func checkSubDir(s *scope, src string) {
 	if strings.Contains(src, "/") {
 		// Target is in a subdirectory, check nobody else owns that.
-		for dir := path.Dir(path.Join(s.pkg.Name, src)); dir != s.pkg.Name && dir != "."; dir = path.Dir(dir) {
+		for dir := path.Dir(path.Join(s.pkg.Name, src)); dir != s.pkg.Name && dir != "." && dir != "/"; dir = path.Dir(dir) {
 			s.Assert(!fs.IsPackage(s.state.Config.Parse.BuildFileName, dir), "Trying to use file %s, but that belongs to another package (%s)", src, dir)
 		}
 	}


### PR DESCRIPTION
If an absolute path gets passed into
`src/parse/asp/targets.go:checkSubDir` (e.g. you have `Location` set to
an absolute path in your `.plzconfig`), it fails to terminate as it will
walk up to `/` and then get into an infinite loop. This change just adds
detection for `/`, to terminate the loop.

Fixes https://github.com/thought-machine/please/issues/489