### PR TITLE
Add definitions support to go_binary() and go_test()

### DIFF
--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -258,7 +258,7 @@ def _merge_cgo_obj(name, a_rule, o_rule=None, visibility=None, test_only=False, 
 
 def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=[],
               visibility:list=None, test_only:bool&testonly=False, static:bool=CONFIG.GO_DEFAULT_STATIC,
-              filter_srcs:bool=True):
+              filter_srcs:bool=True, definitions:str|list|dict=None):
     """Compiles a Go binary.
 
     Args:
@@ -276,6 +276,10 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
                      Note that it may have negative consequences if the binary contains any cgo
                      (including net/http DNS lookup code potentially).
       filter_srcs (bool): If True, filters source files through Go's standard build constraints.
+      definitions (str | list | dict): If set to a string, defines importpath.name=value to the
+                     when calling the Go linker.  If set to a list, pass each value as a
+                     definition to the linker.  If set to a dict, each key/value pair is used to
+                     contruct the list of definitions passed to the linker.
     """
     lib = go_library(
         name=f'_{name}#lib',
@@ -287,7 +291,7 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
         _link_private = True,
         _link_extra = False,
     )
-    cmds, tools = _go_binary_cmds(static=static)
+    cmds, tools = _go_binary_cmds(static=static, definitions=definitions)
     return build_rule(
         name=name,
         srcs=[lib],
@@ -705,17 +709,31 @@ def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True
     return cmds
 
 
-def _go_binary_cmds(static=False, ldflags='', pkg_config=''):
+def _go_binary_cmds(static=False, ldflags='', pkg_config='', definitions=None):
     """Returns the commands to run for linking a Go binary."""
     _link_cmd = '$TOOLS_GO tool link -tmpdir $TMP_DIR -extld $TOOLS_LD %s -L . -o ${OUT} ' % _GOPATH.replace('-I ', '-L ')
     prefix = _LINK_PKGS_CMD + _go_import_path_cmd(CONFIG.GO_IMPORT_PATH)
 
+    linkerdefs = []
+    if definitions is None:
+        pass
+    elif isinstance(definitions, str):
+        linkerdefs += [f'{definitions}']
+    elif isinstance(definitions, list):
+        linkerdefs += [f'{linkerdef}' for linkerdef in definitions]
+    elif isinstance(definitions, dict):
+        linkerdefs = [k if v is None else f'{k}={v}' for k, v in sorted(definitions.items())]
+
+    defs = ''
+    if len(linkerdefs) > 0:
+        defs += ' '.join([f'-X "{linkerdef}"' for linkerdef in linkerdefs])
+
     if static:
-        flags = f'-linkmode external -extldflags "-static {ldflags} {pkg_config}"'
+        flags = f'-linkmode external -extldflags {defs} "-static {ldflags} {pkg_config}"'
     elif ldflags or pkg_config:
-        flags = f'-extldflags "{ldflags} {pkg_config}"'
+        flags = f'-extldflags {defs} "{ldflags} {pkg_config}"'
     else:
-        flags = ''
+        flags = f'{defs}'
 
     return {
         'dbg': f'{prefix} && {_link_cmd} {flags} $SRCS',

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -729,9 +729,7 @@ def _go_binary_cmds(static=False, ldflags='', pkg_config='', definitions=None):
     elif isinstance(definitions, dict):
         linkerdefs = [k if v is None else f'{k}={v}' for k, v in sorted(definitions.items())]
 
-    defs = ''
-    if len(linkerdefs) > 0:
-        defs += ' '.join([f'-X "{linkerdef}"' for linkerdef in linkerdefs])
+    defs = ' '.join([f'-X "{linkerdef}"' for linkerdef in linkerdefs])
 
     if static:
         flags = f'-linkmode external -extldflags "-static {ldflags} {pkg_config}"'

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -276,10 +276,10 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
                      Note that it may have negative consequences if the binary contains any cgo
                      (including net/http DNS lookup code potentially).
       filter_srcs (bool): If True, filters source files through Go's standard build constraints.
-      definitions (str | list | dict): If set to a string, defines importpath.name=value to the
+      definitions (str | list | dict): If set to a string, defines importpath.name=value
                      when calling the Go linker.  If set to a list, pass each value as a
-                     definition to the linker.  If set to a dict, each key/value pair is used to
-                     contruct the list of definitions passed to the linker.
+                     definition to the linker.  If set to a dict, each key/value pair is
+                     used to contruct the list of definitions passed to the linker.
     """
     lib = go_library(
         name=f'_{name}#lib',
@@ -341,10 +341,10 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
                      has absolutely no external dependencies.
                      Note that it may have negative consequences if the binary contains any cgo
                      (including net/http DNS lookup code potentially).
-      definitions (str | list | dict): If set to a string, defines importpath.name=value to the
+      definitions (str | list | dict): If set to a string, defines importpath.name=value
                      when calling the Go linker.  If set to a list, pass each value as a
-                     definition to the linker.  If set to a dict, each key/value pair is used to
-                     contruct the list of definitions passed to the linker.
+                     definition to the linker.  If set to a dict, each key/value pair is
+                     used to contruct the list of definitions passed to the linker.
     """
     timeout, labels = _test_size_and_timeout(size, timeout, labels)
     # Unfortunately we have to recompile this to build the test together with its library.

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -313,7 +313,8 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
 def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', visibility:list=None,
             flags:str='', container:bool|dict=False, sandbox:bool=None, cgo:bool=False,
             external:bool=False, timeout:int=0, flaky:bool|int=0, test_outputs:list=None,
-            labels:list&features&tags=None, size:str=None, static:bool=CONFIG.GO_DEFAULT_STATIC):
+            labels:list&features&tags=None, size:str=None, static:bool=CONFIG.GO_DEFAULT_STATIC,
+            definitions:str|list|dict=None):
     """Defines a Go test rule.
 
     Args:
@@ -340,6 +341,10 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
                      has absolutely no external dependencies.
                      Note that it may have negative consequences if the binary contains any cgo
                      (including net/http DNS lookup code potentially).
+      definitions (str | list | dict): If set to a string, defines importpath.name=value to the
+                     when calling the Go linker.  If set to a list, pass each value as a
+                     definition to the linker.  If set to a dict, each key/value pair is used to
+                     contruct the list of definitions passed to the linker.
     """
     timeout, labels = _test_size_and_timeout(size, timeout, labels)
     # Unfortunately we have to recompile this to build the test together with its library.
@@ -380,7 +385,7 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
             'go': [CONFIG.GO_TOOL],
             'test': [CONFIG.GO_TEST_TOOL],
         },
-        post_build=lambda name, output: _replace_test_package(name, output, static),
+        post_build=lambda name, output: _replace_test_package(name, output, static, definitions=definitions),
     )
     deps.append(lib_rule)
     lib_rule = go_library(
@@ -390,7 +395,7 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
         _needs_transitive_deps=True,  # Rather annoyingly this is only needed for coverage
         test_only=True,
     )
-    cmds, tools = _go_binary_cmds(static=static)
+    cmds, tools = _go_binary_cmds(static=static, definitions=definitions)
 
     test_cmd = '$TEST %s 2>&1 | tee $RESULTS_FILE' % flags
     if worker:
@@ -662,7 +667,7 @@ def _go_github_repo_cmd(name, get, repo, revision):
     ], [remote_rule], [CONFIG.JARCAT_TOOL]
 
 
-def _replace_test_package(name, output, static):
+def _replace_test_package(name, output, static, definitions):
     """Post-build function, called after we template the main function.
 
     The purpose is to replace the real library with the specific one we've
@@ -678,7 +683,7 @@ def _replace_test_package(name, output, static):
             pkg_name = line[9:]
             name_changed = pkg_name != new_name
             if name_changed or ldflags or pkg_config:  # Might not be necessary if names match already.
-                binary_cmds, _ = _go_binary_cmds(static=static, ldflags=ldflags, pkg_config=pkg_config)
+                binary_cmds, _ = _go_binary_cmds(static=static, ldflags=ldflags, pkg_config=pkg_config, definitions)
                 if name_changed:
                     for k, v in binary_cmds.items():
                         set_command(new_name, k, f'mv -f $PKG_DIR/{new_name}.a $PKG_DIR/{pkg_name}.a && {v}')
@@ -729,11 +734,14 @@ def _go_binary_cmds(static=False, ldflags='', pkg_config='', definitions=None):
         defs += ' '.join([f'-X "{linkerdef}"' for linkerdef in linkerdefs])
 
     if static:
-        flags = f'-linkmode external -extldflags {defs} "-static {ldflags} {pkg_config}"'
+        flags = f'-linkmode external -extldflags "-static {ldflags} {pkg_config}"'
     elif ldflags or pkg_config:
-        flags = f'-extldflags {defs} "{ldflags} {pkg_config}"'
+        flags = f'-extldflags "{ldflags} {pkg_config}"'
     else:
-        flags = f'{defs}'
+        flags = f''
+
+    if len(defs) > 0:
+        flags += defs
 
     return {
         'dbg': f'{prefix} && {_link_cmd} {flags} $SRCS',

--- a/test/go_rules/test/BUILD
+++ b/test/go_rules/test/BUILD
@@ -17,4 +17,8 @@ go_test(
         ":test",
         "//third_party/go:testify",
     ],
+    definitions = {
+        "test/go_rules/test.Var": "var",
+        "test/go_rules/test.Var2": "var1 var2",
+    },
 )

--- a/test/go_rules/test/BUILD
+++ b/test/go_rules/test/BUILD
@@ -12,13 +12,13 @@ go_library(
 go_test(
     name = "external_test",
     srcs = ["external_test.go"],
+    definitions = {
+        "test/go_rules/test.Var": "var",
+        "test/go_rules/test.Var2": "var1 var2",
+    },
     external = True,
     deps = [
         ":test",
         "//third_party/go:testify",
     ],
-    definitions = {
-        "test/go_rules/test.Var": "var",
-        "test/go_rules/test.Var2": "var1 var2",
-    },
 )

--- a/test/go_rules/test/external_test.go
+++ b/test/go_rules/test/external_test.go
@@ -10,4 +10,6 @@ import (
 
 func TestAnswer(t *testing.T) {
 	assert.Equal(t, 42, GetAnswer())
+	assert.Equal(t, "var", GetVar())
+	assert.Equal(t, "var1 var2", GetVar2())
 }

--- a/test/go_rules/test/test.go
+++ b/test/go_rules/test/test.go
@@ -1,5 +1,18 @@
 package test
 
+var (
+	Var  string = "missing var"
+	Var2 string = "missing var2"
+)
+
 func GetAnswer() int {
 	return 42
+}
+
+func GetVar() string {
+	return Var
+}
+
+func GetVar2() string {
+	return Var2
 }

--- a/tools/build_langserver/langserver/signature_test.go
+++ b/tools/build_langserver/langserver/signature_test.go
@@ -19,7 +19,7 @@ func TestGetSignaturesEmptyCall(t *testing.T) {
 
 	expectedLabel := "(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=[],\n" +
 		"              visibility:list=None, test_only:bool&testonly=False, static:bool=CONFIG.GO_DEFAULT_STATIC,\n" +
-		"              filter_srcs:bool=True)"
+		"              filter_srcs:bool=True, definitions:str|list|dict=None)"
 	assert.Equal(t, expectedLabel, sig.Signatures[0].Label)
 }
 


### PR DESCRIPTION
Pass in definitions to `go tool link` (the `-X` flag).  This is useful for passing in git SHAs or other build-time information to a go binary.

The name `definitions` was used instead of `constants` because this terminology is aligned with the verbiage used in the `go tool link` command:

```
  -X definition
    	add string value definition of the form importpath.name=value
```

Because you can assign a value to a `const` or to a `var.  From a UX perspective, I think accuracy and consistency with the Go project is more important than being colloquial (e.g. "build-time constants").

```python
go_binary(
    name = "test_dict",
    srcs = ["main.go"],
    definitions = {
        "main.Hello": "dict",
        "main.World": "nice to see you",
    },
)

go_binary(
    name = "test_list",
    srcs = ["main.go"],
    definitions = [
        "main.Hello=test_list",
        "main.World=\"works\"",
    ],
)

go_binary(
    name = "test_str",
    srcs = ["main.go"],
    definitions = "main.Hello=world",
)

# go_test() also has support for definitions. 
```

```go
package main

var (
  Hello string
  World string
)

func main() {
	fmt.Printf("Hello %q %q\n", Hello, World)
}
```

```
% plz build //...
Build finished; total time 1.65s, incrementality 100.0%. Outputs:
//:pleasings:
  plz-out/gen/pleasings
//:test_dict:
  plz-out/bin/test_dict
//:test_list:
  plz-out/bin/test_list
//:test_str:
  plz-out/bin/test_str
Hello "dict" "nice to see you"
Hello "test_list" "works"
Hello "world" ""
```

This is a precursor to being able to run and set values using something like:

```python
go_binary(
    name = "test",
    srcs = ["main.go"],
    definitions = {
        "main.GitCommit": exec(cmd = ["git", "rev-parse", "--short", "HEAD"]),
        "main.GitBranch": exec(cmd = "git symbolic-ref -q --short HEAD"),
        "main.GitSummary": exec(cmd = "git describe --tags --dirty --always"),
        "main.GitState": "dirty" if len(exec("git status --porcelain")) > 0 else "",
    },
)
```

A helper function that that will populate these values will come shortly (once #492 is merged).  This type of information is useful for `myprog --version` or `myprog version` commands, and monitoring if you emit the git-sha of your running program along with your metric data.

Specifying a generic `definitions` that is passed down to `go tool link`'s `-X` flag seemed preferable to allowing users to pass in random linker flags.