### PR TITLE
Improve git/exec error msg

### DIFF
--- a/src/parse/asp/exec.go
+++ b/src/parse/asp/exec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -24,6 +25,8 @@ var (
 	// The output from exec() is memoized by default
 	execCacheLock  sync.RWMutex
 	execCachedOuts map[execKey]string
+
+	execCmdPath sync.Map
 
 	execPromisesLock sync.Mutex
 	execPromises     map[execKey]*execPromise
@@ -54,30 +57,30 @@ func doExec(s *scope, cmdIn pyObject, wantStdout bool, wantStderr bool, cacheOut
 		return s.Error("exec() must have at least stdout or stderr set to true, both can not be false")
 	}
 
-	var cmdArgs []string
+	var argv []string
 	if isType(cmdIn, "str") {
-		cmdArgs = strings.Fields(string(cmdIn.(pyString)))
+		argv = strings.Fields(string(cmdIn.(pyString)))
 	} else if isType(cmdIn, "list") {
 		pl := cmdIn.(pyList)
-		cmdArgs = make([]string, 0, pl.Len())
+		argv = make([]string, 0, pl.Len())
 		for i := 0; i < pl.Len(); i++ {
-			cmdArgs = append(cmdArgs, pl[i].String())
+			argv = append(argv, pl[i].String())
 		}
 	}
 
 	// The cache key is tightly coupled to the operating parameters
-	key := execMakeKey(cmdArgs, wantStdout, wantStderr)
+	key := execMakeKey(argv, wantStdout, wantStderr)
 
 	// Only get cached output if this call is intended to be cached.
 	var completedPromise bool
 	if cacheOutput {
-		out, found := execGetCachedOutput(key, cmdArgs)
+		out, found := execGetCachedOutput(key, argv)
 		if found {
 			return pyString(out)
 		}
 		defer func() {
 			if !completedPromise {
-				execCancelPromise(key, cmdArgs)
+				execCancelPromise(key, argv)
 			}
 		}()
 	}
@@ -85,9 +88,14 @@ func doExec(s *scope, cmdIn pyObject, wantStdout bool, wantStderr bool, cacheOut
 	ctx, cancel := context.WithTimeout(context.TODO(), core.TargetTimeoutOrDefault(nil, s.state))
 	defer cancel()
 
+	cmdPath, err := execFindCmd(argv[0])
+	if err != nil {
+		return s.Error("exec() unable to find %q in PATH %q", argv[0], os.Getenv("PATH"))
+	}
+	cmdArgs := argv[1:]
+
 	var out []byte
-	var err error
-	cmd := exec.CommandContext(ctx, cmdArgs[0], cmdArgs[1:]...)
+	cmd := exec.CommandContext(ctx, cmdPath, cmdArgs...)
 	if wantStdout && wantStderr {
 		out, err = cmd.CombinedOutput()
 	} else {
@@ -108,11 +116,11 @@ func doExec(s *scope, cmdIn pyObject, wantStdout bool, wantStderr bool, cacheOut
 	outStr := string(out)
 
 	if err != nil {
-		return s.Error("exec() unable to run command %q: %v", cmdArgs, err)
+		return s.Error("exec() unable to run command %q: %v", argv, err)
 	}
 
 	if cacheOutput {
-		execSetCachedOutput(key, cmdArgs, outStr)
+		execSetCachedOutput(key, argv, outStr)
 		completedPromise = true
 	}
 
@@ -130,6 +138,24 @@ func execCancelPromise(key execKey, args []string) {
 		promise.cv.Broadcast()
 		promise.cv.L.Unlock()
 	}
+}
+
+// execFindCmd looks for a command using PATH and returns a cached abspath.
+func execFindCmd(cmdName string) (path string, err error) {
+	pathRaw, found := execCmdPath.Load(cmdName)
+	if !found {
+		// Perform a racy LookPath assuming the path is stable between concurrent
+		// lookups for the same cmdName.
+		path, err := exec.LookPath(cmdName)
+		if err != nil {
+			return "", err
+		}
+
+		// First write wins
+		pathRaw, _ = execCmdPath.LoadOrStore(cmdName, path)
+	}
+
+	return pathRaw.(string), nil
 }
 
 // execGetCachedOutput returns the output if found, sets found to true if found,

--- a/src/parse/asp/exec.go
+++ b/src/parse/asp/exec.go
@@ -230,10 +230,11 @@ func execGitBranch(s *scope, args []pyObject) pyObject {
 	}
 
 	// We're in a detached head
-	cmdIn = make([]pyObject, 3)
+	cmdIn = make([]pyObject, 4)
 	cmdIn[0] = pyString("git")
 	cmdIn[1] = pyString("show")
-	cmdIn[2] = pyString("--format=%D")
+	cmdIn[2] = pyString("-q")
+	cmdIn[3] = pyString("--format=%D")
 	gitShowResult, err := doExec(s, pyList(cmdIn), wantStdout, wantStderr, cacheOutput)
 	if err != nil {
 		// doExec returns a formatted error string


### PR DESCRIPTION
Resolve the absolute path of binaries once and cache the result.  If the binary can't be found in `PATH`, return the `PATH` via stdout to aid in debugging via CI.