### PR TITLE
Swap coverage to linux-alt build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
        - image: thoughtmachine/please_ubuntu:latest
      environment:
        PLZ_ARGS: "-p --profile ci -o buildconfig.ci:true"
-       PLZ_COVER: "cover"
      steps:
        - checkout
        - restore_cache:
@@ -50,6 +49,7 @@ jobs:
        - image: thoughtmachine/please_ubuntu_alt:latest
      environment:
        PLZ_ARGS: "-p --profile ci"
+       PLZ_COVER: "cover"
      steps:
        - checkout
        - restore_cache:


### PR DESCRIPTION
The linux build has to do the package step so it should be focusing on building the 'real' version, right now it is having to rebuild a lot unnecessarily.

Not expecting any kind of review on this, but want to run it through CircleCI before pushing.