### PR TITLE
Look up tools via PATH

### DIFF
--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -17,14 +17,10 @@ type BuildEnv []string
 // GeneralBuildEnvironment creates the shell env vars used for a command, not based
 // on any specific target etc.
 func GeneralBuildEnvironment(config *Configuration) BuildEnv {
+	// TODO(peterebden): why is this not just config.GetBuildEnv()?
 	env := BuildEnv{
 		// Need this for certain tools, for example sass
 		"LANG=" + config.Build.Lang,
-		// Use a restricted PATH; it'd be easier for the user if we pass it through
-		// but really external environment variables shouldn't affect this.
-		// The only concession is that ~ is expanded as the user's home directory
-		// in PATH entries.
-		"PATH=" + ExpandHomePath(strings.Join(config.Build.Path, ":")),
 		// Expose the requested build config. We might also want to expose
 		// the command that's actually running (although typically this is more useful,
 		// because targets using this want to avoid defining different commands).

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -564,7 +564,7 @@ func (config *Configuration) getBuildEnv(expanded bool) []string {
 		// but really external environment variables shouldn't affect this.
 		// The only concession is that ~ is expanded as the user's home directory
 		// in PATH entries.
-		env = append(env, "PATH="+config.Please.Location+":"+maybeExpandHomePath(strings.Join(config.Build.Path, ":")))
+		env = append(env, "PATH="+maybeExpandHomePath(strings.Join(append([]string{config.Please.Location}, config.Build.Path...), ":")))
 	}
 
 	sort.Strings(env)

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -553,7 +553,7 @@ func (config *Configuration) getBuildEnv(expanded bool) []string {
 		if v, isSet := os.LookupEnv(k); isSet {
 			if k == "PATH" {
 				// plz's install location always needs to be on the path.
-				v += ":" + maybeExpandHomePath(config.Please.Location)
+				v = maybeExpandHomePath(config.Please.Location) + ":" + v
 				path = true
 			}
 			env = append(env, k+"="+v)
@@ -564,7 +564,7 @@ func (config *Configuration) getBuildEnv(expanded bool) []string {
 		// but really external environment variables shouldn't affect this.
 		// The only concession is that ~ is expanded as the user's home directory
 		// in PATH entries.
-		env = append(env, "PATH="+maybeExpandHomePath(strings.Join(append(config.Build.Path, config.Please.Location), ":")))
+		env = append(env, "PATH="+config.Please.Location+":"+maybeExpandHomePath(strings.Join(config.Build.Path, ":")))
 	}
 
 	sort.Strings(env)

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -234,7 +234,7 @@ func TestBuildEnvSection(t *testing.T) {
 		"GOARCH=" + runtime.GOARCH,
 		"GOOS=" + runtime.GOOS,
 		"OS=" + runtime.GOOS,
-		"PATH=/usr/local/bin:/usr/bin:/bin:" + os.Getenv("TMP_DIR") + "/.please",
+		"PATH=" + os.Getenv("TMP_DIR") + "/.please:/usr/local/bin:/usr/bin:/bin",
 		"XARCH=x86_64",
 		"XOS=" + xos(),
 	}
@@ -255,7 +255,7 @@ func TestPassEnv(t *testing.T) {
 		"GOARCH=" + runtime.GOARCH,
 		"GOOS=" + runtime.GOOS,
 		"OS=" + runtime.GOOS,
-		"PATH=" + os.Getenv("PATH") + ":" + os.Getenv("TMP_DIR") + "/.please",
+		"PATH=" + os.Getenv("TMP_DIR") + "/.please:" + os.Getenv("PATH"),
 		"XARCH=x86_64",
 		"XOS=" + xos(),
 	}

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -234,6 +234,7 @@ func TestBuildEnvSection(t *testing.T) {
 		"GOARCH=" + runtime.GOARCH,
 		"GOOS=" + runtime.GOOS,
 		"OS=" + runtime.GOOS,
+		"PATH=/usr/local/bin:/usr/bin:/bin:" + os.Getenv("TMP_DIR") + "/.please",
 		"XARCH=x86_64",
 		"XOS=" + xos(),
 	}
@@ -254,7 +255,7 @@ func TestPassEnv(t *testing.T) {
 		"GOARCH=" + runtime.GOARCH,
 		"GOOS=" + runtime.GOOS,
 		"OS=" + runtime.GOOS,
-		"PATH=" + os.Getenv("PATH"),
+		"PATH=" + os.Getenv("PATH") + ":" + os.Getenv("TMP_DIR") + "/.please",
 		"XARCH=x86_64",
 		"XOS=" + xos(),
 	}

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -332,7 +332,7 @@ func parseSource(s *scope, src string, systemAllowed, tool bool) core.BuildInput
 		return core.SystemFileLabel{Path: src}
 	} else if tool {
 		// "go" as a source is interpreted as a file, as a tool it's interpreted as something on the PATH.
-		return core.SystemPathLabel{Name: src, Path: s.state.Config.Build.Path}
+		return core.SystemPathLabel{Name: src, Path: s.state.Config.Path()}
 	}
 	// Make sure it's not the actual build file.
 	for _, filename := range s.state.Config.Parse.BuildFileName {

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -40,7 +40,7 @@ func TestEnvVars(t *testing.T) {
 	assert.NotContains(t, env, "PATH=/wibble")
 	env = environ(config, true)
 	assert.NotContains(t, env, "PATH=/usr/local/bin:/usr/bin:/bin")
-	assert.Contains(t, env, "PATH=/wibble")
+	assert.Contains(t, env, "PATH=/wibble:"+os.Getenv("TMP_DIR")+"/.please")
 }
 
 func makeState() (*core.BuildState, []core.BuildLabel, []core.BuildLabel) {

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -40,7 +40,7 @@ func TestEnvVars(t *testing.T) {
 	assert.NotContains(t, env, "PATH=/wibble")
 	env = environ(config, true)
 	assert.NotContains(t, env, "PATH=/usr/local/bin:/usr/bin:/bin")
-	assert.Contains(t, env, "PATH=/wibble:"+os.Getenv("TMP_DIR")+"/.please")
+	assert.Contains(t, env, "PATH="+os.Getenv("TMP_DIR")+"/.please:/wibble")
 }
 
 func makeState() (*core.BuildState, []core.BuildLabel, []core.BuildLabel) {

--- a/src/tool/tool_test.go
+++ b/src/tool/tool_test.go
@@ -11,11 +11,11 @@ import (
 func TestMatchingTools(t *testing.T) {
 	c, err := core.ReadConfigFiles(nil, "")
 	assert.NoError(t, err)
-	assert.Equal(t, map[string]string{"pex": "~/.please/please_pex"}, matchingTools(c, "p"))
-	assert.Equal(t, map[string]string{"pex": "~/.please/please_pex"}, matchingTools(c, "pex"))
+	assert.Equal(t, map[string]string{"pex": "please_pex"}, matchingTools(c, "p"))
+	assert.Equal(t, map[string]string{"pex": "please_pex"}, matchingTools(c, "pex"))
 	assert.Equal(t, map[string]string{
-		"javacworker": "~/.please/javac_worker",
-		"jarcat":      "~/.please/jarcat",
+		"javacworker": "javac_worker",
+		"jarcat":      "jarcat",
 	}, matchingTools(c, "ja"))
 }
 


### PR DESCRIPTION
This fixes a (fairly old now) request in #455: look up the various tools via PATH rather than insisting on them being in the install location.