### PR TITLE
Support Go build flags

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -225,6 +225,7 @@ func DefaultConfiguration() *Configuration {
 	config.Go.GoTool = "go"
 	config.Go.CgoCCTool = "gcc"
 	config.Go.GoPath = "$TMP_DIR:$TMP_DIR/src:$TMP_DIR/$PKG_DIR:$TMP_DIR/third_party/go:$TMP_DIR/third_party/"
+	config.Go.FilterSources = true
 	config.Python.PipTool = "pip3"
 	config.Python.DefaultInterpreter = "python3"
 	config.Python.TestRunner = "unittest"
@@ -379,6 +380,7 @@ type Configuration struct {
 		GoPath        string `help:"If set, will set the GOPATH environment variable appropriately during build actions." var:"GOPATH"`
 		ImportPath    string `help:"Sets the default Go import path at the root of this repository.\nFor example, in the Please repo, we might set it to github.com/thought-machine/please to allow imports from that package within the repo." var:"GO_IMPORT_PATH"`
 		CgoCCTool     string `help:"Sets the location of CC while building cgo_library and cgo_test rules. Defaults to gcc" var:"CGO_CC_TOOL"`
+		FilterSources bool   `help:"Sets whether to run Go source files through the filter tool by default. Can be overridden for individual go_library rules." var:"GO_FILTER_SRCS"`
 		FilterTool    string `help:"Sets the location of the please_go_filter tool that is used to filter source files against build constraints." var:"GO_FILTER_TOOL"`
 		DefaultStatic bool   `help:"Sets Go binaries to default to static linking. Note that enabling this may have negative consequences for some code, including Go's DNS lookup code in the net module." var:"GO_DEFAULT_STATIC"`
 	} `help:"Please has built-in support for compiling Go, and of course is written in Go itself.\nSee the config subfields or the Go rules themselves for more information.\n\nNote that Please is a bit more flexible than Go about directory layout - for example, it is possible to have multiple packages in a directory, but it's not a good idea to push this too far since Go's directory layout is inextricably linked with its import paths."`

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -352,6 +352,8 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
                      definition to the linker.  If set to a dict, each key/value pair is
                      used to contruct the list of definitions passed to the linker.
       tags (list): List of Go build tags to consider satisfied.
+                   N.B. These should include any tags on the go_library as well, they are not
+                        implicitly reused.
     """
     timeout, labels = _test_size_and_timeout(size, timeout, labels)
     # Unfortunately we have to recompile this to build the test together with its library.
@@ -466,6 +468,8 @@ def cgo_test(name:str, srcs:list, data:list=None, deps:list=None, visibility:lis
                      It may not be easy to make cgo tests work when linked statically; depending
                      on your toolchain it may not be possible or may fail.
       tags (list): List of Go build tags to consider satisfied.
+                   N.B. These should include any tags on the go_library as well, they are not
+                        implicitly reused.
     """
     return go_test(
         name = name,

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -16,7 +16,8 @@ _LINK_PKGS_CMD = ' '.join([
 def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=None, deps:list=[],
                visibility:list=None, test_only:bool&testonly=False, complete:bool=True,
                _needs_transitive_deps=False, _all_srcs=False, cover:bool=True,
-               filter_srcs:bool=True, tags:list=[], _link_private:bool=False, _link_extra:bool=True):
+               filter_srcs:bool=CONFIG.GO_FILTER_SRCS, tags:list=[],
+               _link_private:bool=False, _link_extra:bool=True):
     """Generates a Go library which can be reused by other rules.
 
     Args:
@@ -91,37 +92,52 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
             provides = {'go': ':' + name, 'go_src': lib_rule},
             test_only = test_only,
         )
+    tools = { 'go': [CONFIG.GO_TOOL] }
 
     # go_test and cgo_library need access to the sources as well.
-    src_rule = filegroup(
-        name = name,
-        tag = 'srcs',
-        srcs=srcs,
-        exported_deps=deps,
-        visibility=visibility,
-        requires=['go'],
-        labels = src_labels,
-        test_only=test_only,
-    )
-
-    tools = { 'go': [CONFIG.GO_TOOL] }
     if filter_srcs:
-        tools['filter'] = [CONFIG.GO_FILTER_TOOL]
+        tool = [CONFIG.GO_FILTER_TOOL]
+        cmd = '$TOOL $SRCS'
+        if tags:
+            cmd += ' -tags "%s"' % ','.join(tags)
+        src_rule = build_rule(
+            name = name,
+            tag = 'srcs',
+            srcs = srcs,
+            cmd = cmd,
+            post_build = lambda name, output: [add_out(name, out) for out in output],
+            tools = tool,
+            deps = deps,
+            requires = ['go'],
+            labels = src_labels,
+            test_only = test_only,
+        )
+        tools['filter'] = tool
+    else:
+        src_rule = filegroup(
+            name = name,
+            tag = 'srcs',
+            srcs = srcs,
+            deps = deps,
+            requires = ['go'],
+            labels = src_labels,
+            test_only = test_only,
+        )
 
     return build_rule(
-        name=name,
-        srcs=srcs,
-        deps=deps + [src_rule],
-        outs=[out],
-        cmd=_go_library_cmds(complete=complete, all_srcs=_all_srcs, cover=cover, filter_srcs=filter_srcs, tags=','.join(tags)),
-        visibility=visibility,
-        building_description="Compiling...",
-        requires=['go', 'go_src'] if _all_srcs else ['go'],
-        provides={'go': ':' + name, 'go_src': src_rule},
+        name = name,
+        srcs = [src_rule],
+        deps = deps,
+        outs = [out],
+        cmd = _go_library_cmds(complete=complete, all_srcs=_all_srcs, cover=cover),
+        visibility = visibility,
+        building_description = "Compiling...",
+        requires = ['go', 'go_src'] if _all_srcs else ['go'],
+        provides = {'go': ':' + name, 'go_src': src_rule},
         labels = labels,
-        test_only=test_only,
-        tools=tools,
-        needs_transitive_deps=_needs_transitive_deps,
+        test_only = test_only,
+        tools = tools,
+        needs_transitive_deps = _needs_transitive_deps,
     )
 
 
@@ -709,9 +725,8 @@ def _replace_test_package(name, output, static, definitions):
                     set_command(lib, k, f'mv -f $PKG_DIR/{new_name}.a $PKG_DIR/{pkg_name}.a && {v}')
 
 
-def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True, tags=''):
+def _go_library_cmds(complete=True, all_srcs=False, cover=True):
     """Returns the commands to run for building a Go library."""
-    filter_cmd = ('export SRCS="$(${TOOLS_FILTER} -tags="%s" ${SRCS})"; ' % tags) if filter_srcs else ''
     # Invokes the Go compiler.
     complete_flag = '-complete ' if complete else ''
     compile_cmd = '$TOOLS_GO tool compile -trimpath $TMP_DIR %s%s -pack -o $OUT ' % (complete_flag, _GOPATH)
@@ -720,11 +735,11 @@ def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True
     prefix = ('export SRCS="$PKG_DIR/*.go"; ' + _LINK_PKGS_CMD) if all_srcs else _LINK_PKGS_CMD
     prefix += _go_import_path_cmd(CONFIG.GO_IMPORT_PATH)
     cmds = {
-        'dbg': f'{prefix}; {filter_cmd}{compile_cmd} -N -l $SRCS',
-        'opt': f'{prefix}; {filter_cmd}{compile_cmd} $SRCS',
+        'dbg': f'{prefix}; {compile_cmd} -N -l $SRCS',
+        'opt': f'{prefix}; {compile_cmd} $SRCS',
     }
     if cover:
-        cmds['cover'] = f'{prefix}; {filter_cmd}{cover_cmd} && {compile_cmd} $SRCS'
+        cmds['cover'] = f'{prefix}; {cover_cmd} && {compile_cmd} $SRCS'
     return cmds
 
 

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -707,7 +707,7 @@ def _replace_test_package(name, output, static, definitions):
 
 def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True, tags=''):
     """Returns the commands to run for building a Go library."""
-    filter_cmd = 'export SRCS="$(${TOOLS_FILTER} -tags="{tags}" ${SRCS})"; ' if filter_srcs else ''
+    filter_cmd = ('export SRCS="$(${TOOLS_FILTER} -tags="%s" ${SRCS})"; ' % tags) if filter_srcs else ''
     # Invokes the Go compiler.
     complete_flag = '-complete ' if complete else ''
     compile_cmd = '$TOOLS_GO tool compile -trimpath $TMP_DIR %s%s -pack -o $OUT ' % (complete_flag, _GOPATH)

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -16,7 +16,7 @@ _LINK_PKGS_CMD = ' '.join([
 def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=None, deps:list=[],
                visibility:list=None, test_only:bool&testonly=False, complete:bool=True,
                _needs_transitive_deps=False, _all_srcs=False, cover:bool=True,
-               filter_srcs:bool=True, _link_private:bool=False, _link_extra:bool=True):
+               filter_srcs:bool=True, tags:list=[], _link_private:bool=False, _link_extra:bool=True):
     """Generates a Go library which can be reused by other rules.
 
     Args:
@@ -36,6 +36,7 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
                     but if this is false they never will be. Can be useful for e.g. third-party
                     code that you never want to be instrumented.
       filter_srcs (bool): If True, filters source files through Go's standard build constraints.
+      tags (list): List of Go build tags to consider satisfied.
     """
     out = out or name + '.a'
     labels = []
@@ -112,7 +113,7 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
         srcs=srcs,
         deps=deps + [src_rule],
         outs=[out],
-        cmd=_go_library_cmds(complete=complete, all_srcs=_all_srcs, cover=cover, filter_srcs=filter_srcs),
+        cmd=_go_library_cmds(complete=complete, all_srcs=_all_srcs, cover=cover, filter_srcs=filter_srcs, tags=','.join(tags)),
         visibility=visibility,
         building_description="Compiling...",
         requires=['go', 'go_src'] if _all_srcs else ['go'],
@@ -126,7 +127,8 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
 
 def cgo_library(name:str, srcs:list, go_srcs:list=[], c_srcs:list=[], hdrs:list=[],
                 out:str=None, compiler_flags:list&cflags=[], linker_flags:list&ldflags=[], pkg_config:list=[],
-                subdir:str='', deps:list=[], visibility:list=None, test_only:bool&testonly=False):
+                subdir:str='', deps:list=[], visibility:list=None, test_only:bool&testonly=False,
+                tags:list=[]):
     """Generates a Go library which can be reused by other rules.
 
     Note that by its nature this is something of a hybrid of Go and C rules. It can depend
@@ -156,6 +158,7 @@ def cgo_library(name:str, srcs:list, go_srcs:list=[], c_srcs:list=[], hdrs:list=
                    and depending on that.
       visibility (list): Visibility specification
       test_only (bool): If True, is only visible to test rules.
+      tags (list): List of Go build tags to consider satisfied.
     """
     file_srcs = [src for src in srcs if not src.startswith('/') and not src.startswith(':')]
     post_build = lambda rule, output: [add_out(rule, 'c' if line.endswith('.c') else 'go', line) for line in output]
@@ -206,6 +209,7 @@ def cgo_library(name:str, srcs:list, go_srcs:list=[], c_srcs:list=[], hdrs:list=
         test_only = test_only,
         complete = False,
         deps = deps,
+        tags = tags,
     )
     # And finally combine the compiled C code into the Go archive object so go tool link can find it later.
     return _merge_cgo_obj(
@@ -258,7 +262,7 @@ def _merge_cgo_obj(name, a_rule, o_rule=None, visibility=None, test_only=False, 
 
 def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=[],
               visibility:list=None, test_only:bool&testonly=False, static:bool=CONFIG.GO_DEFAULT_STATIC,
-              filter_srcs:bool=True, definitions:str|list|dict=None):
+              filter_srcs:bool=True, definitions:str|list|dict=None, tags:list=[]):
     """Compiles a Go binary.
 
     Args:
@@ -280,6 +284,7 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
                      when calling the Go linker.  If set to a list, pass each value as a
                      definition to the linker.  If set to a dict, each key/value pair is
                      used to contruct the list of definitions passed to the linker.
+      tags (list): List of Go build tags to consider satisfied.
     """
     lib = go_library(
         name=f'_{name}#lib',
@@ -288,6 +293,7 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
         asm_srcs=asm_srcs,
         deps=deps,
         test_only=test_only,
+        tags = tags,
         _link_private = True,
         _link_extra = False,
     )
@@ -314,7 +320,7 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
             flags:str='', container:bool|dict=False, sandbox:bool=None, cgo:bool=False,
             external:bool=False, timeout:int=0, flaky:bool|int=0, test_outputs:list=None,
             labels:list&features&tags=None, size:str=None, static:bool=CONFIG.GO_DEFAULT_STATIC,
-            definitions:str|list|dict=None):
+            definitions:str|list|dict=None, tags:list=[]):
     """Defines a Go test rule.
 
     Args:
@@ -345,6 +351,7 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
                      when calling the Go linker.  If set to a list, pass each value as a
                      definition to the linker.  If set to a dict, each key/value pair is
                      used to contruct the list of definitions passed to the linker.
+      tags (list): List of Go build tags to consider satisfied.
     """
     timeout, labels = _test_size_and_timeout(size, timeout, labels)
     # Unfortunately we have to recompile this to build the test together with its library.
@@ -357,6 +364,7 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
         _all_srcs = not external,
         _link_extra = False,
         complete = False,
+        tags = tags,
     )
     if cgo:
         lib_rule = _merge_cgo_obj(
@@ -429,7 +437,8 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
 
 def cgo_test(name:str, srcs:list, data:list=None, deps:list=None, visibility:list=None,
              flags:str='', container:bool|dict=False, sandbox:bool=None, timeout:int=0, flaky:bool|int=0,
-             test_outputs:list=None, labels:list&features&tags=None, size:str=None, static:bool=False):
+             test_outputs:list=None, labels:list&features&tags=None, size:str=None,
+             static:bool=False, tags:list=[]):
     """Defines a Go test rule over a cgo_library.
 
     If the library you are testing is a cgo_library, you must use this instead of go_test.
@@ -456,6 +465,7 @@ def cgo_test(name:str, srcs:list, data:list=None, deps:list=None, visibility:lis
                      has absolutely no external dependencies.
                      It may not be easy to make cgo tests work when linked statically; depending
                      on your toolchain it may not be possible or may fail.
+      tags (list): List of Go build tags to consider satisfied.
     """
     return go_test(
         name = name,
@@ -695,9 +705,9 @@ def _replace_test_package(name, output, static, definitions):
                     set_command(lib, k, f'mv -f $PKG_DIR/{new_name}.a $PKG_DIR/{pkg_name}.a && {v}')
 
 
-def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True):
+def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True, tags=''):
     """Returns the commands to run for building a Go library."""
-    filter_cmd = 'export SRCS="$(${TOOLS_FILTER} ${SRCS})"; ' if filter_srcs else ''
+    filter_cmd = 'export SRCS="$(${TOOLS_FILTER} -tags="{tags}" ${SRCS})"; ' if filter_srcs else ''
     # Invokes the Go compiler.
     complete_flag = '-complete ' if complete else ''
     compile_cmd = '$TOOLS_GO tool compile -trimpath $TMP_DIR %s%s -pack -o $OUT ' % (complete_flag, _GOPATH)

--- a/test/go_rules/tags/BUILD
+++ b/test/go_rules/tags/BUILD
@@ -1,0 +1,15 @@
+go_library(
+    name = "tags",
+    srcs = ["tags1.go", "tags2.go"],
+    tags = ["test"],
+)
+
+go_test(
+    name = "tags_test",
+    srcs = ["tags_test.go"],
+    tags = ["test"],
+    deps = [
+        ":tags",
+        "//third_party/go:testify",
+    ],
+)

--- a/test/go_rules/tags/tags1.go
+++ b/test/go_rules/tags/tags1.go
@@ -1,0 +1,7 @@
+// +build !test
+
+package tags
+
+func WhatIsTheQuestion() string {
+	return "what do you get if you multiply six by nine"
+}

--- a/test/go_rules/tags/tags2.go
+++ b/test/go_rules/tags/tags2.go
@@ -1,0 +1,7 @@
+// +build test
+
+package tags
+
+func WhatIsTheQuestion() string {
+	return "what do you get if you multiply six by seven"
+}

--- a/test/go_rules/tags/tags_test.go
+++ b/test/go_rules/tags/tags_test.go
@@ -1,0 +1,11 @@
+package tags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuestion(t *testing.T) {
+	assert.Equal(t, "what do you get if you multiply six by seven", WhatIsTheQuestion())
+}

--- a/tools/build_langserver/langserver/BUILD
+++ b/tools/build_langserver/langserver/BUILD
@@ -25,12 +25,8 @@ go_library(
 
 go_test(
     name = "langserver_test",
-    srcs = glob(
-        [
-            "*_test.go",
-            "setup_test.go",
-        ],
-        exclude = ["utils_test.go"],
+    srcs = glob(["*_test.go"],
+        exclude = ["utils_test.go", "analyzer_test.go"],
     ),
     data = ["test_data"],
     deps = [

--- a/tools/build_langserver/langserver/analyzer_test.go
+++ b/tools/build_langserver/langserver/analyzer_test.go
@@ -23,7 +23,7 @@ func TestNewAnalyzer(t *testing.T) {
 	assert.NotEqual(t, nil, a.BuiltIns)
 
 	goLibrary := a.BuiltIns["go_library"]
-	assert.Equal(t, 15, len(goLibrary.ArgMap))
+	assert.Equal(t, 16, len(goLibrary.ArgMap))
 	assert.Equal(t, true, goLibrary.ArgMap["name"].Required)
 
 	// check preloadBuildDefs has being loaded
@@ -64,7 +64,7 @@ func TestNewRuleDef(t *testing.T) {
 	// Test header the definition for build_rule
 	expected := "def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=None, deps:list=[],\n" +
 		"               visibility:list=None, test_only:bool&testonly=False, complete:bool=True, cover:bool=True,\n" +
-		"               filter_srcs:bool=True)"
+		"               filter_srcs:bool=True, tags:list=[])"
 
 	ruleContent := rules.MustAsset("go_rules.build_defs")
 

--- a/tools/build_langserver/langserver/completion_test.go
+++ b/tools/build_langserver/langserver/completion_test.go
@@ -192,7 +192,7 @@ func TestCompletionWithBuiltins(t *testing.T) {
 		if item.Label == "go_library" {
 			expectedDetail := "(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=None, deps:list=[],\n" +
 				"               visibility:list=None, test_only:bool&testonly=False, complete:bool=True, cover:bool=True,\n" +
-				"               filter_srcs:bool=True)"
+				"               filter_srcs:bool=True, tags:list=[])"
 			assert.Equal(t, expectedDetail, item.Detail)
 		}
 	}

--- a/tools/build_langserver/langserver/signature_test.go
+++ b/tools/build_langserver/langserver/signature_test.go
@@ -19,7 +19,7 @@ func TestGetSignaturesEmptyCall(t *testing.T) {
 
 	expectedLabel := "(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=[],\n" +
 		"              visibility:list=None, test_only:bool&testonly=False, static:bool=CONFIG.GO_DEFAULT_STATIC,\n" +
-		"              filter_srcs:bool=True, definitions:str|list|dict=None)"
+		"              filter_srcs:bool=True, definitions:str|list|dict=None, tags:list=[])"
 	assert.Equal(t, expectedLabel, sig.Signatures[0].Label)
 }
 

--- a/tools/please_go_filter/please_go_filter.go
+++ b/tools/please_go_filter/please_go_filter.go
@@ -14,19 +14,30 @@ import (
 
 var taglist = flag.String("tags", "", "Comma-separated list of extra build tags to apply as build constraints.")
 
+func mv(src, dest string) {
+	if err := os.Rename(src, dest); err != nil {
+		fmt.Fprintf(os.Stderr, "Error renaming source: %s", err)
+		os.Exit(1)
+	}
+	fmt.Println(dest)
+}
+
 func main() {
 	flag.Parse()
 
 	ctxt := build.Default
 	ctxt.BuildTags = strings.Split(*taglist, ",")
 
+	pkg := os.Getenv("PKG")
+
 	for _, f := range flag.Args() {
 		dir, file := filepath.Split(f)
+		dest := strings.TrimLeft(strings.TrimPrefix(f, pkg), "/")
 
 		// MatchFile skips _ prefixed files by default, assuming they're editor
 		// temporary files - but we need to include cgo generated files.
 		if strings.HasPrefix(file, "_cgo_") {
-			fmt.Println(f)
+			mv(f, dest)
 			continue
 		}
 
@@ -37,9 +48,7 @@ func main() {
 		}
 
 		if ok {
-			fmt.Println(f)
+			mv(f, dest)
 		}
 	}
-
-	os.Exit(0)
 }


### PR DESCRIPTION
Resolves #532 

Minor nit: flags on a `go_library` have to be repeated on its `go_test` due to the way the library has to be recompiled :( I suspect this is rare enough and easy enough to do that it doesn't really matter, although it might be unintuitive that this is the behaviour.