### PR TITLE
Fix Go coverage for hyphens in path

### DIFF
--- a/test/go_rules/cover-test/BUILD
+++ b/test/go_rules/cover-test/BUILD
@@ -1,0 +1,14 @@
+# This deliberately has hyphens in the name to mimic #537
+proto_library(
+    name = "test-proto",
+    srcs = ["test-proto.proto"],
+)
+
+go_test(
+    name = "cover_test",
+    srcs = ["cover_test.go"],
+    deps = [
+        ":test-proto",
+        "//third_party/go:testify",
+    ],
+)

--- a/test/go_rules/cover-test/cover_test.go
+++ b/test/go_rules/cover-test/cover_test.go
@@ -1,0 +1,15 @@
+package covertest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pb "github.com/thought-machine/please/test/go_rules/cover-test/test-proto"
+)
+
+func TestProto(t *testing.T) {
+	// Not much to be done here, the real test is that this has compiled.
+	msg := &pb.Test{S: "test"}
+	assert.Equal(t, "test", msg.S)
+}

--- a/test/go_rules/cover-test/test-proto.proto
+++ b/test/go_rules/cover-test/test-proto.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package covertest;
+
+message Test {
+    string s = 1;
+}

--- a/tools/please_go_test/gotest/find_cover_vars.go
+++ b/tools/please_go_test/gotest/find_cover_vars.go
@@ -71,7 +71,7 @@ func findCoverVars(filepath, importPath string, srcs []string) ([]CoverVar, erro
 		} else if strings.HasSuffix(name, ".go") && !info.IsDir() && !contains(path.Join(dir, name), srcs) {
 			if ok, err := build.Default.MatchFile(dir, name); ok && err == nil {
 				// N.B. The scheme here must match what we do in go_rules.build_defs
-				v := "GoCover_" + strings.Replace(name, ".", "_", -1)
+				v := "GoCover_" + strings.Replace(strings.Replace(name, ".", "_", -1), "-", "_", -1)
 				fs := token.NewFileSet()
 				ast, err := parser.ParseFile(fs, path.Join(dir, name), nil, parser.PackageClauseOnly)
 				if err != nil {
@@ -102,7 +102,7 @@ func coverVar(dir, importPath, v, pkg string) CoverVar {
 	return CoverVar{
 		Dir:        dir,
 		ImportPath: path.Join(path.Dir(importPath), pkg),
-		Var:        strings.Replace(strings.Replace(v, "-", "_", -1), ".", "_", -1),
+		Var:        v,
 		File:       f,
 	}
 }

--- a/tools/please_go_test/gotest/find_cover_vars.go
+++ b/tools/please_go_test/gotest/find_cover_vars.go
@@ -21,6 +21,13 @@ type CoverVar struct {
 	Dir, ImportPath, ImportName, Var, File string
 }
 
+// replacer is used to replace characters in cover variables.
+// The scheme here must match what we do in go_rules.build_defs
+var replacer = strings.NewReplacer(
+	".", "_",
+	"-", "_",
+)
+
 // FindCoverVars searches the given directory recursively to find all Go files with coverage variables.
 func FindCoverVars(dir, importPath string, exclude, srcs []string) ([]CoverVar, error) {
 	if dir == "" {
@@ -68,8 +75,7 @@ func findCoverVars(filepath, importPath string, srcs []string) ([]CoverVar, erro
 			return nil, nil
 		} else if strings.HasSuffix(name, ".go") && !info.IsDir() && !contains(path.Join(dir, name), srcs) {
 			if ok, err := build.Default.MatchFile(dir, name); ok && err == nil {
-				// N.B. The scheme here must match what we do in go_rules.build_defs
-				v := "GoCover_" + strings.Replace(strings.Replace(name, ".", "_", -1), "-", "_", -1)
+				v := "GoCover_" + replacer.Replace(name)
 				ret = append(ret, coverVar(dir, importPath, v))
 			}
 		}

--- a/tools/please_go_test/gotest/find_cover_vars.go
+++ b/tools/please_go_test/gotest/find_cover_vars.go
@@ -3,8 +3,6 @@ package gotest
 
 import (
 	"go/build"
-	"go/parser"
-	"go/token"
 	"io/ioutil"
 	"path"
 	"path/filepath"
@@ -72,12 +70,7 @@ func findCoverVars(filepath, importPath string, srcs []string) ([]CoverVar, erro
 			if ok, err := build.Default.MatchFile(dir, name); ok && err == nil {
 				// N.B. The scheme here must match what we do in go_rules.build_defs
 				v := "GoCover_" + strings.Replace(strings.Replace(name, ".", "_", -1), "-", "_", -1)
-				fs := token.NewFileSet()
-				ast, err := parser.ParseFile(fs, path.Join(dir, name), nil, parser.PackageClauseOnly)
-				if err != nil {
-					return nil, err
-				}
-				ret = append(ret, coverVar(dir, importPath, v, ast.Name.Name))
+				ret = append(ret, coverVar(dir, importPath, v))
 			}
 		}
 	}
@@ -93,7 +86,7 @@ func contains(needle string, haystack []string) bool {
 	return false
 }
 
-func coverVar(dir, importPath, v, pkg string) CoverVar {
+func coverVar(dir, importPath, v string) CoverVar {
 	log.Info("Found cover variable: %s %s %s", dir, importPath, v)
 	f := path.Join(dir, strings.TrimPrefix(v, "GoCover_"))
 	if strings.HasSuffix(f, "_go") {
@@ -101,7 +94,7 @@ func coverVar(dir, importPath, v, pkg string) CoverVar {
 	}
 	return CoverVar{
 		Dir:        dir,
-		ImportPath: path.Join(path.Dir(importPath), pkg),
+		ImportPath: importPath,
 		Var:        v,
 		File:       f,
 	}

--- a/tools/please_go_test/gotest/find_cover_vars.go
+++ b/tools/please_go_test/gotest/find_cover_vars.go
@@ -102,7 +102,7 @@ func coverVar(dir, importPath, v, pkg string) CoverVar {
 	return CoverVar{
 		Dir:        dir,
 		ImportPath: path.Join(path.Dir(importPath), pkg),
-		Var:        strings.Replace(v, "-", "_", -1),
+		Var:        strings.Replace(strings.Replace(v, "-", "_", -1), ".", "_", -1),
 		File:       f,
 	}
 }


### PR DESCRIPTION
Bit nervous that the space of allowable characters in filenames is a lot higher than that of valid Go identifiers - maybe it should be replacing everything outside a set...

Fixes #537 