### PR TITLE
Sandbox test directories

### DIFF
--- a/.plzconfig.ci
+++ b/.plzconfig.ci
@@ -1,3 +1,11 @@
 ; Config file used for CI.
 [cache]
 dircompress = true
+
+[build]
+path = /usr/local/bin:/usr/bin:/bin:plz-out/bin/tools/sandbox
+pleasesandboxtool = please_sandbox
+
+[test]
+; This will only have any impact on Linux, but shouldn't hurt things on other platforms.
+sandbox = true

--- a/.plzconfig.ci
+++ b/.plzconfig.ci
@@ -1,11 +1,3 @@
 ; Config file used for CI.
 [cache]
 dircompress = true
-
-[build]
-path = /usr/local/bin:/usr/bin:/bin:plz-out/bin/tools/sandbox
-pleasesandboxtool = please_sandbox
-
-[test]
-; This will only have any impact on Linux, but shouldn't hurt things on other platforms.
-sandbox = true

--- a/build_defs/plz_e2e_test.build_defs
+++ b/build_defs/plz_e2e_test.build_defs
@@ -45,5 +45,5 @@ def plz_e2e_test(name, cmd, pre_cmd=None, expected_output=None, expected_failure
         deps = deps,
         labels = ['e2e'] + (labels or []),
         no_test_output = True,
-        sandbox = None,
+        sandbox = False,
     )

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -127,12 +127,7 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) Bui
 		env = append(env, "COVERAGE=true", "COVERAGE_FILE=test.coverage")
 	}
 	if len(target.Outputs()) > 0 {
-		// Bit of a hack; we would prefer to be agnostic to sandboxing here.
-		if target.TestSandbox {
-			env = append(env, "TEST="+path.Join("/tmp/test", target.Outputs()[0]))
-		} else {
-			env = append(env, "TEST="+path.Join(testDir, target.Outputs()[0]))
-		}
+		env = append(env, "TEST="+path.Join(target.SandboxTestDir(), target.Outputs()[0]))
 	}
 	if len(target.Data) > 0 {
 		env = append(env, "DATA="+strings.Join(target.AllData(state.Graph), " "))

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -127,7 +127,12 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) Bui
 		env = append(env, "COVERAGE=true", "COVERAGE_FILE=test.coverage")
 	}
 	if len(target.Outputs()) > 0 {
-		env = append(env, "TEST="+target.Outputs()[0])
+		// Bit of a hack; we would prefer to be agnostic to sandboxing here.
+		if target.TestSandbox {
+			env = append(env, "TEST="+path.Join("/tmp/test", target.Outputs()[0]))
+		} else {
+			env = append(env, "TEST="+path.Join(testDir, target.Outputs()[0]))
+		}
 	}
 	if len(target.Data) > 0 {
 		env = append(env, "DATA="+strings.Join(target.AllData(state.Graph), " "))

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -124,10 +124,10 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) Bui
 		env = append(env, "HOME="+testDir)
 	}
 	if state.NeedCoverage && !target.HasAnyLabel(state.Config.Test.DisableCoverage) {
-		env = append(env, "COVERAGE=true", "COVERAGE_FILE="+path.Join(testDir, "test.coverage"))
+		env = append(env, "COVERAGE=true", "COVERAGE_FILE=test.coverage")
 	}
 	if len(target.Outputs()) > 0 {
-		env = append(env, "TEST="+path.Join(testDir, target.Outputs()[0]))
+		env = append(env, "TEST="+target.Outputs()[0])
 	}
 	if len(target.Data) > 0 {
 		env = append(env, "DATA="+strings.Join(target.AllData(state.Graph), " "))

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -27,7 +27,7 @@ const BinDir string = "plz-out/bin"
 // DefaultBuildingDescription is the default description for targets when they're building.
 const DefaultBuildingDescription = "Building..."
 
-// The directory that sandboxed actions are run in.
+// SandboxDir is the directory that sandboxed actions are run in.
 const SandboxDir = "/tmp/plz_sandbox"
 
 // Suffixes for temporary directories

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -27,6 +27,9 @@ const BinDir string = "plz-out/bin"
 // DefaultBuildingDescription is the default description for targets when they're building.
 const DefaultBuildingDescription = "Building..."
 
+// The directory that sandboxed actions are run in.
+const SandboxDir = "/tmp/plz_sandbox"
+
 // Suffixes for temporary directories
 const buildDirSuffix = "._build"
 const testDirSuffix = "._test"
@@ -284,6 +287,15 @@ func (target *BuildTarget) OutDir() string {
 // and to facilitate containerising tests.
 func (target *BuildTarget) TestDir() string {
 	return path.Join(TmpDir, target.Label.Subrepo, target.Label.PackageName, target.Label.Name+testDirSuffix)
+}
+
+// SandboxTestDir returns the test directory for this target, possibly sandboxed.
+// If it is not sandboxed the returned directory is like TestDir but is an absolute path.
+func (target *BuildTarget) SandboxTestDir() string {
+	if target.TestSandbox {
+		return SandboxDir
+	}
+	return path.Join(RepoRoot, target.TestDir())
 }
 
 // TestResultsFile returns the output results file for tests for this target.

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -585,6 +585,9 @@ func LookPath(filename string, paths []string) (string, error) {
 		for _, p2 := range strings.Split(p, ":") {
 			p3 := path.Join(p2, filename)
 			if _, err := os.Stat(p3); err == nil {
+				if !filepath.IsAbs(p3) {
+					return path.Join(RepoRoot, p3), nil
+				}
 				return p3, nil
 			}
 		}

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -585,9 +585,6 @@ func LookPath(filename string, paths []string) (string, error) {
 		for _, p2 := range strings.Split(p, ":") {
 			p3 := path.Join(p2, filename)
 			if _, err := os.Stat(p3); err == nil {
-				if !filepath.IsAbs(p3) {
-					return path.Join(RepoRoot, p3), nil
-				}
 				return p3, nil
 			}
 		}

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -497,7 +497,12 @@ func printTempDirs(state *core.BuildState, duration time.Duration) {
 			fmt.Printf("   Expanded: %s\n", os.Expand(cmd, env.ReplaceEnvironment))
 		} else {
 			fmt.Printf("\n")
-			cmd := exec.Command("bash", "--noprofile", "--norc", "-o", "pipefail") // plz requires bash, some commands contain bashisms.
+			argv := []string{"bash", "--noprofile", "--norc", "-o", "pipefail"}
+			if (state.NeedTests && target.TestSandbox) || (!state.NeedTests && target.Sandbox) {
+				argv = core.MustSandboxCommand(state, argv)
+			}
+			log.Debug("Full command: %s", strings.Join(argv, " "))
+			cmd := exec.Command(argv[0], argv[1:]...)
 			cmd.Dir = dir
 			cmd.Env = env
 			cmd.Stdin = os.Stdin

--- a/tools/build_langserver/langserver/BUILD
+++ b/tools/build_langserver/langserver/BUILD
@@ -33,24 +33,24 @@ go_test(
         exclude = ["utils_test.go"],
     ),
     data = ["test_data"],
+    # TODO(peterebden): All these tests fail inside the sandbox. Fix.
+    sandbox = False,
     deps = [
         ":langserver",
         "//src/parse/rules",
         "//third_party/go:testify",
     ],
-    # TODO(peterebden): All these tests fail inside the sandbox. Fix.
-    sandbox = False,
 )
 
 go_test(
     name = "utils_test",
     srcs = ["utils_test.go"],
     data = ["test_data"],
+    sandbox = False,
     deps = [
         ":langserver",
         "//third_party/go:testify",
     ],
-    sandbox = False,
 )
 
 go_test(
@@ -60,12 +60,12 @@ go_test(
         "setup_test.go",
     ],
     data = ["test_data"],
+    sandbox = False,
     deps = [
         ":langserver",
         "//third_party/go:testify",
         "//tools/build_langserver/lsp",
     ],
-    sandbox = False,
 )
 
 go_test(
@@ -75,10 +75,10 @@ go_test(
         "setup_test.go",
     ],
     data = ["test_data"],
+    sandbox = False,
     deps = [
         ":langserver",
         "//third_party/go:testify",
         "//tools/build_langserver/lsp",
     ],
-    sandbox = False,
 )

--- a/tools/build_langserver/langserver/BUILD
+++ b/tools/build_langserver/langserver/BUILD
@@ -38,6 +38,8 @@ go_test(
         "//src/parse/rules",
         "//third_party/go:testify",
     ],
+    # TODO(peterebden): All these tests fail inside the sandbox. Fix.
+    sandbox = False,
 )
 
 go_test(
@@ -48,6 +50,7 @@ go_test(
         ":langserver",
         "//third_party/go:testify",
     ],
+    sandbox = False,
 )
 
 go_test(
@@ -62,6 +65,7 @@ go_test(
         "//third_party/go:testify",
         "//tools/build_langserver/lsp",
     ],
+    sandbox = False,
 )
 
 go_test(
@@ -76,4 +80,5 @@ go_test(
         "//third_party/go:testify",
         "//tools/build_langserver/lsp",
     ],
+    sandbox = False,
 )

--- a/tools/cache/cluster/BUILD
+++ b/tools/cache/cluster/BUILD
@@ -16,6 +16,7 @@ go_test(
     name = "cluster_test",
     srcs = ["cluster_test.go"],
     flaky = True,
+    sandbox = False,
     labels = ["no_circleci"],
     deps = [
         ":cluster",

--- a/tools/cache/cluster/BUILD
+++ b/tools/cache/cluster/BUILD
@@ -16,8 +16,8 @@ go_test(
     name = "cluster_test",
     srcs = ["cluster_test.go"],
     flaky = True,
-    sandbox = False,
     labels = ["no_circleci"],
+    sandbox = False,
     deps = [
         ":cluster",
         "//src/cache/proto:rpc_cache",

--- a/tools/sandbox/main.c
+++ b/tools/sandbox/main.c
@@ -100,7 +100,7 @@ int mount_tmp() {
 
 // mount_test bind mounts the test directory to
 int mount_test() {
-    const char* d = "/tmp/test";
+    const char* d = "/tmp/plz_sandbox";
     const char* dir = getenv("TEST_DIR");
     if (!dir) {
         fputs("TEST_DIR not set, will not bind-mount to /tmp/test\n", stderr);
@@ -120,7 +120,7 @@ int mount_test() {
         perror("setenv");
         return 1;
     }
-    return chdir(dir);
+    return chdir(d);
 }
 
 // contain separates the process into new namespaces to sandbox it.


### PR DESCRIPTION
i.e. they are bind-mounted across to /tmp/plz_sandbox and run from there.

Prevents tests from doing bad things like accessing the rest of the repo; it's still relatively "soft" sandboxing in that they could do that if they knew where it was, but they shouldn't have anything that tells them that now.

Most of the in-repo tests pass fine with this, except the e2e tests (expected) and a small set that clearly need some updating.