### PR TITLE
Always use a consistent stdlib.

### DIFF
--- a/test/cc_rules/clang/BUILD
+++ b/test/cc_rules/clang/BUILD
@@ -2,6 +2,12 @@
 # (Note that this only controls the tools we invoke directly, not what they
 # might use underneath - ie. we are not passing -fuse-ld or similar).
 
+# Must pass -stdlib so the STL implementation matches what we use for other deps (i.e. unittest)
+package(
+    default_dbg_cppflags = "--std=c++11 -g3 -DDEBUG -Wall -Wextra -Werror -Wno-unused-parameter -stdlib=libstdc++",
+    default_opt_cppflags = "--std=c++11 -O2 -DNDEBUG -Wall -Wextra -Werror -Wno-unused-parameter -stdlib=libstdc++",
+)
+
 package(
     cpp_tool = "clang++",
     ld_tool = "gold",

--- a/test/cc_rules/clang/modules/BUILD
+++ b/test/cc_rules/clang/modules/BUILD
@@ -2,8 +2,8 @@
 
 package(
     cpp_tool = "clang++",
-    default_dbg_cppflags = "--std=c++1z -g3 -pipe -DDEBUG -Wall -Werror -Wno-unused-command-line-argument",
-    default_opt_cppflags = "--std=c++1z -O3 -pipe -DNDEBUG -Wall -Werror -Wno-unused-command-line-argument",
+    default_dbg_cppflags = "--std=c++1z -g3 -pipe -DDEBUG -Wall -Werror -Wno-unused-command-line-argument -stdlib=libstdc++",
+    default_opt_cppflags = "--std=c++1z -O3 -pipe -DNDEBUG -Wall -Werror -Wno-unused-command-line-argument -stdlib=libstdc++",
 )
 
 cc_module(


### PR DESCRIPTION
Not sure how this passed before. Think maybe the Clang I was using before was choosing not to use libc++ but now it is - maybe new version of clang, or maybe lib was not installed before.