### PR TITLE
Experimenting with /// syntax for subrepos.

### DIFF
--- a/docs/dependencies.html
+++ b/docs/dependencies.html
@@ -55,21 +55,22 @@
 )
 </code></pre></p>
 
-<p>Rules within subrepos can be referenced using an <code>@</code> prefix on rules, anywhere
+<p>Rules within subrepos can be referenced using a triple-slash prefix on rules, anywhere
   where a build rule would normally be accepted. For example:
   <pre><code>
 cc_test(
     name = "my_test",
     ...
     deps = [
-        "@third_party/cc/gtest//:gtest_main",
+        "///third_party/cc/gtest//:gtest_main",
     ],
 )
 </code></pre>
 
 <p>Note that the subrepo label (<code>third_party/cc/gtest</code>) includes the package we defined
   it in earlier. In many ways subrepos mirror the feature in Bazel, but in this case are more
-  flexible since they're not limited to being defined at the repo root.</p>
+  flexible since they're not limited to being defined at the repo root. For compatibility,
+  we also accept an <code>@</code> prefix for subrepos instead of <code>///</code>.</p>
 
 <h2>Comparison to other systems</h2>
 

--- a/src/core/build_label_test.go
+++ b/src/core/build_label_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestString(t *testing.T) {
 	assert.Equal(t, "//src/core:core", BuildLabel{PackageName: "src/core", Name: "core"}.String())
-	assert.Equal(t, "@please//src/core:core", BuildLabel{Subrepo: "please", PackageName: "src/core", Name: "core"}.String())
+	assert.Equal(t, "///please//src/core:core", BuildLabel{Subrepo: "please", PackageName: "src/core", Name: "core"}.String())
 	assert.Equal(t, "//src/core/...", BuildLabel{PackageName: "src/core", Name: "..."}.String())
 	assert.Equal(t, "//...", BuildLabel{Name: "..."}.String())
 }
@@ -72,6 +72,7 @@ func TestLooksLikeABuildLabel(t *testing.T) {
 	assert.True(t, LooksLikeABuildLabel("@test_x86:core"))
 	assert.False(t, LooksLikeABuildLabel("core"))
 	assert.False(t, LooksLikeABuildLabel("@test_x86"))
+	assert.True(t, LooksLikeABuildLabel("///test_x86"))
 }
 
 func TestComplete(t *testing.T) {
@@ -102,7 +103,7 @@ func TestSubrepoLabel(t *testing.T) {
 }
 
 func TestParseBuildLabelParts(t *testing.T) {
-	target1 := "@unittest_cpp//:unittest_cpp"
+	target1 := "///unittest_cpp//:unittest_cpp"
 	targetNewSyntax := "@unittest_cpp"
 	pkg, name, subrepo := parseBuildLabelParts(target1, "/", nil)
 	pkg2, name2, subrepo2 := parseBuildLabelParts(targetNewSyntax, "/", nil)

--- a/src/core/label_parse_test.go
+++ b/src/core/label_parse_test.go
@@ -156,3 +156,10 @@ func TestAbsoluteEmptySubrepo(t *testing.T) {
 	label := ParseBuildLabelContext("@//tools/jarcat", pkg)
 	assert.Equal(t, "", label.Subrepo)
 }
+
+func TestNewSyntaxSubrepo(t *testing.T) {
+	// Test the new triple-slash syntax.
+	assertSubrepoLabel(t, "///subrepo//pkg:target", "pkg", "target", "subrepo")
+	assertSubrepoLabel(t, "///third_party/cc/gtest//:gtest", "", "gtest", "third_party/cc/gtest")
+	assertSubrepoLabel(t, "///third_party/cc/gtest", "", "gtest", "third_party/cc/gtest")
+}

--- a/test/BUILD
+++ b/test/BUILD
@@ -14,7 +14,7 @@ subinclude("//build_defs:plz_e2e_test")
 
 # This isn't really needed in this BUILD file, but is intended to avoid race conditions
 # between this and other BUILD files that have the same dependency.
-subinclude("@pleasings//go:go_bindata")
+subinclude("///pleasings//go:go_bindata")
 
 # Tests the expected output of 'query somepath'.
 # Note that you have to be careful with the choice of targets, since the path

--- a/test/cc_rules/gtest/BUILD
+++ b/test/cc_rules/gtest/BUILD
@@ -1,4 +1,4 @@
-package(cc_test_main = "@third_party/cc/gtest//:gtest_main")
+package(cc_test_main = "///third_party/cc/gtest//:gtest_main")
 
 cc_test(
     name = "gtest_test",

--- a/test/cross_compile/BUILD
+++ b/test/cross_compile/BUILD
@@ -16,7 +16,7 @@ sh_test(
 sh_test(
     name = "auto_arch_test",
     src = "test_arch.sh",
-    data = ["@test_x86:record_arch"],
+    data = ["///test_x86:record_arch"],
 )
 
 plz_e2e_test(

--- a/test/subrepo_subinclude/BUILD
+++ b/test/subrepo_subinclude/BUILD
@@ -1,4 +1,4 @@
-subinclude("@pleasings//go:go_bindata")
+subinclude("///pleasings//go:go_bindata")
 
 go_bindata(
     name = "embed",

--- a/tools/build_langserver/langserver/analyzer_test.go
+++ b/tools/build_langserver/langserver/analyzer_test.go
@@ -223,7 +223,7 @@ func TestBuildLabelFromString(t *testing.T) {
 	label, err = a.BuildLabelFromString(ctx, uri, "@mysubrepo//spam/eggs:ham")
 	assert.Equal(t, err, nil)
 	assert.True(t, nil == label.BuildDef)
-	assert.Equal(t, "Subrepo label: @mysubrepo//spam/eggs:ham", label.Definition)
+	assert.Equal(t, "Subrepo label: ///mysubrepo//spam/eggs:ham", label.Definition)
 }
 
 func TestAnalyzer_BuildLabelFromStringBogusLabel(t *testing.T) {


### PR DESCRIPTION
As discussed the other evening, am playing with what a `///` prefix would look like for subrepos.

I think it's a bit less "alien" than Bazel's @ but maybe a bit less obvious what's going on since there can be quite a lot of slashes.

Also debating how one should indicate something in the root repo - right now `@//tools/jarcat` does that, I don't think I like `/////tools/jarcat` and would prefer `///tools/jarcat`, but that is a little less flexible for some of the cross-compiling stuff that refers to targets in the local package and would have no way of doing that any more.