### PR TITLE
Repurpose stamp attribute to provide SCM revision

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -23,6 +23,7 @@ go_library(
     deps = [
         "//src/cli",
         "//src/fs",
+        "//src/scm",
         "//third_party/go:gcfg",
         "//third_party/go:go-flags",
         "//third_party/go:godirwalk",

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -483,7 +483,7 @@ func printTempDirs(state *core.BuildState, duration time.Duration) {
 		target := state.Graph.TargetOrDie(label)
 		cmd := target.GetCommand(state)
 		dir := target.TmpDir()
-		env := core.BuildEnvironment(state, target)
+		env := core.StampedBuildEnvironment(state, target, nil)
 		if state.NeedTests {
 			cmd = target.GetTestCommand(state)
 			dir = path.Join(core.RepoRoot, target.TestDir())

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -258,7 +258,7 @@ def _merge_cgo_obj(name, a_rule, o_rule=None, visibility=None, test_only=False, 
 
 def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=[],
               visibility:list=None, test_only:bool&testonly=False, static:bool=CONFIG.GO_DEFAULT_STATIC,
-              filter_srcs:bool=True, definitions:str|list|dict=None):
+              filter_srcs:bool=True, definitions:str|list|dict=None, stamp:bool=False):
     """Compiles a Go binary.
 
     Args:
@@ -280,6 +280,8 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
                      when calling the Go linker.  If set to a list, pass each value as a
                      definition to the linker.  If set to a dict, each key/value pair is
                      used to contruct the list of definitions passed to the linker.
+      stamp (bool): Allows this rule to gain access to information about SCM revision etc
+                    via env vars. These can be useful to pass into `definitions`.
     """
     lib = go_library(
         name=f'_{name}#lib',
@@ -307,6 +309,7 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
         visibility=visibility,
         requires=['go'],
         pre_build=_collect_linker_flags(static),
+        stamp = stamp,
     )
 
 

--- a/src/query/changed.go
+++ b/src/query/changed.go
@@ -31,15 +31,16 @@ func ChangedLabels(state *core.BuildState, request ChangedRequest) []core.BuildL
 }
 
 func changedFiles(since string, diffSpec string) []string {
+	git := scm.NewGit(core.RepoRoot)
 	if diffSpec != "" {
-		return scm.ChangesIn(diffSpec, "")
+		return git.ChangesIn(diffSpec, "")
 	}
 
 	if since == "" {
-		since = scm.CurrentRevIdentifier()
+		since = git.CurrentRevIdentifier()
 	}
 
-	return scm.ChangedFiles(since, true, "")
+	return git.ChangedFiles(since, true, "")
 }
 
 func targetsForChangedFiles(graph *core.BuildGraph, files []string, includeDependees string) []*core.BuildTarget {

--- a/src/scm/BUILD
+++ b/src/scm/BUILD
@@ -6,7 +6,6 @@ go_library(
     ),
     visibility = ["PUBLIC"],
     deps = [
-        "//src/core",
         "//third_party/go:logging",
     ],
 )

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -1,9 +1,8 @@
 // Package scm abstracts operations on various tools like git
-// Currently, only git
+// Currently, only git is supported.
 package scm
 
 import (
-	"github.com/thought-machine/please/src/core"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -14,15 +13,40 @@ import (
 
 var log = logging.MustGetLogger("scm")
 
+// An SCM represents an SCM implementation that we can ask for various things.
+type SCM interface {
+	// CurrentRevIdentifier returns the string that specifies what the current revision is.
+	CurrentRevIdentifier() string
+	// ChangesIn returns a list of modified files in the given diffSpec.
+	ChangesIn(diffSpec string, relativeTo string) []string
+	// ChangedFiles returns a list of modified files since the given commit, optionally including untracked files.
+	ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) []string
+}
+
+// git implements operations on a git repository.
+// TODO(peterebden): possibly should change this to use something like github.com/src-d/go-git?
+type git struct {
+	repoRoot string
+}
+
+// NewGit returns a new SCM implementation for Git.
+func NewGit(repoRoot string) SCM {
+	return &git{repoRoot: repoRoot}
+}
+
 // CurrentRevIdentifier returns the string that specifies what the current revision is.
-func CurrentRevIdentifier() string {
-	return "HEAD"
+func (g *git) CurrentRevIdentifier() string {
+	out, err := exec.Command("git", "rev-parse", "HEAD").CombinedOutput()
+	if err != nil {
+		log.Fatalf("Failed to read HEAD: %s", err)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // ChangesIn returns a list of modified files in the given diffSpec.
-func ChangesIn(diffSpec string, relativeTo string) []string {
+func (g *git) ChangesIn(diffSpec string, relativeTo string) []string {
 	if relativeTo == "" {
-		relativeTo = core.RepoRoot
+		relativeTo = g.repoRoot
 	}
 	files := make([]string, 0)
 	command := []string{"diff-tree", "--no-commit-id", "--name-only", "-r", diffSpec}
@@ -32,15 +56,15 @@ func ChangesIn(diffSpec string, relativeTo string) []string {
 	}
 	output := strings.Split(string(out), "\n")
 	for _, o := range output {
-		files = append(files, fixGitRelativePath(strings.TrimSpace(o), relativeTo))
+		files = append(files, g.fixGitRelativePath(strings.TrimSpace(o), relativeTo))
 	}
 	return files
 }
 
 // ChangedFiles returns a list of modified files since the given commit, optionally including untracked files.
-func ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) []string {
+func (g *git) ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) []string {
 	if relativeTo == "" {
-		relativeTo = core.RepoRoot
+		relativeTo = g.repoRoot
 	}
 	relSuffix := []string{"--", relativeTo}
 	command := []string{"diff", "--name-only", "HEAD"}
@@ -74,15 +98,15 @@ func ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) [
 	// git will report changed files relative to the worktree: re-relativize to relativeTo
 	normalized := make([]string, 0)
 	for _, f := range files {
-		normalized = append(normalized, fixGitRelativePath(strings.TrimSpace(f), relativeTo))
+		normalized = append(normalized, g.fixGitRelativePath(strings.TrimSpace(f), relativeTo))
 	}
 	return normalized
 }
 
-func fixGitRelativePath(worktreePath, relativeTo string) string {
-	p, err := filepath.Rel(relativeTo, path.Join(core.RepoRoot, worktreePath))
+func (g *git) fixGitRelativePath(worktreePath, relativeTo string) string {
+	p, err := filepath.Rel(relativeTo, path.Join(g.repoRoot, worktreePath))
 	if err != nil {
-		log.Fatalf("unable to determine relative path for %s and %s", core.RepoRoot, relativeTo)
+		log.Fatalf("unable to determine relative path for %s and %s", g.repoRoot, relativeTo)
 	}
 	return p
 }

--- a/test/stamp/BUILD
+++ b/test/stamp/BUILD
@@ -4,6 +4,12 @@ go_binary(
     deps = ["//test/stamp/lib"],
     stamp = True,
     definitions = {
-        "github.com/thought-machine/please/test/stamp.GitRevision": "$SCM_REVISION",
+        "github.com/thought-machine/please/test/stamp/lib.GitRevision": "$SCM_REVISION",
     },
+)
+
+sh_test(
+    name = "stamp_test",
+    src = "stamp_test.sh",
+    data = [":stamp"],
 )

--- a/test/stamp/BUILD
+++ b/test/stamp/BUILD
@@ -1,0 +1,9 @@
+go_binary(
+    name = "stamp",
+    srcs = ["main.go"],
+    deps = ["//test/stamp/lib"],
+    stamp = True,
+    definitions = {
+        "github.com/thought-machine/please/test/stamp.GitRevision": "$SCM_REVISION",
+    },
+)

--- a/test/stamp/BUILD
+++ b/test/stamp/BUILD
@@ -1,11 +1,11 @@
 go_binary(
     name = "stamp",
     srcs = ["main.go"],
-    deps = ["//test/stamp/lib"],
-    stamp = True,
     definitions = {
         "github.com/thought-machine/please/test/stamp/lib.GitRevision": "$SCM_REVISION",
     },
+    stamp = True,
+    deps = ["//test/stamp/lib"],
 )
 
 sh_test(

--- a/test/stamp/lib/BUILD
+++ b/test/stamp/lib/BUILD
@@ -1,0 +1,5 @@
+go_library(
+    name = "lib",
+    srcs = ["lib.go"],
+    visibility = ["//test/stamp:all"],
+)

--- a/test/stamp/lib/lib.go
+++ b/test/stamp/lib/lib.go
@@ -1,4 +1,6 @@
 package lib
 
 // GitRevision will be overridden at build time with the actual git revision.
-const GitRevision = "12345"
+// N.B. Must be a variable not a constant - constants aren't linker symbols and
+//      hence can't be replaced in the same way.
+var GitRevision = "12345"

--- a/test/stamp/lib/lib.go
+++ b/test/stamp/lib/lib.go
@@ -1,0 +1,4 @@
+package lib
+
+// GitRevision will be overridden at build time with the actual git revision.
+const GitRevision = "12345"

--- a/test/stamp/main.go
+++ b/test/stamp/main.go
@@ -1,0 +1,13 @@
+// Package main implements a simple binary that prints out the git revision
+// at the time it was compiled.
+package main
+
+import (
+	"fmt"
+
+	"github.com/thought-machine/please/test/stamp/lib"
+)
+
+func main() {
+	fmt.Println(lib.GitRevision)
+}

--- a/test/stamp/stamp_test.sh
+++ b/test/stamp/stamp_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "`$DATA`" = "12345" ]; then
     echo "Stamped variable has not been replaced correctly."

--- a/test/stamp/stamp_test.sh
+++ b/test/stamp/stamp_test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ "`$DATA`" = "12345" ]; then
+    echo "Stamped variable has not been replaced correctly."
+    exit 1
+fi

--- a/tools/build_langserver/langserver/definition_test.go
+++ b/tools/build_langserver/langserver/definition_test.go
@@ -47,7 +47,7 @@ func TestGetDefinitionLocationOnBuildDefs(t *testing.T) {
 	expectedURI = lsp.DocumentURI("file://" + path.Join(core.RepoRoot, "src/core/BUILD"))
 	expectedRange = lsp.Range{
 		Start: lsp.Position{Line: 10, Character: 0},
-		End:   lsp.Position{Line: 34, Character: 1},
+		End:   lsp.Position{Line: 35, Character: 1},
 	}
 	assert.Equal(t, 1, len(loc))
 	assert.Equal(t, expectedURI, loc[0].URI)
@@ -83,7 +83,7 @@ func TestGetDefinitionLocationOnAssignments(t *testing.T) {
 	expectedURI = lsp.DocumentURI("file://" + path.Join(core.RepoRoot, "src/core/BUILD"))
 	expectedRange = lsp.Range{
 		Start: lsp.Position{Line: 10, Character: 0},
-		End:   lsp.Position{Line: 34, Character: 1},
+		End:   lsp.Position{Line: 35, Character: 1},
 	}
 	assert.Equal(t, 1, len(loc))
 	assert.Equal(t, expectedURI, loc[0].URI)

--- a/tools/build_langserver/langserver/signature_test.go
+++ b/tools/build_langserver/langserver/signature_test.go
@@ -19,7 +19,7 @@ func TestGetSignaturesEmptyCall(t *testing.T) {
 
 	expectedLabel := "(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=[],\n" +
 		"              visibility:list=None, test_only:bool&testonly=False, static:bool=CONFIG.GO_DEFAULT_STATIC,\n" +
-		"              filter_srcs:bool=True, definitions:str|list|dict=None)"
+		"              filter_srcs:bool=True, definitions:str|list|dict=None, stamp:bool=False)"
 	assert.Equal(t, expectedLabel, sig.Signatures[0].Label)
 }
 


### PR DESCRIPTION
As discussed earlier... rules that have `stamp = True` can now get access to a `SCM_REVISION` env var that gives access to the current git revision on build.

This does not contribute to any hashes so doesn't force rebuilds; it will obviously always be correct at the time the target is built, but isn't necessarily guaranteed to match HEAD if unrelated commits are made after the target has previously built. Theoretically in such cases one shouldn't care since the result would be otherwise indistinguishable.

Quite a bit of this change is just refactoring `scm` so I can get at it from `core`.

Have added the attribute to `go_binary` since it's needed there to be useful. It's less obviously useful directly on e.g. `python_binary` or `java_binary` and one can hand-roll it there anyway.