### PR TITLE
cached suites have junit property cached set to true

### DIFF
--- a/src/test/xml_results.go
+++ b/src/test/xml_results.go
@@ -99,17 +99,15 @@ func toCoreTestSuite(xmlTestSuite jUnitXMLTestSuite) core.TestSuite {
 }
 
 func toCoreCached(properties jUnitXMLProperties) bool {
-	cached := false
 	for _, prop := range properties.Property {
 		if prop.Name == "cached" {
-			p, err := strconv.ParseBool(prop.Value)
-			if err == nil {
-				cached = p
+			if p, err := strconv.ParseBool(prop.Value); err == nil {
+				return p
 			}
-			break
+			return false
 		}
 	}
-	return cached
+	return false
 }
 
 func toCoreProperties(properties jUnitXMLProperties) map[string]string {


### PR DESCRIPTION
This pr sets the suite property in the junit output cached to true if the test suite was cached. If the property doesn't exist or is set to false the suite is assumed to not have been cached.