### PR TITLE
Use Host-OS to determine whether to workaround pip+darwin bug.

### DIFF
--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -237,6 +238,17 @@ func (arch *Arch) UnmarshalFlag(in string) error {
 		return nil
 	}
 	return fmt.Errorf("Can't parse architecture %s (should be a Go-style arch pair, like 'linux_amd64' etc)", in)
+}
+
+// HostOS returns the OS of the host (machine doing the building).
+// Configuring certain tools (e.g. pip) requires this information, even when cross-compiling.
+func (arch *Arch) HostOS() string {
+	return runtime.GOOS
+}
+
+// HostArch returns the architecture of the host (machine doing the building).
+func (arch *Arch) HostArch() string {
+	return runtime.GOARCH
 }
 
 // XOS returns the "alternative" OS spelling which some things prefer.

--- a/src/cli/flags_test.go
+++ b/src/cli/flags_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -121,4 +122,12 @@ func TestGoArch(t *testing.T) {
 	assert.Equal(t, "amd64", a.GoArch())
 	a = NewArch("linux", "x86")
 	assert.Equal(t, "386", a.GoArch())
+}
+
+func TestHostArch(t *testing.T) {
+	a := NewArch("cross_compile_os", "cross_compile_arch")
+	assert.Equal(t, "cross_compile_os", a.OS)
+	assert.Equal(t, "cross_compile_arch", a.Arch)
+	assert.Equal(t, runtime.GOOS, a.HostOS())
+	assert.Equal(t, runtime.GOARCH, a.HostArch())
 }

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -777,6 +777,8 @@ func newConfig(config *core.Configuration) *pyConfig {
 	}
 	c["OS"] = pyString(config.Build.Arch.OS)
 	c["ARCH"] = pyString(config.Build.Arch.Arch)
+	c["HOSTOS"] = pyString(config.Build.Arch.HostOS())
+	c["HOSTARCH"] = pyString(config.Build.Arch.HostArch())
 	return &pyConfig{base: c}
 }
 

--- a/src/parse/rules/python_rules.build_defs
+++ b/src/parse/rules/python_rules.build_defs
@@ -334,17 +334,17 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
     target = outs[0] if install_subdirectory else '.'
 
     cmd = '$TOOLS_PIP install --no-deps --no-compile --no-cache-dir --default-timeout=60 --target=' + target
-    if CONFIG.OS == 'linux':
-        # Fix for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=830892
-        # tl;dr: Debian has broken --target with a custom patch, the only way to fix is to pass --system
-        # which is itself Debian-specific, so we need to find if we're running on Debian. AAAAARGGGHHHH...
-        cmd = f'[ -f /etc/debian_version ] && [ $TOOLS_PIP == "/usr/bin/pip3" ] && SYS_FLAG="--system" || SYS_FLAG=""; {cmd} $SYS_FLAG'
-    elif CONFIG.OS == 'darwin':
+    if CONFIG.HOSTOS == 'darwin':
         # Fix for Homebrew which fails with a superficially similar issue.
         # https://github.com/Homebrew/brew/blob/master/docs/Homebrew-and-Python.md suggests fixing with --install-option
         # but that prevents downloading binary wheels. This is more fiddly but seems to work.
         # Unfortunately it does *not* work similarly on the Debian problem :(
         cmd = 'echo "[install]\nprefix=" > .pydistutils.cfg; ' + cmd
+    if CONFIG.OS == 'linux':
+        # Fix for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=830892
+        # tl;dr: Debian has broken --target with a custom patch, the only way to fix is to pass --system
+        # which is itself Debian-specific, so we need to find if we're running on Debian. AAAAARGGGHHHH...
+        cmd = f'[ -f /etc/debian_version ] && [ $TOOLS_PIP == "/usr/bin/pip3" ] && SYS_FLAG="--system" || SYS_FLAG=""; {cmd} $SYS_FLAG' 
     cmd += f' -b build {repo_flag} {index_flag} {pip_flags} {package_name}'
 
     if strip:


### PR DESCRIPTION
To do this, exposes two new build config entries, `CONFIG.HOSTOS` and `CONFIG.HOSTARCH`. In particular, `HOSTOS` is required for cross-compiling pip libraries from Darwin.

Resolves #581.