### PR TITLE
Allow config_setting rules to switch based on OS.

### DIFF
--- a/src/parse/rules/config_rules.build_defs
+++ b/src/parse/rules/config_rules.build_defs
@@ -61,6 +61,8 @@ def _config_on(name, value):
         return value.upper() in CONFIG
     elif name == 'crosstool_top':
         return False  # Android build - not clear right now how we would best represent this.
+    elif name == 'os':
+        return CONFIG.OS == value.lower()
     else:
         raise ParseError('Unknown config_setting key %s' % name)
 


### PR DESCRIPTION
Small change to allow rules to `select` on conditions like:

```
config_setting(
    name = "linux",
    values = {"os": "linux"},
)
```