### PR TITLE
Add a space if we have definitions, to fix static mode

### DIFF
--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -750,7 +750,7 @@ def _go_binary_cmds(static=False, ldflags='', pkg_config='', definitions=None, g
         flags = f''
 
     if len(defs) > 0:
-        flags += defs
+        flags += " " + defs
 
     cmds = {
         'dbg': f'{prefix} && {_link_cmd} {flags} $SRCS',

--- a/test/stamp/BUILD
+++ b/test/stamp/BUILD
@@ -4,8 +4,8 @@ go_binary(
     definitions = {
         "github.com/thought-machine/please/test/stamp/lib.GitRevision": "$SCM_REVISION",
     },
-    static = True,
     stamp = True,
+    static = True,
     deps = ["//test/stamp/lib"],
 )
 

--- a/test/stamp/BUILD
+++ b/test/stamp/BUILD
@@ -14,7 +14,7 @@ sh_test(
     data = [":stamp"],
 )
 
-if CONFIG.OS == 'linux':
+if CONFIG.OS == "linux":
     go_binary(
         name = "stamp_static",
         srcs = ["main.go"],

--- a/test/stamp/BUILD
+++ b/test/stamp/BUILD
@@ -5,7 +5,6 @@ go_binary(
         "github.com/thought-machine/please/test/stamp/lib.GitRevision": "$SCM_REVISION",
     },
     stamp = True,
-    static = True,
     deps = ["//test/stamp/lib"],
 )
 
@@ -14,3 +13,21 @@ sh_test(
     src = "stamp_test.sh",
     data = [":stamp"],
 )
+
+if CONFIG.OS == 'linux':
+    go_binary(
+        name = "stamp_static",
+        srcs = ["main.go"],
+        definitions = {
+            "github.com/thought-machine/please/test/stamp/lib.GitRevision": "$SCM_REVISION",
+        },
+        stamp = True,
+        static = True,
+        deps = ["//test/stamp/lib"],
+    )
+
+    sh_test(
+        name = "stamp_test_static",
+        src = "stamp_test.sh",
+        data = [":stamp_static"],
+    )

--- a/test/stamp/BUILD
+++ b/test/stamp/BUILD
@@ -4,6 +4,7 @@ go_binary(
     definitions = {
         "github.com/thought-machine/please/test/stamp/lib.GitRevision": "$SCM_REVISION",
     },
+    static = True,
     stamp = True,
     deps = ["//test/stamp/lib"],
 )


### PR DESCRIPTION
Otherwise all the extldflags get rammed together with the -X and it all fails to build.