### PR TITLE
plz/watch: Increase debounce interval to prevent double-builds.

### DIFF
--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -23,7 +23,7 @@ import (
 
 var log = logging.MustGetLogger("watch")
 
-const debounceInterval = 50 * time.Millisecond
+const debounceInterval = 100 * time.Millisecond
 
 // A CallbackFunc is supplied to Watch in order to trigger a build.
 type CallbackFunc func(*core.BuildState, []core.BuildLabel)


### PR DESCRIPTION
With one of my services I'm testing with, I noticed that the service would sometimes be restarted twice, for the same file-change. Doubling the debounce interval fixes the issue.