### PR TITLE
Small fixes for Go cross-compilation and plz-watch.

### DIFF
--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -280,6 +280,8 @@ func (arch *Arch) XArch() string {
 func (arch *Arch) GoArch() string {
 	if arch.Arch == "x86" {
 		return "386"
+	} else if arch.Arch == "x86-64" {
+		return "amd64"
 	}
 	return arch.Arch
 }


### PR DESCRIPTION
- Use `GOARCH` of `amd64` when `ARCH` is `x86-64`.
- Don't cease watching when a target's execution context is terminated before the target can be started.

Total mystery as to why `--arch=linux_x86-64` was ever working with Go in the first place, for me..