### PR TITLE
Small go_get improvement.

### DIFF
--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -660,10 +660,10 @@ def _go_github_repo_cmd(name, get, repo, revision):
     else:
         dest = parts[-1]
     remote_rule = remote_file(
-        name = name,
+        name = name + '-' + parts[-1],
         _tag = 'download',
         url = f'https://{repo}/archive/{revision}.zip',
-        out = name + '.zip',
+        out = name + '-' + parts[-1] + '.zip',
     )
     return [
         'rm -rf src/' + out,


### PR DESCRIPTION
Include the last part of the repo in the naming formula for `go_get` downloads. As previously written, `golang.org/x/crypto` and `golang.org/x/sync` could not exist within the same `go_get` rule with revisions declared. Omitting revisions worked, but caused a fallback to the slow-path of `git clone`.