### PR TITLE
Instruct user to add to PATH manually

### DIFF
--- a/tools/misc/get_plz.sh
+++ b/tools/misc/get_plz.sh
@@ -38,7 +38,7 @@ if ! hash plz 2>/dev/null; then
         echo 'export PATH="${PATH}:${HOME}/.please"' >> ~/.profile
         echo "You may need to run 'source ~/.profile' to pick up the new PATH."
     else
-        echo "Unsure how to add to PATH, not modifying anything."
+        echo "Unsure how to add to PATH, not modifying anything. If desired add '${HOME}/.please' manually to your PATH."
     fi
 fi
 


### PR DESCRIPTION
When attempting to install via `curl -s https://get.please.build | bash` it failed to update my PATH which is fine.  But it didn't instruct me what to add to my PATH.  This updates the message to provide the directory to add to the PATH manually.

Previously:
`Unsure how to add to PATH, not modifying anything.`

Now:
`Unsure how to add to PATH, not modifying anything. If desired add '/Users/brad/.please' manually to your PATH.`