### PR TITLE
Update hash validation

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -338,6 +338,7 @@ func DefaultConfiguration() *Configuration {
 type Configuration struct {
 	Please struct {
 		Version          cli.Version `help:"Defines the version of plz that this repo is supposed to use currently. If it's not present or the version matches the currently running version no special action is taken; otherwise if SelfUpdate is set Please will attempt to download an appropriate version, otherwise it will issue a warning and continue.\n\nNote that if this is not set, you can run plz update to update to the latest version available on the server." var:"PLZ_VERSION"`
+		VersionChecksum  []string    `help:"Defines a hex-encoded sha256 checksum that the downloaded version must match. Can be specified multiple times to support different architectures."`
 		Location         string      `help:"Defines the directory Please is installed into.\nDefaults to ~/.please but you might want it to be somewhere else if you're installing via another method (e.g. the debs and install script still use /opt/please)."`
 		SelfUpdate       bool        `help:"Sets whether plz will attempt to update itself when the version set in the config file is different."`
 		DownloadLocation cli.URL     `help:"Defines the location to download Please from when self-updating. Defaults to the Please web server, but you can point it to some location of your own if you prefer to keep traffic within your network or use home-grown versions."`

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -177,6 +177,10 @@ func downloadPlease(config *core.Configuration, verify bool) {
 	defer mustClose(rc)
 	var r io.Reader = bufio.NewReader(rc)
 
+	if len(config.Please.VersionChecksum) > 0 {
+		r = mustVerifyHash(r, config.Please.VersionChecksum)
+	}
+
 	if verify && config.Please.Version.LessThan(minSignedVersion) {
 		log.Warning("Won't verify signature of download, version is too old to be signed.")
 	} else if verify {

--- a/src/update/verify_test.go
+++ b/src/update/verify_test.go
@@ -60,3 +60,31 @@ func TestMustVerifyBadFile(t *testing.T) {
 	signature := readFile("src/update/test_data/test.txt.asc")
 	assert.Panics(t, func() { mustVerifySignature(signed, signature) })
 }
+
+func TestMustVerifyHash(t *testing.T) {
+	r := readFile("src/update/test_data/test.txt")
+	r = mustVerifyHash(r, []string{
+		"d5ddcfb56bee0bf465da6d8e0ab0db5b4635061b45be18c231a558cf1d86c2e0",
+	})
+	b, err := ioutil.ReadAll(r)
+	assert.NoError(t, err)
+	assert.EqualValues(t, []byte("Test file for verifying release signatures.\n"), b)
+}
+
+func TestMustVerifyHashMultiple(t *testing.T) {
+	r := readFile("src/update/test_data/test.txt")
+	mustVerifyHash(r, []string{
+		"510dc30e9c55d5da05d971bed8568534667640b70295f78082967207745afec0",
+		"d5ddcfb56bee0bf465da6d8e0ab0db5b4635061b45be18c231a558cf1d86c2e0",
+	})
+}
+
+func TestMustVerifyHashBad(t *testing.T) {
+	r := readFile("src/update/test_data/test.txt")
+	assert.Panics(t, func() {
+		mustVerifyHash(r, []string{
+			"510dc30e9c55d5da05d971bed8568534667640b70295f78082967207745afec0",
+			"877265724bc9ba415dc1774569384fcfde80c6694d70f8f29405a917bbdf09db",
+		})
+	})
+}


### PR DESCRIPTION
Support checksums on downloaded updates, and upload during releases. Resolves #615.

I'm about as confident as I can be that this will be OK, but can't be 100% until we test it end-to-end.