### PR TITLE
Allow for non-flat tarballs.

### DIFF
--- a/src/parse/rules/misc_rules.build_defs
+++ b/src/parse/rules/misc_rules.build_defs
@@ -390,7 +390,8 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
 
 
 def tarball(name:str, srcs:list, out:str=None, deps:list=None, subdir:str=None, gzip:bool=True,
-            xzip:bool=False, test_only:bool=False, visibility:list=None, labels:list&features&tags=[]):
+            xzip:bool=False, flatten:bool=True, strip_prefix:str='',
+            test_only:bool=False, visibility:list=None, labels:list&features&tags=[]):
     """Defines a rule to create a tarball containing outputs of other rules.
 
     File mode and ownership are preserved. However, the atime and mtime of all
@@ -400,9 +401,11 @@ def tarball(name:str, srcs:list, out:str=None, deps:list=None, subdir:str=None, 
       name (str): Rule name
       srcs (list): Source files to include in the tarball
       out (str): Name of output tarball (defaults to `name`.tar.gz, but see below re compression)
-      subdir (str): Subdirectory to create in. All files will be flattened into this directory.
+      subdir (str): Subdirectory to create in.
       gzip (bool): If True, the output will be gzipped. If False, it will just be a tarball.
       xzip (bool): If True, the output will be xzipped. Overrides gzip if passed.
+      flatten (bool): If True, the output will be flattened into the subdirectory.
+      strip_prefix (str): If flatten is False, strips this prefix from internal directory structure.
       deps (list): Dependencies
       visibility (list): Visibility specification.
       labels (list): Labels associated with this rule.
@@ -417,6 +420,10 @@ def tarball(name:str, srcs:list, out:str=None, deps:list=None, subdir:str=None, 
         cmd += ' -z'
     if subdir:
         cmd += ' --prefix ' + subdir
+    if flatten:
+        cmd += ' --flatten'
+    elif strip_prefix:
+        cmd += ' --strip-prefix ' + strip_prefix
 
     tar_rule = build_rule(
         name = tar_name,

--- a/tools/jarcat/main.go
+++ b/tools/jarcat/main.go
@@ -81,11 +81,13 @@ var opts = struct {
 	} `command:"zip" alias:"z" description:"Writes an output zipfile"`
 
 	Tar struct {
-		Gzip   bool     `short:"z" long:"gzip" description:"Apply gzip compression to the tar file."`
-		Xzip   bool     `short:"x" long:"xzip" description:"Apply gzip compression to the tar file."`
-		Out    string   `short:"o" long:"output" env:"OUT" description:"Output filename" required:"true"`
-		Srcs   []string `long:"srcs" env:"SRCS" env-delim:" " description:"Source files for the tarball."`
-		Prefix string   `long:"prefix" description:"Prefix all entries with this directory name."`
+		Gzip        bool     `short:"z" long:"gzip" description:"Apply gzip compression to the tar file."`
+		Xzip        bool     `short:"x" long:"xzip" description:"Apply gzip compression to the tar file."`
+		Out         string   `short:"o" long:"output" env:"OUT" description:"Output filename" required:"true"`
+		Srcs        []string `long:"srcs" env:"SRCS" env-delim:" " description:"Source files for the tarball."`
+		Prefix      string   `long:"prefix" description:"Prefix all entries with this directory name."`
+		Flatten     bool     `long:"flatten" description:"Whether to flatten internal tar structure."`
+		StripPrefix string   `long:"strip-prefix" description:"Prefix to remove from files. Only affects non-flattened tarballs."`
 	} `command:"tar" alias:"t" description:"Builds a tarball instead of a zipfile."`
 
 	Extract struct {
@@ -138,7 +140,9 @@ func main() {
 		if opts.Tar.Xzip && opts.Tar.Gzip {
 			log.Fatalf("Can't pass --xzip and --gzip simultaneously")
 		}
-		if err := tar.Write(opts.Tar.Out, opts.Tar.Srcs, opts.Tar.Prefix, opts.Tar.Gzip, opts.Tar.Xzip); err != nil {
+		if err := tar.Write(
+			opts.Tar.Out, opts.Tar.Srcs, opts.Tar.Prefix,
+			opts.Tar.Gzip, opts.Tar.Xzip, opts.Tar.Flatten, opts.Tar.StripPrefix); err != nil {
 			log.Fatalf("Error writing tarball: %s\n", err)
 		}
 		os.Exit(0)

--- a/tools/jarcat/tar/tar_test.go
+++ b/tools/jarcat/tar/tar_test.go
@@ -19,7 +19,7 @@ var testInputs = []string{"tools/jarcat/tar/test_data/dir1", "tools/jarcat/tar/t
 
 func TestNoCompression(t *testing.T) {
 	filename := "test_no_compression.tar"
-	err := Write(filename, testInputs, "", false, false)
+	err := Write(filename, testInputs, "", false, false, true, "")
 	require.NoError(t, err)
 
 	m := ReadTar(t, filename, false, false)
@@ -45,7 +45,7 @@ func TestNoCompression(t *testing.T) {
 
 func TestCompression(t *testing.T) {
 	filename := "test_compression.tar.gz"
-	err := Write(filename, testInputs, "", true, false)
+	err := Write(filename, testInputs, "", true, false, true, "")
 	require.NoError(t, err)
 
 	m := ReadTar(t, filename, true, false)
@@ -57,7 +57,7 @@ func TestCompression(t *testing.T) {
 
 func TestXzipCompression(t *testing.T) {
 	filename := "test_compression.tar.xz"
-	err := Write(filename, testInputs, "", false, true)
+	err := Write(filename, testInputs, "", false, true, true, "")
 	require.NoError(t, err)
 
 	m := ReadTar(t, filename, false, true)
@@ -69,13 +69,49 @@ func TestXzipCompression(t *testing.T) {
 
 func TestWithPrefix(t *testing.T) {
 	filename := "test_prefix.tar"
-	err := Write(filename, testInputs, "/", false, false)
+	err := Write(filename, testInputs, "/", false, false, true, "")
 	require.NoError(t, err)
 
 	m := ReadTar(t, filename, false, false)
 	assert.EqualValues(t, map[string]string{
 		"/dir1/file1.txt": "test file 1",
 		"/dir2/file2.txt": "test file 2",
+	}, toFilenameMap(m))
+}
+
+func TestWithoutFlatten(t *testing.T) {
+	filename := "test_without_flatten.tar"
+	err := Write(filename, testInputs, "", false, false, false, "")
+	require.NoError(t, err)
+
+	m := ReadTar(t, filename, false, false)
+	assert.EqualValues(t, map[string]string{
+		"tools/jarcat/tar/test_data/dir1/file1.txt": "test file 1",
+		"tools/jarcat/tar/test_data/dir2/file2.txt": "test file 2",
+	}, toFilenameMap(m))
+}
+
+func TestStripPrefixWithoutFlatten(t *testing.T) {
+	filename := "test_strip_prefix_without_flatten.tar"
+	err := Write(filename, testInputs, "", false, false, false, "tools/jarcat/tar/test_data/dir1")
+	require.NoError(t, err)
+
+	m := ReadTar(t, filename, false, false)
+	assert.EqualValues(t, map[string]string{
+		"file1.txt": "test file 1",
+		"tools/jarcat/tar/test_data/dir2/file2.txt": "test file 2",
+	}, toFilenameMap(m))
+}
+
+func TestStripPrefixWithPrefix(t *testing.T) {
+	filename := "test_strip_prefix_with_prefix.tar"
+	err := Write(filename, testInputs, "prefix", false, false, false, "tools/jarcat/tar/test_data")
+	require.NoError(t, err)
+
+	m := ReadTar(t, filename, false, false)
+	assert.EqualValues(t, map[string]string{
+		"prefix/dir1/file1.txt": "test file 1",
+		"prefix/dir2/file2.txt": "test file 2",
 	}, toFilenameMap(m))
 }
 


### PR DESCRIPTION
Adds two new options to the `tarball()` rule, via two new arguments to `jarcat tar`:

- `flatten`: If `True`, flattens the internal tarball directory structure. `True` by default, for compatibility. 

- `strip_prefix`: If `flatten` is `False`, strips this prefix from the internal directory structure of the tarball.

For non-flat tarballs, filepaths are therefore built as:
    `PATH = PREFIX + STRIP(STRIP_PREFIX, SRC_PATH)`

Closes #622 