### PR TITLE
Allow specifying python interpreter options through global config.

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -278,6 +278,7 @@ func DefaultConfiguration() *Configuration {
 	config.Python.DefaultInterpreter = "python3"
 	config.Python.TestRunner = "unittest"
 	config.Python.UsePyPI = true
+	config.Python.InterpreterOptions = ""
 	// Annoyingly pip on OSX doesn't seem to work with this flag (you get the dreaded
 	// "must supply either home or prefix/exec-prefix" error). Goodness knows why *adding* this
 	// flag - which otherwise seems exactly what we want - provokes that error, but the logic
@@ -449,6 +450,7 @@ type Configuration struct {
 		WheelRepo          cli.URL `help:"Defines a location for a remote repo that python_wheel rules will download from. See python_wheel for more information." var:"PYTHON_WHEEL_REPO"`
 		UsePyPI            bool    `help:"Whether or not to use PyPI for pip_library rules or not. Defaults to true, if you disable this you will presumably want to set DefaultPipRepo to use one of your own.\nIs overridden by the use_pypi argument to pip_library." var:"USE_PYPI"`
 		WheelNameScheme    string  `help:"Defines a custom templatized wheel naming scheme. Templatized variables should be surrounded in curly braces, and the available options are: url_base, package_name, and version. The default search pattern is '{url_base}/{package_name}-{version}-${{OS}}-${{ARCH}}.whl' along with a few common variants." var:"PYTHON_WHEEL_NAME_SCHEME"`
+		InterpreterOptions string  `help:"Options to pass to the python interpeter, when writing shebangs for pex executables." var:"PYTHON_INTERPRETER_OPTIONS"`
 	} `help:"Please has built-in support for compiling Python.\nPlease's Python artifacts are pex files, which are essentially self-executable zip files containing all needed dependencies, bar the interpreter itself. This fits our aim of at least semi-static binaries for each language.\nSee https://github.com/pantsbuild/pex for more information.\nNote that due to differences between the environment inside a pex and outside some third-party code may not run unmodified (for example, it cannot simply open() files). It's possible to work around a lot of this, but if it all becomes too much it's possible to mark pexes as not zip-safe which typically resolves most of it at a modest speed penalty."`
 	Java struct {
 		JavacTool          string    `help:"Defines the tool used for the Java compiler. Defaults to javac." var:"JAVAC_TOOL"`

--- a/src/parse/rules/python_rules.build_defs
+++ b/src/parse/rules/python_rules.build_defs
@@ -123,7 +123,8 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
       labels (list): Labels to apply to this rule.
     """
     shebang = shebang or interpreter or CONFIG.DEFAULT_PYTHON_INTERPRETER
-    cmd = '$TOOLS_PEX -s "%s" -m "%s" --zip_safe' % (shebang, CONFIG.PYTHON_MODULE_DIR)
+    cmd = '$TOOLS_PEX -s "%s" -m "%s" --zip_safe --interpreter_options="%s"' % (
+        shebang, CONFIG.PYTHON_MODULE_DIR, CONFIG.PYTHON_INTERPRETER_OPTIONS)
     pre_build, cmd = _handle_zip_safe(cmd, zip_safe)
 
     assert main not in srcs, "main file should not be included in srcs"
@@ -220,7 +221,9 @@ def python_test(name:str, srcs:list, data:list=[], resources:list=[], deps:list=
                         'pypy' or whatever.
     """
     interpreter = interpreter or CONFIG.DEFAULT_PYTHON_INTERPRETER
-    cmd = '$TOOLS_PEX -t -s "%s" -m "%s" -r "%s" --zip_safe' % (interpreter, CONFIG.PYTHON_MODULE_DIR, CONFIG.PYTHON_TEST_RUNNER)
+    cmd = '$TOOLS_PEX -t -s "%s" -m "%s" -r "%s" --zip_safe --interpreter_options="%s"' % (
+        interpreter, CONFIG.PYTHON_MODULE_DIR, CONFIG.PYTHON_TEST_RUNNER,
+        CONFIG.PYTHON_INTERPRETER_OPTIONS)
     pre_build, cmd = _handle_zip_safe(cmd, zip_safe)
 
     # Use the pex tool to compress the entry point & add all the bootstrap helpers etc.

--- a/tools/please_pex/pex/pex.go
+++ b/tools/please_pex/pex/pex.go
@@ -6,6 +6,7 @@ package pex
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -24,17 +25,18 @@ type Writer struct {
 }
 
 // NewWriter constructs a new Writer.
-func NewWriter(entryPoint, interpreter string, zipSafe bool) *Writer {
+func NewWriter(entryPoint, interpreter string, options string, zipSafe bool) *Writer {
 	pw := &Writer{
 		zipSafe:        zipSafe,
 		realEntryPoint: toPythonPath(entryPoint),
 	}
-	pw.SetShebang(interpreter)
+	pw.SetShebang(interpreter, options)
 	return pw
 }
 
 // SetShebang sets the leading shebang that will be written to the file.
-func (pw *Writer) SetShebang(shebang string) {
+func (pw *Writer) SetShebang(shebang string, options string) {
+	shebang = strings.TrimSpace(fmt.Sprintf("%s %s", shebang, options))
 	if !path.IsAbs(shebang) {
 		shebang = "/usr/bin/env " + shebang
 	}

--- a/tools/please_pex/pex_main.go
+++ b/tools/please_pex/pex_main.go
@@ -11,18 +11,19 @@ import (
 var log = logging.MustGetLogger("please_pex")
 
 var opts = struct {
-	Usage       string
-	Verbosity   cli.Verbosity `short:"v" long:"verbosity" default:"warning" description:"Verbosity of output (higher number = more output)"`
-	Out         string        `short:"o" long:"out" env:"OUT" description:"Output file"`
-	EntryPoint  string        `short:"e" long:"entry_point" env:"SRC" description:"Entry point to pex file"`
-	ModuleDir   string        `short:"m" long:"module_dir" description:"Python module dir to implicitly load modules from"`
-	TestSrcs    []string      `long:"test_srcs" env:"SRCS" env-delim:" " description:"Test source files"`
-	Test        bool          `short:"t" long:"test" description:"True if we're to build a test"`
-	Interpreter string        `short:"i" long:"interpreter" env:"TOOLS_INTERPRETER" description:"Python interpreter to use"`
-	TestRunner  string        `short:"r" long:"test_runner" choice:"unittest" choice:"pytest" choice:"behave" default:"unittest" description:"Test runner to use"`
-	Shebang     string        `short:"s" long:"shebang" description:"Explicitly set shebang to this"`
-	ZipSafe     bool          `long:"zip_safe" description:"Marks this pex as zip-safe"`
-	NoZipSafe   bool          `long:"nozip_safe" description:"Marks this pex as zip-unsafe"`
+	Usage              string
+	Verbosity          cli.Verbosity `short:"v" long:"verbosity" default:"warning" description:"Verbosity of output (higher number = more output)"`
+	Out                string        `short:"o" long:"out" env:"OUT" description:"Output file"`
+	EntryPoint         string        `short:"e" long:"entry_point" env:"SRC" description:"Entry point to pex file"`
+	ModuleDir          string        `short:"m" long:"module_dir" description:"Python module dir to implicitly load modules from"`
+	TestSrcs           []string      `long:"test_srcs" env:"SRCS" env-delim:" " description:"Test source files"`
+	Test               bool          `short:"t" long:"test" description:"True if we're to build a test"`
+	Interpreter        string        `short:"i" long:"interpreter" env:"TOOLS_INTERPRETER" description:"Python interpreter to use"`
+	TestRunner         string        `short:"r" long:"test_runner" choice:"unittest" choice:"pytest" choice:"behave" default:"unittest" description:"Test runner to use"`
+	Shebang            string        `short:"s" long:"shebang" description:"Explicitly set shebang to this"`
+	ZipSafe            bool          `long:"zip_safe" description:"Marks this pex as zip-safe"`
+	NoZipSafe          bool          `long:"nozip_safe" description:"Marks this pex as zip-unsafe"`
+	InterpreterOptions string        `long:"interpreter_options" description:"Options-string to pass to the python interpreter"`
 }{
 	Usage: `
 please_pex is a tool to create .pex files for Python.
@@ -36,9 +37,9 @@ dependent code as a self-contained self-executable environment.
 func main() {
 	cli.ParseFlagsOrDie("please_pex", &opts)
 	cli.InitLogging(opts.Verbosity)
-	w := pex.NewWriter(opts.EntryPoint, opts.Interpreter, !opts.NoZipSafe)
+	w := pex.NewWriter(opts.EntryPoint, opts.Interpreter, opts.InterpreterOptions, !opts.NoZipSafe)
 	if opts.Shebang != "" {
-		w.SetShebang(opts.Shebang)
+		w.SetShebang(opts.Shebang, opts.InterpreterOptions)
 	}
 	if opts.Test {
 		w.SetTest(opts.TestSrcs, opts.TestRunner)


### PR DESCRIPTION
Motivation: I would like for all `pex` files to be run with [`-S`](https://docs.python.org/3/using/cmdline.html#id3), to
disable installed site packages (e.g. those installed with `pip`). This
helps preserve hermeticity and reproducibility between the local dev
environment and CI, prod, etc.

I sort of think that `-S` should be the default behavior for any built
`pex` executable, but that would be a nontrivial breaking change. This at
least facilitates such a setting, without requiring authors to add an
explicit `shebang`/`interpreter` field to every `python_binary`/`python_test`
rule.