### PR TITLE
Allow targets labelled as manual to be included in queries

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -749,10 +749,6 @@ func (target *BuildTarget) HasAllLabels(labels []string) bool {
 // Each include/exclude can have multiple comma-separated labels; in this case, all of the labels
 // in a given group must match.
 func (target *BuildTarget) ShouldInclude(includes, excludes []string) bool {
-	if target.HasLabel("manual") || target.HasLabel("manual:"+OsArch) {
-		return false
-	}
-
 	if len(includes) == 0 && len(excludes) == 0 {
 		return true
 	}

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -625,20 +625,6 @@ func TestShouldIncludeWithCompoundIncludeAndExclude(t *testing.T) {
 	assert.False(t, target.ShouldInclude(includes, excludes))
 }
 
-func TestShouldIncludeManual(t *testing.T) {
-	target := makeTargetWithLabels("//src/core:target1", "a", "manual")
-	// Doesn't include because "manual" overrides it
-	assert.False(t, target.ShouldInclude([]string{"a"}, nil))
-
-	target = makeTargetWithLabels("//src/core:target1", "a", "manual:test_armhf")
-	// Does include because it's a different architecture
-	assert.True(t, target.ShouldInclude([]string{"a"}, nil))
-
-	target = makeTargetWithLabels("//src/core:target1", "a", "manual:"+OsArch)
-	// Doesn't include because it's manual for this architecture.
-	assert.False(t, target.ShouldInclude([]string{"a"}, nil))
-}
-
 func TestExternalDependencies(t *testing.T) {
 	t1a := makeTarget("//src/core:_target1#a", "PUBLIC")
 	t1 := makeTarget("//src/core:target1", "PUBLIC", t1a)

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -327,6 +327,7 @@ func (state *BuildState) isOriginalTarget(label BuildLabel, exact bool) bool {
 // Handles build labels on Exclude so should be preferred over setting them directly.
 func (state *BuildState) SetIncludeAndExclude(include, exclude []string) {
 	state.Include = include
+	state.Exclude = nil
 	for _, e := range exclude {
 		if LooksLikeABuildLabel(e) {
 			if label, err := parseMaybeRelativeBuildLabel(e, ""); err != nil {

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -17,7 +17,6 @@ func TestExpandOriginalTargets(t *testing.T) {
 	addTarget(state, "//src/core:target2", "py")
 	addTarget(state, "//src/core:target3", "go", "py")
 	addTarget(state, "//src/core:target4")
-	addTarget(state, "//src/core:target5", "go", "manual")
 	addTarget(state, "//src/parse:parse")
 	addTarget(state, "//src/parse:parse2", "go")
 
@@ -43,7 +42,6 @@ func TestExpandOriginalTestTargets(t *testing.T) {
 	addTarget(state, "//src/core:target1_test", "go")
 	addTarget(state, "//src/core:target2_test", "py")
 	addTarget(state, "//src/core:target3_test")
-	addTarget(state, "//src/core:target4_test", "go", "manual")
 	// Only the one target comes out here; it must be a test and otherwise follows
 	// the same include / exclude logic as the previous test.
 	assert.Equal(t, state.ExpandOriginalTargets(), BuildLabels{{PackageName: "src/core", Name: "target1_test"}})

--- a/src/parse/asp/fuzz/fuzz.go
+++ b/src/parse/asp/fuzz/fuzz.go
@@ -62,13 +62,13 @@ func isWhitelisted(err error) bool {
 func Fuzz(data []byte) int {
 	// This lot is copied from src/parse/init.go to load all the builtins.
 	p := asp.NewParser(core.NewBuildState(1, nil, 4, core.DefaultConfiguration()))
-	dir, _ := builtins.AssetDir("")
+	dir, _ := rules.AssetDir("")
 	sort.Strings(dir)
 	for _, filename := range dir {
 		if strings.HasSuffix(filename, ".gob") {
 			srcFile := strings.TrimSuffix(filename, ".gob")
-			src, _ := builtins.Asset(srcFile)
-			p.MustLoadBuiltins("src/parse/rules/"+srcFile, src, builtins.MustAsset(filename))
+			src, _ := rules.Asset(srcFile)
+			p.MustLoadBuiltins("src/parse/rules/"+srcFile, src, rules.MustAsset(filename))
 		}
 	}
 

--- a/src/please.go
+++ b/src/please.go
@@ -575,7 +575,9 @@ var buildFunctions = map[string]func() bool{
 			targets = core.FindOwningPackages(state, files)
 		}
 		return runQuery(true, targets, func(state *core.BuildState) {
-			query.AffectedTargets(state, files.Get(), opts.BuildFlags.Include, opts.BuildFlags.Exclude, opts.Query.AffectedTargets.Tests, !opts.Query.AffectedTargets.Intransitive)
+			// affectedtargets deliberately does not include targets labelled "manual".
+			state.SetIncludeAndExclude(opts.BuildFlags.Include, append(opts.BuildFlags.Exclude, "manual", "manual:"+core.OsArch))
+			query.AffectedTargets(state, files.Get(), opts.Query.AffectedTargets.Tests, !opts.Query.AffectedTargets.Intransitive)
 		})
 	},
 	"input": func() bool {

--- a/src/query/affected_targets.go
+++ b/src/query/affected_targets.go
@@ -5,9 +5,7 @@ import "fmt"
 
 // AffectedTargets walks over the build graph and identifies all targets that have a transitive
 // dependency on the given set of files.
-// Targets are filtered by given include / exclude labels and if 'tests' is true only
-// test targets will be returned.
-func AffectedTargets(state *core.BuildState, files, include, exclude []string, tests, transitive bool) {
+func AffectedTargets(state *core.BuildState, files []string, tests, transitive bool) {
 	affectedTargets := make(chan *core.BuildTarget, 100)
 	done := make(chan bool)
 
@@ -59,7 +57,7 @@ func AffectedTargets(state *core.BuildState, files, include, exclude []string, t
 		done <- true
 	}()
 
-	go handleAffectedTargets(state, affectedTargets, done, include, exclude, tests, transitive)
+	go handleAffectedTargets(state, affectedTargets, done, tests, transitive)
 
 	<-done
 	<-done
@@ -67,7 +65,7 @@ func AffectedTargets(state *core.BuildState, files, include, exclude []string, t
 	<-done
 }
 
-func handleAffectedTargets(state *core.BuildState, affectedTargets <-chan *core.BuildTarget, done chan<- bool, include, exclude []string, tests, transitive bool) {
+func handleAffectedTargets(state *core.BuildState, affectedTargets <-chan *core.BuildTarget, done chan<- bool, tests, transitive bool) {
 	seenTargets := map[*core.BuildTarget]bool{}
 
 	var inner func(*core.BuildTarget)


### PR DESCRIPTION
Still excluded from `plz build` and `plz test` etc.