### PR TITLE
Add a `site` argument to python_binary and python_test that controls whether site is imported at startup.

### DIFF
--- a/src/parse/rules/python_rules.build_defs
+++ b/src/parse/rules/python_rules.build_defs
@@ -93,7 +93,8 @@ def python_library(name:str, srcs:list=[], resources:list=[], deps:list=[], visi
 
 
 def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=None, deps:list=[],
-                  visibility:list=None, test_only:bool=False, zip_safe:bool=None, strip:bool=False,
+                  visibility:list=None, test_only:bool=False, zip_safe:bool=None,
+                  site:bool=False, strip:bool=False,
                   interpreter:str=None, shebang:str='', labels:list&features&tags=[]):
     """Generates a Python binary target.
 
@@ -116,6 +117,8 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
                        appropriately; by default it will be safe unless any of the
                        transitive dependencies are themselves marked as not zip-safe.
       strip (bool): Strips source code from the output .pex file, leaving just bytecode.
+      site (bool): Allows the Python interpreter to import site; conversely if False, it will be
+                   started with the -S flag to avoid importing site.
       interpreter (str): The Python interpreter to use. Defaults to the config setting
                          which is normally just 'python', but could be 'python3' or
                          'pypy' or whatever.
@@ -126,6 +129,8 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
     shebang = shebang or interpreter or CONFIG.DEFAULT_PYTHON_INTERPRETER
     cmd = '$TOOLS_PEX -s "%s" -m "%s" --zip_safe --interpreter_options="%s"' % (
         shebang, CONFIG.PYTHON_MODULE_DIR, CONFIG.PYTHON_INTERPRETER_OPTIONS)
+    if site:
+        cmd += ' -S'
     pre_build, cmd = _handle_zip_safe(cmd, zip_safe)
 
     assert main not in srcs, "main file should not be included in srcs"
@@ -190,7 +195,7 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
 def python_test(name:str, srcs:list, data:list=[], resources:list=[], deps:list=[], worker:str='',
                 labels:list&features&tags=None, size:str=None, flags:str='', visibility:list=None,
                 container:bool|dict=False, sandbox:bool=None, timeout:int=0, flaky:bool|int=0,
-                test_outputs:list=None, zip_safe:bool=None, interpreter:str=None):
+                test_outputs:list=None, zip_safe:bool=None, interpreter:str=None, site:bool=False):
     """Generates a Python test target.
 
     This works very similarly to python_binary; it is also a single .pex file
@@ -223,11 +228,15 @@ def python_test(name:str, srcs:list, data:list=[], resources:list=[], deps:list=
       interpreter (str): The Python interpreter to use. Defaults to the config setting
                          which is normally just 'python', but could be 'python3' or
                         'pypy' or whatever.
+      site (bool): Allows the Python interpreter to import site; conversely if False, it will be
+                   started with the -S flag to avoid importing site.
     """
     interpreter = interpreter or CONFIG.DEFAULT_PYTHON_INTERPRETER
     cmd = '$TOOLS_PEX -t -s "%s" -m "%s" -r "%s" --zip_safe --interpreter_options="%s"' % (
         interpreter, CONFIG.PYTHON_MODULE_DIR, CONFIG.PYTHON_TEST_RUNNER,
         CONFIG.PYTHON_INTERPRETER_OPTIONS)
+    if site:
+        cmd += ' -S'
     pre_build, cmd = _handle_zip_safe(cmd, zip_safe)
 
     # Use the pex tool to compress the entry point & add all the bootstrap helpers etc.
@@ -354,7 +363,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
         # Fix for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=830892
         # tl;dr: Debian has broken --target with a custom patch, the only way to fix is to pass --system
         # which is itself Debian-specific, so we need to find if we're running on Debian. AAAAARGGGHHHH...
-        cmd = f'[ -f /etc/debian_version ] && [ $TOOLS_PIP == "/usr/bin/pip3" ] && SYS_FLAG="--system" || SYS_FLAG=""; {cmd} $SYS_FLAG' 
+        cmd = f'[ -f /etc/debian_version ] && [ $TOOLS_PIP == "/usr/bin/pip3" ] && SYS_FLAG="--system" || SYS_FLAG=""; {cmd} $SYS_FLAG'
     cmd += f' -b build {repo_flag} {index_flag} {pip_flags} {package_name}'
 
     if strip:

--- a/test/python_rules/local/BUILD
+++ b/test/python_rules/local/BUILD
@@ -1,0 +1,11 @@
+python_test(
+    name = "local_lib_import_test",
+    srcs = ["local_lib_import_test.py"],
+    site = True,
+)
+
+python_test(
+    name = "local_lib_no_import_test",
+    srcs = ["local_lib_no_import_test.py"],
+    site = False,
+)

--- a/test/python_rules/local/local_lib_import_test.py
+++ b/test/python_rules/local/local_lib_import_test.py
@@ -1,0 +1,7 @@
+import unittest
+
+
+class LocalLibImportTest(unittest.TestCase):
+
+    def test_can_import_setuptools(self):
+        import setuptools

--- a/test/python_rules/local/local_lib_no_import_test.py
+++ b/test/python_rules/local/local_lib_no_import_test.py
@@ -1,0 +1,8 @@
+import unittest
+
+
+class LocalLibNoImportForYouTest(unittest.TestCase):
+
+    def test_cannot_import_setuptools(self):
+        with self.assertRaises(ImportError):
+            import setuptools

--- a/tools/jarcat/main.go
+++ b/tools/jarcat/main.go
@@ -44,8 +44,12 @@ func mustReadPreamble(path string) string {
 	defer f.Close()
 	r := bufio.NewReader(f)
 	s, err := r.ReadString('\n')
-	if err != nil {
-		log.Fatalf("%s", err)
+	must(err)
+	if s == "#!/bin/sh\n" {
+		// Preamble continues onto the next line. Read that too.
+		s2, err := r.ReadString('\n')
+		must(err)
+		return s + s2
 	}
 	return s
 }

--- a/tools/please_pex/pex/pex.go
+++ b/tools/please_pex/pex/pex.go
@@ -46,7 +46,7 @@ func (pw *Writer) SetShebang(shebang string, options string) {
 		// In many environments shebangs cannot have more than one argument; we can work around
 		// that by treating it as a shell script.
 		if strings.Contains(shebang, " ") {
-			shebang = "#!/bin/sh\nexec " + shebang + " -S $0 $@"
+			shebang = "#!/bin/sh\nexec " + shebang + ` -S $0 "$@"`
 		} else {
 			shebang += " -S"
 		}

--- a/tools/please_pex/pex_main.go
+++ b/tools/please_pex/pex_main.go
@@ -21,6 +21,7 @@ var opts = struct {
 	Interpreter        string        `short:"i" long:"interpreter" env:"TOOLS_INTERPRETER" description:"Python interpreter to use"`
 	TestRunner         string        `short:"r" long:"test_runner" choice:"unittest" choice:"pytest" choice:"behave" default:"unittest" description:"Test runner to use"`
 	Shebang            string        `short:"s" long:"shebang" description:"Explicitly set shebang to this"`
+	Site               bool          `short:"S" long:"site" description:"Allow the pex to import site at startup"`
 	ZipSafe            bool          `long:"zip_safe" description:"Marks this pex as zip-safe"`
 	NoZipSafe          bool          `long:"nozip_safe" description:"Marks this pex as zip-unsafe"`
 	InterpreterOptions string        `long:"interpreter_options" description:"Options-string to pass to the python interpreter"`
@@ -37,7 +38,7 @@ dependent code as a self-contained self-executable environment.
 func main() {
 	cli.ParseFlagsOrDie("please_pex", &opts)
 	cli.InitLogging(opts.Verbosity)
-	w := pex.NewWriter(opts.EntryPoint, opts.Interpreter, opts.InterpreterOptions, !opts.NoZipSafe)
+	w := pex.NewWriter(opts.EntryPoint, opts.Interpreter, opts.InterpreterOptions, !opts.NoZipSafe, !opts.Site)
 	if opts.Shebang != "" {
 		w.SetShebang(opts.Shebang, opts.InterpreterOptions)
 	}

--- a/tools/please_pex/pex_main.py
+++ b/tools/please_pex/pex_main.py
@@ -141,18 +141,6 @@ class ModuleDirImport(object):
         return module.__loader__.get_code(fullname)
 
 
-def clean_sys_path():
-    """Remove anything from sys.path that isn't either the pex or the main Python install dir.
-
-    NB: *not* site-packages or dist-packages or any of that malarkey, just the place where
-        we get the actual Python standard library packages from).
-    This would be cleaner if we could suppress loading site in the first place, but that isn't
-    as easy as all that to build into a pex, unfortunately.
-    """
-    site_packages = getsitepackages()
-    sys.path = [x for x in sys.path if not any(x.startswith(pkg) for pkg in site_packages)]
-
-
 def explode_zip():
     """Extracts the current pex to a temp directory where we can import everything from.
 

--- a/tools/please_pex/pex_run.py
+++ b/tools/please_pex/pex_run.py
@@ -6,7 +6,6 @@ def add_module_dir_to_sys_path(dirname):
 
 
 def run():
-    clean_sys_path()
     if not ZIP_SAFE:
         with explode_zip()():
             add_module_dir_to_sys_path(MODULE_DIR)


### PR DESCRIPTION
By default it is off which is possibly a breaking change (although lets us clean up some hacky path-stripping code). When on it will be possible to import local modules from within that pex.
Fixes #619 , albeit in a fairly crude way...