### PR TITLE
Non-xattr fallbacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
    build-linux:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20190226
+       - image: thoughtmachine/please_ubuntu:20190605
      environment:
        PLZ_ARGS: "-p --profile ci"
      steps:
@@ -48,7 +48,7 @@ jobs:
    build-linux-alt:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu_alt:20190201
+       - image: thoughtmachine/please_ubuntu_alt:20190605
      environment:
        PLZ_ARGS: "-p --profile ci"
        PLZ_COVER: "cover"

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -342,7 +342,7 @@ func readRuleHash(state *core.BuildState, target *core.BuildTarget, postBuild bo
 func readRuleHashOnFile(state *core.BuildState, target *core.BuildTarget, output string) []byte {
 	if !state.XattrsSupported {
 		// Read from the fallback file.
-		f, err := os.Open(output)
+		f, err := os.Open(ruleHashFileName(output))
 		if err != nil {
 			return nil
 		}
@@ -416,15 +416,19 @@ func writeRuleHashOnFile(state *core.BuildState, target *core.BuildTarget, outpu
 
 // writeFallbackRuleHashFile writes a rule hash to the fallback file.
 func writeFallbackRuleHashFile(target *core.BuildTarget, hash []byte, output string) error {
-	dir, file := path.Split(output)
-	output = dir + ".rule_hash_" + file
-	f, err := os.Create(output)
+	f, err := os.Create(ruleHashFileName(output))
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 	_, err = f.Write(hash)
 	return err
+}
+
+// ruleHashFileName returns the name we'd use for the rule hash file for an output.
+func ruleHashFileName(output string) string {
+	dir, file := path.Split(output)
+	return dir + ".rule_hash_" + file
 }
 
 // fallbackRuleHashFile returns the filename we'll store the hashes for this file on if we have

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -243,6 +243,7 @@ func DefaultConfiguration() *Configuration {
 	config.Build.Config = "opt"         // Optimised builds by default
 	config.Build.FallbackConfig = "opt" // Optimised builds as a fallback on any target that doesn't have a matching one set
 	config.Build.PleaseSandboxTool = "please_sandbox"
+	config.Build.Xattrs = true
 	config.BuildConfig = map[string]string{}
 	config.BuildEnv = map[string]string{}
 	config.Aliases = map[string]string{}
@@ -373,6 +374,7 @@ type Configuration struct {
 		FallbackConfig    string       `help:"The build config to use when one is chosen and a required target does not have one by the same name. Also defaults to opt." example:"opt | dbg"`
 		Lang              string       `help:"Sets the language passed to build rules when building. This can be important for some tools (although hopefully not many) - we've mostly observed it with Sass."`
 		Sandbox           bool         `help:"True to sandbox individual build actions, which isolates them from network access and some aspects of the filesystem. Currently only works on Linux." var:"BUILD_SANDBOX"`
+		Xattrs            bool         `help:"True (the default) to attempt to use xattrs to record file metadata. If false Please will fall back to using additional files where needed, which is more compatible but has slightly worse performance."`
 		PleaseSandboxTool string       `help:"The location of the please_sandbox tool to use."`
 		Nonce             string       `help:"This is an arbitrary string that is added to the hash of every build target. It provides a way to force a rebuild of everything when it's changed.\nWe will bump the default of this whenever we think it's required - although it's been a pretty long time now and we hope that'll continue."`
 		PassEnv           []string     `help:"A list of environment variables to pass from the current environment to build rules. For example\n\nPassEnv = HTTP_PROXY\n\nwould copy your HTTP_PROXY environment variable to the build env for any rules."`

--- a/src/core/lock.go
+++ b/src/core/lock.go
@@ -20,7 +20,7 @@ var lockFile *os.File
 
 // AcquireRepoLock opens the lock file and acquires the lock.
 // Dies if the lock cannot be successfully acquired.
-func AcquireRepoLock() {
+func AcquireRepoLock(state *BuildState) {
 	var err error
 	// There is of course technically a bit of a race condition between the file & flock operations here,
 	// but it shouldn't matter much since we're trying to mutually exclude plz processes started by the user
@@ -51,10 +51,10 @@ func AcquireRepoLock() {
 		}
 	}
 
-	// Quick test of xattrs; everything will fail later if we can't write them, so make
-	// sure plz-out supports them now and give a clear error if not.
+	// Quick test of xattrs; we don't keep trying to use them if they fail here.
 	if err := xattr.Set(lockFilePath, "user.plz_build", []byte("lock")); err != nil {
-		log.Fatalf("Failed to set xattrs:%s\nMaybe plz-out is on a filesystem that doesn't support them?", err)
+		log.Notice("xattrs are not supported on this filesystem, using fallbacks")
+		state.XattrsSupported = false
 	}
 }
 

--- a/src/core/lock.go
+++ b/src/core/lock.go
@@ -52,9 +52,11 @@ func AcquireRepoLock(state *BuildState) {
 	}
 
 	// Quick test of xattrs; we don't keep trying to use them if they fail here.
-	if err := xattr.Set(lockFilePath, "user.plz_build", []byte("lock")); err != nil {
-		log.Notice("xattrs are not supported on this filesystem, using fallbacks")
-		state.XattrsSupported = false
+	if state != nil && state.XattrsSupported {
+		if err := xattr.Set(lockFilePath, "user.plz_build", []byte("lock")); err != nil {
+			log.Warning("xattrs are not supported on this filesystem, using fallbacks")
+			state.DisableXattrs()
+		}
 	}
 }
 

--- a/src/core/lock_test.go
+++ b/src/core/lock_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAcquireRepoLock(t *testing.T) {
 	// Grab the lock
-	AcquireRepoLock()
+	AcquireRepoLock(nil)
 	// Now we should be able to open the file (ie. it exists)
 	lockFile, err := os.Open(lockFilePath)
 	assert.NoError(t, err)

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -147,6 +147,8 @@ type BuildState struct {
 	ShowAllOutput bool
 	// True to attach a debugger on test failure.
 	DebugTests bool
+	// True if we think the underlying filesystem supports xattrs (which affects how we write some metadata).
+	XattrsSupported bool
 	// True once we have killed the workers, so we only do it once.
 	workersKilled bool
 	// Number of running workers
@@ -754,6 +756,7 @@ func NewBuildState(numThreads int, cache Cache, verbosity int, config *Configura
 		VerifyHashes:    true,
 		NeedBuild:       true,
 		Success:         true,
+		XattrsSupported: true, // until proven otherwise
 		Coverage:        TestCoverage{Files: map[string][]LineCoverage{}},
 		OriginalArch:    cli.HostArch(),
 		numWorkers:      numThreads,

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -736,6 +736,13 @@ func (state *BuildState) ForConfig(config ...string) *BuildState {
 	return s
 }
 
+// DisableXattrs disables xattr support for this build. This is done for filesystems that
+// don't support it.
+func (state *BuildState) DisableXattrs() {
+	state.XattrsSupported = false
+	state.PathHasher.DisableXattrs()
+}
+
 // NewBuildState constructs and returns a new BuildState.
 // Everyone should use this rather than attempting to construct it themselves;
 // callers can't initialise all the required private fields.
@@ -746,7 +753,7 @@ func NewBuildState(numThreads int, cache Cache, verbosity int, config *Configura
 		Graph:           NewGraph(),
 		pendingTasks:    queue.NewPriorityQueue(10000, true), // big hint, why not
 		lastResults:     make([]*BuildResult, numThreads),
-		PathHasher:      fs.NewPathHasher(RepoRoot),
+		PathHasher:      fs.NewPathHasher(RepoRoot, config.Build.Xattrs),
 		ProcessExecutor: process.New(sandboxTool),
 		StartTime:       startTime,
 		Config:          config,
@@ -756,7 +763,7 @@ func NewBuildState(numThreads int, cache Cache, verbosity int, config *Configura
 		VerifyHashes:    true,
 		NeedBuild:       true,
 		Success:         true,
-		XattrsSupported: true, // until proven otherwise
+		XattrsSupported: config.Build.Xattrs,
 		Coverage:        TestCoverage{Files: map[string][]LineCoverage{}},
 		OriginalArch:    cli.HostArch(),
 		numWorkers:      numThreads,

--- a/src/fs/hash_test.go
+++ b/src/fs/hash_test.go
@@ -11,7 +11,7 @@ import (
 func TestHash(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	h := NewPathHasher(wd)
+	h := NewPathHasher(wd, true)
 	b1, err1 := h.Hash("src/fs/test_data/test_subfolder1/a.txt", false, false)
 	b2, err2 := h.Hash("src/fs/test_data/test_subfolder1/a.txt", false, false)
 	assert.NoError(t, err1)
@@ -22,7 +22,7 @@ func TestHash(t *testing.T) {
 func TestMoveHash(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	h := NewPathHasher(wd)
+	h := NewPathHasher(wd, true)
 	b1, err1 := h.Hash("src/fs/test_data/test_subfolder1/a.txt", false, false)
 	h.MoveHash("src/fs/test_data/test_subfolder1/a.txt", "doesnt_exist.txt", true)
 	b2, err2 := h.Hash("doesnt_exist.txt", false, false)
@@ -34,7 +34,7 @@ func TestMoveHash(t *testing.T) {
 func TestSetHash(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	h := NewPathHasher(wd)
+	h := NewPathHasher(wd, true)
 	b1, err1 := h.Hash("src/fs/test_data/test_subfolder1/a.txt", false, false)
 	h.SetHash("doesnt_exist.txt", b1)
 	b2, err2 := h.Hash("doesnt_exist.txt", false, false)

--- a/src/please.go
+++ b/src/please.go
@@ -795,7 +795,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 func runPlease(state *core.BuildState, targets []core.BuildLabel) {
 	// Acquire the lock before we start building
 	if (state.NeedBuild || state.NeedTests) && !opts.FeatureFlags.NoLock {
-		core.AcquireRepoLock()
+		core.AcquireRepoLock(state)
 		defer core.ReleaseRepoLock()
 	}
 

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -62,7 +62,7 @@ func CheckAndUpdate(config *core.Configuration, updatesEnabled, updateCommand, f
 
 	// Must lock here so that the update process doesn't race when running two instances
 	// simultaneously.
-	core.AcquireRepoLock()
+	core.AcquireRepoLock(nil)
 	defer core.ReleaseRepoLock()
 
 	// If the destination exists and the user passed --force, remove it to force a redownload.

--- a/tools/images/ubuntu/Dockerfile
+++ b/tools/images/ubuntu/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get clean
 
 # Go - we want 1.12 here but the latest package available is 1.10.
-RUN curl -fsSL https://dl.google.com/go/go1.12.linux-amd64.tar.gz | tar -xzC /usr/local
+RUN curl -fsSL https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 # Golint
 RUN go get golang.org/x/lint/golint && mv ~/go/bin/golint /usr/local/bin && rm -rf ~/go

--- a/tools/images/ubuntu_alt/Dockerfile
+++ b/tools/images/ubuntu_alt/Dockerfile
@@ -8,11 +8,14 @@ RUN apt-get update && \
     apt-get clean
 
 # Go - we want 1.11 here but the latest package available is 1.10.
-RUN curl -fsSL https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -xzC /usr/local
+RUN curl -fsSL https://dl.google.com/go/go1.11.10.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Locale
 RUN locale-gen en_GB.UTF-8
+
+# Custom plzconfig
+COPY /plzconfig /etc/plzconfig
 
 # Welcome message
 COPY /motd.txt /etc/motd

--- a/tools/images/ubuntu_alt/plzconfig
+++ b/tools/images/ubuntu_alt/plzconfig
@@ -1,0 +1,3 @@
+[build]
+; For testing this flow on CI.
+xattrs = false


### PR DESCRIPTION
Allows disabling these, and falls back to a file-based scheme (similar but not identical to the one we had before xattrs) in such a case. I think it avoids the issues we had with that one by writing one file per output rather than one per target, although there's a teensy bit more overhead as a result.

Resolves #548 