### PR TITLE
Remove support for testing Go versions prior to 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To build Please yourself, run `./bootstrap.sh` in the repo root.
 This will set up the minimal environment needed to build Please,
 build it once manually and then rebuild it again using itself.
 You'll need to have Go 1.11+ installed to build Please although once
-built it can target any version from 1.5+ onwards.
+built it can target any version from 1.8+ onwards.
 
 Optional dependencies for various tests include Python, Java, unittest++
 (`sudo apt-get install libunittest++-dev`), clang, gold and docker - none

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -376,17 +376,14 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
         outs=[name + '_main.go'],
         deps=deps,
         cmd={
-            'dbg': f'$TOOLS_TEST $TOOLS_GO -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS',
-            'opt': f'$TOOLS_TEST $TOOLS_GO -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS',
-            'cover': f'$TOOLS_TEST $TOOLS_GO -d . -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS ',
+            'dbg': f'$TOOLS -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS',
+            'opt': f'$TOOLS -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS',
+            'cover': f'$TOOLS -d . -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS ',
         },
         needs_transitive_deps=True,  # Need all .a files to template coverage variables
         requires=['go', 'go_src'],
         test_only=True,
-        tools={
-            'go': [CONFIG.GO_TOOL],
-            'test': [CONFIG.GO_TEST_TOOL],
-        },
+        tools = [CONFIG.GO_TEST_TOOL],
         post_build=lambda name, output: _replace_test_package(name, output, static, definitions=definitions, cgo=cgo),
     )
     deps += [lib_rule]

--- a/tools/please_go_test/gotest/write_test_main_test.go
+++ b/tools/please_go_test/gotest/write_test_main_test.go
@@ -49,7 +49,6 @@ func TestWriteTestMain(t *testing.T) {
 	err := WriteTestMain(
 		"tools/please_go_test/gotest/test_data",
 		"",
-		false, // not version 1.8
 		[]string{"tools/please_go_test/gotest/test_data/example_test.go"},
 		"test.go",
 		[]CoverVar{},
@@ -66,7 +65,6 @@ func TestWriteTestMainWithCoverage(t *testing.T) {
 	err := WriteTestMain(
 		"tools/please_go_test/gotest/test_data",
 		"",
-		false, // not version 1.8
 		[]string{"tools/please_go_test/gotest/test_data/example_test.go"},
 		"test.go",
 		[]CoverVar{{
@@ -104,16 +102,4 @@ func TestExtraImportPathsWithImportPath(t *testing.T) {
 		"_cover0 \"github.com/thought-machine/please/src/core\"",
 		"_cover1 \"github.com/thought-machine/please/output\"",
 	})
-}
-
-func TestIsVersion18(t *testing.T) {
-	assert.True(t, isVersion18([]byte("go version go1.8beta2 linux/amd64")))
-	assert.True(t, isVersion18([]byte("go version go1.8 linux/amd64")))
-	assert.True(t, isVersion18([]byte("go version go1.8.2 linux/amd64")))
-	assert.False(t, isVersion18([]byte("go version go1.7beta2 linux/amd64")))
-	assert.False(t, isVersion18([]byte("go version go1.7 linux/amd64")))
-	assert.False(t, isVersion18([]byte("go version go1.7.2 linux/amd64")))
-	assert.True(t, isVersion18([]byte("go version go1.10beta2 linux/amd64")))
-	assert.True(t, isVersion18([]byte("go version go1.10 linux/amd64")))
-	assert.True(t, isVersion18([]byte("go version go1.10.2 linux/amd64")))
 }

--- a/tools/please_go_test/plz_go_test.go
+++ b/tools/please_go_test/plz_go_test.go
@@ -24,7 +24,6 @@ var opts struct {
 	Package    string        `short:"p" long:"package" description:"Package containing this test" env:"PKG"`
 	ImportPath string        `short:"i" long:"import_path" description:"Full import path to the package"`
 	Args       struct {
-		Go      string   `positional-arg-name:"go" description:"Location of go command" required:"true"`
 		Sources []string `positional-arg-name:"sources" description:"Test source files" required:"true"`
 	} `positional-args:"true" required:"true"`
 }
@@ -36,7 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error scanning for coverage: %s", err)
 	}
-	if err = gotest.WriteTestMain(opts.Package, opts.ImportPath, gotest.IsVersion18(opts.Args.Go), opts.Args.Sources, opts.Output, coverVars); err != nil {
+	if err = gotest.WriteTestMain(opts.Package, opts.ImportPath, opts.Args.Sources, opts.Output, coverVars); err != nil {
 		log.Fatalf("Error writing test main: %s", err)
 	}
 	os.Exit(0)


### PR DESCRIPTION
Technically you can still build binaries from 1.5 - 1.7, but I doubt anyone cares.

Resolves #515 