### PR TITLE
Allow either Unchanged or Reused statuses to reuse test results.

### DIFF
--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -117,7 +117,7 @@ func test(tid int, state *core.BuildState, label core.BuildLabel, target *core.B
 	}
 
 	needToRun := func() bool {
-		if target.State() == core.Unchanged && core.PathExists(cachedOutputFile) {
+		if s := target.State(); (s == core.Unchanged || s == core.Reused) && core.PathExists(cachedOutputFile) {
 			// Output file exists already and appears to be valid. We might still need to rerun though
 			// if the coverage files aren't available.
 			if needCoverage && !verifyHash(state, cachedCoverageFile, hash) {


### PR DESCRIPTION
This fixes an observed issue where tests re-run unnecessarily in some circumstances (e.g. when restarting a Docker container between each run)