### PR TITLE
Don't deadlock when cross-compiling all subpackages.

### DIFF
--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -42,7 +42,7 @@ func parse(tid int, state *core.BuildState, label, dependor core.BuildLabel, inc
 	pkg := state.WaitForPackage(label)
 	if pkg != nil {
 		// Does exist, all we need to do is toggle on this target
-		return activateTarget(state, pkg, label, dependor, forSubinclude, include, exclude)
+		return activateTarget(tid, state, pkg, label, dependor, forSubinclude, include, exclude)
 	}
 	// If we get here then it falls to us to parse this package.
 	state.LogBuildResult(tid, label, core.PackageParsing, "Parsing...")
@@ -63,7 +63,7 @@ func parse(tid int, state *core.BuildState, label, dependor core.BuildLabel, inc
 		return err
 	}
 	state.LogBuildResult(tid, label, core.PackageParsed, "Parsed package")
-	return activateTarget(state, pkg, label, dependor, forSubinclude, include, exclude)
+	return activateTarget(tid, state, pkg, label, dependor, forSubinclude, include, exclude)
 }
 
 // checkSubrepo checks whether this guy exists within a subrepo. If so we will need to make sure that's available first.
@@ -115,10 +115,11 @@ func checkArchSubrepo(state *core.BuildState, name string) *core.Subrepo {
 }
 
 // activateTarget marks a target as active (ie. to be built) and adds its dependencies as pending parses.
-func activateTarget(state *core.BuildState, pkg *core.Package, label, dependor core.BuildLabel, forSubinclude bool, include, exclude []string) error {
+func activateTarget(tid int, state *core.BuildState, pkg *core.Package, label, dependor core.BuildLabel, forSubinclude bool, include, exclude []string) error {
 	if !label.IsAllTargets() && state.Graph.Target(label) == nil {
 		if label.Subrepo == "" && label.PackageName == "" && label.Name == dependor.Subrepo {
 			if subrepo := checkArchSubrepo(state, label.Name); subrepo != nil {
+				state.LogBuildResult(tid, label, core.TargetBuilt, "Instantiated subrepo")
 				return nil
 			}
 		}

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -11,11 +11,12 @@ import (
 )
 
 var empty = []string{}
+var tid int = 1
 
 func TestAddDepSimple(t *testing.T) {
 	// Simple case with only one package parsed and one target added
 	state := makeState(true, false)
-	activateTarget(state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
 	assertPendingParses(t, state, "//package2:target1", "//package2:target1")
 	assertPendingBuilds(t, state) // None until package2 parses
 	assert.Equal(t, 5, state.NumActive())
@@ -24,9 +25,9 @@ func TestAddDepSimple(t *testing.T) {
 func TestAddDepMultiple(t *testing.T) {
 	// Similar to above but doing all targets in that package
 	state := makeState(true, false)
-	activateTarget(state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
-	activateTarget(state, nil, buildLabel("//package1:target2"), core.OriginalTarget, false, empty, empty)
-	activateTarget(state, nil, buildLabel("//package1:target3"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package1:target2"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package1:target3"), core.OriginalTarget, false, empty, empty)
 	// We get an additional dep on target2, but not another on package2:target1 because target2
 	// is already activated since package1:target1 depends on it
 	assertPendingParses(t, state, "//package2:target1", "//package2:target1", "//package2:target2")
@@ -37,7 +38,7 @@ func TestAddDepMultiple(t *testing.T) {
 func TestAddDepMultiplePackages(t *testing.T) {
 	// This time we already have package2 parsed
 	state := makeState(true, true)
-	activateTarget(state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
 	assertPendingBuilds(t, state, "//package2:target2") // This is the only candidate target
 	assertPendingParses(t, state)                       // None, we have both packages already
 	assert.Equal(t, 6, state.NumActive())
@@ -47,7 +48,7 @@ func TestAddDepNoBuild(t *testing.T) {
 	// Tag state as not needing build. We shouldn't get any pending builds at this point.
 	state := makeState(true, true)
 	state.NeedBuild = false
-	activateTarget(state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
 	assertPendingParses(t, state)         // None, we have both packages already
 	assertPendingBuilds(t, state)         // Nothing because we don't need to build.
 	assert.Equal(t, 1, state.NumActive()) // Parses only
@@ -58,7 +59,7 @@ func TestAddParseDep(t *testing.T) {
 	// should still get queued for build though. Recall that we indicate this with :all...
 	state := makeState(true, true)
 	state.NeedBuild = false
-	activateTarget(state, nil, buildLabel("//package2:target2"), buildLabel("//package3:all"), false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package2:target2"), buildLabel("//package3:all"), false, empty, empty)
 	assertPendingBuilds(t, state, "//package2:target2") // Queued because it's needed for parse
 	assertPendingParses(t, state)                       // None, we have both packages already
 	assert.Equal(t, 2, state.NumActive())
@@ -67,7 +68,7 @@ func TestAddParseDep(t *testing.T) {
 func TestAddDepRescan(t *testing.T) {
 	// Simulate a post-build function and rescan.
 	state := makeState(true, true)
-	activateTarget(state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
 	assertPendingBuilds(t, state, "//package2:target2") // This is the only candidate target
 	assertPendingParses(t, state)                       // None, we have both packages already
 	assert.Equal(t, 6, state.NumActive())
@@ -98,12 +99,12 @@ func TestAddParseDepDeferred(t *testing.T) {
 	state := makeState(true, true)
 	state.NeedBuild = false
 	assert.Equal(t, 1, state.NumActive())
-	activateTarget(state, nil, buildLabel("//package2:target2"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package2:target2"), core.OriginalTarget, false, empty, empty)
 	assertPendingParses(t, state)
 	assertPendingBuilds(t, state) // Not yet.
 
 	// Now the undefer kicks off...
-	activateTarget(state, nil, buildLabel("//package2:target2"), buildLabel("//package1:all"), false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package2:target2"), buildLabel("//package1:all"), false, empty, empty)
 	assertPendingBuilds(t, state, "//package2:target2") // This time!
 	assertPendingParses(t, state)
 	assert.Equal(t, 2, state.NumActive())


### PR DESCRIPTION
Addresses #654. By setting the subrepo target to `TargetBuilt`, we close the associated channel and unblock dependors waiting for the subrepo to be instantiated.