### PR TITLE
Change Go assembly implementation to support 1.12 (and not older versions)

### DIFF
--- a/.circleci/setup_osx.sh
+++ b/.circleci/setup_osx.sh
@@ -4,7 +4,7 @@ set -eu
 
 # /usr/local/go might get cached.
 if [ ! -d "/usr/local/go" ]; then
-    curl -fsSL https://dl.google.com/go/go1.11.5.darwin-amd64.tar.gz | sudo tar -xz -C /usr/local
+    curl -fsSL https://dl.google.com/go/go1.12.6.darwin-amd64.tar.gz | sudo tar -xz -C /usr/local
 fi
 sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -53,7 +53,7 @@ fi
 # TODO(peterebden): Once Go 1.13 is out we will need to update (or remove) this.
 if [ ! "`go version | grep 1.12`" ]; then
     warn "Go version != 1.12 detected, excluding assembly tests"
-    EXCLUDES="${EXCLUDES} --exclude=asm"
+    EXCLUDES="${EXCLUDES} --exclude=asm --exclude=//test/go_rules/asm_binary/..."
 fi
 if ! hash python2 2>/dev/null ; then
     warn "python2 not found, excluding python2 tests"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -50,6 +50,11 @@ elif ! hash docker 2>/dev/null ; then
     warn "Docker not found, excluding containerised tests"
     EXCLUDES="${EXCLUDES} --exclude=container"
 fi
+# TODO(peterebden): Once Go 1.13 is out we will need to update (or remove) this.
+if [ ! "`go version | grep 1.12`" ]; then
+    warn "Go version != 1.12 detected, excluding assembly tests"
+    EXCLUDES="${EXCLUDES} --exclude=asm"
+fi
 if ! hash python2 2>/dev/null ; then
     warn "python2 not found, excluding python2 tests"
     EXCLUDES="${EXCLUDES} --exclude=py2"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -53,7 +53,7 @@ fi
 # TODO(peterebden): Once Go 1.13 is out we will need to update (or remove) this.
 if [ ! "`go version | grep 1.12`" ]; then
     warn "Go version != 1.12 detected, excluding assembly tests"
-    EXCLUDES="${EXCLUDES} --exclude=asm --exclude=//test/go_rules/asm_binary/..."
+    EXCLUDES="${EXCLUDES} --exclude=asm --exclude=//test/go_rules/asm_binary/... --exclude=//test/go_rules/asm/..."
 fi
 if ! hash python2 2>/dev/null ; then
     warn "python2 not found, excluding python2 tests"

--- a/src/parse/rules/go_rules.build_defs
+++ b/src/parse/rules/go_rules.build_defs
@@ -15,7 +15,7 @@ _LINK_PKGS_CMD = ' '.join([
 def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=None, deps:list=[],
                visibility:list=None, test_only:bool&testonly=False, complete:bool=True,
                _needs_transitive_deps=False, _all_srcs=False, cover:bool=True,
-               filter_srcs:bool=True, _link_private:bool=False, _link_extra:bool=True):
+               filter_srcs:bool=True, _link_private:bool=False, _link_extra:bool=True, _abi:str=False):
     """Generates a Go library which can be reused by other rules.
 
     Args:
@@ -50,6 +50,19 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
             # a subdirectory for go to be able to transparently import them.
             src_labels += [f'link:plz-out/go/src/$PKG/{libname}']
     if asm_srcs:
+        abi_rule = build_rule(
+            name = name,
+            tag = 'abi',
+            srcs = {
+                'asm': asm_srcs,
+                'hdrs': hdrs,
+            },
+            outs = [name + '.abi'],
+            building_description = 'Creating ABI...',
+            cmd = 'eval `$TOOL env` && $TOOL tool asm -trimpath $TMP_DIR -I ${GOROOT}/pkg/include -D GOOS_${OS} -D GOARCH_${ARCH} -gensymabis -o $OUT $SRCS_ASM',
+            tools=[CONFIG.GO_TOOL],
+            test_only = test_only,
+        )
         lib_rule = go_library(
             name = f'_{name}#lib',
             srcs = srcs,
@@ -57,6 +70,7 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
             test_only = test_only,
             complete = False,
             cover = cover,
+            _abi = abi_rule,
             _needs_transitive_deps = _needs_transitive_deps,
             _all_srcs = _all_srcs,
         )
@@ -66,6 +80,7 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
             srcs = {
                 'asm': asm_srcs,
                 'hdrs': hdrs,
+                'hdr': [lib_rule + '|h'],
             },
             outs = [name + '.o'],
             building_description = 'Assembling...',
@@ -76,7 +91,7 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
         return build_rule(
             name = name,
             srcs = {
-                'lib': [lib_rule],
+                'lib': [lib_rule + '|o'],
                 'asm': [asm_rule],
             },
             outs=[out],
@@ -106,13 +121,25 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
     if filter_srcs:
         tools['filter'] = [CONFIG.GO_FILTER_TOOL]
 
+    if _abi:
+        outs = {
+            'o': [out],
+            'h': [name + '.h'],
+        }
+        srcs = {
+            'go': srcs,
+            'abi': [_abi],
+        }
+    else:
+        outs = [out]
+
     return build_rule(
         name=name,
         srcs=srcs,
         deps=deps,
         internal_deps = [src_rule],
-        outs=[out],
-        cmd=_go_library_cmds(complete=complete, all_srcs=_all_srcs, cover=cover, filter_srcs=filter_srcs),
+        outs=outs,
+        cmd=_go_library_cmds(complete=complete, all_srcs=_all_srcs, cover=cover, filter_srcs=filter_srcs, abi=_abi),
         visibility=visibility,
         building_description="Compiling...",
         requires=['go', 'go_src'] if _all_srcs else ['go'],
@@ -700,15 +727,15 @@ def _replace_test_package(name, output, static, definitions, cgo):
                     set_command(lib, k, f'mv -f $PKG_DIR/{new_name}.a $PKG_DIR/{pkg_name}.a && {v}')
 
 
-def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True):
+def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True, abi=False):
     """Returns the commands to run for building a Go library."""
     filter_cmd = 'export SRCS="$(${TOOLS_FILTER} ${SRCS})"; ' if filter_srcs else ''
     # Invokes the Go compiler.
     complete_flag = '-complete ' if complete else ''
-
+    out_cmd = ' -o $OUTS_O -symabis $SRCS_ABI -asmhdr $OUTS_H' if abi else ' -o $OUT'
     _GOPATH = ' '.join(
         ['-I %s -I %s/pkg/%s_%s' % (p, p, CONFIG.GOOS, CONFIG.GOARCH) for p in CONFIG.GOPATH.split(':')])
-    compile_cmd = f'$TOOLS_GO tool compile -trimpath $TMP_DIR {complete_flag}{_GOPATH} $(for i in $(find $TMP_DIR -name pkg -type d); do echo -n " -I $i/{CONFIG.GOOS}_{CONFIG.GOARCH} "; done) -pack -o $OUT '
+    compile_cmd = f'$TOOLS_GO tool compile -trimpath $TMP_DIR {complete_flag}{_GOPATH} $(for i in $(find $TMP_DIR -name pkg -type d); do echo -n " -I $i/{CONFIG.GOOS}_{CONFIG.GOARCH} "; done) -pack {out_cmd}'
     # Annotates files for coverage.
     cover_cmd = 'for SRC in $SRCS; do BN=$(basename $SRC); go tool cover -mode=set -var=GoCover_${BN//[.-]/_} $SRC > _tmp.go && mv -f _tmp.go $SRC; done'
     prefix = ('export SRCS="$PKG_DIR/*.go"; ' + _LINK_PKGS_CMD) if all_srcs else _LINK_PKGS_CMD

--- a/test/go_rules/asm/BUILD
+++ b/test/go_rules/asm/BUILD
@@ -8,7 +8,7 @@ go_test(
     name = "asm_test",
     srcs = ["asm_test.go"],
     external = True,
-    labels = ["manual"],  # does not work in go 1.12 yet
+    labels = ["asm"],
     deps = [
         ":asm",
         "//third_party/go:testify",

--- a/tools/build_langserver/langserver/analyzer_test.go
+++ b/tools/build_langserver/langserver/analyzer_test.go
@@ -23,7 +23,7 @@ func TestNewAnalyzer(t *testing.T) {
 	assert.NotEqual(t, nil, a.BuiltIns)
 
 	goLibrary := a.BuiltIns["go_library"]
-	assert.Equal(t, 15, len(goLibrary.ArgMap))
+	assert.Equal(t, 16, len(goLibrary.ArgMap))
 	assert.Equal(t, true, goLibrary.ArgMap["name"].Required)
 
 	// check preloadBuildDefs has being loaded


### PR DESCRIPTION
1.12 has this new ABI stuff which requires extra build steps, and they don't work on older versions. Please 14.x will support only 1.12+.

Not really expecting a review here, but want to run this through CI to check that's happy before merging.