### PR TITLE
Allow users to BYO test-runner pks/deps. Resolves #578.

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -261,6 +261,7 @@ func DefaultConfiguration() *Configuration {
 	config.Python.PexTool = "please_pex"
 	config.Python.DefaultInterpreter = "python3"
 	config.Python.TestRunner = "unittest"
+	config.Python.TestRunnerBootstrap = ""
 	config.Python.UsePyPI = true
 	config.Python.InterpreterOptions = ""
 	// Annoyingly pip on OSX doesn't seem to work with this flag (you get the dreaded
@@ -413,17 +414,18 @@ type Configuration struct {
 		DefaultStatic bool   `help:"Sets Go binaries to default to static linking. Note that enabling this may have negative consequences for some code, including Go's DNS lookup code in the net module." var:"GO_DEFAULT_STATIC"`
 	} `help:"Please has built-in support for compiling Go, and of course is written in Go itself.\nSee the config subfields or the Go rules themselves for more information.\n\nNote that Please is a bit more flexible than Go about directory layout - for example, it is possible to have multiple packages in a directory, but it's not a good idea to push this too far since Go's directory layout is inextricably linked with its import paths."`
 	Python struct {
-		PipTool            string  `help:"The tool that is invoked during pip_library rules." var:"PIP_TOOL"`
-		PipFlags           string  `help:"Additional flags to pass to pip invocations in pip_library rules." var:"PIP_FLAGS"`
-		PexTool            string  `help:"The tool that's invoked to build pexes. Defaults to please_pex in the install directory." var:"PEX_TOOL"`
-		DefaultInterpreter string  `help:"The interpreter used for python_binary and python_test rules when none is specified on the rule itself. Defaults to python but you could of course set it to, say, pypy." var:"DEFAULT_PYTHON_INTERPRETER"`
-		TestRunner         string  `help:"The test runner used to discover & run Python tests; one of unittest, pytest or behave." var:"PYTHON_TEST_RUNNER" options:"unittest,pytest,behave"`
-		ModuleDir          string  `help:"Defines a directory containing modules from which they can be imported at the top level.\nBy default this is empty but by convention we define our pip_library rules in third_party/python and set this appropriately. Hence any of those third-party libraries that try something like import six will have it work as they expect, even though it's actually in a different location within the .pex." var:"PYTHON_MODULE_DIR"`
-		DefaultPipRepo     cli.URL `help:"Defines a location for a pip repo to download wheels from.\nBy default pip_library uses PyPI (although see below on that) but you may well want to use this define another location to upload your own wheels to.\nIs overridden by the repo argument to pip_library." var:"PYTHON_DEFAULT_PIP_REPO"`
-		WheelRepo          cli.URL `help:"Defines a location for a remote repo that python_wheel rules will download from. See python_wheel for more information." var:"PYTHON_WHEEL_REPO"`
-		UsePyPI            bool    `help:"Whether or not to use PyPI for pip_library rules or not. Defaults to true, if you disable this you will presumably want to set DefaultPipRepo to use one of your own.\nIs overridden by the use_pypi argument to pip_library." var:"USE_PYPI"`
-		WheelNameScheme    string  `help:"Defines a custom templatized wheel naming scheme. Templatized variables should be surrounded in curly braces, and the available options are: url_base, package_name, and version. The default search pattern is '{url_base}/{package_name}-{version}-${{OS}}-${{ARCH}}.whl' along with a few common variants." var:"PYTHON_WHEEL_NAME_SCHEME"`
-		InterpreterOptions string  `help:"Options to pass to the python interpeter, when writing shebangs for pex executables." var:"PYTHON_INTERPRETER_OPTIONS"`
+		PipTool             string  `help:"The tool that is invoked during pip_library rules." var:"PIP_TOOL"`
+		PipFlags            string  `help:"Additional flags to pass to pip invocations in pip_library rules." var:"PIP_FLAGS"`
+		PexTool             string  `help:"The tool that's invoked to build pexes. Defaults to please_pex in the install directory." var:"PEX_TOOL"`
+		DefaultInterpreter  string  `help:"The interpreter used for python_binary and python_test rules when none is specified on the rule itself. Defaults to python but you could of course set it to, say, pypy." var:"DEFAULT_PYTHON_INTERPRETER"`
+		TestRunner          string  `help:"The test runner used to discover & run Python tests; one of unittest, pytest or behave." var:"PYTHON_TEST_RUNNER" options:"unittest,pytest,behave"`
+		TestRunnerBootstrap string  `help:"Target providing test-runner library and its transitive dependencies. Injects plz-provided bootstraps if not given." var:"PYTHON_TEST_RUNNER_BOOTSTRAP"`
+		ModuleDir           string  `help:"Defines a directory containing modules from which they can be imported at the top level.\nBy default this is empty but by convention we define our pip_library rules in third_party/python and set this appropriately. Hence any of those third-party libraries that try something like import six will have it work as they expect, even though it's actually in a different location within the .pex." var:"PYTHON_MODULE_DIR"`
+		DefaultPipRepo      cli.URL `help:"Defines a location for a pip repo to download wheels from.\nBy default pip_library uses PyPI (although see below on that) but you may well want to use this define another location to upload your own wheels to.\nIs overridden by the repo argument to pip_library." var:"PYTHON_DEFAULT_PIP_REPO"`
+		WheelRepo           cli.URL `help:"Defines a location for a remote repo that python_wheel rules will download from. See python_wheel for more information." var:"PYTHON_WHEEL_REPO"`
+		UsePyPI             bool    `help:"Whether or not to use PyPI for pip_library rules or not. Defaults to true, if you disable this you will presumably want to set DefaultPipRepo to use one of your own.\nIs overridden by the use_pypi argument to pip_library." var:"USE_PYPI"`
+		WheelNameScheme     string  `help:"Defines a custom templatized wheel naming scheme. Templatized variables should be surrounded in curly braces, and the available options are: url_base, package_name, and version. The default search pattern is '{url_base}/{package_name}-{version}-${{OS}}-${{ARCH}}.whl' along with a few common variants." var:"PYTHON_WHEEL_NAME_SCHEME"`
+		InterpreterOptions  string  `help:"Options to pass to the python interpeter, when writing shebangs for pex executables." var:"PYTHON_INTERPRETER_OPTIONS"`
 	} `help:"Please has built-in support for compiling Python.\nPlease's Python artifacts are pex files, which are essentially self-executable zip files containing all needed dependencies, bar the interpreter itself. This fits our aim of at least semi-static binaries for each language.\nSee https://github.com/pantsbuild/pex for more information.\nNote that due to differences between the environment inside a pex and outside some third-party code may not run unmodified (for example, it cannot simply open() files). It's possible to work around a lot of this, but if it all becomes too much it's possible to mark pexes as not zip-safe which typically resolves most of it at a modest speed penalty."`
 	Java struct {
 		JavacTool          string    `help:"Defines the tool used for the Java compiler. Defaults to javac." var:"JAVAC_TOOL"`

--- a/src/parse/rules/python_rules.build_defs
+++ b/src/parse/rules/python_rules.build_defs
@@ -231,12 +231,23 @@ def python_test(name:str, srcs:list, data:list=[], resources:list=[], deps:list=
                    started with the -S flag to avoid importing site.
     """
     interpreter = interpreter or CONFIG.DEFAULT_PYTHON_INTERPRETER
-    cmd = '$TOOLS_PEX -t -s "%s" -m "%s" -r "%s" --zip_safe --interpreter_options="%s"' % (
+    cmd = '$TOOLS_PEX -t -s "%s" -m "%s" -r "%s" --zip_safe --add_test_runner_deps --interpreter_options="%s"' % (
         interpreter, CONFIG.PYTHON_MODULE_DIR, CONFIG.PYTHON_TEST_RUNNER,
         CONFIG.PYTHON_INTERPRETER_OPTIONS)
     if site:
         cmd += ' -S'
     pre_build, cmd = _handle_zip_safe(cmd, zip_safe)
+
+    # If the config specifies a PYTHON_TEST_RUNNER_BOOTSTRAP target, then this ought to contain
+    # the test-runner library (e.g. pytest), and its transitive dependencies. In this case, we just
+    # add the specified target as a dependency.
+    #
+    # If no bootstrap target is provided, then plz will provide a pinned set of dependencies to
+    # support the specified test-runner framework.
+    bootstrap = CONFIG.PYTHON_TEST_RUNNER_BOOTSTRAP
+    if bootstrap:
+        deps += [bootstrap] if bootstrap not in deps else []
+        cmd = cmd.replace(' --add_test_runner_deps', '')
 
     # Use the pex tool to compress the entry point & add all the bootstrap helpers etc.
     pex_rule = build_rule(
@@ -555,12 +566,12 @@ def python_wheel(name:str, version:str, hashes:list=None, package_name:str=None,
 def _handle_zip_safe(cmd, zip_safe):
     """Handles the zip safe flag. Returns a tuple of (pre-build function, new command)."""
     if zip_safe is None:
-        return lambda name: (set_command(name, cmd.replace('--zip_safe', ' --nozip_safe'))
+        return lambda name: (set_command(name, cmd.replace(' --zip_safe', ''))
                              if has_label(name, 'py:zip-unsafe') else None), cmd
     elif zip_safe:
         return None, cmd
     else:
-        return None, cmd.replace('--zip_safe', ' --nozip_safe')
+        return None, cmd.replace(' --zip_safe', '')
 
 
 def _add_licences(name, output):

--- a/tools/please_pex/pex_main.go
+++ b/tools/please_pex/pex_main.go
@@ -23,8 +23,8 @@ var opts = struct {
 	Shebang            string        `short:"s" long:"shebang" description:"Explicitly set shebang to this"`
 	Site               bool          `short:"S" long:"site" description:"Allow the pex to import site at startup"`
 	ZipSafe            bool          `long:"zip_safe" description:"Marks this pex as zip-safe"`
-	NoZipSafe          bool          `long:"nozip_safe" description:"Marks this pex as zip-unsafe"`
 	InterpreterOptions string        `long:"interpreter_options" description:"Options-string to pass to the python interpreter"`
+	AddTestRunnerDeps  bool          `long:"add_test_runner_deps" description:"True if test-runner dependencies should be baked into test binaries"`
 }{
 	Usage: `
 please_pex is a tool to create .pex files for Python.
@@ -38,12 +38,13 @@ dependent code as a self-contained self-executable environment.
 func main() {
 	cli.ParseFlagsOrDie("please_pex", &opts)
 	cli.InitLogging(opts.Verbosity)
-	w := pex.NewWriter(opts.EntryPoint, opts.Interpreter, opts.InterpreterOptions, !opts.NoZipSafe, !opts.Site)
+	w := pex.NewWriter(
+		opts.EntryPoint, opts.Interpreter, opts.InterpreterOptions, opts.ZipSafe, !opts.Site)
 	if opts.Shebang != "" {
 		w.SetShebang(opts.Shebang, opts.InterpreterOptions)
 	}
 	if opts.Test {
-		w.SetTest(opts.TestSrcs, opts.TestRunner)
+		w.SetTest(opts.TestSrcs, opts.TestRunner, opts.AddTestRunnerDeps)
 	}
 	if err := w.Write(opts.Out, opts.ModuleDir); err != nil {
 		log.Fatalf("%s", err)


### PR DESCRIPTION
Would be nice to unify the `TestRunner` and `TestRunnerBootstrap` flags in the future, but this seems like a good medium-term way to give some flexibility back to repository-maintainers.