### PR TITLE
Cache contents of expanded zip-unsafe PEX files for subsequent runs.

### DIFF
--- a/src/parse/rules/python_rules.build_defs
+++ b/src/parse/rules/python_rules.build_defs
@@ -127,7 +127,7 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
       labels (list): Labels to apply to this rule.
     """
     shebang = shebang or interpreter or CONFIG.DEFAULT_PYTHON_INTERPRETER
-    cmd = '$TOOLS_PEX -s "%s" -m "%s" --zip_safe --interpreter_options="%s"' % (
+    cmd = '$TOOLS_PEX -s "%s" -m "%s" --zip_safe --interpreter_options="%s" --stamp="$STAMP"' % (
         shebang, CONFIG.PYTHON_MODULE_DIR, CONFIG.PYTHON_INTERPRETER_OPTIONS)
     if site:
         cmd += ' -S'
@@ -162,6 +162,7 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
             'pex': [CONFIG.PEX_TOOL],
         },
         test_only=test_only,
+        stamp=True,  # Used to derive a unique cache-directory for zip-unsafe binaries.
     )
     # This rule concatenates the .pex with all the other precompiled zip files from dependent rules.
     cmd = '$TOOL z -i . -s .pex.zip -s .whl --preamble_from="$SRC" --include_other --add_init_py --strict'

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -139,12 +139,20 @@ func run(ctx context.Context, state *core.BuildState, label core.BuildLabel, arg
 // environ returns an appropriate environment for a command.
 func environ(config *core.Configuration, setenv bool) []string {
 	env := os.Environ()
+	for _, e := range adRunEnviron {
+		env = addEnv(env, e)
+	}
 	if setenv {
 		for _, e := range core.GeneralBuildEnvironment(config) {
 			env = addEnv(env, e)
 		}
 	}
 	return env
+}
+
+// adRunEnviron returns values that are appended to the environment for a command.
+var adRunEnviron = []string{
+	"PEX_NOCACHE=true",
 }
 
 // addEnv adds an env var to an existing set, with replacement.

--- a/tools/please_pex/pex/pex.go
+++ b/tools/please_pex/pex/pex.go
@@ -20,17 +20,19 @@ type Writer struct {
 	noSite         bool
 	shebang        string
 	realEntryPoint string
+	pexStamp       string
 	testSrcs       []string
 	testIncludes   []string
 	testRunner     string
 }
 
 // NewWriter constructs a new Writer.
-func NewWriter(entryPoint, interpreter string, options string, zipSafe, noSite bool) *Writer {
+func NewWriter(entryPoint, interpreter, options, stamp string, zipSafe, noSite bool) *Writer {
 	pw := &Writer{
 		zipSafe:        zipSafe,
 		noSite:         noSite,
 		realEntryPoint: toPythonPath(entryPoint),
+		pexStamp:       stamp,
 	}
 	pw.SetShebang(interpreter, options)
 	return pw
@@ -132,6 +134,7 @@ func (pw *Writer) Write(out, moduleDir string) error {
 	b = bytes.Replace(b, []byte("__MODULE_DIR__"), []byte(strings.Replace(moduleDir, ".", "/", -1)), 1)
 	b = bytes.Replace(b, []byte("__ENTRY_POINT__"), []byte(pw.realEntryPoint), 1)
 	b = bytes.Replace(b, []byte("__ZIP_SAFE__"), []byte(pythonBool(pw.zipSafe)), 1)
+	b = bytes.Replace(b, []byte("__PEX_STAMP__"), []byte(pw.pexStamp), 1)
 
 	if len(pw.testSrcs) != 0 {
 		// If we're writing a test, we append test_main.py to it.

--- a/tools/please_pex/pex_main.go
+++ b/tools/please_pex/pex_main.go
@@ -23,6 +23,7 @@ var opts = struct {
 	Shebang            string        `short:"s" long:"shebang" description:"Explicitly set shebang to this"`
 	Site               bool          `short:"S" long:"site" description:"Allow the pex to import site at startup"`
 	ZipSafe            bool          `long:"zip_safe" description:"Marks this pex as zip-safe"`
+	Stamp              string        `long:"stamp" description:"Unique value used to derive cache directory for pex"`
 	InterpreterOptions string        `long:"interpreter_options" description:"Options-string to pass to the python interpreter"`
 	AddTestRunnerDeps  bool          `long:"add_test_runner_deps" description:"True if test-runner dependencies should be baked into test binaries"`
 }{
@@ -39,7 +40,8 @@ func main() {
 	cli.ParseFlagsOrDie("please_pex", &opts)
 	cli.InitLogging(opts.Verbosity)
 	w := pex.NewWriter(
-		opts.EntryPoint, opts.Interpreter, opts.InterpreterOptions, opts.ZipSafe, !opts.Site)
+		opts.EntryPoint, opts.Interpreter, opts.InterpreterOptions, opts.Stamp,
+		opts.ZipSafe, !opts.Site)
 	if opts.Shebang != "" {
 		w.SetShebang(opts.Shebang, opts.InterpreterOptions)
 	}


### PR DESCRIPTION
Implements a caching scheme for zip-unsafe PEX python executables. In particular, the unzipped+compiled contents of PEX files are persisted into subdirectories of `~/.pex`. This yields significantly better performance on subsequent invocations of a PEX.

The motivating example for this PR is an internal command-line tool that utilizes the [boto3](https://github.com/boto/boto3) python library, which is [infamously](https://github.com/boto/boto3/issues/849#issuecomment-442795689) zip-unsafe.

When exploding a zip-unsafe PEX, we do the following:
1. Acquire a lock on a file with a unique name derived from plz's injected `$STAMP`.
2. Check whether the file is empty. Nonempty lockfile indicates that the cache-directory corresponding to the PEX has already been written to and made ready for use. In this case, release the lock and proceed with execution.
3. If the file is empty, then explode the PEX archive into the unique directory `~/.pex/pex-$STAMP/`, and use the `compileall` module to precompile its contents. Write a string to the lockfile before releasing it, to let future invocations know that the cache contents are ready for use.
4. Rewrite `sys.path` and proceed with program invocation.

An environment variable, `PEX_NOCACHE`, is introduced to disable caching. When this variable is present, the PEX is instead extracted to `TEMP_DIR`, and the contents (and lockfile) are erased on program-exit.

This  requires changes in a few other locations:
* `python_binary` is marked with `stamp=True`, to provide a deterministic mapping from "built PEX" to "cache directory".
* The `$STAMP` variable must be piped through `pex_tool`, to replace the macro `__PEX_STAMP__` in `pex_main.py`
* I extend the command-environment of all `plz run` executions with `PEX_NOCACHE=true`, in order to prevent caching of one-off `plz run`-invocations, every time a change is tested with an executable.