### PR TITLE
Move the pex cache from ~/.pex to ~/.cache/pex.

### DIFF
--- a/tools/please_pex/pex_main.py
+++ b/tools/please_pex/pex_main.py
@@ -148,7 +148,7 @@ def pex_basepath(temp=False):
         import tempfile
         return tempfile.mkdtemp(dir=os.environ.get('TEMP_DIR'), prefix='pex_')
     else:
-        return os.path.expanduser('~/.pex')
+        return os.path.expanduser('~/.cache/pex')
 
 def pex_uniquedir():
     return 'pex-%s' % PEX_STAMP


### PR DESCRIPTION
In response to post-merge comments on #668.

cc @agenticarus