### PR TITLE
Add arch() subrepo-rule, for adding user-defined arch-subrepos.

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -554,3 +554,4 @@
     {{ template "lexicon_entry.html" .Named "http_archive" }}
     {{ template "lexicon_entry.html" .Named "new_http_archive" }}
     {{ template "lexicon_entry.html" .Named "github_repo" }}
+    {{ template "lexicon_entry.html" .Named "arch" }}

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -63,7 +63,7 @@ def subinclude(target:str, hash:str=None):
     pass
 def load(target:str, names:str=None):
     pass
-def subrepo(name:str, dep:str='', path:str=None, config:str=None, bazel_compat:bool=False):
+def subrepo(name:str, dep:str='', path:str=None, config:str=None, bazel_compat:bool=False, arch:str=None):
     pass
 
 

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -173,3 +173,24 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
         config = config,
         bazel_compat = bazel_compat,
     )
+
+def arch(name:str, os:str, arch:str):
+    """ Defines an architecture subrepo.
+
+    This is a convenience alias to the more general subrepo rule. It allows for a user-defined
+    subrepo for cross-built rules targeting a specific architecture. This lets users define
+    architectures that won't conflict with the subrepos implicitly instantiated by plz.
+
+    Args:
+      name: Name of the rule.
+      os:  Target operating system (e.g. "darwin")..
+      arch: Target architecture (e.g. "amd64").
+    """
+    arch_str = f'{os}_{arch}'
+    assert arch_str.count('_') == 1, "Character '_' disallowed in OS/Arch names"
+
+    subrepo(
+        name = name,
+        path = "",
+        arch = arch_str,
+    )

--- a/src/core/graph.go
+++ b/src/core/graph.go
@@ -5,6 +5,7 @@
 package core
 
 import (
+	"reflect"
 	"sort"
 	"sync"
 )
@@ -120,6 +121,10 @@ func (graph *BuildGraph) MaybeAddSubrepo(subrepo *Subrepo) *Subrepo {
 	graph.mutex.Lock()
 	defer graph.mutex.Unlock()
 	if s, present := graph.subrepos[subrepo.Name]; present {
+		if !reflect.DeepEqual(s, subrepo) {
+			log.Fatalf("Found multiple definitions for subrepo '%s' (%+v s %+v)",
+				s.Name, s, subrepo)
+		}
 		return s
 	}
 	graph.subrepos[subrepo.Name] = subrepo


### PR DESCRIPTION
Partially addresses #660. In the medium-term future, we might consider a more fundamental restructuring of subrepos/archs (perhaps before a hypothetical 15.0.0 release?)

This PR introduces a new subrepo-rule, `arch()`. It can be used as:

```
arch(
    name = "linux",
    os = "linux",
    arch = "amd64",
)
```

This allows for user-defined arch-subrepos, which remain distinct from plz's implicitly instantiated arch-subrepos. The motivating use for this is a target that packages a collection of binary distributions spanning multiple architectures.

In the process, we introduce a few small semantic changes - A `subrepo()` rule **_may_** instantiate an already-existing subrepo, **_if_** the declared subrepo is identical to the one already registered. This avoids a fatal assertion-failure in the event that `plz` parses the package that declares a subrepo, from within the same subrepo. We implement this subrepo-equality-check in the `MaybeAddSubrepo` function, and use this instead of `AddSubrepo` (with the belief that this should be nonbreaking, and that any new breakages ought to be discovered).