### PR TITLE
Streamline `plz query changes`

### DIFF
--- a/src/query/BUILD
+++ b/src/query/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//src/scm",
         "//src/utils",
         "//third_party/go:logging",
-        "//third_party/go:shlex",
     ],
 )
 

--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -4,38 +4,11 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"fmt"
-	"os/exec"
 	"sort"
-
-	"github.com/google/shlex"
 
 	"github.com/thought-machine/please/src/build"
 	"github.com/thought-machine/please/src/core"
 )
-
-// MustCheckout checks out the given revision.
-func MustCheckout(revision, command string) {
-	log.Notice("Checking out %s...", revision)
-	if argv, err := shlex.Split(fmt.Sprintf(command, revision)); err != nil {
-		log.Fatalf("Invalid checkout command: %s", err)
-	} else if out, err := exec.Command(argv[0], argv[1:]...).CombinedOutput(); err != nil {
-		log.Fatalf("Failed to check out %s: %s\n%s", revision, err, out)
-	}
-}
-
-// MustGetRevision runs a command to determine the current revision.
-func MustGetRevision(command string) string {
-	log.Notice("Determining current revision...")
-	argv, err := shlex.Split(command)
-	if err != nil {
-		log.Fatalf("Invalid revision command: %s", err)
-	}
-	out, err := exec.Command(argv[0], argv[1:]...).Output()
-	if err != nil {
-		log.Fatalf("Failed to determine current revision: %s\n%s", err, out)
-	}
-	return string(bytes.TrimSpace(out))
-}
 
 // DiffGraphs calculates the difference between two build graphs.
 // Note that this is not symmetric; targets that have been removed from 'before' do not appear

--- a/src/scm/git.go
+++ b/src/scm/git.go
@@ -145,3 +145,10 @@ func (g *git) parseHunks(hunks []*diff.Hunk) []int {
 	}
 	return ret
 }
+
+func (g *git) Checkout(revision string) error {
+	if out, err := exec.Command("git", "checkout", revision).CombinedOutput(); err != nil {
+		return fmt.Errorf("git checkout failed: %s\n%s", err, out)
+	}
+	return nil
+}

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -27,6 +27,8 @@ type SCM interface {
 	// ChangedLines returns the set of lines that have been modified,
 	// as a map of filename -> affected line numbers.
 	ChangedLines() (map[string][]int, error)
+	// Checkout checks out the given revision.
+	Checkout(revision string) error
 }
 
 // New returns a new SCM instance for this repo root.
@@ -46,4 +48,13 @@ func NewFallback(repoRoot string) SCM {
 	}
 	log.Warning("Cannot determine SCM, revision identifiers will be unavailable and `plz query changes/changed` will not work correctly.")
 	return &stub{}
+}
+
+// MustNew returns a new SCM instance for this repo root. It dies on any errors.
+func MustNew(repoRoot string) SCM {
+	scm := New(repoRoot)
+	if scm == nil {
+		log.Fatalf("Cannot determine SCM implementation")
+	}
+	return scm
 }

--- a/src/scm/stub.go
+++ b/src/scm/stub.go
@@ -27,3 +27,7 @@ func (s *stub) Remove(names []string) error {
 func (s *stub) ChangedLines() (map[string][]int, error) {
 	return nil, fmt.Errorf("Unknown SCM, can't calculate changed lines")
 }
+
+func (s *stub) Checkout(revision string) error {
+	return fmt.Errorf("Unknown SCM, can't checkout")
+}

--- a/tools/misc/plz_ci.sh
+++ b/tools/misc/plz_ci.sh
@@ -9,6 +9,4 @@ set -o pipefail
 
 # Set $ORIGIN to a branch or tag name if you want to build vs. something other than master.
 ORIGIN="${ORIGIN:-origin/master}"
-git diff --name-only "$ORIGIN" | \
-    plz query changes --since "$ORIGIN" - | \
-    plz test -
+plz query changes --since "$ORIGIN" | plz test -


### PR DESCRIPTION
Basically gets rid of the piping file list in and the command flags.

This is less flexible (the old one didn't really know about the SCM so you could use whatever you wanted) but since we have a concept of SCM in plz now we might as well use it. It's also a lot more intuitive without the piping of files in which was easy not to realise that you had to do to get sensible results. If someone wants to support say hg or svn it should be easy enough to write an implementation.