### PR TITLE
Python coverage is broken after update to new PEX cache location

### DIFF
--- a/tools/please_pex/pex_main.py
+++ b/tools/please_pex/pex_main.py
@@ -154,6 +154,13 @@ def pex_uniquedir():
     return 'pex-%s' % PEX_STAMP
 
 
+def pex_paths():
+    no_cache = os.environ.get('PEX_NOCACHE')
+    no_cache = no_cache and no_cache.lower() == 'true'
+    basepath, uniquedir = pex_basepath(no_cache), pex_uniquedir()
+    pex_path = os.path.join(basepath, uniquedir)
+    return pex_path, basepath, uniquedir, no_cache
+
 def explode_zip():
     """Extracts the current pex to a temp directory where we can import everything from.
 
@@ -178,12 +185,9 @@ def explode_zip():
         # these variables to find out what's going on (e.g. are we zip-safe or not).
         global PEX_PATH
 
-        no_cache = os.environ.get('PEX_NOCACHE')
-        no_cache = no_cache and no_cache.lower() == 'true'
-        basepath, uniquedir = pex_basepath(no_cache), pex_uniquedir()
+        PEX_PATH, basepath, uniquedir, no_cache = pex_paths()
         os.makedirs(basepath, exist_ok=True)
         with pex_lockfile(basepath, uniquedir) as lockfile:
-            PEX_PATH = os.path.join(basepath, uniquedir)
             if len(lockfile.read()) == 0:
                 import compileall, zipfile
 

--- a/tools/please_pex/test_main.py
+++ b/tools/please_pex/test_main.py
@@ -14,9 +14,11 @@ def initialise_coverage():
     _original_xml_file = coverage_control.XmlReporter.xml_file
     # Fix up paths in coverage output which are absolute; we want paths relative to
     # the repository root. Also skip empty __init__.py files.
+    pex_path = pex_paths()[0]
+
     def _xml_file(self, fr, analysis):
-        if '.pex' in fr.filename:
-            fr.filename = fr.filename[fr.filename.index('.pex') + 5:]  # +5 to take off .pex/
+        if pex_path in fr.filename:
+            fr.filename = fr.filename[len(pex_path) + 1:]  # +1 to remove the remaining /
         if fr.filename == '__main__.py':
             return  # Don't calculate coverage for the synthetic entrypoint.
         if not (fr.filename.endswith('__init__.py') and len(analysis.statements) <= 1):


### PR DESCRIPTION
Update the coverage locations for Python to follow new PEX cache location. #670 