### PR TITLE
Fixes to a few rough edges around PEXs.

### DIFF
--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -232,7 +232,7 @@ def python_test(name:str, srcs:list, data:list=[], resources:list=[], deps:list=
                    started with the -S flag to avoid importing site.
     """
     interpreter = interpreter or CONFIG.DEFAULT_PYTHON_INTERPRETER
-    cmd = '$TOOLS_PEX -t -s "%s" -m "%s" -r "%s" --zip_safe --add_test_runner_deps --interpreter_options="%s"' % (
+    cmd = '$TOOLS_PEX -t -s "%s" -m "%s" -r "%s" --zip_safe --add_test_runner_deps --interpreter_options="%s" --stamp="$STAMP"' % (
         interpreter, CONFIG.PYTHON_MODULE_DIR, CONFIG.PYTHON_TEST_RUNNER,
         CONFIG.PYTHON_INTERPRETER_OPTIONS)
     if site:
@@ -267,6 +267,7 @@ def python_test(name:str, srcs:list, data:list=[], resources:list=[], deps:list=
             'interpreter': [interpreter or CONFIG.DEFAULT_PYTHON_INTERPRETER],
             'pex': [CONFIG.PEX_TOOL],
         },
+        stamp = True,
     )
 
     # If there are resources specified, they have to get built into the pex.

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -135,6 +135,7 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) Bui
 		"RESULTS_FILE="+resultsFile,
 		// We shouldn't really have specific things like this here, but it really is just easier to set it.
 		"GTEST_OUTPUT=xml:"+resultsFile,
+		"PEX_NOCACHE=true",
 	)
 	env = append(env, "HOME="+testDir)
 	if state.NeedCoverage && !target.HasAnyLabel(state.Config.Test.DisableCoverage) {

--- a/tools/please_pex/pex_main.py
+++ b/tools/please_pex/pex_main.py
@@ -219,7 +219,7 @@ def explode_zip():
         yield
         if no_cache:
             import shutil
-            shutil.rmtree(pex_basepath)
+            shutil.rmtree(basepath)
 
     return _explode_zip
 


### PR DESCRIPTION
- Include PEX_NOCACHE in the test-environment, so zip-unsafe tempdirs
are gc'd.
- Propagate stamp to python_test targets.
- Gc the correct tempdir during cleanup.