### PR TITLE
Add a json() builtin, for rendering JSON representations of plz values.

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -238,3 +238,8 @@ def licenses(licences):
     """Sets the default licences for the package."""
     assert CONFIG.BAZEL_COMPATIBILITY, 'licenses() can only be called in Bazel compat mode'
     package(default_licences = licences)
+
+
+def json(value) -> str:
+    """Returns a JSON-formatted representation of a plz value"""
+    pass

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1,6 +1,7 @@
 package asp
 
 import (
+	"encoding/json"
 	"fmt"
 	"path"
 	"reflect"
@@ -48,6 +49,7 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "get_licences", getLicences)
 	setNativeCode(s, "get_command", getCommand)
 	setNativeCode(s, "set_command", setCommand)
+	setNativeCode(s, "json", valueAsJSON)
 	stringMethods = map[string]*pyFunc{
 		"join":       setNativeCode(s, "join", strJoin),
 		"split":      setNativeCode(s, "split", strSplit),
@@ -689,6 +691,16 @@ func getLicences(s *scope, args []pyObject) pyObject {
 func getCommand(s *scope, args []pyObject) pyObject {
 	target := getTargetPost(s, string(args[0].(pyString)))
 	return pyString(target.GetCommandConfig(string(args[1].(pyString))))
+}
+
+// valueAsJSON returns a JSON-formatted string representation of a plz value.
+func valueAsJSON(s *scope, args []pyObject) pyObject {
+	js, err := json.Marshal(args[0])
+	if err != nil {
+		s.Error("Could not marshal object as JSON")
+		return None
+	}
+	return pyString(js)
 }
 
 // setCommand sets the command of a target, optionally for a configuration.

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -85,6 +85,15 @@ func (b pyBool) String() string {
 	return "False"
 }
 
+func (b pyBool) MarshalJSON() ([]byte, error) {
+	if b.IsTruthy() {
+		return []byte("true"), nil
+	} else if b == None {
+		return []byte("null"), nil
+	}
+	return []byte("false"), nil
+}
+
 type pyInt int
 
 // pyIndex converts an object that's being used as an index to an int.


### PR DESCRIPTION
This is helpful when a `genrule` wants to pass arbitrary structured data from a build-target specification to an underlying implementation binary.

As discussed [on gitter](https://gitter.im/please-build/Lobby?at=5d128a4d1f64724daabd426b).