### PR TITLE
Un-deprecate .format()

### DIFF
--- a/docs/language.html
+++ b/docs/language.html
@@ -94,8 +94,8 @@
           - returns true if this string begins with <code>prefix</code></li>
 	    <li><code><span class="fn-name">endswith</span><span class="fn-p">(</span><span class="fn-arg">suffix</span><span class="fn-p">)</span></code>
           - returns true if this string ends with <code>suffix</code></li>
-	    <li><code><span class="fn-name">format</span><span class="fn-p">(</span><span class="fn-arg">args...</span><span class="fn-p">)</span></code>
-          - <span class="red">deprecated</span>, prefer f-strings instead.</li>
+	    <li><code><span class="fn-name">format</span><span class="fn-p">(</span><span class="fn-arg">arg1=val1</span>, <span class="fn-arg">arg2=val2</span>, <span class="fn-arg">...</span>)</span><span class="fn-p">)</span></code>
+          - Replaces named parameters in the string.</li>
 	    <li><code><span class="fn-name">lstrip</span><span class="fn-p">(</span><span class="fn-arg">cutset</span><span class="fn-p">)</span></code>
           - strips all characters in <code>cutset</code> from the beginning of this string.</li>
 	    <li><code><span class="fn-name">rstrip</span><span class="fn-p">(</span><span class="fn-arg">cutset</span><span class="fn-p">)</span></code>


### PR DESCRIPTION
As discussed on Gitter, it's useful for matching Bazel.