### PR TITLE
Rewriting cache interface

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -122,7 +122,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 			postBuildOutput, err := loadPostBuildOutput(target)
 			if err != nil {
 				log.Warning("Missing post-build output for %s; will rebuild.", target.Label)
-			} else if err := runPostBuildFunctionIfNeeded(tid, state, target, postBuildOutput); err != nil {
+			} else if err := runPostBuildFunction(tid, state, target, postBuildOutput, ""); err != nil {
 				log.Warning("Error from post-build function for %s: %s; will rebuild", target.Label, err)
 			}
 		}
@@ -202,7 +202,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 			if metadata := state.Cache.Retrieve(target, cacheKey); metadata != nil {
 				storePostBuildOutput(target, metadata.Stdout)
 				postBuildOutput = string(metadata.Stdout)
-				if err := runPostBuildFunctionIfNeeded(tid, state, target, postBuildOutput); err != nil {
+				if err := runPostBuildFunction(tid, state, target, postBuildOutput, ""); err != nil {
 					return err
 				} else if retrieveArtifacts() {
 					return writeRuleHash(state, target)
@@ -564,14 +564,6 @@ func checkRuleHashesOfType(target *core.BuildTarget, outputs []string, hasher *f
 		}
 	}
 	return false
-}
-
-// Runs the post-build function for a target if it's got one.
-func runPostBuildFunctionIfNeeded(tid int, state *core.BuildState, target *core.BuildTarget, out string) error {
-	if target.PostBuildFunction != nil {
-		return runPostBuildFunction(tid, state, target, out, "")
-	}
-	return nil
 }
 
 // Runs the post-build function for a target.

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -173,7 +173,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 		}
 		state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Checking cache...")
 
-		if state.Cache.Retrieve(target, mustShortTargetHash(state, target)) != nil {
+		if state.Cache.Retrieve(target, mustShortTargetHash(state, target), target.Outputs()) != nil {
 			log.Debug("Retrieved artifacts for %s from cache", target.Label)
 			checkLicences(state, target)
 			newOutputHash, err := calculateAndCheckRuleHash(state, target)
@@ -199,7 +199,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 		// what we would retrieve from the cache.
 		if target.PostBuildFunction != nil && !haveRunPostBuildFunction {
 			log.Debug("Checking for post-build output for %s in cache...", target.Label)
-			if metadata := state.Cache.Retrieve(target, cacheKey); metadata != nil {
+			if metadata := state.Cache.Retrieve(target, cacheKey, nil); metadata != nil {
 				storePostBuildOutput(target, metadata.Stdout)
 				postBuildOutput = string(metadata.Stdout)
 				if err := runPostBuildFunction(tid, state, target, postBuildOutput, ""); err != nil {

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -77,6 +77,8 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 		}
 	}()
 
+	metadata := &core.BuildMetadata{StartTime: time.Now()}
+
 	if err := target.CheckDependencyVisibility(state); err != nil {
 		return err
 	}
@@ -116,23 +118,27 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 	haveRunPostBuildFunction := false
 	if !target.IsFilegroup && !needsBuilding(state, target, false) {
 		log.Debug("Not rebuilding %s, nothing's changed", target.Label)
-		if postBuildOutput, err = runPostBuildFunctionIfNeeded(tid, state, target, ""); err != nil {
-			log.Warning("Missing post-build output for %s; will rebuild.", target.Label)
-		} else {
-			// If a post-build function ran it may modify the rule definition. In that case we
-			// need to check again whether the rule needs building.
-			if target.PostBuildFunction == nil || !needsBuilding(state, target, true) {
-				if target.IsFilegroup {
-					// Small optimisation to ensure we don't need to rehash things unnecessarily.
-					copyFilegroupHashes(state, target)
-				}
-				target.SetState(core.Reused)
-				state.LogBuildResult(tid, target.Label, core.TargetCached, "Unchanged")
-				buildLinks(state, target)
-				return nil // Nothing needs to be done.
+		if target.PostBuildFunction != nil {
+			postBuildOutput, err := loadPostBuildOutput(target)
+			if err != nil {
+				log.Warning("Missing post-build output for %s; will rebuild.", target.Label)
+			} else if err := runPostBuildFunctionIfNeeded(tid, state, target, postBuildOutput); err != nil {
+				log.Warning("Error from post-build function for %s: %s; will rebuild", target.Label, err)
 			}
-			log.Debug("Rebuilding %s after post-build function", target.Label)
 		}
+		// If a post-build function ran it may modify the rule definition. In that case we
+		// need to check again whether the rule needs building.
+		if target.PostBuildFunction == nil || !needsBuilding(state, target, true) {
+			if target.IsFilegroup {
+				// Small optimisation to ensure we don't need to rehash things unnecessarily.
+				copyFilegroupHashes(state, target)
+			}
+			target.SetState(core.Reused)
+			state.LogBuildResult(tid, target.Label, core.TargetCached, "Unchanged")
+			buildLinks(state, target)
+			return nil // Nothing needs to be done.
+		}
+		log.Debug("Rebuilding %s after post-build function", target.Label)
 		haveRunPostBuildFunction = true
 	}
 	if target.IsFilegroup {
@@ -166,7 +172,8 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 			return true
 		}
 		state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Checking cache...")
-		if _, retrieved := retrieveFromCache(state, target); retrieved {
+
+		if state.Cache.Retrieve(target, mustShortTargetHash(state, target)) != nil {
 			log.Debug("Retrieved artifacts for %s from cache", target.Label)
 			checkLicences(state, target)
 			newOutputHash, err := calculateAndCheckRuleHash(state, target)
@@ -191,9 +198,11 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 		// Note that ordering here is quite sensitive since the post-build function can modify
 		// what we would retrieve from the cache.
 		if target.PostBuildFunction != nil && !haveRunPostBuildFunction {
-			log.Debug("Checking for post-build output file for %s in cache...", target.Label)
-			if state.Cache.RetrieveExtra(target, cacheKey, target.PostBuildOutputFileName()) {
-				if postBuildOutput, err = runPostBuildFunctionIfNeeded(tid, state, target, postBuildOutput); err != nil {
+			log.Debug("Checking for post-build output for %s in cache...", target.Label)
+			if metadata := state.Cache.Retrieve(target, cacheKey); metadata != nil {
+				storePostBuildOutput(target, metadata.Stdout)
+				postBuildOutput = string(metadata.Stdout)
+				if err := runPostBuildFunctionIfNeeded(tid, state, target, postBuildOutput); err != nil {
 					return err
 				} else if retrieveArtifacts() {
 					return writeRuleHash(state, target)
@@ -221,11 +230,13 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 		if err := runPostBuildFunction(tid, state, target, string(out), postBuildOutput); err != nil {
 			return err
 		}
+		metadata.Stdout = out
 		storePostBuildOutput(target, out)
 	}
+	metadata.EndTime = time.Now()
 	checkLicences(state, target)
 	state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Collecting outputs...")
-	extraOuts, outputsChanged, err := moveOutputs(state, target)
+	outs, outputsChanged, err := moveOutputs(state, target)
 	if err != nil {
 		return fmt.Errorf("Error moving outputs for target %s: %s", target.Label, err)
 	}
@@ -245,12 +256,10 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget) (err
 			if !bytes.Equal(newCacheKey, cacheKey) {
 				// NB. Important this is stored with the earlier hash - if we calculate the hash
 				//     now, it might be different, and we could of course never retrieve it again.
-				state.Cache.StoreExtra(target, cacheKey, target.PostBuildOutputFileName())
-			} else {
-				extraOuts = append(extraOuts, target.PostBuildOutputFileName())
+				state.Cache.Store(target, cacheKey, metadata, nil)
 			}
 		}
-		state.Cache.Store(target, newCacheKey, extraOuts...)
+		state.Cache.Store(target, newCacheKey, metadata, outs)
 	}
 	// Clean up the temporary directory once it's done.
 	if state.CleanWorkdirs {
@@ -335,7 +344,10 @@ func moveOutputs(state *core.BuildState, target *core.BuildTarget) ([]string, bo
 	changed := false
 	tmpDir := target.TmpDir()
 	outDir := target.OutDir()
-	for _, output := range target.Outputs() {
+	outs := target.Outputs()
+	allOuts := make([]string, len(outs))
+	for i, output := range outs {
+		allOuts[i] = output
 		tmpOutput := path.Join(tmpDir, target.GetTmpOutput(output))
 		realOutput := path.Join(outDir, output)
 		if !core.PathExists(tmpOutput) {
@@ -354,7 +366,6 @@ func moveOutputs(state *core.BuildState, target *core.BuildTarget) ([]string, bo
 	}
 	// Optional outputs get moved but don't contribute to the hash or for incrementality.
 	// Glob patterns are supported on these.
-	extraOuts := []string{}
 	for _, output := range fs.Glob(state.Config.Parse.BuildFileName, tmpDir, target.OptionalOutputs, nil, nil, true) {
 		log.Debug("Discovered optional output %s", output)
 		tmpOutput := path.Join(tmpDir, output)
@@ -362,9 +373,9 @@ func moveOutputs(state *core.BuildState, target *core.BuildTarget) ([]string, bo
 		if _, err := moveOutput(state, target, tmpOutput, realOutput); err != nil {
 			return nil, changed, err
 		}
-		extraOuts = append(extraOuts, output)
+		allOuts = append(allOuts, output)
 	}
-	return extraOuts, changed, nil
+	return allOuts, changed, nil
 }
 
 func moveOutput(state *core.BuildState, target *core.BuildTarget, tmpOutput, realOutput string) (bool, error) {
@@ -555,21 +566,12 @@ func checkRuleHashesOfType(target *core.BuildTarget, outputs []string, hasher *f
 	return false
 }
 
-func retrieveFromCache(state *core.BuildState, target *core.BuildTarget) ([]byte, bool) {
-	hash := mustShortTargetHash(state, target)
-	return hash, state.Cache.Retrieve(target, hash)
-}
-
 // Runs the post-build function for a target if it's got one.
-func runPostBuildFunctionIfNeeded(tid int, state *core.BuildState, target *core.BuildTarget, prevOutput string) (string, error) {
+func runPostBuildFunctionIfNeeded(tid int, state *core.BuildState, target *core.BuildTarget, out string) error {
 	if target.PostBuildFunction != nil {
-		out, err := loadPostBuildOutput(target)
-		if err != nil {
-			return "", err
-		}
-		return out, runPostBuildFunction(tid, state, target, out, prevOutput)
+		return runPostBuildFunction(tid, state, target, out, "")
 	}
-	return "", nil
+	return nil
 }
 
 // Runs the post-build function for a target.

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -306,29 +306,18 @@ func newPyFilegroup(state *core.BuildState, label, filename string) *core.BuildT
 // Fake cache implementation with hardcoded behaviour for the various tests above.
 type mockCache struct{}
 
-func (*mockCache) Store(target *core.BuildTarget, key []byte, files ...string) {
+func (*mockCache) Store(target *core.BuildTarget, key []byte, metadata *core.BuildMetadata, files []string) {
 }
 
-func (*mockCache) StoreExtra(target *core.BuildTarget, key []byte, file string) {
-}
-
-func (*mockCache) Retrieve(target *core.BuildTarget, key []byte) bool {
+func (*mockCache) Retrieve(target *core.BuildTarget, key []byte) *core.BuildMetadata {
 	if target.Label.Name == "target8" {
 		ioutil.WriteFile("plz-out/gen/package1/file8", []byte("retrieved from cache"), 0664)
-		return true
+		return &core.BuildMetadata{}
 	} else if target.Label.Name == "target10" {
 		ioutil.WriteFile("plz-out/gen/package1/file10", []byte("retrieved from cache"), 0664)
-		return true
+		return &core.BuildMetadata{Stdout: []byte("retrieved from cache")}
 	}
-	return false
-}
-
-func (*mockCache) RetrieveExtra(target *core.BuildTarget, key []byte, file string) bool {
-	if target.Label.Name == "target10" && file == target.PostBuildOutputFileName() {
-		ioutil.WriteFile(postBuildOutputFileName(target), []byte("retrieved from cache"), 0664)
-		return true
-	}
-	return false
+	return nil
 }
 
 func (*mockCache) Clean(target *core.BuildTarget) {}

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -309,7 +309,7 @@ type mockCache struct{}
 func (*mockCache) Store(target *core.BuildTarget, key []byte, metadata *core.BuildMetadata, files []string) {
 }
 
-func (*mockCache) Retrieve(target *core.BuildTarget, key []byte) *core.BuildMetadata {
+func (*mockCache) Retrieve(target *core.BuildTarget, key []byte, outputs []string) *core.BuildMetadata {
 	if target.Label.Name == "target8" {
 		ioutil.WriteFile("plz-out/gen/package1/file8", []byte("retrieved from cache"), 0664)
 		return &core.BuildMetadata{}

--- a/src/cache/async_cache.go
+++ b/src/cache/async_cache.go
@@ -47,8 +47,8 @@ func (c *asyncCache) Store(target *core.BuildTarget, key []byte, metadata *core.
 	}
 }
 
-func (c *asyncCache) Retrieve(target *core.BuildTarget, key []byte) *core.BuildMetadata {
-	return c.realCache.Retrieve(target, key)
+func (c *asyncCache) Retrieve(target *core.BuildTarget, key []byte, files []string) *core.BuildMetadata {
+	return c.realCache.Retrieve(target, key, files)
 }
 
 func (c *asyncCache) Clean(target *core.BuildTarget) {

--- a/src/cache/async_cache_test.go
+++ b/src/cache/async_cache_test.go
@@ -23,7 +23,7 @@ func TestStore(t *testing.T) {
 func TestRetrieve(t *testing.T) {
 	mCache, aCache := makeCaches()
 	target := makeTarget("//pkg1:test_retrieve")
-	aCache.Retrieve(target, nil)
+	aCache.Retrieve(target, nil, target.Outputs())
 	aCache.Shutdown()
 	assert.False(t, mCache.inFlight[target])
 	assert.True(t, mCache.completed[target])
@@ -91,7 +91,7 @@ func (c *mockCache) Store(target *core.BuildTarget, key []byte, metadata *core.B
 	c.Unlock()
 }
 
-func (c *mockCache) Retrieve(target *core.BuildTarget, key []byte) *core.BuildMetadata {
+func (c *mockCache) Retrieve(target *core.BuildTarget, key []byte, files []string) *core.BuildMetadata {
 	c.Lock()
 	c.completed[target] = true
 	c.Unlock()
@@ -99,7 +99,7 @@ func (c *mockCache) Retrieve(target *core.BuildTarget, key []byte) *core.BuildMe
 }
 
 func (c *mockCache) Clean(target *core.BuildTarget) {
-	c.Retrieve(target, nil)
+	c.Retrieve(target, nil, nil)
 }
 
 func (c *mockCache) CleanAll() {}

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -86,13 +86,13 @@ func (mplex cacheMultiplexer) storeUntil(target *core.BuildTarget, key []byte, m
 	wg.Wait()
 }
 
-func (mplex cacheMultiplexer) Retrieve(target *core.BuildTarget, key []byte) *core.BuildMetadata {
+func (mplex cacheMultiplexer) Retrieve(target *core.BuildTarget, key []byte, files []string) *core.BuildMetadata {
 	// Retrieve from caches sequentially; if we did them simultaneously we could
 	// easily write the same file from two goroutines at once.
 	for i, cache := range mplex.caches {
-		if metadata := cache.Retrieve(target, key); metadata != nil {
+		if metadata := cache.Retrieve(target, key, files); metadata != nil {
 			// Store this into other caches
-			mplex.storeUntil(target, key, metadata, target.Outputs(), i)
+			mplex.storeUntil(target, key, metadata, files, i)
 			return metadata
 		}
 	}

--- a/src/cache/dir_cache.go
+++ b/src/cache/dir_cache.go
@@ -180,8 +180,7 @@ func (cache *dirCache) storeFile(target *core.BuildTarget, out, cacheDir string)
 	return size
 }
 
-func (cache *dirCache) Retrieve(target *core.BuildTarget, key []byte) *core.BuildMetadata {
-	outs := target.Outputs()
+func (cache *dirCache) Retrieve(target *core.BuildTarget, key []byte, outs []string) *core.BuildMetadata {
 	if needsPostBuildFile(target) {
 		outs = append(outs, target.PostBuildOutputFileName())
 	}
@@ -223,6 +222,7 @@ func (cache *dirCache) retrieveFiles2(target *core.BuildTarget, cacheDir string,
 		}
 		cachedOut := path.Join(cacheDir, out)
 		log.Debug("Retrieving %s: %s from dir cache...", target.Label, cachedOut)
+		log.Debug("here %s  %s -> %s", target.Label, cachedOut, realOut)
 		if err := fs.RecursiveLink(cachedOut, realOut, target.OutMode()); err != nil {
 			return false, err
 		}

--- a/src/cache/dir_cache_test.go
+++ b/src/cache/dir_cache_test.go
@@ -48,23 +48,23 @@ func inCompressedCache(target *core.BuildTarget) bool {
 func TestStoreAndRetrieve(t *testing.T) {
 	cache := makeCache(".plz-cache-test1", false)
 	target := makeTarget("//test1:target1", 20)
-	cache.Store(target, hash)
+	cache.Store(target, hash, &core.BuildMetadata{}, target.Outputs())
 	// Should now exist in cache at this path
 	assert.True(t, inCache(target))
-	assert.True(t, cache.Retrieve(target, hash))
+	assert.NotNil(t, cache.Retrieve(target, hash))
 	// Should be able to store it again without problems
-	cache.Store(target, hash)
+	cache.Store(target, hash, &core.BuildMetadata{}, target.Outputs())
 	assert.True(t, inCache(target))
-	assert.True(t, cache.Retrieve(target, hash))
+	assert.NotNil(t, cache.Retrieve(target, hash))
 }
 
 func TestCleanNoop(t *testing.T) {
 	cache := makeCache(".plz-cache-test2", false)
 	target1 := makeTarget("//test2:target1", 2000)
-	cache.Store(target1, hash)
+	cache.Store(target1, hash, &core.BuildMetadata{}, target1.Outputs())
 	assert.True(t, inCache(target1))
 	target2 := makeTarget("//test2:target2", 2000)
-	cache.Store(target2, hash)
+	cache.Store(target2, hash, &core.BuildMetadata{}, target2.Outputs())
 	assert.True(t, inCache(target2))
 	// Doesn't clean anything this time because the high water mark is sufficiently high
 	totalSize := cache.clean(20000, 1000)
@@ -76,10 +76,10 @@ func TestCleanNoop(t *testing.T) {
 func TestCleanNoop2(t *testing.T) {
 	cache := makeCache(".plz-cache-test3", false)
 	target1 := makeTarget("//test3:target1", 2000)
-	cache.Store(target1, hash)
+	cache.Store(target1, hash, &core.BuildMetadata{}, target1.Outputs())
 	assert.True(t, inCache(target1))
 	target2 := makeTarget("//test3:target2", 2000)
-	cache.Store(target2, hash)
+	cache.Store(target2, hash, &core.BuildMetadata{}, target2.Outputs())
 	assert.True(t, inCache(target2))
 	// Doesn't clean anything this time, the high water mark is lower but both targets have
 	// just been built.
@@ -92,7 +92,7 @@ func TestCleanNoop2(t *testing.T) {
 func TestCleanForReal(t *testing.T) {
 	cache := makeCache(".plz-cache-test4", false)
 	target1 := makeTarget("//test4:target1", 2000)
-	cache.Store(target1, hash)
+	cache.Store(target1, hash, &core.BuildMetadata{}, target1.Outputs())
 	assert.True(t, inCache(target1))
 	target2 := makeTarget("//test4:target2", 2000)
 	writeFile(cachePath(target2, false), 2000)
@@ -110,7 +110,7 @@ func TestCleanForReal2(t *testing.T) {
 	writeFile(cachePath(target1, false), 2000)
 	assert.True(t, inCache(target1))
 	target2 := makeTarget("//test5:target2", 2000)
-	cache.Store(target2, hash)
+	cache.Store(target2, hash, &core.BuildMetadata{}, target2.Outputs())
 	assert.True(t, inCache(target2))
 	// This time it should clean target1, because target2 has just been stored
 	totalSize := cache.clean(10000, 1000)
@@ -122,14 +122,14 @@ func TestCleanForReal2(t *testing.T) {
 func TestStoreAndRetrieveCompressed(t *testing.T) {
 	cache := makeCache(".plz-cache-test6", true)
 	target := makeTarget("//test6:target6", 20)
-	cache.Store(target, hash)
+	cache.Store(target, hash, &core.BuildMetadata{}, target.Outputs())
 	// Should now exist in cache at this path
 	assert.True(t, inCompressedCache(target))
-	assert.True(t, cache.Retrieve(target, hash))
+	assert.NotNil(t, cache.Retrieve(target, hash))
 	// Should be able to store it again without problems
-	cache.Store(target, hash)
+	cache.Store(target, hash, &core.BuildMetadata{}, target.Outputs())
 	assert.True(t, inCompressedCache(target))
-	assert.True(t, cache.Retrieve(target, hash))
+	assert.NotNil(t, cache.Retrieve(target, hash))
 }
 
 func TestCleanCompressed(t *testing.T) {
@@ -138,7 +138,7 @@ func TestCleanCompressed(t *testing.T) {
 	writeFile(cachePath(target1, true), 2000)
 	assert.True(t, inCompressedCache(target1))
 	target2 := makeTarget("//test7:target2", 2000)
-	cache.Store(target2, hash)
+	cache.Store(target2, hash, &core.BuildMetadata{}, target2.Outputs())
 	assert.True(t, inCompressedCache(target2))
 	// Don't want to assert the size here since it depends on how well gzip compresses.
 	// It's a bit hard to know exactly what the sizes here should be too but we'll guess

--- a/src/cache/dir_cache_test.go
+++ b/src/cache/dir_cache_test.go
@@ -51,11 +51,11 @@ func TestStoreAndRetrieve(t *testing.T) {
 	cache.Store(target, hash, &core.BuildMetadata{}, target.Outputs())
 	// Should now exist in cache at this path
 	assert.True(t, inCache(target))
-	assert.NotNil(t, cache.Retrieve(target, hash))
+	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs()))
 	// Should be able to store it again without problems
 	cache.Store(target, hash, &core.BuildMetadata{}, target.Outputs())
 	assert.True(t, inCache(target))
-	assert.NotNil(t, cache.Retrieve(target, hash))
+	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs()))
 }
 
 func TestCleanNoop(t *testing.T) {
@@ -125,11 +125,11 @@ func TestStoreAndRetrieveCompressed(t *testing.T) {
 	cache.Store(target, hash, &core.BuildMetadata{}, target.Outputs())
 	// Should now exist in cache at this path
 	assert.True(t, inCompressedCache(target))
-	assert.NotNil(t, cache.Retrieve(target, hash))
+	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs()))
 	// Should be able to store it again without problems
 	cache.Store(target, hash, &core.BuildMetadata{}, target.Outputs())
 	assert.True(t, inCompressedCache(target))
-	assert.NotNil(t, cache.Retrieve(target, hash))
+	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs()))
 }
 
 func TestCleanCompressed(t *testing.T) {

--- a/src/cache/http_cache.go
+++ b/src/cache/http_cache.go
@@ -73,12 +73,12 @@ func (cache *httpCache) storeOne(target *core.BuildTarget, key []byte, file stri
 	}
 }
 
-func (cache *httpCache) Retrieve(target *core.BuildTarget, key []byte) *core.BuildMetadata {
+func (cache *httpCache) Retrieve(target *core.BuildTarget, key []byte, files []string) *core.BuildMetadata {
 	// We can't tell from outside if this works or not (as we can for the dir cache)
 	// so we must assume that a target with no artifacts can't be retrieved. It's a weird
 	// case but a test already exists in the plz test suite so...
 	var metadata *core.BuildMetadata
-	for _, out := range target.Outputs() {
+	for _, out := range files {
 		if !cache.retrieveOne(target, key, out) {
 			return nil
 		}

--- a/src/cache/http_cache_test.go
+++ b/src/cache/http_cache_test.go
@@ -36,7 +36,7 @@ func init() {
 
 func TestStore(t *testing.T) {
 	target.AddOutput("testfile")
-	httpcache.Store(target, []byte("test_key"))
+	httpcache.Store(target, []byte("test_key"), &core.BuildMetadata{}, target.Outputs())
 	abs, _ := filepath.Abs(path.Join("src/cache/test_data", core.OsArch, "pkg/name", "label_name"))
 	if !core.PathExists(abs) {
 		t.Errorf("Test file %s was not stored in cache.", abs)
@@ -44,7 +44,7 @@ func TestStore(t *testing.T) {
 }
 
 func TestRetrieve(t *testing.T) {
-	if !httpcache.Retrieve(target, []byte("test_key")) {
+	if httpcache.Retrieve(target, []byte("test_key")) == nil {
 		t.Error("Artifact expected and not found.")
 	}
 }

--- a/src/cache/http_cache_test.go
+++ b/src/cache/http_cache_test.go
@@ -44,7 +44,7 @@ func TestStore(t *testing.T) {
 }
 
 func TestRetrieve(t *testing.T) {
-	if httpcache.Retrieve(target, []byte("test_key")) == nil {
+	if httpcache.Retrieve(target, []byte("test_key"), target.Outputs()) == nil {
 		t.Error("Artifact expected and not found.")
 	}
 }

--- a/src/cache/rex_cache.go
+++ b/src/cache/rex_cache.go
@@ -27,7 +27,7 @@ func (rc *rexCache) Store(target *core.BuildTarget, key []byte, metadata *core.B
 	}
 }
 
-func (rc *rexCache) Retrieve(target *core.BuildTarget, key []byte) *core.BuildMetadata {
+func (rc *rexCache) Retrieve(target *core.BuildTarget, key []byte, files []string) *core.BuildMetadata {
 	metadata, err := rc.client.Retrieve(target, key)
 	if err != nil {
 		if remote.IsNotFound(err) {

--- a/src/cache/rpc_cache.go
+++ b/src/cache/rpc_cache.go
@@ -58,12 +58,15 @@ type cacheNode struct {
 	hashEnd   uint32
 }
 
-func (cache *rpcCache) Store(target *core.BuildTarget, key []byte, files ...string) {
+func (cache *rpcCache) Store(target *core.BuildTarget, key []byte, metadata *core.BuildMetadata, files []string) {
 	if cache.isConnected() && cache.Writeable {
 		log.Debug("Storing %s in RPC cache...", target.Label)
 		artifacts := []*pb.Artifact{}
 		totalSize := 0
-		for _, out := range cacheArtifacts(target, files...) {
+		if needsPostBuildFile(target) {
+			files = append(files, target.PostBuildOutputFileName())
+		}
+		for _, out := range files {
 			artifacts2, size, err := cache.loadArtifacts(target, out)
 			if err != nil {
 				log.Warning("RPC cache failed to load artifact %s: %s", out, err)
@@ -75,23 +78,6 @@ func (cache *rpcCache) Store(target *core.BuildTarget, key []byte, files ...stri
 		}
 		if totalSize > cache.maxMsgSize {
 			log.Info("Artifacts for %s exceed maximum message size of %s bytes", target.Label, cache.maxMsgSize)
-			return
-		}
-		cache.sendArtifacts(target, key, artifacts)
-	}
-}
-
-func (cache *rpcCache) StoreExtra(target *core.BuildTarget, key []byte, file string) {
-	if cache.isConnected() && cache.Writeable {
-		log.Debug("Storing %s : %s in RPC cache...", target.Label, file)
-		artifacts, totalSize, err := cache.loadArtifacts(target, file)
-		if err != nil {
-			log.Warning("RPC cache failed to load artifact %s: %s", file, err)
-			cache.error()
-			return
-		}
-		if totalSize > cache.maxMsgSize {
-			log.Info("Artifact %s for %s exceeds maximum message size of %s bytes", file, target.Label, cache.maxMsgSize)
 			return
 		}
 		cache.sendArtifacts(target, key, artifacts)
@@ -155,22 +141,37 @@ func (cache *rpcCache) sendArtifacts(target *core.BuildTarget, key []byte, artif
 	})
 }
 
-func (cache *rpcCache) Retrieve(target *core.BuildTarget, key []byte) bool {
+func (cache *rpcCache) Retrieve(target *core.BuildTarget, key []byte) *core.BuildMetadata {
 	if !cache.isConnected() {
-		return false
+		return nil
 	}
 	req := pb.RetrieveRequest{Hash: key, Os: runtime.GOOS, Arch: runtime.GOARCH}
-	for _, out := range cacheArtifacts(target) {
-		artifact := pb.Artifact{Package: target.Label.PackageName, Target: target.Label.Name, File: out}
-		req.Artifacts = append(req.Artifacts, &artifact)
+	for _, out := range target.Outputs() {
+		req.Artifacts = append(req.Artifacts, &pb.Artifact{
+			Package: target.Label.PackageName,
+			Target:  target.Label.Name,
+			File:    out,
+		})
+	}
+	if needsPostBuildFile(target) {
+		req.Artifacts = append(req.Artifacts, &pb.Artifact{
+			Package: target.Label.PackageName,
+			Target:  target.Label.Name,
+			File:    target.PostBuildOutputFileName(),
+		})
 	}
 	// We can't tell from here if retrieval has been successful for a target with no outputs.
 	// This is kind of weird but not actually disallowed, and we already have a test case for it,
 	// so might as well try to get it right here.
 	if len(req.Artifacts) == 0 {
-		return false
+		return nil
 	}
-	return cache.retrieveArtifacts(target, &req, true)
+	if !cache.retrieveArtifacts(target, &req, true) {
+		return nil
+	} else if needsPostBuildFile(target) {
+		return loadPostBuildFile(target)
+	}
+	return &core.BuildMetadata{}
 }
 
 func (cache *rpcCache) RetrieveExtra(target *core.BuildTarget, key []byte, file string) bool {

--- a/src/cache/rpc_cache.go
+++ b/src/cache/rpc_cache.go
@@ -141,12 +141,12 @@ func (cache *rpcCache) sendArtifacts(target *core.BuildTarget, key []byte, artif
 	})
 }
 
-func (cache *rpcCache) Retrieve(target *core.BuildTarget, key []byte) *core.BuildMetadata {
+func (cache *rpcCache) Retrieve(target *core.BuildTarget, key []byte, files []string) *core.BuildMetadata {
 	if !cache.isConnected() {
 		return nil
 	}
 	req := pb.RetrieveRequest{Hash: key, Os: runtime.GOOS, Arch: runtime.GOARCH}
-	for _, out := range target.Outputs() {
+	for _, out := range files {
 		req.Artifacts = append(req.Artifacts, &pb.Artifact{
 			Package: target.Label.PackageName,
 			Target:  target.Label.Name,
@@ -172,16 +172,6 @@ func (cache *rpcCache) Retrieve(target *core.BuildTarget, key []byte) *core.Buil
 		return loadPostBuildFile(target)
 	}
 	return &core.BuildMetadata{}
-}
-
-func (cache *rpcCache) RetrieveExtra(target *core.BuildTarget, key []byte, file string) bool {
-	if !cache.isConnected() {
-		return false
-	}
-	artifact := pb.Artifact{Package: target.Label.PackageName, Target: target.Label.Name, File: file}
-	artifacts := []*pb.Artifact{&artifact}
-	req := pb.RetrieveRequest{Hash: key, Os: runtime.GOOS, Arch: runtime.GOARCH, Artifacts: artifacts}
-	return cache.retrieveArtifacts(target, &req, false)
 }
 
 func (cache *rpcCache) retrieveArtifacts(target *core.BuildTarget, req *pb.RetrieveRequest, remove bool) bool {

--- a/src/cache/rpc_cache_test.go
+++ b/src/cache/rpc_cache_test.go
@@ -65,7 +65,7 @@ func buildClient(addr, ca string) *rpcCache {
 func TestStore(t *testing.T) {
 	target := core.NewBuildTarget(label)
 	target.AddOutput("testfile2")
-	rpccache.Store(target, []byte("test_key"))
+	rpccache.Store(target, []byte("test_key"), &core.BuildMetadata{}, target.Outputs())
 	expectedPath := path.Join("src/cache/test_data", core.OsArch, "pkg/name", "label_name", "dGVzdF9rZXk", target.Outputs()[0])
 	if !core.PathExists(expectedPath) {
 		t.Errorf("Test file %s was not stored in cache.", expectedPath)
@@ -75,7 +75,7 @@ func TestStore(t *testing.T) {
 func TestRetrieve(t *testing.T) {
 	target := core.NewBuildTarget(label)
 	target.AddOutput("testfile")
-	if !rpccache.Retrieve(target, []byte("test_key")) {
+	if rpccache.Retrieve(target, []byte("test_key")) == nil {
 		t.Error("Artifact expected and not found.")
 	}
 }
@@ -83,13 +83,13 @@ func TestRetrieve(t *testing.T) {
 func TestStoreAndRetrieve(t *testing.T) {
 	target := core.NewBuildTarget(label)
 	target.AddOutput("testfile3")
-	rpccache.Store(target, []byte("test_key"))
+	rpccache.Store(target, []byte("test_key"), &core.BuildMetadata{}, target.Outputs())
 	// Remove the file so we can test retrieval correctly
 	outPath := path.Join(target.OutDir(), target.Outputs()[0])
 	if err := os.Remove(outPath); err != nil {
 		t.Errorf("Failed to remove artifact: %s", err)
 	}
-	if !rpccache.Retrieve(target, []byte("test_key")) {
+	if rpccache.Retrieve(target, []byte("test_key")) == nil {
 		t.Error("Artifact expected and not found.")
 	} else if !core.PathExists(outPath) {
 		t.Errorf("Artifact %s doesn't exist after alleged cache retrieval", outPath)
@@ -113,13 +113,13 @@ func TestDisconnectAfterEnoughErrors(t *testing.T) {
 	target := core.NewBuildTarget(label)
 	target.AddOutput("testfile4")
 	key := []byte("test_key")
-	c.Store(target, []byte("test_key"))
-	assert.True(t, c.Retrieve(target, key))
+	c.Store(target, []byte("test_key"), &core.BuildMetadata{}, target.Outputs())
+	assert.NotNil(t, c.Retrieve(target, key))
 	s.Stop()
 	// Now after we hit the max number of errors it should disconnect.
 	for i := 0; i < maxErrors; i++ {
 		assert.True(t, c.Connected)
-		assert.False(t, c.Retrieve(target, key))
+		assert.Nil(t, c.Retrieve(target, key))
 	}
 	assert.False(t, c.Connected)
 }

--- a/src/cache/rpc_cache_test.go
+++ b/src/cache/rpc_cache_test.go
@@ -75,7 +75,7 @@ func TestStore(t *testing.T) {
 func TestRetrieve(t *testing.T) {
 	target := core.NewBuildTarget(label)
 	target.AddOutput("testfile")
-	if rpccache.Retrieve(target, []byte("test_key")) == nil {
+	if rpccache.Retrieve(target, []byte("test_key"), target.Outputs()) == nil {
 		t.Error("Artifact expected and not found.")
 	}
 }
@@ -89,7 +89,7 @@ func TestStoreAndRetrieve(t *testing.T) {
 	if err := os.Remove(outPath); err != nil {
 		t.Errorf("Failed to remove artifact: %s", err)
 	}
-	if rpccache.Retrieve(target, []byte("test_key")) == nil {
+	if rpccache.Retrieve(target, []byte("test_key"), target.Outputs()) == nil {
 		t.Error("Artifact expected and not found.")
 	} else if !core.PathExists(outPath) {
 		t.Errorf("Artifact %s doesn't exist after alleged cache retrieval", outPath)
@@ -114,12 +114,12 @@ func TestDisconnectAfterEnoughErrors(t *testing.T) {
 	target.AddOutput("testfile4")
 	key := []byte("test_key")
 	c.Store(target, []byte("test_key"), &core.BuildMetadata{}, target.Outputs())
-	assert.NotNil(t, c.Retrieve(target, key))
+	assert.NotNil(t, c.Retrieve(target, key, target.Outputs()))
 	s.Stop()
 	// Now after we hit the max number of errors it should disconnect.
 	for i := 0; i < maxErrors; i++ {
 		assert.True(t, c.Connected)
-		assert.Nil(t, c.Retrieve(target, key))
+		assert.Nil(t, c.Retrieve(target, key, target.Outputs()))
 	}
 	assert.False(t, c.Connected)
 }

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -126,7 +126,7 @@ func BuildEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 // TestEnvironment creates the environment variables for a test.
 func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) BuildEnv {
 	env := buildEnvironment(state, target)
-	resultsFile := path.Join(testDir, "test.results")
+	resultsFile := path.Join(testDir, TestResultsFile)
 	env = append(env,
 		"TEST_DIR="+testDir,
 		"TMP_DIR="+testDir,
@@ -141,7 +141,7 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) Bui
 	if state.NeedCoverage && !target.HasAnyLabel(state.Config.Test.DisableCoverage) {
 		env = append(env,
 			"COVERAGE=true",
-			"COVERAGE_FILE="+path.Join(testDir, "test.coverage"),
+			"COVERAGE_FILE="+path.Join(testDir, CoverageFile),
 		)
 	}
 	if len(target.Outputs()) > 0 {

--- a/src/core/cache.go
+++ b/src/core/cache.go
@@ -12,7 +12,7 @@ type Cache interface {
 	// (the only field that is guaranteed is standard output though, and only for targets
 	// that have post-build functions).
 	// If unsuccessful, it will return nil.
-	Retrieve(target *BuildTarget, key []byte) *BuildMetadata
+	Retrieve(target *BuildTarget, key []byte, files []string) *BuildMetadata
 	// Retrieves the results of a test run.
 	// Cleans any artifacts associated with this target from the cache, for any possible key.
 	// Some implementations may not honour this, depending on configuration etc.

--- a/src/core/cache.go
+++ b/src/core/cache.go
@@ -5,18 +5,17 @@ package core
 // it's passed around on the BuildState object.
 type Cache interface {
 	// Stores the results of a single build target.
-	// Optionally can store extra files against it at the same time.
-	Store(target *BuildTarget, key []byte, files ...string)
-	// Stores an extra file against a build target.
-	// The file name is relative to the target's out directory.
-	StoreExtra(target *BuildTarget, key []byte, file string)
+	Store(target *BuildTarget, key []byte, metadata *BuildMetadata, files []string)
 	// Retrieves the results of a single build target.
-	// If successful, the outputs will be placed into the output file tree.
-	Retrieve(target *BuildTarget, key []byte) bool
-	// Retrieves an extra file previously stored by StoreExtra.
-	// If successful, the file will be placed into the output file tree.
-	RetrieveExtra(target *BuildTarget, key []byte, file string) bool
+	// If successful, the outputs will be placed into the output file tree and
+	// the returned metadata structure will be populated with whatever is stored
+	// (the only field that is guaranteed is standard output though, and only for targets
+	// that have post-build functions).
+	// If unsuccessful, it will return nil.
+	Retrieve(target *BuildTarget, key []byte) *BuildMetadata
+	// Retrieves the results of a test run.
 	// Cleans any artifacts associated with this target from the cache, for any possible key.
+	// Some implementations may not honour this, depending on configuration etc.
 	Clean(target *BuildTarget)
 	// Cleans the entire cache.
 	CleanAll()

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -10,6 +10,7 @@ import (
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/bazelbuild/remote-apis/build/bazel/semver"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -71,6 +72,13 @@ func toTimestamp(t time.Time) *timestamp.Timestamp {
 		Seconds: t.Unix(),
 		Nanos:   int32(t.Nanosecond()),
 	}
+}
+
+// toTime converts a protobuf timestamp into a time.Time.
+// It's like the ptypes one but we ignore errors (we don't generally care that much)
+func toTime(ts *timestamp.Timestamp) time.Time {
+	t, _ := ptypes.Timestamp(ts)
+	return t
 }
 
 // extraPerms returns any additional permission bits we should apply for this file.

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -134,7 +134,11 @@ func test(tid int, state *core.BuildState, label core.BuildLabel, target *core.B
 		}
 		log.Debug("Output file %s does not exist for %s", cachedOutputFile, target.Label)
 		// Check the cache for these artifacts.
-		return state.Cache == nil || state.Cache.Retrieve(target, hash) == nil
+		files := []string{core.TestResultsFile}
+		if needCoverage {
+			files = append(files, core.CoverageFile)
+		}
+		return state.Cache == nil || state.Cache.Retrieve(target, hash, files) == nil
 	}
 
 	// Don't cache when doing multiple runs, presumably the user explicitly wants to check it.


### PR DESCRIPTION
This makes it a lot easier to work with the remote API; IMO it is a bit cleaner overall without the "Extra" functions. Will also be useful for some other things (e.g. have some plans around the HTTP cache that would depend on this too).