### PR TITLE
Cleanup NewBuildState()

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -276,10 +276,6 @@ func runBuildCommand(state *core.BuildState, target *core.BuildTarget, command s
 	log.Debug("Building target %s\nENVIRONMENT:\n%s\n%s", target.Label, env, command)
 	out, combined, err := state.ProcessExecutor.ExecWithTimeoutShell(target, target.TmpDir(), env, target.BuildTimeout, state.ShowAllOutput, command, target.Sandbox)
 	if err != nil {
-		if state.Verbosity >= 4 {
-			return nil, fmt.Errorf("Error building target %s: %s\nENVIRONMENT:\n%s\n%s\n%s",
-				target.Label, err, env, target.GetCommand(state), combined)
-		}
 		return nil, fmt.Errorf("Error building target %s: %s\n%s", target.Label, err, combined)
 	}
 	return out, nil

--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -21,7 +21,7 @@ var state *core.BuildState
 
 func TestBuildLotsOfTargets(t *testing.T) {
 	config, _ := core.ReadConfigFiles(nil, nil)
-	state = core.NewBuildState(numWorkers, nil, 4, config)
+	state = core.NewBuildState(config)
 	state.Parser = &fakeParser{
 		PostBuildFunctions: buildFunctionMap{},
 	}

--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -21,6 +21,7 @@ var state *core.BuildState
 
 func TestBuildLotsOfTargets(t *testing.T) {
 	config, _ := core.ReadConfigFiles(nil, nil)
+	config.Please.NumThreads = 10
 	state = core.NewBuildState(config)
 	state.Parser = &fakeParser{
 		PostBuildFunctions: buildFunctionMap{},

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -284,7 +284,7 @@ func TestCheckRuleHashes(t *testing.T) {
 
 func newState(label string) (*core.BuildState, *core.BuildTarget) {
 	config, _ := core.ReadConfigFiles(nil, nil)
-	state := core.NewBuildState(1, nil, 4, config)
+	state := core.NewBuildState(config)
 	target := core.NewBuildTarget(core.ParseBuildLabel(label, ""))
 	target.Command = fmt.Sprintf("echo 'output of %s' > $OUT", target.Label)
 	target.BuildTimeout = 100 * time.Second

--- a/src/build/command_replacements_test.go
+++ b/src/build/command_replacements_test.go
@@ -141,7 +141,7 @@ func TestBazelCompatReplacements(t *testing.T) {
 	target := makeTarget("//path/to:target", "cp $< $@", nil)
 	assert.Equal(t, "cp $< $@", replaceSequences(state, target))
 	// In Bazel compat mode we do though.
-	state := core.NewBuildState(1, nil, 1, core.DefaultConfiguration())
+	state := core.NewDefaultBuildState()
 	state.Config.Bazel.Compatibility = true
 	assert.Equal(t, "cp $SRCS $OUTS", replaceSequences(state, target))
 	// @D is the output dir, for us it's the tmp dir.

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -78,7 +78,7 @@ func TestCanSee(t *testing.T) {
 func TestCanSeeExperimental(t *testing.T) {
 	config := DefaultConfiguration()
 	config.Parse.ExperimentalDir = []string{"experimental"}
-	state := NewBuildState(1, nil, 1, config)
+	state := NewBuildState(config)
 
 	target1 := makeTarget("//src/core:target1", "")
 	target2 := makeTarget("//experimental/user:target2", "PUBLIC")

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -209,6 +209,7 @@ func DefaultConfiguration() *Configuration {
 	config.Please.Autoclean = true
 	config.Please.DownloadLocation = "https://get.please.build"
 	config.Please.NumOldVersions = 10
+	config.Please.NumThreads = runtime.NumCPU() + 2
 	config.Parse.BuiltinPleasings = true
 	config.Parse.GitFunctions = true
 	config.Build.Arch = cli.NewArch(runtime.GOOS, runtime.GOARCH)

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -724,28 +724,26 @@ func (state *BuildState) DisableXattrs() {
 // NewBuildState constructs and returns a new BuildState.
 // Everyone should use this rather than attempting to construct it themselves;
 // callers can't initialise all the required private fields.
-func NewBuildState(numThreads int, cache Cache, verbosity int, config *Configuration) *BuildState {
+func NewBuildState(config *Configuration) *BuildState {
 	// Deliberately ignore the error here so we don't require the sandbox tool until it's needed.
 	sandboxTool, _ := LookBuildPath(config.Build.PleaseSandboxTool, config)
 	state := &BuildState{
 		Graph:           NewGraph(),
 		pendingTasks:    queue.NewPriorityQueue(10000, true), // big hint, why not
-		lastResults:     make([]*BuildResult, numThreads),
+		lastResults:     make([]*BuildResult, config.Please.NumThreads),
 		PathHasher:      fs.NewPathHasher(RepoRoot, config.Build.Xattrs, sha1.New, ""),
 		SHA256Hasher:    fs.NewPathHasher(RepoRoot, config.Build.Xattrs, sha256.New, "_sha256"),
 		ProcessExecutor: process.New(sandboxTool),
 		StartTime:       startTime,
 		Config:          config,
-		Verbosity:       verbosity,
-		Cache:           cache,
-		ParsePool:       NewPool(numThreads),
+		ParsePool:       NewPool(config.Please.NumThreads),
 		VerifyHashes:    true,
 		NeedBuild:       true,
 		Success:         true,
 		XattrsSupported: config.Build.Xattrs,
 		Coverage:        TestCoverage{Files: map[string][]LineCoverage{}},
 		OriginalArch:    cli.HostArch(),
-		numWorkers:      numThreads,
+		numWorkers:      config.Please.NumThreads,
 		Stats:           &SystemStats{},
 		progress: &stateProgress{
 			numActive:       1, // One for the initial target adding on the main thread.
@@ -757,7 +755,6 @@ func NewBuildState(numThreads int, cache Cache, verbosity int, config *Configura
 	}
 	state.progress.allStates = []*BuildState{state}
 	state.Hashes.Config = config.Hash()
-	config.Please.NumThreads = numThreads
 	for _, exp := range config.Parse.ExperimentalDir {
 		state.experimentalLabels = append(state.experimentalLabels, BuildLabel{PackageName: exp, Name: "..."})
 	}
@@ -767,7 +764,7 @@ func NewBuildState(numThreads int, cache Cache, verbosity int, config *Configura
 // NewDefaultBuildState creates a BuildState for the default configuration.
 // This is useful for tests etc that don't need to customise anything about it.
 func NewDefaultBuildState() *BuildState {
-	return NewDefaultBuildState()
+	return NewBuildState(DefaultConfiguration())
 }
 
 // A BuildResult represents a single event in the build process, i.e. a target starting or finishing

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -97,8 +97,6 @@ type BuildState struct {
 	PathHasher *fs.PathHasher
 	// Backup hasher that's used for sha256 hashes
 	SHA256Hasher *fs.PathHasher
-	// Level of verbosity during the build
-	Verbosity int
 	// Cache to store / retrieve old build results.
 	Cache Cache
 	// Targets that we were originally requested to build

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -767,7 +767,7 @@ func NewBuildState(numThreads int, cache Cache, verbosity int, config *Configura
 // NewDefaultBuildState creates a BuildState for the default configuration.
 // This is useful for tests etc that don't need to customise anything about it.
 func NewDefaultBuildState() *BuildState {
-	return NewBuildState(1, nil, 4, DefaultConfiguration())
+	return NewDefaultBuildState()
 }
 
 // A BuildResult represents a single event in the build process, i.e. a target starting or finishing

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestExpandOriginalTargets(t *testing.T) {
-	state := NewBuildState(1, nil, 4, DefaultConfiguration())
+	state := NewDefaultBuildState()
 	state.OriginalTargets = []BuildLabel{{PackageName: "src/core", Name: "all"}, {PackageName: "src/parse", Name: "parse"}}
 	state.Include = []string{"go"}
 	state.Exclude = []string{"py"}
@@ -32,7 +32,7 @@ func TestExpandOriginalTargets(t *testing.T) {
 }
 
 func TestExpandOriginalTestTargets(t *testing.T) {
-	state := NewBuildState(1, nil, 4, DefaultConfiguration())
+	state := NewDefaultBuildState()
 	state.OriginalTargets = []BuildLabel{{PackageName: "src/core", Name: "all"}}
 	state.NeedTests = true
 	state.Include = []string{"go"}
@@ -48,7 +48,7 @@ func TestExpandOriginalTestTargets(t *testing.T) {
 }
 
 func TestExpandVisibleOriginalTargets(t *testing.T) {
-	state := NewBuildState(1, nil, 4, DefaultConfiguration())
+	state := NewDefaultBuildState()
 	state.OriginalTargets = []BuildLabel{{PackageName: "src/core", Name: "all"}}
 
 	addTarget(state, "//src/core:target1", "py")
@@ -57,7 +57,7 @@ func TestExpandVisibleOriginalTargets(t *testing.T) {
 }
 
 func TestExpandOriginalSubTargets(t *testing.T) {
-	state := NewBuildState(1, nil, 4, DefaultConfiguration())
+	state := NewDefaultBuildState()
 	state.OriginalTargets = []BuildLabel{{PackageName: "src/core", Name: "..."}}
 	state.Include = []string{"go"}
 	state.Exclude = []string{"py"}
@@ -73,7 +73,7 @@ func TestExpandOriginalSubTargets(t *testing.T) {
 }
 
 func TestExpandOriginalTargetsOrdering(t *testing.T) {
-	state := NewBuildState(1, nil, 4, DefaultConfiguration())
+	state := NewDefaultBuildState()
 	state.OriginalTargets = []BuildLabel{
 		{PackageName: "src/parse", Name: "parse"},
 		{PackageName: "src/core", Name: "..."},

--- a/src/follow/grpc_client.go
+++ b/src/follow/grpc_client.go
@@ -138,7 +138,7 @@ func streamResources(state *core.BuildState, client pb.PlzEventsClient) {
 
 // runOutput is just a wrapper around output.MonitorState for convenience in testing.
 func runOutput(state *core.BuildState) bool {
-	output.MonitorState(state, state.Config.Please.NumThreads, state.Verbosity >= 4, false, "")
+	output.MonitorState(state, state.Config.Please.NumThreads, false, false, "")
 	output.PrintDisconnectionMessage(state.Success, remoteClosed, remoteDisconnected)
 	return state.Success
 }

--- a/src/follow/grpc_test.go
+++ b/src/follow/grpc_test.go
@@ -42,7 +42,9 @@ func TestClientToServerCommunication(t *testing.T) {
 	// Note that the ordering of things here is pretty important; we need to get the
 	// client connected & ready to receive events before we push them all into the
 	// server and shut it down again.
-	serverState := core.NewDefaultBuildState()
+	config := core.DefaultConfiguration()
+	config.Please.NumThreads = 5
+	serverState := core.NewBuildState(config)
 	addr, shutdown := initialiseServer(serverState, 0)
 
 	// This is a bit awkward. We want to assert that we receive a matching set of

--- a/src/follow/grpc_test.go
+++ b/src/follow/grpc_test.go
@@ -42,7 +42,7 @@ func TestClientToServerCommunication(t *testing.T) {
 	// Note that the ordering of things here is pretty important; we need to get the
 	// client connected & ready to receive events before we push them all into the
 	// server and shut it down again.
-	serverState := core.NewBuildState(5, nil, 4, core.DefaultConfiguration())
+	serverState := core.NewDefaultBuildState()
 	addr, shutdown := initialiseServer(serverState, 0)
 
 	// This is a bit awkward. We want to assert that we receive a matching set of
@@ -58,7 +58,7 @@ func TestClientToServerCommunication(t *testing.T) {
 	serverState.LogBuildResult(0, l1, core.TargetBuilt, fmt.Sprintf("Built %s", l1))
 	serverState.LogBuildResult(1, l3, core.TargetBuilding, fmt.Sprintf("Building %s", l3))
 
-	clientState := core.NewBuildState(1, nil, 4, core.DefaultConfiguration())
+	clientState := core.NewDefaultBuildState()
 	results := clientState.Results()
 	connectClient(clientState, addr, retries, delay)
 	// The client state should have synced up with the server's number of threads
@@ -98,9 +98,9 @@ func TestClientToServerCommunication(t *testing.T) {
 }
 
 func TestWithOutput(t *testing.T) {
-	serverState := core.NewBuildState(5, nil, 4, core.DefaultConfiguration())
+	serverState := core.NewDefaultBuildState()
 	addr, shutdown := initialiseServer(serverState, 0)
-	clientState := core.NewBuildState(1, nil, 4, core.DefaultConfiguration())
+	clientState := core.NewDefaultBuildState()
 	connectClient(clientState, addr, retries, delay)
 	go func() {
 		serverState.LogBuildResult(0, l1, core.PackageParsed, fmt.Sprintf("Parsed %s", l1))
@@ -117,11 +117,11 @@ func TestWithOutput(t *testing.T) {
 }
 
 func TestResources(t *testing.T) {
-	serverState := core.NewBuildState(5, nil, 4, core.DefaultConfiguration())
+	serverState := core.NewDefaultBuildState()
 	go UpdateResources(serverState)
 	addr, shutdown := initialiseServer(serverState, 0)
 	defer shutdown()
-	clientState := core.NewBuildState(1, nil, 4, core.DefaultConfiguration())
+	clientState := core.NewDefaultBuildState()
 	connectClient(clientState, addr, retries, delay)
 	// Fortunately this is a lot less fiddly than the others, because we always
 	// receive updates eventually. On the downside it's hard to know when it'll

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -92,9 +92,7 @@ func MonitorState(state *core.BuildState, numThreads int, plainOutput, detailedT
 	}
 	duration := time.Since(state.StartTime).Round(durationGranularity)
 	if len(failedNonTests) > 0 { // Something failed in the build step.
-		if state.Verbosity > 0 {
-			printFailedBuildResults(failedNonTests, failedTargetMap, duration)
-		}
+		printFailedBuildResults(failedNonTests, failedTargetMap, duration)
 		return
 	}
 	// Check all the targets we wanted to build actually have been built.
@@ -110,7 +108,7 @@ func MonitorState(state *core.BuildState, numThreads int, plainOutput, detailedT
 			log.Fatalf("Target %s hasn't built but we have no pending tasks left.\n%s", label, cycle)
 		}
 	}
-	if state.Verbosity > 0 && state.NeedBuild && len(failedNonTests) == 0 {
+	if state.NeedBuild && len(failedNonTests) == 0 {
 		if state.PrepareOnly || state.PrepareShell {
 			printTempDirs(state, duration)
 		} else if state.NeedTests { // Got to the test phase, report their results.

--- a/src/parse/asp/fuzz/fuzz.go
+++ b/src/parse/asp/fuzz/fuzz.go
@@ -61,7 +61,7 @@ func isWhitelisted(err error) bool {
 // Fuzz implements the interface that go-fuzz requires for fuzz testing of the parser.
 func Fuzz(data []byte) int {
 	// This lot is copied from src/parse/init.go to load all the builtins.
-	p := asp.NewParser(core.NewBuildState(1, nil, 4, core.DefaultConfiguration()))
+	p := asp.NewParser(core.NewDefaultBuildState())
 	dir, _ := rules.AssetDir("")
 	sort.Strings(dir)
 	for _, filename := range dir {

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func parseFileToStatements(filename string) (*scope, []*Statement, error) {
-	state := core.NewBuildState(1, nil, 4, core.DefaultConfiguration())
+	state := core.NewDefaultBuildState()
 	state.Config.BuildConfig = map[string]string{"parser-engine": "python27"}
 	pkg := core.NewPackage("test/package")
 	parser := NewParser(state)

--- a/src/parse/asp/logging_test.go
+++ b/src/parse/asp/logging_test.go
@@ -21,7 +21,7 @@ type record struct {
 }
 
 func parseFile(filename string) (*scope, error) {
-	state := core.NewBuildState(1, nil, 4, core.DefaultConfiguration())
+	state := core.NewDefaultBuildState()
 	pkg := core.NewPackage("test/package")
 	pkg.Filename = "test/package/BUILD"
 	parser := NewParser(state)

--- a/src/parse/asp/main/main.go
+++ b/src/parse/asp/main/main.go
@@ -17,10 +17,10 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"gopkg.in/op/go-logging.v1"
 
+	"github.com/thought-machine/please/rules"
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/parse/asp"
-	"github.com/thought-machine/please/rules"
 )
 
 var log = logging.MustGetLogger("parser")
@@ -95,8 +95,9 @@ func main() {
 			log.Fatalf("%s", err)
 		}
 	}
+	config.Please.NumThreads = opts.NumThreads
 
-	state := core.NewBuildState(opts.NumThreads, nil, int(opts.Verbosity), config)
+	state := core.NewBuildState(config)
 	if opts.BuildDefsDir != "" {
 		mustLoadBuildDefsDir(state, opts.BuildDefsDir)
 	}

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -121,7 +121,7 @@ func makeTarget(label string, deps ...string) *core.BuildTarget {
 // makeState creates a new build state with optionally one or two packages in it.
 // Used in various tests above.
 func makeState(withPackage1, withPackage2 bool) *core.BuildState {
-	state := core.NewBuildState(5, nil, 4, core.DefaultConfiguration())
+	state := core.NewDefaultBuildState()
 	if withPackage1 {
 		pkg := core.NewPackage("package1")
 		state.Graph.AddPackage(pkg)

--- a/src/please.go
+++ b/src/please.go
@@ -7,7 +7,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"path"
-	"runtime"
 	"runtime/pprof"
 	"strings"
 	"sync"
@@ -749,8 +748,6 @@ func newCache(state *core.BuildState) core.Cache {
 func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, shouldTest bool) (bool, *core.BuildState) {
 	if opts.BuildFlags.NumThreads > 0 {
 		config.Please.NumThreads = opts.BuildFlags.NumThreads
-	} else if config.Please.NumThreads <= 0 {
-		config.Please.NumThreads = runtime.NumCPU() + 2
 	}
 	debugTests := opts.Test.Debug || opts.Cover.Debug
 	if opts.BuildFlags.Config != "" {

--- a/src/please.go
+++ b/src/please.go
@@ -453,7 +453,7 @@ var buildFunctions = map[string]func() bool{
 					config.Cache.RPCURL = ""
 					config.Cache.HTTPURL = ""
 				}
-				state := core.NewBuildState(1, nil, 4, config)
+				state := core.NewBuildState(config)
 				clean.Clean(config, newCache(state), !opts.Clean.NoBackground)
 				return true
 			}
@@ -512,7 +512,7 @@ var buildFunctions = map[string]func() bool{
 	},
 	"follow": func() bool {
 		// This is only temporary, ConnectClient will alter it to match the server.
-		state := core.NewBuildState(1, nil, int(opts.OutputFlags.Verbosity), config)
+		state := core.NewBuildState(config)
 		return follow.ConnectClient(state, opts.Follow.Args.URL.String(), opts.Follow.Retries, time.Duration(opts.Follow.Delay))
 	},
 	"outputs": func() bool {
@@ -561,7 +561,7 @@ var buildFunctions = map[string]func() bool{
 		files := opts.Query.AffectedTargets.Args.Files
 		targets := core.WholeGraph
 		if opts.Query.AffectedTargets.Intransitive {
-			state := core.NewBuildState(1, nil, 1, config)
+			state := core.NewBuildState(config)
 			targets = core.FindOwningPackages(state, files)
 		}
 		return runQuery(true, targets, func(state *core.BuildState) {
@@ -758,7 +758,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	} else if debugTests {
 		config.Build.Config = "dbg"
 	}
-	state := core.NewBuildState(config.Please.NumThreads, nil, int(opts.OutputFlags.Verbosity), config)
+	state := core.NewBuildState(config)
 	state.VerifyHashes = !opts.FeatureFlags.NoHashVerification
 	state.NumTestRuns = utils.Max(opts.Test.NumRuns, opts.Cover.NumRuns)  // Only one of these can be passed
 	state.TestArgs = append(opts.Test.Args.Args, opts.Cover.Args.Args...) // Similarly here.

--- a/src/remote/remote_test.go
+++ b/src/remote/remote_test.go
@@ -76,7 +76,7 @@ func newClient() *Client {
 	config := core.DefaultConfiguration()
 	config.Build.Path = []string{"/usr/local/bin", "/usr/bin", "/bin"}
 	// Can't use NewDefaultBuildState since we need to modify the config first.
-	state := core.NewBuildState(1, nil, 4, config)
+	state := core.NewBuildState(config)
 	state.Config.Remote.URL = "127.0.0.1:9987"
 	return New(state)
 }

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -45,7 +45,7 @@ func TestEnvVars(t *testing.T) {
 }
 
 func makeState() (*core.BuildState, []core.BuildLabel, []core.BuildLabel) {
-	state := core.NewBuildState(1, nil, 0, core.DefaultConfiguration())
+	state := core.NewDefaultBuildState()
 	target1 := core.NewBuildTarget(core.ParseBuildLabel("//:true", ""))
 	target1.IsBinary = true
 	target1.AddOutput("true")

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -167,7 +167,8 @@ func anyTests(state *core.BuildState, labels []core.BuildLabel) bool {
 // build invokes a single build while watching.
 func build(ctx context.Context, state *core.BuildState, labels []core.BuildLabel, callback CallbackFunc) {
 	// Set up a new state & copy relevant parts off the existing one.
-	ns := core.NewBuildState(state.Config.Please.NumThreads, state.Cache, state.Verbosity, state.Config)
+	ns := core.NewBuildState(state.Config)
+	ns.Cache = state.Cache
 	ns.VerifyHashes = state.VerifyHashes
 	ns.NumTestRuns = state.NumTestRuns
 	ns.NeedTests = state.NeedTests

--- a/tools/build_langserver/langserver/analyzer.go
+++ b/tools/build_langserver/langserver/analyzer.go
@@ -119,7 +119,7 @@ func newAnalyzer() (*Analyzer, error) {
 	for i, def := range config.Parse.PreloadBuildDefs {
 		config.Parse.PreloadBuildDefs[i] = path.Join(core.RepoRoot, def)
 	}
-	state := core.NewBuildState(1, nil, 4, config)
+	state := core.NewBuildState(config)
 	parser := asp.NewParser(state)
 
 	a := &Analyzer{
@@ -731,8 +731,7 @@ func (a *Analyzer) RevDepsFromBuildDef(def *BuildDef, uri lsp.DocumentURI) (core
 // of the core.BuildLabel object passed in
 func (a *Analyzer) RevDepsFromCoreBuildLabel(label core.BuildLabel, uri lsp.DocumentURI) (core.BuildLabels, error) {
 
-	//Ensure we do not get locked out
-	state := core.NewBuildState(1, nil, 4, a.State.Config)
+	state := core.NewBuildState(a.State.Config)
 	state.NeedBuild = false
 	state.NeedTests = false
 

--- a/tools/cache/server/cache_test.go
+++ b/tools/cache/server/cache_test.go
@@ -20,7 +20,7 @@ const cachePath = "tools/cache/server/test_data"
 
 func init() {
 	cache = newCache(cachePath)
-	core.NewBuildState(1, nil, 4, core.DefaultConfiguration())
+	core.NewDefaultBuildState()
 }
 
 func TestFilesToClean(t *testing.T) {

--- a/tools/please_go_test/gotest/test_data/example_test_main.go
+++ b/tools/please_go_test/gotest/test_data/example_test_main.go
@@ -92,6 +92,6 @@ func TestAddTarget(t *testing.T) {
 func TestMain(m *testing.M) {
 	// Need to set this before calling parseSource. It's a bit of a hack but whatevs.
 	buildFileNames = []string{"TEST_BUILD"}
-	core.NewBuildState(10, nil, 2, core.DefaultConfiguration())
+	core.NewDefaultBuildState()
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Basically stop having all these opaque `1, nil, 4` things everywhere.
Also ripped out the `Verbosity` setting which was only used in a couple of places and frankly seems pretty unimportant.