### PR TITLE
Remove --keep_going flag from docs

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -23,10 +23,6 @@
           Sets the location of the repo root to use. Normally plz assumes it is within the repo
           somewhere and locates the root itself, this forces it to a specific location.</li>
 
-        <li><code>-k, --keep_going</code><br/>
-          Continues after a build failure until it's not possible to proceed any further with
-          the build. By default plz stops immediately as soon as one target fails.</li>
-
         <li><code>-n, --num_threads</code><br/>
           Sets the number of parallel workers to use while building. The default is the number
           of logical CPUs of the current machine plus two.</li>


### PR DESCRIPTION
This was removed from the codebase by #655.