### PR TITLE
Redo some internals of how tasks are handled

### DIFF
--- a/src/build/BUILD
+++ b/src/build/BUILD
@@ -50,10 +50,14 @@ go_test(
 go_test(
     name = "build_step_stress_test",
     srcs = ["build_step_stress_test.go"],
+    external = True,
     deps = [
         ":build",
+        "//src/cli",
         "//src/core",
         "//src/output",
+        "//src/plz",
+        "//third_party/go:logging",
         "//third_party/go:testify",
     ],
 )

--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -1,18 +1,22 @@
 // Stress test around the build step stuff, specifically trying to
 // identify concurrent map read / writes.
 
-package build
+package build_test
 
 import (
 	"fmt"
 	"io"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/op/go-logging.v1"
 
+	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/plz"
 )
+
+var log = logging.MustGetLogger("build_test")
 
 const size = 1000
 const numWorkers = 10
@@ -28,18 +32,15 @@ func TestBuildLotsOfTargets(t *testing.T) {
 	}
 	pkg := core.NewPackage("pkg")
 	state.Graph.AddPackage(pkg)
-	for i := 1; i <= size; i++ {
-		addTarget(state, i)
-	}
+
+	go func() {
+		for i := 1; i <= size; i++ {
+			addTarget(state, i)
+		}
+		state.TaskDone(true) // Initial target adding counts as one.
+	}()
+
 	results := state.Results()
-	var wg sync.WaitGroup
-	wg.Add(numWorkers)
-	for i := 0; i < numWorkers; i++ {
-		go func(i int) {
-			please(i, state)
-			wg.Done()
-		}(i)
-	}
 	// Consume and discard any results
 	go func() {
 		for result := range results {
@@ -47,8 +48,8 @@ func TestBuildLotsOfTargets(t *testing.T) {
 			log.Info("%s", result.Description)
 		}
 	}()
-	state.TaskDone(true) // Initial target adding counts as one.
-	wg.Wait()
+
+	plz.Run(nil, nil, state, state.Config, cli.HostArch())
 }
 
 func addTarget(state *core.BuildState, i int) *core.BuildTarget {
@@ -80,22 +81,6 @@ func addTarget(state *core.BuildState, i int) *core.BuildTarget {
 
 func label(i int) core.BuildLabel {
 	return core.ParseBuildLabel(fmt.Sprintf("//pkg:target%d", i), "")
-}
-
-// please mimics the core build 'loop' from src/please.go.
-func please(tid int, state *core.BuildState) {
-	for {
-		label, _, t := state.NextTask()
-		switch t {
-		case core.Stop, core.Kill:
-			return
-		case core.Build:
-			Build(tid, state, label)
-		default:
-			panic(fmt.Sprintf("unexpected task type: %d", t))
-		}
-		state.TaskDone(true)
-	}
 }
 
 // Post-build function that adds new targets & ties in dependencies.

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -237,11 +237,11 @@ func (state *BuildState) AddPendingTest(label BuildLabel) {
 // TaskQueues returns a set of channels to listen on for tasks of various types.
 // This should only be called once per state (otherwise you will not get a full set of tasks).
 func (state *BuildState) TaskQueues() (parses <-chan LabelPair, builds, tests <-chan BuildLabel) {
-	parses = make(chan BuildLabelPair, 100)
-	builds = make(chan BuildLabel, 100)
-	tests = make(chan BuildLabel, 100)
-	go state.feedQueues(parses, builds, tests)
-	return parses, builds, tests
+	p := make(chan LabelPair, 100)
+	b := make(chan BuildLabel, 100)
+	t := make(chan BuildLabel, 100)
+	go state.feedQueues(p, b, t)
+	return p, b, t
 }
 
 // feedQueues feeds the build queues created in TaskQueues.

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -20,8 +20,8 @@ import (
 // startTime is as close as we can conveniently get to process start time.
 var startTime = time.Now()
 
-// A TaskType identifies the kind of task returned from NextTask()
-type TaskType int
+// A taskType identifies the kind of task returned from NextTask()
+type taskType int
 
 // The values here are fiddled to make Compare work easily.
 // Essentially we prioritise on the higher bits only and use the lower ones to make
@@ -29,7 +29,7 @@ type TaskType int
 // Subinclude tasks order first, but we're happy for all build / parse / test tasks
 // to be treated equivalently.
 const (
-	Kill            TaskType = 0x0000 | 0
+	Kill            taskType = 0x0000 | 0
 	SubincludeBuild          = 0x1000 | 1
 	SubincludeParse          = 0x2000 | 2
 	Build                    = 0x4000 | 3
@@ -42,7 +42,7 @@ const (
 type pendingTask struct {
 	Label    BuildLabel // Label of target to parse
 	Dependor BuildLabel // The target that depended on it (only for parse tasks)
-	Type     TaskType
+	Type     taskType
 }
 
 func (t pendingTask) Compare(that queue.Item) int {
@@ -275,7 +275,7 @@ func (state *BuildState) feedQueues(parses chan<- LabelPair, builds, tests chan<
 	}
 }
 
-func (state *BuildState) addPending(label BuildLabel, t TaskType) {
+func (state *BuildState) addPending(label BuildLabel, t taskType) {
 	atomic.AddInt64(&state.progress.numPending, 1)
 	state.pendingTasks.Put(pendingTask{Label: label, Type: t})
 }

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -93,14 +93,14 @@ func TestExpandOriginalTargetsOrdering(t *testing.T) {
 }
 
 func TestComparePendingTasks(t *testing.T) {
-	p := func(taskType TaskType) pendingTask { return pendingTask{Type: taskType} }
+	p := func(taskType taskType) pendingTask { return pendingTask{Type: taskType} }
 	// NB. "Higher priority" means the task comes first, does not refer to numeric values.
-	assertHigherPriority := func(a, b TaskType) {
+	assertHigherPriority := func(a, b taskType) {
 		// relationship should be commutative
 		assert.True(t, p(a).Compare(p(b)) < 0)
 		assert.True(t, p(b).Compare(p(a)) > 0)
 	}
-	assertEqualPriority := func(a, b TaskType) {
+	assertEqualPriority := func(a, b taskType) {
 		assert.True(t, p(a).Compare(p(b)) == 0)
 		assert.True(t, p(b).Compare(p(a)) == 0)
 	}

--- a/src/follow/grpc_client.go
+++ b/src/follow/grpc_client.go
@@ -33,6 +33,7 @@ func ConnectClient(state *core.BuildState, url string, retries int, delay time.D
 // connectClient connects a gRPC client to the given URL.
 // It is split out of the above for testing purposes.
 func connectClient(state *core.BuildState, url string, retries int, delay time.Duration) {
+	state.TaskQueues() // This is important to start consuming events in the background
 	var err error
 	for i := 0; i <= retries; i++ {
 		if err = connectSingleTry(state, url); err == nil {
@@ -138,7 +139,7 @@ func streamResources(state *core.BuildState, client pb.PlzEventsClient) {
 
 // runOutput is just a wrapper around output.MonitorState for convenience in testing.
 func runOutput(state *core.BuildState) bool {
-	output.MonitorState(state, state.Config.Please.NumThreads, false, false, "")
+	output.MonitorState(state, state.Config.Please.NumThreads, true, false, "")
 	output.PrintDisconnectionMessage(state.Success, remoteClosed, remoteDisconnected)
 	return state.Success
 }

--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -18,7 +18,9 @@ import (
 
 // InitParser initialises the parser engine. This is guaranteed to be called exactly once before any calls to Parse().
 func InitParser(state *core.BuildState) {
-	state.Parser = &aspParser{asp: newAspParser(state)}
+	if state.Parser == nil {
+		state.Parser = &aspParser{asp: newAspParser(state)}
+	}
 }
 
 // An aspParser implements the core.Parser interface around our asp package.

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -99,7 +99,7 @@ func parseSubrepoPackage(tid int, state *core.BuildState, pkg, subrepo string, d
 	if state.Graph.Package(pkg, subrepo) == nil {
 		// Don't have it already, must parse.
 		label := core.BuildLabel{Subrepo: subrepo, PackageName: pkg, Name: "all"}
-		return true, parse(tid, state, label, dependor, nil, nil, true)
+		return true, parse(tid, state, label, dependor, true)
 	}
 	return false, nil
 }

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -154,7 +154,7 @@ func addDeps(graph *core.BuildGraph, pkg *core.Package) {
 }
 
 func assertPendingParses(t *testing.T, state *core.BuildState, targets ...string) {
-	state.Stop(1)
+	state.Stop()
 	pending := []core.BuildLabel{}
 	for {
 		label, _, typ := state.NextTask()
@@ -174,7 +174,7 @@ func assertPendingParses(t *testing.T, state *core.BuildState, targets ...string
 }
 
 func assertPendingBuilds(t *testing.T, state *core.BuildState, targets ...string) {
-	state.Stop(1)
+	state.Stop()
 	pending := []core.BuildLabel{}
 	for {
 		label, _, typ := state.NextTask()

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -10,13 +10,12 @@ import (
 	"github.com/thought-machine/please/src/core"
 )
 
-var empty = []string{}
 var tid int = 1
 
 func TestAddDepSimple(t *testing.T) {
 	// Simple case with only one package parsed and one target added
 	state := makeState(true, false)
-	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false)
 	assertPendingParses(t, state, "//package2:target1", "//package2:target1")
 	assertPendingBuilds(t, state) // None until package2 parses
 	assert.Equal(t, 5, state.NumActive())
@@ -25,9 +24,9 @@ func TestAddDepSimple(t *testing.T) {
 func TestAddDepMultiple(t *testing.T) {
 	// Similar to above but doing all targets in that package
 	state := makeState(true, false)
-	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
-	activateTarget(tid, state, nil, buildLabel("//package1:target2"), core.OriginalTarget, false, empty, empty)
-	activateTarget(tid, state, nil, buildLabel("//package1:target3"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false)
+	activateTarget(tid, state, nil, buildLabel("//package1:target2"), core.OriginalTarget, false)
+	activateTarget(tid, state, nil, buildLabel("//package1:target3"), core.OriginalTarget, false)
 	// We get an additional dep on target2, but not another on package2:target1 because target2
 	// is already activated since package1:target1 depends on it
 	assertPendingParses(t, state, "//package2:target1", "//package2:target1", "//package2:target2")
@@ -38,7 +37,7 @@ func TestAddDepMultiple(t *testing.T) {
 func TestAddDepMultiplePackages(t *testing.T) {
 	// This time we already have package2 parsed
 	state := makeState(true, true)
-	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false)
 	assertPendingBuilds(t, state, "//package2:target2") // This is the only candidate target
 	assertPendingParses(t, state)                       // None, we have both packages already
 	assert.Equal(t, 6, state.NumActive())
@@ -48,7 +47,7 @@ func TestAddDepNoBuild(t *testing.T) {
 	// Tag state as not needing build. We shouldn't get any pending builds at this point.
 	state := makeState(true, true)
 	state.NeedBuild = false
-	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false)
 	assertPendingParses(t, state)         // None, we have both packages already
 	assertPendingBuilds(t, state)         // Nothing because we don't need to build.
 	assert.Equal(t, 1, state.NumActive()) // Parses only
@@ -59,7 +58,7 @@ func TestAddParseDep(t *testing.T) {
 	// should still get queued for build though. Recall that we indicate this with :all...
 	state := makeState(true, true)
 	state.NeedBuild = false
-	activateTarget(tid, state, nil, buildLabel("//package2:target2"), buildLabel("//package3:all"), false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package2:target2"), buildLabel("//package3:all"), false)
 	assertPendingBuilds(t, state, "//package2:target2") // Queued because it's needed for parse
 	assertPendingParses(t, state)                       // None, we have both packages already
 	assert.Equal(t, 2, state.NumActive())
@@ -68,7 +67,7 @@ func TestAddParseDep(t *testing.T) {
 func TestAddDepRescan(t *testing.T) {
 	// Simulate a post-build function and rescan.
 	state := makeState(true, true)
-	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package1:target1"), core.OriginalTarget, false)
 	assertPendingBuilds(t, state, "//package2:target2") // This is the only candidate target
 	assertPendingParses(t, state)                       // None, we have both packages already
 	assert.Equal(t, 6, state.NumActive())
@@ -99,12 +98,12 @@ func TestAddParseDepDeferred(t *testing.T) {
 	state := makeState(true, true)
 	state.NeedBuild = false
 	assert.Equal(t, 1, state.NumActive())
-	activateTarget(tid, state, nil, buildLabel("//package2:target2"), core.OriginalTarget, false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package2:target2"), core.OriginalTarget, false)
 	assertPendingParses(t, state)
 	assertPendingBuilds(t, state) // Not yet.
 
 	// Now the undefer kicks off...
-	activateTarget(tid, state, nil, buildLabel("//package2:target2"), buildLabel("//package1:all"), false, empty, empty)
+	activateTarget(tid, state, nil, buildLabel("//package2:target2"), buildLabel("//package1:all"), false)
 	assertPendingBuilds(t, state, "//package2:target2") // This time!
 	assertPendingParses(t, state)
 	assert.Equal(t, 2, state.NumActive())

--- a/src/parse/suggest.go
+++ b/src/parse/suggest.go
@@ -13,14 +13,14 @@ const maxSuggestionDistance = 3
 
 // suggestTargets suggests the targets in the given package that might be misspellings of
 // the requested one.
-func suggestTargets(pkg *core.Package, label, dependor core.BuildLabel) string {
+func suggestTargets(pkg *core.Package, label, dependent core.BuildLabel) string {
 	// The initial haystack only contains target names
 	haystack := []string{}
 	for _, t := range pkg.AllTargets() {
 		haystack = append(haystack, fmt.Sprintf("//%s:%s", pkg.Name, t.Label.Name))
 	}
 	msg := utils.PrettyPrintSuggestion(label.String(), haystack, maxSuggestionDistance)
-	if pkg.Name != dependor.PackageName {
+	if pkg.Name != dependent.PackageName {
 		return msg
 	}
 	// Use relative package labels where possible.

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -65,7 +65,7 @@ func doTasks(tid int, state *core.BuildState, parses <-chan core.LabelPair, buil
 				break
 			}
 			state.ParsePool <- func() {
-				parse.Parse(tid, state, p.Label, p.Dependor, p.ForSubinclude)
+				parse.Parse(tid, state, p.Label, p.Dependent, p.ForSubinclude)
 				state.TaskDone(false)
 			}
 		case l, ok := <-builds:

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -91,7 +91,7 @@ func findOriginalTasks(state *core.BuildState, preTargets, targets []core.BuildL
 	if state.Config.Bazel.Compatibility && fs.FileExists("WORKSPACE") {
 		// We have to parse the WORKSPACE file before anything else to understand subrepos.
 		// This is a bit crap really since it inhibits parallelism for the first step.
-		parse.Parse(0, state, core.NewBuildLabel("workspace", "all"), core.OriginalTarget, state.Include, state.Exclude, false)
+		parse.Parse(0, state, core.NewBuildLabel("workspace", "all"), core.OriginalTarget, false)
 	}
 	if arch.Arch != "" {
 		// Set up a new subrepo for this architecture.


### PR DESCRIPTION
Basically expose them as channels rather than a function interface to get the next task.

This hides a few more details (like the taskType enum) and also allows the caller to be more flexible about how it routes events, which will be needed to have an asymmetric worker pool.