### PR TITLE
Add option to stream test results on stdout

### DIFF
--- a/src/follow/grpc_client.go
+++ b/src/follow/grpc_client.go
@@ -139,7 +139,7 @@ func streamResources(state *core.BuildState, client pb.PlzEventsClient) {
 
 // runOutput is just a wrapper around output.MonitorState for convenience in testing.
 func runOutput(state *core.BuildState) bool {
-	output.MonitorState(state, true, false, "")
+	output.MonitorState(state, true, false, false, "")
 	output.PrintDisconnectionMessage(state.Success, remoteClosed, remoteDisconnected)
 	return state.Success
 }


### PR DESCRIPTION
Comes out one per line on stdout; AFAICT newlines get escaped like HTML so a ~lazy~ efficient parser could just read them line-at-a-time. I don't think there's much else that appears on stdout during normal operation of a `plz test` or `plz cover` run.