### PR TITLE
Fix url parsing for ips

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -390,10 +390,10 @@ type Configuration struct {
 		Upload          cli.URL      `help:"URL to upload test results to (in XML format)"`
 	}
 	Remote struct {
-		URL          cli.URL `help:"URL for the remote server. If this is set but no executors are configured then it can still act as a remote cache."`
-		NumExecutors int     `help:"Maximum number of remote executors to use simultaneously."`
-		Instance     string  `help:"Remote instance name to request; depending on the server this may be required."`
-		Name         string  `help:"A name for this worker instance. This is attached to artifacts uploaded to remote storage." example:"agent-001"`
+		URL          string `help:"URL for the remote server. If this is set but no executors are configured then it can still act as a remote cache."`
+		NumExecutors int    `help:"Maximum number of remote executors to use simultaneously."`
+		Instance     string `help:"Remote instance name to request; depending on the server this may be required."`
+		Name         string `help:"A name for this worker instance. This is attached to artifacts uploaded to remote storage." example:"agent-001"`
 	} `help:"Settings related to remote execution & caching using the Google remote execution APIs. This section is still experimental and subject to change."`
 	Size  map[string]*Size `help:"Named sizes of targets; these are the definitions of what can be passed to the 'size' argument."`
 	Cover struct {

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -95,7 +95,7 @@ func (c *Client) init() {
 		// TODO(peterebden): We may need to add the ability to have multiple URLs which we
 		//                   would then query for capabilities to discover which is which.
 		// TODO(peterebden): Add support for TLS.
-		conn, err := grpc.Dial(c.state.Config.Remote.URL.String(),
+		conn, err := grpc.Dial(c.state.Config.Remote.URL,
 			grpc.WithTimeout(dialTimeout),
 			grpc.WithInsecure(),
 			grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor(grpc_retry.WithMax(maxRetries))))


### PR DESCRIPTION
I don't like this terribly, but the GRPC client expects IP addresses in the form 1.2.3.4:5555, whereas url.Parse() will fail if they're not in the form //1.2.3.4:5555.

@peterebden any better ideas?