### PR TITLE
Replace WindowSize impl with terminal.GetSize

### DIFF
--- a/src/cli/window.go
+++ b/src/cli/window.go
@@ -1,32 +1,17 @@
 package cli
 
 import (
-	"fmt"
+	"golang.org/x/crypto/ssh/terminal"
 	"runtime"
-	"syscall"
-	"unsafe"
 )
-
-// For calculating the size of the console window; this is pretty important when we're writing
-// arbitrary-length log messages around the interactive display.
-type winsize struct {
-	Row    uint16
-	Col    uint16
-	Xpixel uint16
-	Ypixel uint16
-}
 
 // WindowSize finds and returns the size of the console window as (rows, columns)
 func WindowSize() (int, int, error) {
-	ws := winsize{}
-	if ret, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
-		uintptr(syscall.Stderr),
-		uintptr(tiocgwinsz()),
-		uintptr(unsafe.Pointer(&ws)),
-	); int(ret) == -1 {
-		return 25, 80, fmt.Errorf("error %d getting window size", int(errno))
+	cols, rows, err := terminal.GetSize(tiocgwinsz())
+	if err != nil {
+		return 25, 80, err
 	}
-	return int(ws.Row), int(ws.Col), nil
+	return rows, cols, err
 }
 
 // tiocgwinsz returns the ioctl number corresponding to TIOCGWINSZ.


### PR DESCRIPTION
closes #691 

The entire cli/window.go could be replaced and instead directly use GetSize() but this is a less invasive change