### PR TITLE
Break out Go test main templating to a separate rule

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -340,6 +340,7 @@
     {{ template "lexicon_entry.html" .Named "go_binary" }}
     {{ template "lexicon_entry.html" .Named "go_test" }}
     {{ template "lexicon_entry.html" .Named "cgo_test" }}
+    {{ template "lexicon_entry.html" .Named "go_test_main" }}
     {{ template "lexicon_entry.html" .Named "go_get" }}
 
 

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -396,21 +396,13 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
             test_only = True,
             deps = deps,
         )
-    main_rule = build_rule(
-        name='_%s#main' % name,
-        srcs=srcs,
-        outs=[name + '_main.go'],
-        deps=deps,
-        cmd={
-            'dbg': f'$TOOLS -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS',
-            'opt': f'$TOOLS -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS',
-            'cover': f'$TOOLS -d . -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS ',
-        },
-        needs_transitive_deps=True,  # Need all .a files to template coverage variables
-        requires=['go', 'go_src'],
-        test_only=True,
-        tools = [CONFIG.GO_TEST_TOOL],
-        post_build=lambda name, output: _replace_test_package(name, output, static, definitions=definitions, cgo=cgo),
+    main_rule = go_test_main(
+        name = name,
+        _tag = 'main',
+        srcs = srcs,
+        deps = deps,
+        _post_build = lambda name, output: _replace_test_package(name, output, static, definitions=definitions, cgo=cgo),
+        test_only = True,
     )
     deps += [lib_rule]
     lib_rule = go_library(
@@ -449,6 +441,38 @@ def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', vi
         building_description="Compiling...",
         needs_transitive_deps=True,
         output_is_complete=True,
+    )
+
+
+def go_test_main(name:str, srcs:list, test_only:bool=False,
+                 deps:list=[], visibility:list=None, _post_build:function=None, _tag=None):
+    """Outputs the main file for a Go test.
+
+    This essentially does the test discovery and templates out the entry point from it.
+
+    Args:
+      name: Name of the rule
+      srcs: Source .go files that define the tests.
+      test_only: If True, can only be consumed by tests (or other test_only rules).
+      deps: Any additional dependencies
+      visibility: Visibility of the rule.
+    """
+    return build_rule(
+        name = name,
+        tag = _tag,
+        srcs = srcs,
+        outs = [name + '_main.go'],
+        deps = deps,
+        cmd = {
+            'dbg': f'$TOOLS -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS',
+            'opt': f'$TOOLS -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS',
+            'cover': f'$TOOLS -d . -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS ',
+        },
+        needs_transitive_deps = True,  # Need all dependencies to template coverage variables
+        requires = ['go', 'go_src'],
+        test_only = True,
+        tools = [CONFIG.GO_TEST_TOOL],
+        post_build = _post_build,
     )
 
 

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -448,7 +448,9 @@ def go_test_main(name:str, srcs:list, test_only:bool=False,
                  deps:list=[], visibility:list=None, _post_build:function=None, _tag=None):
     """Outputs the main file for a Go test.
 
-    This essentially does the test discovery and templates out the entry point from it.
+    This essentially does the test discovery and templates out the entry point from it. Note that
+    it only generates the main; you will likely need to arrange for compilation of the inputs via
+    a separate go_library rule.
 
     Args:
       name: Name of the rule
@@ -470,7 +472,7 @@ def go_test_main(name:str, srcs:list, test_only:bool=False,
         },
         needs_transitive_deps = True,  # Need all dependencies to template coverage variables
         requires = ['go', 'go_src'],
-        test_only = True,
+        test_only = test_only,
         tools = [CONFIG.GO_TEST_TOOL],
         post_build = _post_build,
     )

--- a/test/go_rules/BUILD
+++ b/test/go_rules/BUILD
@@ -51,3 +51,29 @@ go_test(
     name = "example_test",
     srcs = ["example_test.go"],
 )
+
+go_library(
+    name = "test_main_lib",
+    out = "whatever.a",
+    srcs = ["main_test.go"],
+    test_only = True,
+)
+
+go_test_main(
+    name = "test_main",
+    srcs = ["main_test.go"],
+    test_only = True,
+)
+
+go_binary(
+    name = "test_main_bin",
+    srcs = [":test_main"],
+    test_only = True,
+    deps = [":test_main_lib"],
+)
+
+gentest(
+    name = "test_main_test",
+    data = [":test_main_bin"],
+    test_cmd = "$DATA | tee $RESULTS_FILE",
+)

--- a/test/go_rules/BUILD
+++ b/test/go_rules/BUILD
@@ -54,8 +54,8 @@ go_test(
 
 go_library(
     name = "test_main_lib",
-    out = "whatever.a",
     srcs = ["main_test.go"],
+    out = "whatever.a",
     test_only = True,
 )
 

--- a/test/go_rules/main_test.go
+++ b/test/go_rules/main_test.go
@@ -1,0 +1,6 @@
+package whatever
+
+import "testing"
+
+func TestAThing(t *testing.T) {
+}


### PR DESCRIPTION
This lets users take advantage of the templating in more arbitrary ways (for example building a non-test binary from it) without exposing any internal details (e.g. having them deal with the please_go_test binary directly).