### PR TITLE
Set exit codes to contain a bit more detail

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -137,6 +137,10 @@ type BuildState struct {
 	Coverage TestCoverage
 	// True if the build has been successful so far (i.e. nothing has failed yet).
 	Success bool
+	// True if >= 1 target has failed to build
+	BuildFailed bool
+	// True if >= 1 target has failed test cases
+	TestFailed bool
 	// True if tests should calculate coverage metrics
 	NeedCoverage bool
 	// True if we intend to build targets. False if we're just parsing
@@ -478,6 +482,11 @@ func (state *BuildState) LogResult(result *BuildResult) {
 	}
 	if result.Status.IsFailure() {
 		state.Success = false
+		if result.Status == TargetBuildFailed {
+			state.BuildFailed = true
+		} else if result.Status == TargetTestFailed {
+			state.TestFailed = true
+		}
 	}
 }
 

--- a/tools/build_langserver/lsp/BUILD
+++ b/tools/build_langserver/lsp/BUILD
@@ -6,11 +6,11 @@ go_library(
     ),
     visibility = ["//tools/build_langserver/..."],
     deps = [
+        "//rules",
         "//src/core",
         "//src/help",
         "//src/parse/asp",
         "//src/plz",
-        "//rules",
         "//third_party/go:buildtools",
         "//third_party/go:jsonrpc2",
         "//third_party/go:logging",


### PR DESCRIPTION
As mentioned in the file:
0 -> success
1 -> general failure
2 -> a target failed to build
7 -> a test failed

The last one is staying (slightly awkwardly) as 7 for compatibility. We can't change it until plz 15...