### PR TITLE
terminal.GetSize takes a file descriptor not an ioctl

### DIFF
--- a/src/cli/window.go
+++ b/src/cli/window.go
@@ -1,25 +1,16 @@
 package cli
 
 import (
+	"os"
+
 	"golang.org/x/crypto/ssh/terminal"
-	"runtime"
 )
 
 // WindowSize finds and returns the size of the console window as (rows, columns)
 func WindowSize() (int, int, error) {
-	cols, rows, err := terminal.GetSize(tiocgwinsz())
+	cols, rows, err := terminal.GetSize(int(os.Stderr.Fd()))
 	if err != nil {
 		return 25, 80, err
 	}
 	return rows, cols, err
-}
-
-// tiocgwinsz returns the ioctl number corresponding to TIOCGWINSZ.
-// We could determine this using cgo which would be more robust, but I'd really
-// rather not invoke cgo for something as static as this.
-func tiocgwinsz() int {
-	if runtime.GOOS == "linux" {
-		return 0x5413
-	}
-	return 1074295912 // OSX and FreeBSD.
 }


### PR DESCRIPTION
On the bright side we can get rid of some grungy runtime OS detection...