### PR TITLE
Include tools in input root

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -343,7 +343,7 @@ func prepareDirectory(directory string, remove bool) error {
 
 // Symlinks the source files of this rule into its temp directory.
 func prepareSources(graph *core.BuildGraph, target *core.BuildTarget) error {
-	for source := range core.IterSources(graph, target) {
+	for source := range core.IterSources(graph, target, false) {
 		if err := core.PrepareSourcePair(source); err != nil {
 			return err
 		}

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -142,7 +142,7 @@ func mustSourceHash(state *core.BuildState, target *core.BuildTarget) []byte {
 // Calculate the hash of all sources of this rule
 func sourceHash(state *core.BuildState, target *core.BuildTarget) ([]byte, error) {
 	h := sha1.New()
-	for source := range core.IterSources(state.Graph, target) {
+	for source := range core.IterSources(state.Graph, target, false) {
 		result, err := state.PathHasher.Hash(source.Src, false, true)
 		if err != nil {
 			return nil, err
@@ -442,7 +442,7 @@ func PrintHashes(state *core.BuildState, target *core.BuildTarget) {
 	fmt.Printf("  Source: %s\n", b64(mustSourceHash(state, target)))
 	// Note that the logic here mimics sourceHash, but I don't want to pollute that with
 	// optional printing nonsense since it's on our hot path.
-	for source := range core.IterSources(state.Graph, target) {
+	for source := range core.IterSources(state.Graph, target, false) {
 		fmt.Printf("  Source: %s: %s\n", source.Src, b64(state.PathHasher.MustHash(source.Src)))
 	}
 	for _, tool := range target.AllTools() {

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -125,7 +125,8 @@ type SourcePair struct{ Src, Tmp string }
 // IterSources returns all the sources for a function, allowing for sources that are other rules
 // and rules that require transitive dependencies.
 // Yielded values are pairs of the original source location and its temporary location for this rule.
-func IterSources(graph *BuildGraph, target *BuildTarget) <-chan SourcePair {
+// If includeTools is true it yields the target's tools as well.
+func IterSources(graph *BuildGraph, target *BuildTarget, includeTools bool) <-chan SourcePair {
 	ch := make(chan SourcePair)
 	done := map[BuildLabel]bool{}
 	donePaths := map[string]bool{}
@@ -135,6 +136,9 @@ func IterSources(graph *BuildGraph, target *BuildTarget) <-chan SourcePair {
 		sources := dependency.AllSources()
 		if target == dependency {
 			// This is the current build rule, so link its sources.
+			if includeTools {
+				sources = append(sources, target.AllTools()...)
+			}
 			for _, source := range sources {
 				for _, providedSource := range recursivelyProvideSource(graph, target, source) {
 					fullPaths := providedSource.FullPaths(graph)

--- a/src/core/utils_test.go
+++ b/src/core/utils_test.go
@@ -37,7 +37,7 @@ func TestCollapseHash2(t *testing.T) {
 func TestIterSources(t *testing.T) {
 	graph := buildGraph()
 	iterSources := func(label string) []SourcePair {
-		return toSlice(IterSources(graph, graph.TargetOrDie(ParseBuildLabel(label, ""))))
+		return toSlice(IterSources(graph, graph.TargetOrDie(ParseBuildLabel(label, "")), false))
 	}
 
 	assert.Equal(t, []SourcePair{

--- a/src/query/graph.go
+++ b/src/query/graph.go
@@ -125,7 +125,7 @@ func makeJSONTarget(state *core.BuildState, target *core.BuildTarget) JSONTarget
 	t := JSONTarget{
 		Sources: target.AllSourcePaths(state.Graph),
 	}
-	for in := range core.IterSources(state.Graph, target) {
+	for in := range core.IterSources(state.Graph, target, false) {
 		t.Inputs = append(t.Inputs, in.Src)
 	}
 	for _, out := range target.Outputs() {

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -154,7 +154,7 @@ func (c *Client) buildInputRoot(target *core.BuildTarget, upload, isTest bool) (
 	if isTest {
 		sources = core.IterRuntimeFiles(c.state.Graph, target, false)
 	} else {
-		sources = core.IterSources(c.state.Graph, target)
+		sources = core.IterSources(c.state.Graph, target, true)
 		strip = len(target.TmpDir()) + 1 // Amount we have to strip off the start of the temp paths
 	}
 	err := c.uploadBlobs(func(ch chan<- *blob) error {
@@ -184,7 +184,7 @@ func (c *Client) buildInputRoot(target *core.BuildTarget, upload, isTest bool) (
 						parent.Directories = append(parent.Directories, &pb.DirectoryNode{Name: path.Base(child)})
 					}
 					child = d
-					if d == "." {
+					if d == "." || d == "/" {
 						break
 					}
 				}


### PR DESCRIPTION
This is an issue with correctness - the tools were not included in the hash previously so them changing did not force rebuilds as they should have.