### PR TITLE
Improve error handling and logging when using a remote cache

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -74,7 +75,8 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 			} else {
 				err = fmt.Errorf("%s", r)
 			}
-			log.Debug(errors.Wrap(r, 2).ErrorStack())
+			log.Debug("Build failed: %s", err)
+			log.Debug(string(debug.Stack()))
 		}
 	}()
 

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -74,6 +74,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 			} else {
 				err = fmt.Errorf("%s", r)
 			}
+			log.Debug(errors.Wrap(r, 2).ErrorStack())
 		}
 	}()
 

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -192,6 +192,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 			buildLinks(state, target)
 			return true // got from cache
 		}
+		log.Debug("Nothing retrieved from remote cache for %s", target.Label)
 		return false
 	}
 	cacheKey := mustShortTargetHash(state, target)

--- a/src/cache/dir_cache.go
+++ b/src/cache/dir_cache.go
@@ -1,4 +1,4 @@
-// Diretory-based cache.
+// Directory-based cache.
 
 package cache
 

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"encoding/hex"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -242,6 +243,9 @@ func (c *Client) buildInputRoot(target *core.BuildTarget, upload, isTest bool) (
 
 // buildMetadata converts an ActionResult into one of our BuildMetadata protos.
 func (c *Client) buildMetadata(ar *pb.ActionResult, needStdout, needStderr bool) (*core.BuildMetadata, error) {
+	if ar.ExecutionMetadata == nil {
+		return nil, fmt.Errorf("Build server returned no metadata for target - remote build failed or did not run")
+	}
 	metadata := &core.BuildMetadata{
 		StartTime: toTime(ar.ExecutionMetadata.ExecutionStartTimestamp),
 		EndTime:   toTime(ar.ExecutionMetadata.ExecutionCompletedTimestamp),

--- a/src/remote/blobs.go
+++ b/src/remote/blobs.go
@@ -311,6 +311,9 @@ func (c *Client) downloadBlobs(f func(ch chan<- *blob) error) error {
 
 // retrieveByteStream receives a file back from the server as a byte stream.
 func (c *Client) retrieveByteStream(b *blob) error {
+	if b.Digest == nil {
+		return fmt.Errorf("can't retrieve byte stream from nil digest")
+	}
 	r, err := c.readByteStream(b.Digest)
 	if err != nil {
 		return err
@@ -321,9 +324,6 @@ func (c *Client) retrieveByteStream(b *blob) error {
 
 // readByteStream returns a reader for a bytestream for the given digest.
 func (c *Client) readByteStream(digest *pb.Digest) (io.ReadCloser, error) {
-	if digest == nil {
-		return nil, fmt.Errorf("can't read byte stream from nil digest")
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), reqTimeout)
 	stream, err := c.bsClient.Read(ctx, &bs.ReadRequest{
 		ResourceName: c.byteStreamDownloadName(digest),

--- a/src/remote/blobs.go
+++ b/src/remote/blobs.go
@@ -321,6 +321,9 @@ func (c *Client) retrieveByteStream(b *blob) error {
 
 // readByteStream returns a reader for a bytestream for the given digest.
 func (c *Client) readByteStream(digest *pb.Digest) (io.ReadCloser, error) {
+	if digest == nil {
+		return nil, fmt.Errorf("can't read byte stream from nil digest")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), reqTimeout)
 	stream, err := c.bsClient.Read(ctx, &bs.ReadRequest{
 		ResourceName: c.byteStreamDownloadName(digest),

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -424,7 +424,7 @@ func (c *Client) execute(tid int, target *core.BuildTarget, digest *pb.Digest, t
 				}
 				// TODO(henryaj): if messages are only emitted on error, we should upgrade this to a warning
 				if response.Message != "" {
-					log.Debug("Message from build server:\n     %s",response.Message)
+					log.Debug("Message from build server:\n     %s", response.Message)
 				}
 				// TODO(henryaj): are there cases where a non-zero exit code isn't a failed build?
 				if response.Result.ExitCode > 0 {

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -418,6 +418,10 @@ func (c *Client) execute(tid int, target *core.BuildTarget, digest *pb.Digest, t
 				if resp.Result == nil { // This is optional on failure.
 					return nil, nil, respErr
 				}
+				if response.Result == nil { // This seems to happen when things go wrong on the build server end.
+					log.Debug("Bad result from build server: %+v", response)
+					return nil, nil, fmt.Errorf("Build server did not return valid result")
+				}
 				if response.Result.ExitCode > 0 {
 					return nil, nil, fmt.Errorf("Remotely executed command exited with %d", response.Result.ExitCode)
 				}

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -422,6 +422,7 @@ func (c *Client) execute(tid int, target *core.BuildTarget, digest *pb.Digest, t
 					log.Debug("Bad result from build server: %+v", response)
 					return nil, nil, fmt.Errorf("Build server did not return valid result")
 				}
+				// TODO(henryaj): are there cases where a non-zero exit code isn't a failed build?
 				if response.Result.ExitCode > 0 {
 					return nil, nil, fmt.Errorf("Remotely executed command exited with %d", response.Result.ExitCode)
 				}

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -422,6 +422,10 @@ func (c *Client) execute(tid int, target *core.BuildTarget, digest *pb.Digest, t
 					log.Debug("Bad result from build server: %+v", response)
 					return nil, nil, fmt.Errorf("Build server did not return valid result")
 				}
+				// TODO(henryaj): if messages are only emitted on error, we should upgrade this to a warning
+				if response.Message != "" {
+					log.Debug("Message from build server:\n     %s",response.Message)
+				}
 				// TODO(henryaj): are there cases where a non-zero exit code isn't a failed build?
 				if response.Result.ExitCode > 0 {
 					return nil, nil, fmt.Errorf("Remotely executed command exited with %d", response.Result.ExitCode)

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -130,14 +130,18 @@ func (c *Client) init() {
 		c.canBatchBlobReads = c.checkBatchReadBlobs()
 		log.Debug("Remote execution client initialised for storage")
 		// Now check if it can do remote execution
-		if caps := resp.ExecutionCapabilities; caps != nil && c.state.Config.Remote.NumExecutors > 0 {
-			if err := c.chooseDigest([]pb.DigestFunction_Value{caps.DigestFunction}); err != nil {
-				return err
-			} else if !caps.ExecEnabled {
-				return fmt.Errorf("Remote execution not enabled for this server")
+		if c.state.Config.Remote.NumExecutors > 0 {
+			if caps := resp.ExecutionCapabilities; caps != nil {
+				if err := c.chooseDigest([]pb.DigestFunction_Value{caps.DigestFunction}); err != nil {
+					return err
+				} else if !caps.ExecEnabled {
+					return fmt.Errorf("Remote execution not enabled for this server")
+				}
+				c.execClient = pb.NewExecutionClient(conn)
+				log.Debug("Remote execution client initialised for execution")
+			} else {
+				log.Fatalf("Remote execution is configured but the build server doesn't support it")
 			}
-			c.execClient = pb.NewExecutionClient(conn)
-			log.Debug("Remote execution client initialised for execution")
 		}
 		return err
 	}()
@@ -407,9 +411,15 @@ func (c *Client) execute(tid int, target *core.BuildTarget, digest *pb.Digest, t
 				for k, v := range response.ServerLogs {
 					log.Debug("Server log available: %s: hash key %s", k, v.Digest.Hash)
 				}
-				respErr := convertError(response.Status)
+				var respErr error
+				if response.Status != nil {
+					respErr = convertError(response.Status)
+				}
 				if resp.Result == nil { // This is optional on failure.
 					return nil, nil, respErr
+				}
+				if response.Result.ExitCode > 0 {
+					return nil, nil, fmt.Errorf("Remotely executed command exited with %d", response.Result.ExitCode)
 				}
 				metadata, err := c.buildMetadata(response.Result, needStdout || respErr != nil, respErr != nil)
 				// The original error is higher priority than us trying to retrieve the

--- a/tools/build_langserver/lsp/BUILD
+++ b/tools/build_langserver/lsp/BUILD
@@ -6,11 +6,11 @@ go_library(
     ),
     visibility = ["//tools/build_langserver/..."],
     deps = [
+        "//rules",
         "//src/core",
         "//src/help",
         "//src/parse/asp",
         "//src/plz",
-        "//rules",
         "//third_party/go:buildtools",
         "//third_party/go:jsonrpc2",
         "//third_party/go:logging",


### PR DESCRIPTION
- Print stacktrace in debug logs on panic
- Fail fast if remote execution is enabled but remote end doesn't support it
- Gracefully handle invalid responses from build server (e.g. when expected proto fields are left nil)
- Print helpful error if remote build exits with non-zero code

In time I'd like to improve all this such that remote build failures are non-fatal - please should just fall back to building locally I guess.