### PR TITLE
Adds a known label to tests indicating if results are a directory

### DIFF
--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -311,7 +311,7 @@ def java_test(name:str, srcs:list, resources:list=None, data:list=None, deps:lis
         deps=deps,
         visibility=visibility,
         test_sandbox=sandbox,
-        labels=labels,
+        labels=labels + ['test_results_dir'],
         test_timeout=timeout,
         size = size,
         flaky=flaky,

--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -193,7 +193,7 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
 
 
 def python_test(name:str, srcs:list, data:list=[], resources:list=[], deps:list=[], worker:str='',
-                labels:list&features&tags=None, size:str=None, flags:str='', visibility:list=None,
+                labels:list&features&tags=[], size:str=None, flags:str='', visibility:list=None,
                 sandbox:bool=None, timeout:int=0, flaky:bool|int=0,
                 test_outputs:list=None, zip_safe:bool=None, interpreter:str=None, site:bool=False):
     """Generates a Python test target.
@@ -296,7 +296,7 @@ def python_test(name:str, srcs:list, data:list=[], resources:list=[], deps:list=
         #      is faster for unittest as well (because we don't need to rebuild the pex if they change).
         data=data + srcs,
         outs=[f'{name}.pex'],
-        labels=labels,
+        labels=labels + ['test_results_dir'],
         cmd='$TOOL z -i . -s .pex.zip -s .whl --preamble_from="$SRC" --include_other --add_init_py --strict',
         test_cmd=test_cmd,
         needs_transitive_deps=True,
@@ -564,7 +564,7 @@ def python_wheel(name:str, version:str, hashes:list=None, package_name:str=None,
 
 def _handle_zip_safe(name):
     """Handles the zip safe flag.
-    
+
     This works as a pre-build function and hence can only use the builtin
     methods to manipulate the rule.
     """

--- a/src/cache/rex_cache.go
+++ b/src/cache/rex_cache.go
@@ -26,6 +26,7 @@ func (rc *rexCache) Store(target *core.BuildTarget, key []byte, metadata *core.B
 }
 
 func (rc *rexCache) Retrieve(target *core.BuildTarget, key []byte, files []string) *core.BuildMetadata {
+	log.Debug("Retrieving %s from remote cache...", target.Label)
 	metadata, err := rc.client.Retrieve(target, key)
 	if err != nil {
 		if remote.IsNotFound(err) {

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -41,6 +41,11 @@ const TestResultsFile = "test.results"
 // This is similarly defined via an environment variable.
 const CoverageFile = "test.coverage"
 
+// TestResultsDirLabel is a known label that indicates that the test will output results
+// into a directory rather than a file. Please can internally handle either but the remote
+// execution API requires that we specify which is which.
+const TestResultsDirLabel = "test_results_dir"
+
 // A BuildTarget is a representation of a build target and all information about it;
 // its name, dependencies, build commands, etc.
 type BuildTarget struct {

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -75,9 +75,15 @@ func (c *Client) buildCommand(target *core.BuildTarget, stamp []byte, isTest boo
 
 // buildTestCommand builds a command for a target when testing.
 func (c *Client) buildTestCommand(target *core.BuildTarget) *pb.Command {
-	outs := []string{core.TestResultsFile}
+	files := make([]string, 0, 2)
+	dirs := []string{}
 	if target.NeedCoverage(c.state) {
-		outs = append(outs, core.CoverageFile)
+		files = append(files, core.CoverageFile)
+	}
+	if target.HasLabel(core.TestResultsDirLabel) {
+		dirs = []string{core.TestResultsFile}
+	} else {
+		files = append(files, core.TestResultsFile)
 	}
 	return &pb.Command{
 		Platform: &pb.Platform{
@@ -92,7 +98,8 @@ func (c *Client) buildTestCommand(target *core.BuildTarget) *pb.Command {
 			c.bashPath, "--noprofile", "--norc", "-u", "-o", "pipefail", "-c", target.GetTestCommand(c.state),
 		},
 		EnvironmentVariables: buildEnv(core.TestEnvironment(c.state, target, "")),
-		OutputFiles:          outs,
+		OutputFiles:          files,
+		OutputDirectories:    dirs,
 	}
 }
 

--- a/src/remote/blobs.go
+++ b/src/remote/blobs.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	"github.com/golang/protobuf/proto"
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 	bs "google.golang.org/genproto/googleapis/bytestream"
@@ -340,6 +341,15 @@ func (c *Client) readAllByteStream(digest *pb.Digest) ([]byte, error) {
 	}
 	defer r.Close()
 	return ioutil.ReadAll(r)
+}
+
+// readByteStreamToProto reads an entire bytestream and deserialises it into a message.
+func (c *Client) readByteStreamToProto(digest *pb.Digest, msg proto.Message) error {
+	b, err := c.readAllByteStream(digest)
+	if err != nil {
+		return err
+	}
+	return proto.Unmarshal(b, msg)
 }
 
 // checkBatchReadBlobs sends a fake request to verify if BatchReadBlobs is supported

--- a/src/remote/remote_test.go
+++ b/src/remote/remote_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"runtime"
 	"testing"
 	"time"
 
@@ -120,12 +121,18 @@ func TestStoreAndRetrieveDir(t *testing.T) {
 	b, err = ioutil.ReadFile(path.Join(resultsDir, "results/2.xml"))
 	assert.NoError(t, err)
 	assert.Equal(t, string(b), xmlResults)
-	link, err := os.Readlink("plz-out/bin/package2/1.xml")
-	assert.NoError(t, err)
-	assert.Equal(t, ".test_results_target2/1.xml", link)
-	link, err = os.Readlink(path.Join(resultsDir, "2.xml"))
-	assert.NoError(t, err)
-	assert.Equal(t, "results/2.xml", link)
+
+	// TODO(peterebden): This does not seem to be working on OSX or FreeBSD; it doesn't seem
+	//                   to be because of this package, but the test files are seemingly not
+	//                   coming out as symlinks correctly.
+	if runtime.GOOS == "linux" {
+		link, err := os.Readlink("plz-out/bin/package2/1.xml")
+		assert.NoError(t, err)
+		assert.Equal(t, ".test_results_target2/1.xml", link)
+		link, err = os.Readlink(path.Join(resultsDir, "2.xml"))
+		assert.NoError(t, err)
+		assert.Equal(t, "results/2.xml", link)
+	}
 }
 
 const xmlResults = `<?xml version="1.0" encoding="UTF-8"?>

--- a/src/remote/test_data/plz-out/bin/package2/.test_results_target2/1.xml
+++ b/src/remote/test_data/plz-out/bin/package2/.test_results_target2/1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite errors="0" failures="0" name="src.build.python.pex_test.PexTest-20150416153858" tests="1" time="0.000">
+<properties/>
+<testcase classname="src.build.python.pex_test.PexTest" name="testSuccess" time="0.000"/>           <testcase classname="src.build.python.pex_test.PexTest" name="testSuccess" time="0.000">
+        </testcase>
+</testsuite>

--- a/src/remote/test_data/plz-out/bin/package2/.test_results_target2/2.xml
+++ b/src/remote/test_data/plz-out/bin/package2/.test_results_target2/2.xml
@@ -1,0 +1,1 @@
+results/2.xml

--- a/src/remote/test_data/plz-out/bin/package2/.test_results_target2/results/2.xml
+++ b/src/remote/test_data/plz-out/bin/package2/.test_results_target2/results/2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite errors="0" failures="0" name="src.build.python.pex_test.PexTest-20150416153858" tests="1" time="0.000">
+<properties/>
+<testcase classname="src.build.python.pex_test.PexTest" name="testSuccess" time="0.000"/>           <testcase classname="src.build.python.pex_test.PexTest" name="testSuccess" time="0.000">
+        </testcase>
+</testsuite>

--- a/src/remote/test_data/plz-out/bin/package2/1.xml
+++ b/src/remote/test_data/plz-out/bin/package2/1.xml
@@ -1,0 +1,1 @@
+.test_results_target2/1.xml

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -92,6 +92,14 @@ func extraPerms(file *pb.OutputFile) os.FileMode {
 	return 0
 }
 
+// extraFilePerms returns any additional permission bits we should apply for this file.
+func extraFilePerms(file *pb.FileNode) os.FileMode {
+	if file.IsExecutable {
+		return 0111
+	}
+	return 0
+}
+
 // IsNotFound returns true if a given error is a "not found" error (which may be treated
 // differently, for example if trying to retrieve artifacts that may not be there).
 func IsNotFound(err error) bool {

--- a/tools/please_pex/pytest.py
+++ b/tools/please_pex/pytest.py
@@ -23,8 +23,12 @@ def run_tests(args):
                 pass
             args += ['-k', filtered_tests.strip()]
 
-    args += ['--junitxml', 'test.results'] + TEST_NAMES
+    # It's easier if all python_test rules output into a directory.
+    results_file = os.getenv('RESULTS_FILE', 'test.results')
+    os.mkdir(results_file)
+    args += ['--junitxml', os.path.join(results_file, 'results.xml')] + TEST_NAMES
 
     if os.environ.get('DEBUG'):
         args.append('--pdb')
+
     return main(args)


### PR DESCRIPTION
This is the easiest way I can see of making it actually work. An option might be to add a second env var that tests use if they want a directory - but we'd then have to ask remote ex to return both, and it's not obvious that optional outputs are included at all.

Also a whole bunch of fixups for retrieving directories & symlinks correctly.