### PR TITLE
Optimise go_get a bit for downstream consumers

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -574,6 +574,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
     all_installs = []
     outs = extra_outs
     provides = None
+    srcs = []
     for getone, revision, tag in zip(get, revision, tags):
         get_rule, getroot = _go_get_download(
             name = name,
@@ -587,7 +588,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
             strip = strip,
         )
         outs += [getroot]
-        deps += [get_rule]
+        srcs += [get_rule]
         provides = {'go': ':' + name, 'go_src': get_rule}
         if install:
             all_installs += [i if i.startswith(getroot) else (getroot + '/' + i) for i in install]
@@ -616,6 +617,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
         name = name,
         outs = outs,
         deps = deps,
+        srcs = srcs,
         exported_deps = exported_deps,
         tools = {
             'go': [CONFIG.GO_TOOL],
@@ -625,7 +627,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
         building_description = 'Compiling...',
         cmd = ' && '.join(cmd),
         binary = binary,
-        requires = ['go'],
+        requires = ['go', 'go_src'],
         test_only = test_only,
         labels = ['link:plz-out/go'],
         sandbox = False,


### PR DESCRIPTION
This is a little obtuse but basically makes things faster for `go_binary` et al which are currently receiving all the sources for all third-party dependencies when they actually only need the binary artifacts.

By using `srcs` rather than `deps` it skips the recursive search; we need an extra `require` for `go_get` itself which does need both.