### PR TITLE
pip somewhat imposes user site by default

### DIFF
--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -361,7 +361,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
 
     target = outs[0] if install_subdirectory else '.'
 
-    cmd = '$TOOLS_PIP install --no-deps --no-compile --no-cache-dir --default-timeout=60 --target=' + target
+    cmd = '$TOOLS_PIP install --isolated --no-user --no-deps --no-compile --no-cache-dir --default-timeout=60 --target=' + target
     if CONFIG.HOSTOS == 'darwin':
         # Fix for Homebrew which fails with a superficially similar issue.
         # https://github.com/Homebrew/brew/blob/master/docs/Homebrew-and-Python.md suggests fixing with --install-option

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -262,13 +262,7 @@ func DefaultConfiguration() *Configuration {
 	config.Python.TestRunnerBootstrap = ""
 	config.Python.UsePyPI = true
 	config.Python.InterpreterOptions = ""
-	// Annoyingly pip on OSX doesn't seem to work with this flag (you get the dreaded
-	// "must supply either home or prefix/exec-prefix" error). Goodness knows why *adding* this
-	// flag - which otherwise seems exactly what we want - provokes that error, but the logic
-	// of pip is rather a mystery to me.
-	if runtime.GOOS != "darwin" {
-		config.Python.PipFlags = "--isolated"
-	}
+	config.Python.PipFlags = ""
 	config.Java.DefaultTestPackage = ""
 	config.Java.SourceLevel = "8"
 	config.Java.TargetLevel = "8"


### PR DESCRIPTION
This should fix the disttools exception "must supply either home or prefix/exec-prefix".