### PR TITLE
use correct filename

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -226,7 +226,7 @@ func (c *Client) buildInputRoot(target *core.BuildTarget, upload, isTest bool) (
 				}
 				d := dirs[dir]
 				if info.Mode()&os.ModeSymlink != 0 {
-					link, err := os.Readlink(dest)
+					link, err := os.Readlink(name)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
Fixes `readlink <file>: no such file or directory` when an input is a symlink.