### PR TITLE
Some remote ex 'fixes' to remote files

### DIFF
--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -50,7 +50,9 @@ func createTarget(s *scope, args []pyObject) *core.BuildTarget {
 	target.TestOnly = test || isTruthy(15)
 	target.ShowProgress = isTruthy(36)
 	target.IsRemoteFile = isTruthy(38)
-	target.Local = isTruthy(41)
+	// TODO(peterebden): temporarily forcing remote files to be built locally, but we should
+	//                   have a better solution for this.
+	target.Local = isTruthy(41) || target.IsRemoteFile
 
 	var size *core.Size
 	if args[37] != None {


### PR DESCRIPTION
Force them to always be built locally for now since we don't have a sensible way of doing it.

Make up a command for them to encode the source URLs since otherwise they are not expressed in the input root (and once we stop sending absolute paths for the environment all remote files would hash the same).