### PR TITLE
Allow home dir to be overridden when building remotely

### DIFF
--- a/src/core/test_data/remote_execution.plzconfig
+++ b/src/core/test_data/remote_execution.plzconfig
@@ -1,0 +1,6 @@
+[Remote]
+URL = remote-build-machine
+instance = instance-1
+numExecutors = 1
+name = runner-1
+homedir = /home/agent/.please


### PR DESCRIPTION
Also conditionally exclude local directories from PATH when building remotely.