### PR TITLE
Fix label replacements for tools in subrepos

### DIFF
--- a/src/core/build_label_test.go
+++ b/src/core/build_label_test.go
@@ -120,8 +120,8 @@ func TestSubrepoLabel(t *testing.T) {
 func TestParseBuildLabelParts(t *testing.T) {
 	target1 := "///unittest_cpp//:unittest_cpp"
 	targetNewSyntax := "@unittest_cpp"
-	pkg, name, subrepo := parseBuildLabelParts(target1, "/", nil)
-	pkg2, name2, subrepo2 := parseBuildLabelParts(targetNewSyntax, "/", nil)
+	pkg, name, subrepo := parseBuildLabelParts(target1, "/", "")
+	pkg2, name2, subrepo2 := parseBuildLabelParts(targetNewSyntax, "/", "")
 	assert.Equal(t, pkg, "")
 	assert.Equal(t, pkg2, "")
 	assert.Equal(t, name, "unittest_cpp")

--- a/src/core/command_replacements.go
+++ b/src/core/command_replacements.go
@@ -155,7 +155,10 @@ func replaceSequencesInternal(state *BuildState, target *BuildTarget, command st
 // replaceSequence replaces a single escape sequence in a command.
 func replaceSequence(state *BuildState, target *BuildTarget, in string, runnable, multiple, dir, outPrefix, hash, test bool) string {
 	if LooksLikeABuildLabel(in) {
-		label := ParseBuildLabel(in, target.Label.PackageName)
+		label, err := TryParseBuildLabel(in, target.Label.PackageName, target.Label.Subrepo)
+		if err != nil {
+			panic(err)
+		}
 		return replaceSequenceLabel(state, target, label, in, runnable, multiple, dir, outPrefix, hash, test, true)
 	}
 	for _, src := range sourcesOrTools(target, runnable) {

--- a/src/core/command_replacements_test.go
+++ b/src/core/command_replacements_test.go
@@ -116,6 +116,17 @@ func TestToolReplacement(t *testing.T) {
 	assert.Equal(t, expected, cmd)
 }
 
+func TestToolReplacementSubrepo(t *testing.T) {
+	target2 := makeTarget("///subrepo//path/to:target2", "blah", nil)
+	target1 := makeTarget("///subrepo//path/to:target1", "$(location //path/to:target2)", target2)
+	target1.Tools = append(target1.Tools, target2.Label)
+
+	wd, _ := os.Getwd()
+	expected := quote(path.Join(wd, "plz-out/gen/path/to/target2.py"))
+	cmd, _ := ReplaceSequences(state, target1, target1.Command)
+	assert.Equal(t, expected, cmd)
+}
+
 func TestDirReplacement(t *testing.T) {
 	target2 := makeTarget("//path/to:target2", "blah", nil)
 	target2.AddOutput("blah2.txt")

--- a/src/core/command_replacements_test.go
+++ b/src/core/command_replacements_test.go
@@ -122,7 +122,7 @@ func TestToolReplacementSubrepo(t *testing.T) {
 	target1.Tools = append(target1.Tools, target2.Label)
 
 	wd, _ := os.Getwd()
-	expected := quote(path.Join(wd, "plz-out/gen/path/to/target2.py"))
+	expected := quote(path.Join(wd, "plz-out/gen/subrepo/path/to/target2.py"))
 	cmd, _ := ReplaceSequences(state, target1, target1.Command)
 	assert.Equal(t, expected, cmd)
 }

--- a/src/core/package.go
+++ b/src/core/package.go
@@ -118,7 +118,7 @@ func (pkg *Package) HasSubinclude(label BuildLabel) bool {
 
 // SubrepoArchName returns a subrepo name, modified for the architecture of this package if it's not the host.
 func (pkg *Package) SubrepoArchName(subrepo string) string {
-	if subrepo != "" && pkg.Subrepo != nil && pkg.Subrepo.IsCrossCompile {
+	if subrepo != "" && pkg.Subrepo != nil && pkg.Subrepo.IsCrossCompile && pkg.SubrepoName != subrepo {
 		return subrepo + "_" + pkg.SubrepoName
 	}
 	return subrepo

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -91,7 +91,7 @@ func checkSubrepo(tid int, state *core.BuildState, label, dependent core.BuildLa
 	if handled, err := parseSubrepoPackage(tid, state, sl.PackageName, dependent.Subrepo, label); handled && err == nil {
 		return state.Graph.Subrepo(label.Subrepo), nil
 	}
-	return nil, fmt.Errorf("Subrepo %s is not defined", label.Subrepo)
+	return nil, fmt.Errorf("Subrepo %s is not defined (referenced by %s)", label.Subrepo, dependent)
 }
 
 // parseSubrepoPackage parses a package to make sure subrepos are available.

--- a/tools/build_langserver/lsp/completion.go
+++ b/tools/build_langserver/lsp/completion.go
@@ -29,7 +29,7 @@ func (h *Handler) completeLabel(doc *doc, partial string, line, col int) (*lsp.C
 		list := &lsp.CompletionList{}
 		pkgName := path.Base(doc.Filename)
 		pkgLabel := core.BuildLabel{PackageName: pkgName, Name: "all"}
-		label, err := core.TryParseBuildLabel(labelName, pkgName)
+		label, err := core.TryParseBuildLabel(labelName, pkgName, pkgLabel.Subrepo)
 		if err != nil {
 			return nil, err
 		}

--- a/tools/build_langserver/lsp/diagnostics.go
+++ b/tools/build_langserver/lsp/diagnostics.go
@@ -35,7 +35,7 @@ func (h *Handler) diagnostics(d *doc, ast []*asp.Statement) []lsp.Diagnostic {
 	asp.WalkAST(ast, func(expr *asp.Expression) bool {
 		if expr.Val != nil && expr.Val.String != "" {
 			if s := stringLiteral(expr.Val.String); core.LooksLikeABuildLabel(s) {
-				if l, err := core.TryParseBuildLabel(s, pkgLabel.PackageName); err == nil {
+				if l, err := core.TryParseBuildLabel(s, pkgLabel.PackageName, pkgLabel.Subrepo); err == nil {
 					if l.IsAllTargets() || l.IsAllSubpackages() {
 						// Can't emit any useful info for these.
 						// TODO(peterebden): If we know what argument we were in we could emit info


### PR DESCRIPTION
Fixes #743 ; when `$(out_location)` (and probably others too) is used on a tool  of a target that's within a subrepo, it now correctly produces the replacement for a tool.

Actual change is nearly a oneliner (in `command_replacements.go`) but ended up finding it nicer for tests to jiggle around the parsing code a little to avoid having to look up a package.