### PR TITLE
Allow assert statements to take an arbitrary expression after the comma

### DIFF
--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -6,7 +6,7 @@ statement = ( "pass" | "continue" | func_def | for | if | return |
           raise | assert | ident_statement | literal ) EOL;
 return = "return" [ expression { "," expression } ];
 raise = "raise" expression;
-assert = "assert" expression [ "," String ];
+assert = "assert" expression [ "," expression ];
 for = "for" Ident { "," Ident } "in" expression ":" EOL { statement };
 if = "if" expression ":" EOL { statement }
      [ "elif" expression ":" EOL { statement } ]

--- a/src/parse/asp/grammar.go
+++ b/src/parse/asp/grammar.go
@@ -35,7 +35,7 @@ type Statement struct {
 	Raise   *Expression
 	Assert  *struct {
 		Expr    *Expression
-		Message string
+		Message *Expression
 	}
 	Ident    *IdentStatement
 	Literal  *Expression

--- a/src/parse/asp/grammar_parse.go
+++ b/src/parse/asp/grammar_parse.go
@@ -173,9 +173,8 @@ func (p *parser) parseStatement() *Statement {
 		p.l.Next()
 		s.Assert.Expr = p.parseExpression()
 		if p.optional(',') {
-			tok := p.next(String)
-			s.Assert.Message = tok.Value
-			p.endPos = tok.EndPos()
+			s.Assert.Message = p.parseExpression()
+			p.endPos = s.Assert.Message.EndPos
 		}
 		p.next(EOL)
 	default:

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -330,7 +330,9 @@ func (s *scope) interpretStatements(statements []*Statement) pyObject {
 		} else if stmt.Ident != nil {
 			s.interpretIdentStatement(stmt.Ident)
 		} else if stmt.Assert != nil {
-			s.Assert(s.interpretExpression(stmt.Assert.Expr).IsTruthy(), stmt.Assert.Message)
+			if !s.interpretExpression(stmt.Assert.Expr).IsTruthy() {
+				s.Assert(false, s.interpretExpression(stmt.Assert.Message).String())
+			}
 		} else if stmt.Raise != nil {
 			s.Error(s.interpretExpression(stmt.Raise).String())
 		} else if stmt.Literal != nil {

--- a/src/parse/asp/parser_test.go
+++ b/src/parse/asp/parser_test.go
@@ -430,7 +430,7 @@ func TestMultipleActions(t *testing.T) {
 func TestAssert(t *testing.T) {
 	statements, err := newParser().parse("src/parse/asp/test_data/assert.build")
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(statements))
+	assert.Equal(t, 3, len(statements))
 
 	// Test for Endpos
 	assert.Equal(t, 1, statements[0].EndPos.Line)

--- a/src/parse/asp/test_data/assert.build
+++ b/src/parse/asp/test_data/assert.build
@@ -2,3 +2,5 @@ assert isinstance(name, str), "Argument name to cc_library must be a str"
 
 def test_assert():
     assert 1 == 1
+
+assert True, "True is %s" % True

--- a/tools/build_langserver/lsp/lsp_test.go
+++ b/tools/build_langserver/lsp/lsp_test.go
@@ -632,6 +632,8 @@ func (h *Handler) WaitForPackage(pkg string) {
 	for result := range h.state.Results() {
 		if result.Status == core.PackageParsed && result.Label.PackageName == pkg {
 			return
+		} else if h.state.Graph.Package(pkg, "") != nil {
+			return
 		}
 	}
 }


### PR DESCRIPTION
This is cheap enough to support and more useful.