### PR TITLE
Dynamically add shared object deps

### DIFF
--- a/rules/cc_rules.build_defs
+++ b/rules/cc_rules.build_defs
@@ -103,7 +103,6 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
         compiler_flags += ['-fmodules-ts' if CONFIG.CC_MODULES_CLANG else '-fmodules']
     # TODO(pebers): handle includes and defines in _library_cmds as well.
     pre_build = _library_transitive_labels(_c, compiler_flags, pkg_config_libs, pkg_config_cflags) if (deps or includes or defines or _interfaces) else None
-    pkg = package_name()
 
     if _interfaces:
         # Generate the module interface file
@@ -118,7 +117,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
             building_description = 'Compiling...',
             requires = requires,
             test_only = test_only,
-            labels = labels + [f'cc:mod:{pkg}/{name}.pcm'],
+            labels = labels + [f'cc:mod:{pkg_name}/{name}.pcm'],
             tools = tools,
             needs_transitive_deps = True,
         )
@@ -170,7 +169,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
             },
         )
         if alwayslink:
-            labels += [f'cc:al:{pkg}/{name}.a']
+            labels += [f'cc:al:{pkg_name}/{name}.a']
 
         # Filegroup to pick that up with extra deps. This is a little annoying but means that
         # things depending on this get the combined rule and not the individual ones, but do get
@@ -205,7 +204,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
             needs_transitive_deps=True,
         )
         if alwayslink:
-            labels += [f'cc:al:{pkg}/{name}.a']
+            labels += [f'cc:al:{pkg_name}/{name}.a']
         # Need another rule to cover require / provide stuff. This is getting a bit complicated...
         lib_rule = filegroup(
             name = name,
@@ -398,6 +397,7 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
             'cc_hdrs': f':_{name}#lib_hdrs',
             'cc': ':' + name,
         }
+    pkg_name = package_name()
     cmds, tools = _binary_cmds(_c, linker_flags, pkg_config_libs, shared=True)
     return build_rule(
         name=name,
@@ -414,6 +414,10 @@ def cc_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_
         tools=tools,
         test_only=test_only,
         requires=['cc', 'cc_hdrs'],
+        labels = [
+            f'cc:so:-L{pkg_name}',
+            f'cc:so:-l{name}',
+        ],
         pre_build=_binary_transitive_labels(_c, linker_flags, pkg_config_libs, shared=True) if deps else None,
     )
 
@@ -743,6 +747,8 @@ def _binary_transitive_labels(c, linker_flags, pkg_config_libs, shared=False):
         labels = get_labels(name, 'cc:')
         linker_prefix = '' if CONFIG.LINK_WITH_LD_TOOL else '-Wl,'
         flags = [linker_prefix + l[3:] for l in labels if l.startswith('ld:')]
+        if not shared:
+            flags += [linker_prefix + l[3:] for l in labels if l.startswith('so:')]
 
         flags += ['`pkg-config --libs %s`' % l[3:] for l in labels if l.startswith('pc:')]
 

--- a/test/cc_rules/so_deps/BUILD
+++ b/test/cc_rules/so_deps/BUILD
@@ -1,7 +1,7 @@
 cc_shared_object(
     name = "answer",
-    out = "libanswer.so",
     srcs = ["lib.cc"],
+    out = "libanswer.so",
     hdrs = ["lib.h"],
 )
 
@@ -14,10 +14,10 @@ cc_binary(
 
 gentest(
     name = "so_deps_test",
-    test_cmd = "$DATA",
-    no_test_output = True,
     data = [
-        ":bin",
         ":answer",
+        ":bin",
     ],
+    no_test_output = True,
+    test_cmd = "$DATA",
 )

--- a/test/cc_rules/so_deps/BUILD
+++ b/test/cc_rules/so_deps/BUILD
@@ -8,6 +8,7 @@ cc_shared_object(
 cc_binary(
     name = "bin",
     srcs = ["main.cc"],
+    ldflags = ["-rpath='$ORIGIN'"],
     deps = [":answer"],
 )
 

--- a/test/cc_rules/so_deps/BUILD
+++ b/test/cc_rules/so_deps/BUILD
@@ -1,5 +1,6 @@
 cc_shared_object(
-    name = "lib",
+    name = "answer",
+    out = "libanswer.so",
     srcs = ["lib.cc"],
     hdrs = ["lib.h"],
 )
@@ -7,7 +8,7 @@ cc_shared_object(
 cc_binary(
     name = "bin",
     srcs = ["main.cc"],
-    deps = [":lib"],
+    deps = [":answer"],
 )
 
 gentest(
@@ -16,6 +17,6 @@ gentest(
     no_test_output = True,
     data = [
         ":bin",
-        ":lib",
+        ":answer",
     ],
 )

--- a/test/cc_rules/so_deps/BUILD
+++ b/test/cc_rules/so_deps/BUILD
@@ -1,0 +1,21 @@
+cc_shared_object(
+    name = "lib",
+    srcs = ["lib.cc"],
+    hdrs = ["lib.h"],
+)
+
+cc_binary(
+    name = "bin",
+    srcs = ["main.cc"],
+    deps = [":lib"],
+)
+
+gentest(
+    name = "so_deps_test",
+    test_cmd = "$DATA",
+    no_test_output = True,
+    data = [
+        ":bin",
+        ":lib",
+    ],
+)

--- a/test/cc_rules/so_deps/lib.cc
+++ b/test/cc_rules/so_deps/lib.cc
@@ -1,0 +1,3 @@
+int WhatIsTheAnswerToLifeTheUniverseAndEverything() {
+  return 42;
+}

--- a/test/cc_rules/so_deps/lib.h
+++ b/test/cc_rules/so_deps/lib.h
@@ -1,0 +1,2 @@
+// Returns the Answer to the great Question.
+int WhatIsTheAnswerToLifeTheUniverseAndEverything();

--- a/test/cc_rules/so_deps/main.cc
+++ b/test/cc_rules/so_deps/main.cc
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+#include "test/cc_rules/so_deps/lib.h"
+
+int main(int argc, char* argv[]) {
+  printf("%d\n", WhatIsTheAnswerToLifeTheUniverseAndEverything());
+  return 0;
+}


### PR DESCRIPTION
This addresses the request in #734 , that dependencies on `cc_shared_object` should get picked up automatically at build time.

Still some issues though:
 - need to properly exclude own labels from search (the `if not shared` clause isn't really right)
 - default output name for `cc_shared_object` should be `lib{name}.so` not `{name}.so`, right now you
   have to make sure it gets named correctly. Would like to fix but this is a breaking change.
 - need to set RPATH on the resulting binary, or set LD_LIBRARY_PATH when running. Don't think I want to change that implicitly but it's not hard to add to `ldflags`.