### PR TITLE
Introduce PEX_CACHE_DIR envvar to override default

### DIFF
--- a/tools/please_pex/pex_main.py
+++ b/tools/please_pex/pex_main.py
@@ -162,7 +162,7 @@ def pex_basepath(temp=False):
         import tempfile
         return tempfile.mkdtemp(dir=os.environ.get('TEMP_DIR'), prefix='pex_')
     else:
-        return os.path.expanduser('~/.cache/pex')
+        return os.environ.get('PEX_CACHE_DIR',os.path.expanduser('~/.cache/pex'))
 
 
 def pex_uniquedir():


### PR DESCRIPTION
We have identified a scenario launching pex files on AWS Lambda is
failing when launched second and more times.
AWS Lambda reuses interpreter and current setup with zip-unsafe pexes
isn't handled properly, because subsequent invocations override sys.path
again, not to mention that modules have already been loaded and their
physial location removed.

Nonetheless, providing a way to specify cache dir solves this problem --
as we cannot possibly use read-only ~/ dir on lambdas, specifying the
dir ourselves (/tmp/pex in my case) solves the issue. And provides a
little bit more configurability