### PR TITLE
Fix protoc flags being passed twice

### DIFF
--- a/rules/proto_rules.build_defs
+++ b/rules/proto_rules.build_defs
@@ -50,7 +50,7 @@ def proto_library(name:str, srcs:list, deps:list=[], visibility:list=None, label
     outs = {ext_lang: [src.replace('.proto', ext) for src in file_srcs for ext in exts]
                       if plugin['use_file_names'] else []
             for language, plugin in lang_plugins for ext_lang, exts in plugin['extensions'].items()}
-    flags = [' '.join(plugin['protoc_flags']) for plugin in plugins] + protoc_flags
+    flags = [' '.join(plugin['protoc_flags']) for plugin in plugins]
     tools = {lang: plugin.get('tools') for lang, plugin in lang_plugins}
     tools['protoc'] = [CONFIG.PROTOC_TOOL]
     cmd = '$TOOLS_PROTOC ' + ' '.join(flags)
@@ -183,8 +183,8 @@ def _go_path_mapping(grpc):
     return _map_go_paths
 
 
-def proto_language(language:str, extensions:list|dict, func:function, use_file_names:bool=True, protoc_flags:list=None,
-                   tools:list=None, deps:list=None, pre_build:function=None, proto_language:str=''):
+def proto_language(language:str, extensions:list|dict, func:function, use_file_names:bool=True, protoc_flags:list=[],
+                   tools:list=[], deps:list=[], pre_build:function=None, proto_language:str=''):
     """Returns the definition of how to build a particular language for proto_library or grpc_library.
 
     Args:
@@ -211,9 +211,9 @@ def proto_language(language:str, extensions:list|dict, func:function, use_file_n
         'extensions': {language: extensions} if isinstance(extensions, list) else extensions,
         'func': func,
         'use_file_names': use_file_names,
-        'protoc_flags': protoc_flags or [],
-        'tools': tools or [],
-        'deps': deps or [],
+        'protoc_flags': protoc_flags,
+        'tools': tools,
+        'deps': deps,
         'pre_build': pre_build,
     }
 

--- a/test/proto_rules/BUILD
+++ b/test/proto_rules/BUILD
@@ -45,8 +45,8 @@ python_test(
 grpc_library(
     name = "flags_proto",
     srcs = ["flags.proto"],
-    protoc_flags = ["--include_source_info"],
     languages = ["go"],
+    protoc_flags = ["--include_source_info"],
 )
 
 go_test(

--- a/test/proto_rules/BUILD
+++ b/test/proto_rules/BUILD
@@ -41,3 +41,16 @@ python_test(
         ":js_test_proto_filegroup",
     ],
 )
+
+grpc_library(
+    name = "flags_proto",
+    srcs = ["flags.proto"],
+    protoc_flags = ["--include_source_info"],
+    languages = ["go"],
+)
+
+go_test(
+    name = "flags_test",
+    srcs = ["flags_test.go"],
+    deps = [":flags_proto"],
+)

--- a/test/proto_rules/flags.proto
+++ b/test/proto_rules/flags.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+message TestMessage {}

--- a/test/proto_rules/flags_test.go
+++ b/test/proto_rules/flags_test.go
@@ -1,4 +1,4 @@
-package proto_rules
+package flags
 
 import "testing"
 

--- a/test/proto_rules/flags_test.go
+++ b/test/proto_rules/flags_test.go
@@ -1,0 +1,7 @@
+package proto_rules
+
+import "testing"
+
+func TestFlags(t *testing.T) {
+	// Nothing to actually do here, this is a test that it all compiles.
+}


### PR DESCRIPTION
They are applied based on all transitive dependencies (needed in order to make flags like -I work sensibly) but that includes the current rules, so we ended up adding them twice. In most cases we didn't notice but some flags can only be passed once.