### PR TITLE
Changing .pydistutils.cfg to setup.cfg per specs

### DIFF
--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -368,7 +368,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
         # https://github.com/Homebrew/brew/blob/master/docs/Homebrew-and-Python.md suggests fixing with --install-option
         # but that prevents downloading binary wheels. This is more fiddly but seems to work.
         # Unfortunately it does *not* work similarly on the Debian problem :(
-        cmd = 'echo "[install]\nprefix=" > .pydistutils.cfg; ' + cmd
+        cmd = 'echo "[install]\nprefix=" > setup.cfg; ' + cmd
     if CONFIG.OS == 'linux':
         # Fix for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=830892
         # tl;dr: Debian has broken --target with a custom patch, the only way to fix is to pass --system


### PR DESCRIPTION
Oh boy, this caused me some time to find and debug.
We populate [install] prefix= in .pydistutils.cfg file local to
wheel build directory in order to circumvent brew's messed up python.

This, however, didn't work properly for me. Sometime between 14.0.0 and
14.1.7 --isolated has been introduced and it _might_ be the culprit:
see, according to specs we should populate setup.cfg, not
.pydistutils.cfg:

https://github.com/python/cpython/blob/master/Lib/distutils/dist.py#L343

setup.cfg is loaded from cwd, while .pydistutils.cfg is loaded from
$HOME iff --isolated is not specified (and in our case it is)