### PR TITLE
importlib_metadata compatibility

### DIFF
--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -360,7 +360,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
             repo_flag = '-f ' + repo
 
     target = outs[0] if install_subdirectory else '.'
-    
+
     # TODO: This is a total mess on pip's side with --user flag. https://github.com/pypa/pip/issues/1668
     cmd = 'PIP_CONFIG_FILE=/dev/null $TOOLS_PIP install --isolated --no-deps --no-compile --no-cache-dir --default-timeout=60 --target=' + target
     if CONFIG.HOSTOS == 'darwin':
@@ -400,7 +400,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
 
     # TODO(peterebden): --prefix preserves the old behaviour here, but I'm not sure how intuitive that is; leaving it
     #                   out puts everything at the top level of the pex, which is more normal for Python really.
-    cmd += ' && $TOOLS_JARCAT z -d --prefix $PKG_DIR -i ' + ' -i '.join(outs)
+    cmd += ' && $TOOLS_JARCAT z -d --prefix $PKG_DIR -i ' + ' -i '.join(outs) + ' -i *.*-info'
 
     wheel_rule = build_rule(
         name = name,
@@ -426,7 +426,8 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
         name = name,
         srcs = [wheel_rule],
         outs = outs,
-        cmd = '$TOOL x $SRCS -s $PKG_DIR',
+        post_build = _add_dist_info,
+        cmd = '$TOOL x $SRCS -s $PKG_DIR; find . -maxdepth 1 -regex \'.*\.\(dist\|egg\)-info\'',
         tools = [CONFIG.JARCAT_TOOL],
         labels = ['py', 'pip:' + package_name],
         provides = {'py': wheel_rule},
@@ -588,6 +589,12 @@ def _add_licences(name, output):
             found = True
     if not found:
         log.warning('No licence found for %s, should add licences = [...] to the rule', name.lstrip('_').split('#')[0])
+
+def _add_dist_info(name, output):
+    """Add dist-info (or egg-info) folder if present."""
+    for line in output:
+        if line.endswith("-info"):
+            add_out(name, line)
 
 if CONFIG.BAZEL_COMPATIBILITY:
     py_library = python_library

--- a/test/python_rules/BUILD
+++ b/test/python_rules/BUILD
@@ -171,3 +171,13 @@ python_test(
     srcs = ["worker_test.py"],
     worker = "//test/workers:worker",
 )
+
+python_test(
+    name = "importlib_metadata_test",
+    srcs = ["importlib_metadata_test.py"],
+    labels = [
+        "py3",
+        "pip",
+    ],
+    deps = ["//third_party/python:importlib_metadata"],
+)

--- a/test/python_rules/importlib_metadata_test.py
+++ b/test/python_rules/importlib_metadata_test.py
@@ -1,0 +1,22 @@
+import unittest
+
+
+class ImportlibMetadataTest(unittest.TestCase):
+    def test_can_detect_version(self):
+        # This fails  if .dist-info isn't  available for wheels downloaded from
+        # pip
+        from importlib_metadata import version
+
+        self.assertEqual(version("importlib_metadata"), "0.23")
+
+    def test_nonexistant_module(self):
+        from importlib_metadata import distribution, PackageNotFoundError
+
+        with self.assertRaises(PackageNotFoundError):
+            distribution("nonexistant")
+
+    def test_system_module(self):
+        from importlib_metadata import distribution, PackageNotFoundError
+
+        with self.assertRaises(PackageNotFoundError):
+            distribution("sys")

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -231,3 +231,29 @@ pip_library(
     zip_safe = False,
     deps = [":numpy"],
 )
+
+pip_library(
+    name = "importlib_metadata",
+    package_name = "importlib-metadata",
+    licences = ["Apache License, Version 2.0"],
+    test_only = True,
+    version = "0.23",
+    deps = [
+        ":more_itertools",
+        ":zipp",
+    ],
+)
+
+pip_library(
+    name = "zipp",
+    outs = ["zipp.py"],
+    test_only = True,
+    version = "0.6.0",
+)
+
+pip_library(
+    name = "more_itertools",
+    package_name = "more-itertools",
+    test_only = True,
+    version = "7.2.0",
+)


### PR DESCRIPTION
Following #755, add a `find_distributions()` method to `ModuleDirImport` in `pex_main.py`.
This method is required by `importlib_metadata` to find and read metadata.

Fix. #753