### PR TITLE
Make remote client timeout configurable

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -388,13 +388,14 @@ type Configuration struct {
 		Upload          cli.URL      `help:"URL to upload test results to (in XML format)"`
 	}
 	Remote struct {
-		URL          string `help:"URL for the remote server. If this is set but no executors are configured then it can still act as a remote cache."`
-		NumExecutors int    `help:"Maximum number of remote executors to use simultaneously."`
-		Instance     string `help:"Remote instance name to request; depending on the server this may be required."`
-		Name         string `help:"A name for this worker instance. This is attached to artifacts uploaded to remote storage." example:"agent-001"`
-		DisplayURL   string `help:"A URL to browse the remote server with (e.g. using buildbarn-browser). Only used when printing hashes."`
-		ReadOnly     bool   `help:"If true, prevents this client from writing to the remote storage. Is overridden if being used for execution."`
-		HomeDir      string `help:"The home directory on the build machine."`
+		URL          string       `help:"URL for the remote server. If this is set but no executors are configured then it can still act as a remote cache."`
+		NumExecutors int          `help:"Maximum number of remote executors to use simultaneously."`
+		Instance     string       `help:"Remote instance name to request; depending on the server this may be required."`
+		Name         string       `help:"A name for this worker instance. This is attached to artifacts uploaded to remote storage." example:"agent-001"`
+		DisplayURL   string       `help:"A URL to browse the remote server with (e.g. using buildbarn-browser). Only used when printing hashes."`
+		Timeout      cli.Duration `help:"Timeout for connections made to the remote server."`
+		ReadOnly     bool         `help:"If true, prevents this client from writing to the remote storage. Is overridden if being used for execution."`
+		HomeDir      string       `help:"The home directory on the build machine."`
 	} `help:"Settings related to remote execution & caching using the Google remote execution APIs. This section is still experimental and subject to change."`
 	Size  map[string]*Size `help:"Named sizes of targets; these are the definitions of what can be passed to the 'size' argument."`
 	Cover struct {

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -309,6 +309,7 @@ func DefaultConfiguration() *Configuration {
 	config.Proto.PythonGrpcDep = "//third_party/python:grpc"
 	config.Proto.JavaGrpcDep = "//third_party/java:grpc-all"
 	config.Proto.GoGrpcDep = "//third_party/go:grpc"
+	config.Remote.Timeout = cli.Duration(2 * time.Minute)
 	config.Bazel.Compatibility = usingBazelWorkspace
 	return &config
 }

--- a/src/remote/blobs.go
+++ b/src/remote/blobs.go
@@ -59,7 +59,7 @@ func (c *Client) uploadBlobs(f func(ch chan<- *blob) error) error {
 			req.BlobDigests[i] = b.Digest
 			m[b.Digest.Hash] = b
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), reqTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), c.reqTimeout)
 		defer cancel()
 		resp, err := c.storageClient.FindMissingBlobs(ctx, req)
 		if err != nil {
@@ -149,7 +149,7 @@ func (c *Client) reallyUploadBlobs(ch <-chan *blob) error {
 
 // sendBlobs dispatches a set of blobs to the remote CAS server.
 func (c *Client) sendBlobs(reqs []*pb.BatchUpdateBlobsRequest_Request) error {
-	ctx, cancel := context.WithTimeout(context.Background(), reqTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), c.reqTimeout)
 	defer cancel()
 	resp, err := c.storageClient.BatchUpdateBlobs(ctx, &pb.BatchUpdateBlobsRequest{
 		InstanceName: c.instance,
@@ -171,7 +171,7 @@ func (c *Client) sendBlobs(reqs []*pb.BatchUpdateBlobsRequest_Request) error {
 
 // receiveBlobs retrieves a set of blobs from the remote CAS server.
 func (c *Client) receiveBlobs(digests []*pb.Digest, filenames map[string]string, modes map[string]os.FileMode) error {
-	ctx, cancel := context.WithTimeout(context.Background(), reqTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), c.reqTimeout)
 	defer cancel()
 	resp, err := c.storageClient.BatchReadBlobs(ctx, &pb.BatchReadBlobsRequest{
 		InstanceName: c.instance,
@@ -216,7 +216,7 @@ func (c *Client) storeByteStream(b *blob) error {
 
 func (c *Client) reallyStoreByteStream(b *blob, r io.ReadSeeker) error {
 	name := c.byteStreamUploadName(b.Digest)
-	ctx, cancel := context.WithTimeout(context.Background(), reqTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), c.reqTimeout)
 	defer cancel()
 	stream, err := c.bsClient.Write(ctx)
 	if err != nil {
@@ -325,7 +325,7 @@ func (c *Client) retrieveByteStream(b *blob) error {
 
 // readByteStream returns a reader for a bytestream for the given digest.
 func (c *Client) readByteStream(digest *pb.Digest) (io.ReadCloser, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), reqTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), c.reqTimeout)
 	stream, err := c.bsClient.Read(ctx, &bs.ReadRequest{
 		ResourceName: c.byteStreamDownloadName(digest),
 	})

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -334,7 +334,7 @@ func (c *Client) Retrieve(target *core.BuildTarget) (*core.BuildMetadata, error)
 			return nil, fmt.Errorf("Failed to remove output: %s", err)
 		}
 	}
-	if err := c.downloadBlobs(func(ch chan<- *blob) error {
+	if err := c.downloadBlobs(ctx, func(ch chan<- *blob) error {
 		defer close(ch)
 		for _, file := range resp.OutputFiles {
 			filePath := path.Join(outDir, file.Path)


### PR DESCRIPTION
Was digging into why a please job is hanging downloading artifacts from the rex cache; this won't fix it but seemed like a useful addition regardless.