### PR TITLE
Special-case filegroups for remote execution

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -253,7 +253,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 	checkLicences(state, target)
 
 	if runRemotely {
-		if state.IsOriginalTarget(target.Label) {
+		if state.IsOriginalTarget(target.Label) || target.NeededForSubinclude {
 			state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Downloading")
 			if _, err := state.RemoteClient.Retrieve(target); err != nil {
 				return fmt.Errorf("Failed to retrieve outputs for %s: %s", target.Label, err)

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -118,88 +118,6 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 	if target.IsHashFilegroup {
 		updateHashFilegroupPaths(state, target)
 	}
-	// We don't record rule hashes for filegroups since we know the implementation and the check
-	// is just "are these the same file" which we do anyway, and it means we don't have to worry
-	// about two rules outputting the same file.
-	haveRunPostBuildFunction := false
-	if !target.IsFilegroup && !needsBuilding(state, target, false) {
-		log.Debug("Not rebuilding %s, nothing's changed", target.Label)
-		if target.PostBuildFunction != nil {
-			postBuildOutput, err := loadPostBuildOutput(target)
-			if err != nil {
-				log.Warning("Missing post-build output for %s; will rebuild.", target.Label)
-			} else if err := runPostBuildFunction(tid, state, target, postBuildOutput, ""); err != nil {
-				log.Warning("Error from post-build function for %s: %s; will rebuild", target.Label, err)
-			}
-		}
-		// If a post-build function ran it may modify the rule definition. In that case we
-		// need to check again whether the rule needs building.
-		if target.PostBuildFunction == nil || !needsBuilding(state, target, true) {
-			if target.IsFilegroup {
-				// Small optimisation to ensure we don't need to rehash things unnecessarily.
-				copyFilegroupHashes(state, target)
-			}
-			target.SetState(core.Reused)
-			state.LogBuildResult(tid, target.Label, core.TargetCached, "Unchanged")
-			buildLinks(state, target)
-			return nil // Nothing needs to be done.
-		}
-		log.Debug("Rebuilding %s after post-build function", target.Label)
-		haveRunPostBuildFunction = true
-	}
-	if target.IsFilegroup {
-		log.Debug("Building %s...", target.Label)
-		if changed, err := buildFilegroup(state, target); err != nil {
-			return err
-		} else if _, err := calculateAndCheckRuleHash(state, target); err != nil {
-			return err
-		} else if changed {
-			target.SetState(core.Built)
-			state.LogBuildResult(tid, target.Label, core.TargetBuilt, "Built")
-		} else {
-			target.SetState(core.Unchanged)
-			state.LogBuildResult(tid, target.Label, core.TargetCached, "Unchanged")
-		}
-		buildLinks(state, target)
-		return nil
-	}
-	if err := prepareDirectories(target); err != nil {
-		return fmt.Errorf("Error preparing directories for %s: %s", target.Label, err)
-	}
-
-	oldOutputHash, outputHashErr := state.TargetHasher.OutputHash(target)
-	retrieveArtifacts := func() bool {
-		// If there aren't any outputs, we don't have to do anything right now.
-		// Checks later will handle the case of something with a post-build function that
-		// later tries to add more outputs.
-		if len(target.DeclaredOutputs()) == 0 && len(target.DeclaredNamedOutputs()) == 0 {
-			target.SetState(core.Unchanged)
-			state.LogBuildResult(tid, target.Label, core.TargetCached, "Nothing to do")
-			return true
-		}
-		state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Checking cache...")
-
-		if state.Cache.Retrieve(target, mustShortTargetHash(state, target), target.Outputs()) != nil {
-			log.Debug("Retrieved artifacts for %s from cache", target.Label)
-			checkLicences(state, target)
-			newOutputHash, err := calculateAndCheckRuleHash(state, target)
-			if err != nil { // Most likely hash verification failure
-				log.Warning("Error retrieving cached artifacts for %s: %s", target.Label, err)
-				RemoveOutputs(target)
-				return false
-			} else if outputHashErr != nil || !bytes.Equal(oldOutputHash, newOutputHash) {
-				target.SetState(core.Cached)
-				state.LogBuildResult(tid, target.Label, core.TargetCached, "Cached")
-			} else {
-				target.SetState(core.Unchanged)
-				state.LogBuildResult(tid, target.Label, core.TargetCached, "Cached (unchanged)")
-			}
-			buildLinks(state, target)
-			return true // got from cache
-		}
-		log.Debug("Nothing retrieved from remote cache for %s", target.Label)
-		return false
-	}
 	var cacheKey, out []byte
 	if runRemotely {
 		m, err := state.RemoteClient.Build(tid, target)
@@ -208,6 +126,88 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 		}
 		out = m.Stdout
 	} else {
+		// We don't record rule hashes for filegroups since we know the implementation and the check
+		// is just "are these the same file" which we do anyway, and it means we don't have to worry
+		// about two rules outputting the same file.
+		haveRunPostBuildFunction := false
+		if !target.IsFilegroup && !needsBuilding(state, target, false) {
+			log.Debug("Not rebuilding %s, nothing's changed", target.Label)
+			if target.PostBuildFunction != nil {
+				postBuildOutput, err := loadPostBuildOutput(target)
+				if err != nil {
+					log.Warning("Missing post-build output for %s; will rebuild.", target.Label)
+				} else if err := runPostBuildFunction(tid, state, target, postBuildOutput, ""); err != nil {
+					log.Warning("Error from post-build function for %s: %s; will rebuild", target.Label, err)
+				}
+			}
+			// If a post-build function ran it may modify the rule definition. In that case we
+			// need to check again whether the rule needs building.
+			if target.PostBuildFunction == nil || !needsBuilding(state, target, true) {
+				if target.IsFilegroup {
+					// Small optimisation to ensure we don't need to rehash things unnecessarily.
+					copyFilegroupHashes(state, target)
+				}
+				target.SetState(core.Reused)
+				state.LogBuildResult(tid, target.Label, core.TargetCached, "Unchanged")
+				buildLinks(state, target)
+				return nil // Nothing needs to be done.
+			}
+			log.Debug("Rebuilding %s after post-build function", target.Label)
+			haveRunPostBuildFunction = true
+		}
+		if target.IsFilegroup {
+			log.Debug("Building %s...", target.Label)
+			if changed, err := buildFilegroup(state, target); err != nil {
+				return err
+			} else if _, err := calculateAndCheckRuleHash(state, target); err != nil {
+				return err
+			} else if changed {
+				target.SetState(core.Built)
+				state.LogBuildResult(tid, target.Label, core.TargetBuilt, "Built")
+			} else {
+				target.SetState(core.Unchanged)
+				state.LogBuildResult(tid, target.Label, core.TargetCached, "Unchanged")
+			}
+			buildLinks(state, target)
+			return nil
+		}
+		if err := prepareDirectories(target); err != nil {
+			return fmt.Errorf("Error preparing directories for %s: %s", target.Label, err)
+		}
+
+		oldOutputHash, outputHashErr := state.TargetHasher.OutputHash(target)
+		retrieveArtifacts := func() bool {
+			// If there aren't any outputs, we don't have to do anything right now.
+			// Checks later will handle the case of something with a post-build function that
+			// later tries to add more outputs.
+			if len(target.DeclaredOutputs()) == 0 && len(target.DeclaredNamedOutputs()) == 0 {
+				target.SetState(core.Unchanged)
+				state.LogBuildResult(tid, target.Label, core.TargetCached, "Nothing to do")
+				return true
+			}
+			state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Checking cache...")
+
+			if state.Cache.Retrieve(target, mustShortTargetHash(state, target), target.Outputs()) != nil {
+				log.Debug("Retrieved artifacts for %s from cache", target.Label)
+				checkLicences(state, target)
+				newOutputHash, err := calculateAndCheckRuleHash(state, target)
+				if err != nil { // Most likely hash verification failure
+					log.Warning("Error retrieving cached artifacts for %s: %s", target.Label, err)
+					RemoveOutputs(target)
+					return false
+				} else if outputHashErr != nil || !bytes.Equal(oldOutputHash, newOutputHash) {
+					target.SetState(core.Cached)
+					state.LogBuildResult(tid, target.Label, core.TargetCached, "Cached")
+				} else {
+					target.SetState(core.Unchanged)
+					state.LogBuildResult(tid, target.Label, core.TargetCached, "Cached (unchanged)")
+				}
+				buildLinks(state, target)
+				return true // got from cache
+			}
+			log.Debug("Nothing retrieved from remote cache for %s", target.Label)
+			return false
+		}
 		cacheKey = mustShortTargetHash(state, target)
 		if state.Cache != nil && !runRemotely {
 			// Note that ordering here is quite sensitive since the post-build function can modify

--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -75,6 +75,7 @@ var KnownFields = map[string]bool{
 	"BuildingDescription": true,
 	"ShowProgress":        true,
 	"Progress":            true,
+	"NeededForSubinclude": true,
 
 	// Used to save the rule hash rather than actually being hashed itself.
 	"RuleHash": true,

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -115,6 +115,9 @@ type BuildTarget struct {
 	Stamp bool
 	// If true, the target must be run locally (i.e. is not compatible with remote execution).
 	Local bool
+	// If true, the target is needed for a subinclude and therefore we will have to make sure its
+	// outputs are available locally when built.
+	NeededForSubinclude bool
 	// Marks the target as a filegroup.
 	IsFilegroup bool `print:"false"`
 	// Marks the target as a hash_filegroup.

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -397,6 +397,7 @@ type Configuration struct {
 		Timeout      cli.Duration `help:"Timeout for connections made to the remote server."`
 		ReadOnly     bool         `help:"If true, prevents this client from writing to the remote storage. Is overridden if being used for execution."`
 		HomeDir      string       `help:"The home directory on the build machine."`
+		Platform     []string     `help:"Platform properties to request from remote workers, in the format key=value."`
 	} `help:"Settings related to remote execution & caching using the Google remote execution APIs. This section is still experimental and subject to change."`
 	Size  map[string]*Size `help:"Named sizes of targets; these are the definitions of what can be passed to the 'size' argument."`
 	Cover struct {

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -694,6 +694,7 @@ func (state *BuildState) QueueTarget(label, dependent BuildLabel, rescan, forceB
 	if !target.SyncUpdateState(Inactive, Semiactive) && !rescan && !forceBuild {
 		return nil
 	}
+	target.NeededForSubinclude = forceBuild
 	if state.NeedBuild || forceBuild {
 		if target.SyncUpdateState(Semiactive, Active) {
 			state.AddActiveTarget()

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -50,9 +50,7 @@ func createTarget(s *scope, args []pyObject) *core.BuildTarget {
 	target.TestOnly = test || isTruthy(15)
 	target.ShowProgress = isTruthy(36)
 	target.IsRemoteFile = isTruthy(38)
-	// TODO(peterebden): temporarily forcing remote files to be built locally, but we should
-	//                   have a better solution for this.
-	target.Local = isTruthy(41) || target.IsRemoteFile
+	target.Local = isTruthy(41)
 
 	var size *core.Size
 	if args[37] != None {

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -58,16 +58,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 	files, dirs := outputs(target)
 	cmd, err := core.ReplaceSequences(c.state, target, c.getCommand(target))
 	return &pb.Command{
-		Platform: &pb.Platform{
-			Properties: []*pb.Platform_Property{
-				{
-					Name:  "OSFamily",
-					Value: translateOS(target.Subrepo),
-				},
-				// We don't really keep information around about ISA. Can look at adding
-				// that later if it becomes relevant & interesting.
-			},
-		},
+		Platform: c.platform,
 		// We have to run everything through bash since our commands are arbitrary.
 		// Unfortunately we can't just say "bash", we need an absolute path which is
 		// a bit weird since it assumes that our absolute path is the same as the

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -216,7 +216,7 @@ func (c *Client) uploadInputs(ch chan<- *blob, target *core.BuildTarget, isTest,
 			if o := c.targetOutputs(*l); o == nil {
 				if c.remoteExecution {
 					// Classic "we shouldn't get here" stuff
-					return nil, fmt.Errorf("Outputs not known for %s (should be built by now)", target)
+					return nil, fmt.Errorf("Outputs not known for %s (should be built by now)", *l)
 				}
 			} else {
 				pkgName := l.PackageName

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -204,126 +204,100 @@ func (c *Client) digestDir(dir string, children []*pb.Directory) (*pb.Directory,
 }
 
 // buildInputRoot constructs the directory that is the input root and optionally uploads it.
-func (c *Client) buildInputRoot(target *core.BuildTarget, upload, isTest bool) (*pb.Directory, error) {
-	// This is pretty awkward; we need to recursively build this whole set of directories
-	// which does not match up to how we represent it (which is a series of files, with
-	// no corresponding directories, that are not usefully ordered for this purpose).
-	// We also need to handle the case of existing targets where we already know the
-	// directory structure but may not have the files physically on disk.
-	dirs := map[string]*pb.Directory{}
-	root := &pb.Directory{}
-	dirs["."] = root // Ensure the root is in there
-	dirs[""] = root  // Some things might try to name it this way
-
-	var ensureDirExists func(string, string) *pb.Directory
-	ensureDirExists = func(dir, child string) *pb.Directory {
-		if dir == "." || dir == "/" {
-			return root
-		}
-		dir = strings.TrimSuffix(dir, "/")
-		d, present := dirs[dir]
-		if !present {
-			d = &pb.Directory{}
-			dirs[dir] = d
-			dir, base := path.Split(dir)
-			ensureDirExists(dir, base)
-		}
-		// TODO(peterebden): The linear scan in hasChild is a bit suboptimal, we should
-		//                   really use the dirs map to determine this.
-		if child != "" && !hasChild(d, child) {
-			d.Directories = append(d.Directories, &pb.DirectoryNode{Name: child})
-		}
-		return d
-	}
-
-	err := c.uploadBlobs(func(ch chan<- *blob) error {
+func (c *Client) buildInputRoot(target *core.BuildTarget, upload, isTest bool) (root *pb.Directory, err error) {
+	c.uploadBlobs(func(ch chan<- *blob) error {
 		defer close(ch)
-		for input := range c.iterInputs(target, isTest) {
-			l := input.Label()
-			if l != nil {
-				if o := c.targetOutputs(*l); o != nil {
-					d := ensureDirExists(l.PackageName, "")
-					d.Files = append(d.Files, o.Files...)
-					d.Directories = append(d.Directories, o.Directories...)
-					d.Symlinks = append(d.Symlinks, o.Symlinks...)
-					continue
-				}
-				// If we get here we haven't built the target before. That is at least
-				// potentially OK - assume it has been built locally.
-			}
-			executable := l != nil && c.state.Graph.TargetOrDie(*l).IsBinary
-			fullPaths := input.FullPaths(c.state.Graph)
-			for i, out := range input.Paths(c.state.Graph) {
-				in := fullPaths[i]
-				if err := fs.Walk(in, func(name string, isDir bool) error {
-					if isDir {
-						return nil // nothing to do
-					}
-					dest := path.Join(out, name[len(in):])
-					d := ensureDirExists(path.Dir(dest), "")
-					// Now handle the file itself
-					info, err := os.Lstat(name)
-					if err != nil {
-						return err
-					}
-					if info.Mode()&os.ModeSymlink != 0 {
-						link, err := os.Readlink(name)
-						if err != nil {
-							return err
-						}
-						d.Symlinks = append(d.Symlinks, &pb.SymlinkNode{
-							Name:   path.Base(dest),
-							Target: link,
-						})
-						return nil
-					}
-					h, err := c.state.PathHasher.Hash(name, false, true)
-					if err != nil {
-						return err
-					}
-					digest := &pb.Digest{
-						Hash:      hex.EncodeToString(h),
-						SizeBytes: info.Size(),
-					}
-					d.Files = append(d.Files, &pb.FileNode{
-						Name:         path.Base(dest),
-						Digest:       digest,
-						IsExecutable: executable,
-					})
-					if upload {
-						ch <- &blob{
-							File:   name,
-							Digest: digest,
-						}
-					}
-					return nil
-				}); err != nil {
-					return err
-				}
-			}
+		if upload {
+			root, err = c.uploadInputs(ch, target, isTest, false)
+		} else {
+			root, err = c.uploadInputs(nil, target, isTest, false)
 		}
-		// Now the protos are complete we need to calculate all the digests...
-		var dfs func(string) *pb.Digest
-		dfs = func(name string) *pb.Digest {
-			dir := dirs[name]
-			for _, d := range dir.Directories {
-				if d.Digest == nil { // It's not nil if we're reusing outputs from an earlier call.
-					d.Digest = dfs(path.Join(name, d.Name))
-				}
-			}
-			digest, contents := c.digestMessageContents(dir)
-			if upload {
-				ch <- &blob{
-					Digest: digest,
-					Data:   contents,
-				}
-			}
-			return digest
-		}
-		dfs(".")
 		return nil
 	})
-	return root, err
+	return
+}
+
+// uploadInputs finds and uploads a set of inputs from a target.
+func (c *Client) uploadInputs(ch chan<- *blob, target *core.BuildTarget, isTest, useTargetPackage bool) (*pb.Directory, error) {
+	b := newDirBuilder(c)
+	for input := range c.iterInputs(target, isTest) {
+		if l := input.Label(); l != nil {
+			o := c.targetOutputs(*l)
+			if o == nil {
+				// Classic "we shouldn't get here" stuff
+				return nil, fmt.Errorf("Outputs not known for %s (should be built by now)", target)
+			}
+			pkgName := l.PackageName
+			if useTargetPackage {
+				pkgName = target.Label.PackageName
+			}
+			d := b.Dir(pkgName)
+			d.Files = append(d.Files, o.Files...)
+			d.Directories = append(d.Directories, o.Directories...)
+			d.Symlinks = append(d.Symlinks, o.Symlinks...)
+		} else if err := c.uploadInput(b, ch, input); err != nil {
+			return nil, err
+		}
+	}
+	if useTargetPackage {
+		b.Root(ch)
+		return b.Dir(target.Label.PackageName), nil
+	}
+	return b.Root(ch), nil
+}
+
+// uploadInput finds and uploads a single input.
+func (c *Client) uploadInput(b *dirBuilder, ch chan<- *blob, input core.BuildInput) error {
+	fullPaths := input.FullPaths(c.state.Graph)
+	for i, out := range input.Paths(c.state.Graph) {
+		in := fullPaths[i]
+		if err := fs.Walk(in, func(name string, isDir bool) error {
+			if isDir {
+				return nil // nothing to do
+			}
+			dest := path.Join(out, name[len(in):])
+			d := b.Dir(path.Dir(dest))
+			// Now handle the file itself
+			info, err := os.Lstat(name)
+			if err != nil {
+				return err
+			}
+			if info.Mode()&os.ModeSymlink != 0 {
+				link, err := os.Readlink(name)
+				if err != nil {
+					return err
+				}
+				d.Symlinks = append(d.Symlinks, &pb.SymlinkNode{
+					Name:   path.Base(dest),
+					Target: link,
+				})
+				return nil
+			}
+			h, err := c.state.PathHasher.Hash(name, false, true)
+			if err != nil {
+				return err
+			}
+			digest := &pb.Digest{
+				Hash:      hex.EncodeToString(h),
+				SizeBytes: info.Size(),
+			}
+			d.Files = append(d.Files, &pb.FileNode{
+				Name:         path.Base(dest),
+				Digest:       digest,
+				IsExecutable: info.Mode()&0100 != 0,
+			})
+			if ch != nil {
+				ch <- &blob{
+					File:   name,
+					Digest: digest,
+				}
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // iterInputs yields all the input files needed for a target.

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -120,13 +120,12 @@ func (c *Client) buildTestCommand(target *core.BuildTarget) (*pb.Command, error)
 // getCommand returns the appropriate command to use for a target.
 func (c *Client) getCommand(target *core.BuildTarget) string {
 	if target.IsRemoteFile {
-		// This is not a real command, but we need to encode the URLs into the action somehow
-		// to force it to be distinct from other remote_file rules.
+		// TODO(peterebden): we should handle this using the Remote Fetch API once that's available.
 		srcs := make([]string, len(target.Sources))
 		for i, s := range target.Sources {
 			srcs[i] = s.String()
 		}
-		return "plz_fetch " + strings.Join(srcs, " ")
+		return "curl -fsSLo $OUT " + strings.Join(srcs, " ")
 	}
 	return target.GetCommand(c.state)
 }

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -385,6 +385,10 @@ func (c *Client) Build(tid int, target *core.BuildTarget) (*core.BuildMetadata, 
 	if err := c.CheckInitialised(); err != nil {
 		return nil, err
 	}
+	if target.IsFilegroup {
+		// Filegroups get special-cased since they are just a movement of files.
+		return &core.BuildMetadata{}, c.setFilegroupOutputs(target)
+	}
 	command, digest, err := c.uploadAction(target, true, false)
 	if err != nil {
 		return nil, err

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -65,6 +65,9 @@ type Client struct {
 
 	// True if we are doing proper remote execution (false if we are caching only)
 	remoteExecution bool
+	// Platform properties that we will request from the remote.
+	// TODO(peterebden): this will need some modification for cross-compiling support.
+	platform *pb.Platform
 
 	// Cache this for later
 	bashPath string
@@ -153,6 +156,7 @@ func (c *Client) init() {
 				}
 				c.execClient = pb.NewExecutionClient(conn)
 				c.remoteExecution = true
+				c.platform = convertPlatform(c.state.Config)
 				log.Debug("Remote execution client initialised for execution")
 			} else {
 				log.Fatalf("Remote execution is configured but the build server doesn't support it")

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -63,6 +63,9 @@ type Client struct {
 	cacheWritable     bool
 	canBatchBlobReads bool // This isn't supported by all servers.
 
+	// True if we are doing proper remote execution (false if we are caching only)
+	remoteExecution bool
+
 	// Cache this for later
 	bashPath string
 }
@@ -149,6 +152,7 @@ func (c *Client) init() {
 					return fmt.Errorf("Remote execution not enabled for this server")
 				}
 				c.execClient = pb.NewExecutionClient(conn)
+				c.remoteExecution = true
 				log.Debug("Remote execution client initialised for execution")
 			} else {
 				log.Fatalf("Remote execution is configured but the build server doesn't support it")

--- a/src/remote/remote_test.go
+++ b/src/remote/remote_test.go
@@ -80,7 +80,9 @@ func TestStoreAndRetrieveDir(t *testing.T) {
 	target.AddLabel(core.TestResultsDirLabel)
 	target.AddOutput("target2")
 	c.state.Graph.AddTarget(target)
-	err := c.Store(target, &core.BuildMetadata{
+	err := c.Store(target, &core.BuildMetadata{}, target.Outputs())
+	assert.NoError(t, err)
+	err = c.Store(target, &core.BuildMetadata{
 		Stdout: []byte("test stdout"),
 		Test:   true,
 	}, []string{
@@ -152,6 +154,8 @@ func TestExecuteTest(t *testing.T) {
 	target.IsTest = true
 	target.IsBinary = true
 	target.SetState(core.Building)
+	err := c.Store(target, &core.BuildMetadata{}, target.Outputs())
+	assert.NoError(t, err)
 	c.state.Graph.AddTarget(target)
 	_, results, coverage, err := c.Test(0, target)
 	assert.NoError(t, err)
@@ -168,6 +172,8 @@ func TestExecuteTestWithCoverage(t *testing.T) {
 	target.TestCommand = "$TEST"
 	target.IsTest = true
 	target.IsBinary = true
+	err := c.Store(target, &core.BuildMetadata{}, target.Outputs())
+	assert.NoError(t, err)
 	target.SetState(core.Built)
 	c.state.Graph.AddTarget(target)
 	_, results, coverage, err := c.Test(0, target)

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -81,6 +81,18 @@ func (c *Client) setOutputs(label core.BuildLabel, ar *pb.ActionResult) error {
 	return nil
 }
 
+// setFilegroupOutputs sets the outputs for a filegroup from its inputs.
+func (c *Client) setFilegroupOutputs(target *core.BuildTarget) error {
+	return c.uploadBlobs(func(ch chan<- *blob) error {
+		defer close(ch)
+		dir, err := c.uploadInputs(ch, target, false, true)
+		c.outputMutex.Lock()
+		defer c.outputMutex.Unlock()
+		c.outputs[target.Label] = dir
+		return err
+	})
+}
+
 // digestMessage calculates the digest of a proto message as described in the
 // Digest message's comments.
 func (c *Client) digestMessage(msg proto.Message) *pb.Digest {
@@ -255,4 +267,78 @@ func outputs(target *core.BuildTarget) (files, dirs []string) {
 		}
 	}
 	return files, dirs
+}
+
+// A dirBuilder is for helping build up a tree of Directory protos.
+//
+// This is pretty awkward; we need to recursively build a whole set of directories
+// which does not match up to how we represent it (which is a series of files, with
+// no corresponding directories, that are not usefully ordered for this purpose).
+// We also need to handle the case of existing targets where we already know the
+// directory structure but may not have the files physically on disk.
+type dirBuilder struct {
+	c    *Client
+	root *pb.Directory
+	dirs map[string]*pb.Directory
+}
+
+func newDirBuilder(c *Client) *dirBuilder {
+	root := &pb.Directory{}
+	return &dirBuilder{
+		dirs: map[string]*pb.Directory{
+			".": root, // Ensure the root is in there
+			"":  root, // Some things might try to name it this way
+		},
+		root: root,
+		c:    c,
+	}
+}
+
+// Dir ensures the given directory exists, and constructs any necessary parents.
+func (b *dirBuilder) Dir(name string) *pb.Directory {
+	return b.dir(name, "")
+}
+
+func (b *dirBuilder) dir(dir, child string) *pb.Directory {
+	if dir == "." || dir == "/" {
+		return b.root
+	}
+	dir = strings.TrimSuffix(dir, "/")
+	d, present := b.dirs[dir]
+	if !present {
+		d = &pb.Directory{}
+		b.dirs[dir] = d
+		dir, base := path.Split(dir)
+		b.dir(dir, base)
+	}
+	// TODO(peterebden): The linear scan in hasChild is a bit suboptimal, we should
+	//                   really use the dirs map to determine this.
+	if child != "" && !hasChild(d, child) {
+		d.Directories = append(d.Directories, &pb.DirectoryNode{Name: child})
+	}
+	return d
+}
+
+// Root returns the root directory, calculates the digests of all others and uploads them
+// if the given channel is not nil.
+func (b *dirBuilder) Root(ch chan<- *blob) *pb.Directory {
+	b.dfs(".", ch)
+	return b.root
+}
+
+func (b *dirBuilder) dfs(name string, ch chan<- *blob) *pb.Digest {
+	dir := b.dirs[name]
+	for _, d := range dir.Directories {
+		if d.Digest == nil { // It's not nil if we're reusing outputs from an earlier call.
+			d.Digest = b.dfs(path.Join(name, d.Name), ch)
+		}
+	}
+	digest, contents := b.c.digestMessageContents(dir)
+	if ch != nil {
+		ch <- &blob{
+			Digest: digest,
+			Data:   contents,
+		}
+	}
+	return digest
 }

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -358,3 +358,14 @@ func convertPlatform(config *core.Configuration) *pb.Platform {
 	}
 	return platform
 }
+
+// removeOutputs removes all outputs for a target.
+func removeOutputs(target *core.BuildTarget) error {
+	outDir := target.OutDir()
+	for _, out := range target.Outputs() {
+		if err := os.RemoveAll(path.Join(outDir, out)); err != nil {
+			return fmt.Errorf("Failed to remove output for %s: %s", target, err)
+		}
+	}
+	return nil
+}

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -342,3 +342,19 @@ func (b *dirBuilder) dfs(name string, ch chan<- *blob) *pb.Digest {
 	}
 	return digest
 }
+
+// convertPlatform converts the platform entries from the config into a Platform proto.
+func convertPlatform(config *core.Configuration) *pb.Platform {
+	platform := &pb.Platform{}
+	for _, p := range config.Remote.Platform {
+		if parts := strings.SplitN(p, "=", 2); len(parts) == 2 {
+			platform.Properties = append(platform.Properties, &pb.Platform_Property{
+				Name:  parts[0],
+				Value: parts[1],
+			})
+		} else {
+			log.Warning("Invalid config setting in remote.platform %s; will ignore", p)
+		}
+	}
+	return platform
+}


### PR DESCRIPTION
Since they do not have an actual command to run, we can handle them locally by just copying stuff about. Needed a bit of refactoring to share some logic.

Also fixes a few other things; makes platform requests configurable (have some vague long-term plans there) and in general moves towards a "nothing local" setup when executing remotely.