### PR TITLE
Provide the well-known types out of the protoc_binary build rule.

### DIFF
--- a/rules/proto_rules.build_defs
+++ b/rules/proto_rules.build_defs
@@ -430,6 +430,19 @@ def protoc_binary(name, version, hashes=None, deps=None, visibility=None):
         hashes = hashes,
         deps = deps,
     )
+    # The well-known types are included in the same zipfile.
+    wkt = build_rule(
+        name = name,
+        tag = 'wkt',
+        srcs = [download_rule],
+        outs = ['google'],
+        tools = [CONFIG.JARCAT_TOOL],
+        cmd = '$TOOL x $SRCS --strip_prefix include',
+        labels = [
+            'protoc:-I$TMP_DIR/' + package_name(),
+            'protoc:-I$TMP_DIR',
+        ],
+    )
     return genrule(
         name = name,
         srcs = [download_rule],
@@ -438,4 +451,5 @@ def protoc_binary(name, version, hashes=None, deps=None, visibility=None):
         binary = True,
         cmd = '$TOOL x $SRCS bin/protoc',
         visibility = visibility,
+        provides = {'proto': wkt},
     )

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -787,11 +787,14 @@ func (target *BuildTarget) AddProvide(language string, label BuildLabel) {
 func (target *BuildTarget) ProvideFor(other *BuildTarget) []BuildLabel {
 	ret := []BuildLabel{}
 	if target.Provides != nil {
-		// Never do this if the other target has a data dependency on us.
+		// Never do this if the other target has a data or tool dependency on us.
 		for _, data := range other.Data {
 			if label := data.Label(); label != nil && *label == target.Label {
 				return []BuildLabel{target.Label}
 			}
+		}
+		if other.IsTool(target.Label) {
+			return []BuildLabel{target.Label}
 		}
 		for _, require := range other.Requires {
 			if label, present := target.Provides[require]; present {

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -786,7 +786,7 @@ func (target *BuildTarget) AddProvide(language string, label BuildLabel) {
 // ProvideFor returns the build label that we'd provide for the given target.
 func (target *BuildTarget) ProvideFor(other *BuildTarget) []BuildLabel {
 	ret := []BuildLabel{}
-	if target.Provides != nil {
+	if target.Provides != nil && len(other.Requires) != 0 {
 		// Never do this if the other target has a data or tool dependency on us.
 		for _, data := range other.Data {
 			if label := data.Label(); label != nil && *label == target.Label {

--- a/src/core/graph.go
+++ b/src/core/graph.go
@@ -246,8 +246,7 @@ func (graph *BuildGraph) AllDependenciesResolved(target *BuildTarget) bool {
 // point, but some of the dependencies may not yet exist.
 func (graph *BuildGraph) linkDependencies(fromTarget, toTarget *BuildTarget) {
 	for _, label := range toTarget.ProvideFor(fromTarget) {
-		target, present := graph.targets[label]
-		if present {
+		if target, present := graph.targets[label]; present {
 			fromTarget.resolveDependency(toTarget.Label, target)
 			graph.revDeps[label] = append(graph.revDeps[label], fromTarget)
 		} else {

--- a/tools/jarcat/zip/writer.go
+++ b/tools/jarcat/zip/writer.go
@@ -333,6 +333,7 @@ func (f *File) AddInitPyFiles() error {
 	}
 	sort.Strings(s)
 	for _, p := range s {
+		n := filepath.Base(p)
 		for d := filepath.Dir(p); d != "."; d = filepath.Dir(d) {
 			if filepath.Base(d) == "__pycache__" {
 				break // Don't need to add an __init__.py here.
@@ -340,6 +341,9 @@ func (f *File) AddInitPyFiles() error {
 			initPyPath := path.Join(d, "__init__.py")
 			// Don't write one at the root, it's not necessary.
 			if _, present := f.files[initPyPath]; present || initPyPath == "__init__.py" {
+				if n == "__init__.py" && d == filepath.Dir(p) {
+					continue
+				}
 				break
 			} else if _, present := f.files[initPyPath+"c"]; present {
 				// If we already have a pyc / pyo we don't need the __init__.py as well.


### PR DESCRIPTION
Having them in the same one means things that need them can more or less "just work" without necessarily having to add the dep :-o