### PR TITLE
Update to latest remote-apis version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/Songmu/prompter v0.0.0-20181014095714-d227c68538bd
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/bazelbuild/buildtools v0.0.0-20190228125936-4bcdbd1064fc
-	github.com/bazelbuild/remote-apis v0.0.0-20191104140458-e77c4eb2ca48
-	github.com/bazelbuild/remote-apis-sdks v0.0.0-20191119014045-9f0428c343a9 // indirect
+	github.com/bazelbuild/remote-apis v0.0.0-20191119143007-b5123b1bb285
+	github.com/bazelbuild/remote-apis-sdks v0.0.0-20191125202410-a21ff57ff57c // indirect
 	github.com/coreos/go-semver v0.2.0
 	github.com/djherbis/atime v1.0.0
 	github.com/dustin/go-humanize v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/bazelbuild/buildtools v0.0.0-20190228125936-4bcdbd1064fc
 	github.com/bazelbuild/remote-apis v0.0.0-20191119143007-b5123b1bb285
-	github.com/bazelbuild/remote-apis-sdks v0.0.0-20191125202410-a21ff57ff57c // indirect
+	github.com/bazelbuild/remote-apis-sdks v0.0.0-20191125202410-a21ff57ff57c
 	github.com/coreos/go-semver v0.2.0
 	github.com/djherbis/atime v1.0.0
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,12 @@ github.com/bazelbuild/remote-apis v0.0.0-20190709012138-e7282cf0f0e1 h1:faRBoPUf
 github.com/bazelbuild/remote-apis v0.0.0-20190709012138-e7282cf0f0e1/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/bazelbuild/remote-apis v0.0.0-20191104140458-e77c4eb2ca48 h1:bgj+Oufa8F4rCHe/8omhml7cBlg3VmNhF66ed1vT2Bw=
 github.com/bazelbuild/remote-apis v0.0.0-20191104140458-e77c4eb2ca48/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
+github.com/bazelbuild/remote-apis v0.0.0-20191119143007-b5123b1bb285 h1:OPH+hf+ICw8WEp2CV2ncfdyWPC30Cmw8b5NKun0n5IQ=
+github.com/bazelbuild/remote-apis v0.0.0-20191119143007-b5123b1bb285/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20191119014045-9f0428c343a9 h1:KU66ZTme1RxNuBPyseaHmSHZKQMM52yrCDhGhMCqOUU=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20191119014045-9f0428c343a9/go.mod h1:qgVeF5etXayzvt6OKXzeSg9Y0QDXfeH9H4EWKo/MNLM=
+github.com/bazelbuild/remote-apis-sdks v0.0.0-20191125202410-a21ff57ff57c h1:8zx14LG5/YyL54A3R/oIOG5TsilYs7EnVLlVMWXjHOU=
+github.com/bazelbuild/remote-apis-sdks v0.0.0-20191125202410-a21ff57ff57c/go.mod h1:qgVeF5etXayzvt6OKXzeSg9Y0QDXfeH9H4EWKo/MNLM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -260,6 +264,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90Pveol
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190424203555-c05e17bb3b2d/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmVhcMLU6v5fEb/ok4wyqtNU=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -55,6 +55,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 	// We can't predict what variables like this should be so we sneakily bung something on
 	// the front of the command. It'd be nicer if there were a better way though...
 	const commandPrefix = "export TMP_DIR=\"`pwd`\" && "
+	// TODO(peterebden): Remove this nonsense once API v2.1 is released.
 	files, dirs := outputs(target)
 	cmd, err := core.ReplaceSequences(c.state, target, c.getCommand(target))
 	return &pb.Command{
@@ -70,6 +71,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 		EnvironmentVariables: buildEnv(c.stampedBuildEnvironment(target, inputRoot)),
 		OutputFiles:          files,
 		OutputDirectories:    dirs,
+		OutputPaths:          append(files, dirs...),
 	}, err
 }
 
@@ -87,6 +89,7 @@ func (c *Client) stampedBuildEnvironment(target *core.BuildTarget, inputRoot *pb
 
 // buildTestCommand builds a command for a target when testing.
 func (c *Client) buildTestCommand(target *core.BuildTarget) (*pb.Command, error) {
+	// TODO(peterebden): Remove all this nonsense once API v2.1 is released.
 	files := make([]string, 0, 2)
 	dirs := []string{}
 	if target.NeedCoverage(c.state) {
@@ -114,6 +117,7 @@ func (c *Client) buildTestCommand(target *core.BuildTarget) (*pb.Command, error)
 		EnvironmentVariables: buildEnv(core.TestEnvironment(c.state, target, "")),
 		OutputFiles:          files,
 		OutputDirectories:    dirs,
+		OutputPaths:          append(files, dirs...),
 	}, err
 }
 

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bazelbuild/remote-apis-sdks/go/client"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/bazelbuild/remote-apis/build/bazel/semver"
 	"github.com/golang/protobuf/ptypes"

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -442,7 +442,7 @@ go_get(
 go_get(
     name = "remote-apis-sdks",
     get = "github.com/bazelbuild/remote-apis-sdks/go/...",
-    revision = "9f0428c343a9ade6557e40e5d805239e7cd35cf7",
+    revision = "a21ff57ff57ce7e1dc04ed96f786ade301c793a5",
     deps = [
         ":annotations",
         ":bytestream",

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -429,7 +429,7 @@ go_get(
 go_get(
     name = "remote-apis",
     get = "github.com/bazelbuild/remote-apis/build/...",
-    revision = "e7282cf0f0e16e7ba84209be5417279e6815bee7",
+    revision = "b5123b1bb2853393c7b9aa43236db924d7e32d61",
     deps = [
         ":annotations",
         ":grpc",


### PR DESCRIPTION
Start using the new output_paths field in the proto in case a server starts honouring it.