### PR TITLE
Ensure binary rules are made executable by rex backend

### DIFF
--- a/rules/sh_rules.build_defs
+++ b/rules/sh_rules.build_defs
@@ -160,9 +160,9 @@ def sh_cmd(name:str, cmd:str|dict|list, srcs:list|dict=None, out:str="", shell:s
     """
     cmd = ' && '.join(cmd) if isinstance(cmd, list) else cmd
     if isinstance(cmd, str):
-        cmds = f'cat > $OUT << EOF\n#!{shell}\n{cmd}\nEOF'
+        cmds = f'{{ cat > $OUT << EOF\n#!{shell}\n{cmd}\nEOF\n}}'
     elif isinstance(cmd, dict):
-        cmds = {k: f'cat > $OUT << EOF\n#!{shell}\n{v}\nEOF' for k, v in cmd.items()}
+        cmds = {k: f'{{ cat > $OUT << EOF\n#!{shell}\n{v}\nEOF\n}}' for k, v in cmd.items()}
     return build_rule(
         name = name,
         outs = [out or name + '.sh'],

--- a/rules/sh_rules.build_defs
+++ b/rules/sh_rules.build_defs
@@ -160,9 +160,9 @@ def sh_cmd(name:str, cmd:str|dict|list, srcs:list|dict=None, out:str="", shell:s
     """
     cmd = ' && '.join(cmd) if isinstance(cmd, list) else cmd
     if isinstance(cmd, str):
-        cmds = f'cat > $OUT <<< \'#!{shell}; {cmd}\''
+        cmds = f'cat > $OUT << EOF\n#!{shell}\n{cmd}\nEOF'
     elif isinstance(cmd, dict):
-        cmds = {k: f'cat > $OUT <<< \'#!{shell}; {v}\'' for k, v in cmd.items()}
+        cmds = {k: f'cat > $OUT << EOF\n#!{shell}\n{v}\nEOF' for k, v in cmd.items()}
     return build_rule(
         name = name,
         outs = [out or name + '.sh'],

--- a/rules/sh_rules.build_defs
+++ b/rules/sh_rules.build_defs
@@ -160,9 +160,9 @@ def sh_cmd(name:str, cmd:str|dict|list, srcs:list|dict=None, out:str="", shell:s
     """
     cmd = ' && '.join(cmd) if isinstance(cmd, list) else cmd
     if isinstance(cmd, str):
-        cmds = f'cat > $OUT << EOF\n#!{shell}\n{cmd}\nEOF'
+        cmds = f'cat > $OUT <<< \'#!{shell}; {cmd}\''
     elif isinstance(cmd, dict):
-        cmds = {k: f'cat > $OUT << EOF\n#!{shell}\n{v}\nEOF' for k, v in cmd.items()}
+        cmds = {k: f'cat > $OUT <<< \'#!{shell}; {v}\'' for k, v in cmd.items()}
     return build_rule(
         name = name,
         outs = [out or name + '.sh'],

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -123,9 +123,6 @@ func (c *Client) buildTestCommand(target *core.BuildTarget) (*pb.Command, error)
 
 // getCommand returns the appropriate command to use for a target.
 func (c *Client) getCommand(target *core.BuildTarget) string {
-	if target.TestOnly {
-		return "true"
-	}
 	if target.IsRemoteFile {
 		// TODO(peterebden): we should handle this using the Remote Fetch API once that's available.
 		urls := make([]string, len(target.Sources))
@@ -139,7 +136,10 @@ func (c *Client) getCommand(target *core.BuildTarget) string {
 		return cmd
 	}
 	cmd := target.GetCommand(c.state)
-	if target.IsBinary {
+	if cmd == "" {
+		cmd = "true"
+	}
+	if target.IsBinary && len(target.Outputs()) > 0 {
 		return "( " + cmd + " ) && chmod +x $OUTS"
 	}
 	return cmd

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -123,6 +123,9 @@ func (c *Client) buildTestCommand(target *core.BuildTarget) (*pb.Command, error)
 
 // getCommand returns the appropriate command to use for a target.
 func (c *Client) getCommand(target *core.BuildTarget) string {
+	if target.TestOnly {
+		return "true"
+	}
 	if target.IsRemoteFile {
 		// TODO(peterebden): we should handle this using the Remote Fetch API once that's available.
 		urls := make([]string, len(target.Sources))

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -140,7 +140,7 @@ func (c *Client) getCommand(target *core.BuildTarget) string {
 	}
 	cmd := target.GetCommand(c.state)
 	if target.IsBinary {
-		return "(" + cmd + ") && chmod +x $OUT"
+		return "( " + cmd + " ) && chmod +x $OUTS"
 	}
 	return cmd
 }

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -135,7 +135,11 @@ func (c *Client) getCommand(target *core.BuildTarget) string {
 		}
 		return cmd
 	}
-	return target.GetCommand(c.state)
+	cmd := target.GetCommand(c.state)
+	if target.IsBinary {
+		return "(" + cmd + ") && chmod +x $OUT"
+	}
+	return cmd
 }
 
 // digestDir calculates the digest for a directory.


### PR DESCRIPTION
Fixes problems we were seeing with .pex files not being executable.

Is there a good reason we weren't doing this already?