### PR TITLE
Update java build def to support remote execution

### DIFF
--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -94,7 +94,7 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=None
         # TODO(agenticarus): Turn `resources` into a first-class construct, and just use them in `deps` normally.
         # Can't run javac since there are no java files.
         if resources_root:
-            cmd = 'cd ${PKG_DIR}/%s && $TOOL z -d -o ${OUT} -i . && file=$(readlink -f ${OUT}) && (mv ${file} ${TMP_DIR}/${OUT} || true)' % resources_root
+            cmd = 'cd ${PKG_DIR}/%s && $TOOL z -d -o ${OUT} -i .' % resources_root
         else:
             cmd = '$TOOL z -d -o ${OUTS} -i .'
         return build_rule(

--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -94,7 +94,7 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=None
         # TODO(agenticarus): Turn `resources` into a first-class construct, and just use them in `deps` normally.
         # Can't run javac since there are no java files.
         if resources_root:
-            cmd = 'cd ${PKG_DIR}/%s && $TOOL z -d -o ${OUT} -i .' % resources_root
+            cmd = 'cd ${PKG_DIR}/%s && $TOOL z -d -o ${OUT} -i . && file=$(readlink -f ${OUT}) && (mv ${file} ${TMP_DIR}/${OUT} || true)' % resources_root
         else:
             cmd = '$TOOL z -d -o ${OUTS} -i .'
         return build_rule(

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -54,9 +54,12 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 	}
 	// We can't predict what variables like this should be so we sneakily bung something on
 	// the front of the command. It'd be nicer if there were a better way though...
-	const commandPrefix = "export TMP_DIR=\"`pwd`\" && export OUT=\"$TMP_DIR/$OUT\" && "
+	var commandPrefix = "export TMP_DIR=\"`pwd`\" && "
 	// TODO(peterebden): Remove this nonsense once API v2.1 is released.
 	files, dirs := outputs(target)
+	if len(target.Outputs()) == 1 { // if there's a single output, we need to ensure it ends up in the right place
+		commandPrefix += "export OUT=\"$TMP_DIR/$OUT\" && "
+	}
 	cmd, err := core.ReplaceSequences(c.state, target, c.getCommand(target))
 	return &pb.Command{
 		Platform: c.platform,

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -58,7 +58,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 	// TODO(peterebden): Remove this nonsense once API v2.1 is released.
 	files, dirs := outputs(target)
 	if len(target.Outputs()) == 1 { // $OUT is relative when running remotely; make it absolute
-		commandPrefix += "export OUT=\"$TMP_DIR/$OUT\" && "
+		commandPrefix += `export OUT="$TMP_DIR/$OUT" && `
 	}
 	cmd, err := core.ReplaceSequences(c.state, target, c.getCommand(target))
 	return &pb.Command{

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -54,7 +54,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 	}
 	// We can't predict what variables like this should be so we sneakily bung something on
 	// the front of the command. It'd be nicer if there were a better way though...
-	const commandPrefix = "export TMP_DIR=\"`pwd`\" && "
+	const commandPrefix = "export TMP_DIR=\"`pwd`\" && export OUT=\"$TMP_DIR/$OUT\" && "
 	// TODO(peterebden): Remove this nonsense once API v2.1 is released.
 	files, dirs := outputs(target)
 	cmd, err := core.ReplaceSequences(c.state, target, c.getCommand(target))

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -57,7 +57,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 	var commandPrefix = "export TMP_DIR=\"`pwd`\" && "
 	// TODO(peterebden): Remove this nonsense once API v2.1 is released.
 	files, dirs := outputs(target)
-	if len(target.Outputs()) == 1 { // if there's a single output, we need to ensure it ends up in the right place
+	if len(target.Outputs()) == 1 { // $OUT is relative when running remotely; make it absolute
 		commandPrefix += "export OUT=\"$TMP_DIR/$OUT\" && "
 	}
 	cmd, err := core.ReplaceSequences(c.state, target, c.getCommand(target))


### PR DESCRIPTION
When using remote execution, `$OUT` is a relative path (which the backend expects to be relative to `$TMP_DIR`). This changes the java build rule to get the file's abspath and move it to the expected location.

`|| true` is required for the rule to build locally as the file is already in the right place.