### PR TITLE
Fix "not a directory" errors

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -359,14 +359,8 @@ func (c *Client) Retrieve(target *core.BuildTarget) (*core.BuildMetadata, error)
 			tree := &pb.Tree{}
 			if err := c.readByteStreamToProto(dir.TreeDigest, tree); err != nil {
 				return err
-			}
-			if err := c.downloadDirectory(dirPath, tree.Root); err != nil {
+			} else if err := c.downloadDirectory(dirPath, tree.Root); err != nil {
 				return err
-			}
-			for _, child := range tree.Children {
-				if err := c.downloadDirectory(dirPath, child); err != nil {
-					return err
-				}
 			}
 		}
 		// For unexplained reasons the protocol treats symlinks differently based on what


### PR DESCRIPTION
We're double-downloading some things because of the weird nested Tree proto stuff. This fixes some of the "not a directory" errors.

Also limit the number of blobs in a single request arbitrarily since some servers seem unable to cope well, even if still under the size limit.