### PR TITLE
add human-readable scm identifier

### DIFF
--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -183,7 +183,12 @@ var stampEnv BuildEnv
 var stampEnvOnce sync.Once
 
 func initStampEnv() {
-	stampEnv = BuildEnv{"SCM_REVISION=" + scm.NewFallback(RepoRoot).CurrentRevIdentifier()}
+	repoScm := scm.NewFallback(RepoRoot)
+	revision := repoScm.CurrentRevIdentifier()
+	stampEnv = BuildEnv{
+		"SCM_REVISION=" + revision,
+		"SCM_DESCRIBE=" + repoScm.DescribeIdentifier(revision),
+	}
 }
 
 func toolPath(state *BuildState, tool BuildInput, abs bool) string {

--- a/src/scm/git.go
+++ b/src/scm/git.go
@@ -19,6 +19,15 @@ type git struct {
 	repoRoot string
 }
 
+// DescribeIdentifier returns the string that is a "human-readable" identifier of the given revision.
+func (g *git) DescribeIdentifier(sha string) string {
+	out, err := exec.Command("git", "describe", "--always", sha).CombinedOutput()
+	if err != nil {
+		log.Fatalf("Failed to read %s: %s", sha, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
 // CurrentRevIdentifier returns the string that specifies what the current revision is.
 func (g *git) CurrentRevIdentifier() string {
 	out, err := exec.Command("git", "rev-parse", "HEAD").CombinedOutput()

--- a/src/scm/git.go
+++ b/src/scm/git.go
@@ -20,10 +20,10 @@ type git struct {
 }
 
 // DescribeIdentifier returns the string that is a "human-readable" identifier of the given revision.
-func (g *git) DescribeIdentifier(sha string) string {
-	out, err := exec.Command("git", "describe", "--always", sha).CombinedOutput()
+func (g *git) DescribeIdentifier(revision string) string {
+	out, err := exec.Command("git", "describe", "--always", revision).CombinedOutput()
 	if err != nil {
-		log.Fatalf("Failed to read %s: %s", sha, err)
+		log.Fatalf("Failed to read %s: %s", revision, err)
 	}
 	return strings.TrimSpace(string(out))
 }

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -14,6 +14,8 @@ var log = logging.MustGetLogger("scm")
 
 // An SCM represents an SCM implementation that we can ask for various things.
 type SCM interface {
+	// DescribeIdentifier returns the string that is a "human-readable" identifier of the given revision.
+	DescribeIdentifier(sha string) string
 	// CurrentRevIdentifier returns the string that specifies what the current revision is.
 	CurrentRevIdentifier() string
 	// ChangesIn returns a list of modified files in the given diffSpec.

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -15,7 +15,7 @@ var log = logging.MustGetLogger("scm")
 // An SCM represents an SCM implementation that we can ask for various things.
 type SCM interface {
 	// DescribeIdentifier returns the string that is a "human-readable" identifier of the given revision.
-	DescribeIdentifier(sha string) string
+	DescribeIdentifier(revision string) string
 	// CurrentRevIdentifier returns the string that specifies what the current revision is.
 	CurrentRevIdentifier() string
 	// ChangesIn returns a list of modified files in the given diffSpec.

--- a/src/scm/stub.go
+++ b/src/scm/stub.go
@@ -4,6 +4,10 @@ import "fmt"
 
 type stub struct{}
 
+func (s *stub) DescribeIdentifier(sha string) string {
+	return "<unknown>"
+}
+
 func (s *stub) CurrentRevIdentifier() string {
 	return "<unknown>"
 }

--- a/test/stamp/BUILD
+++ b/test/stamp/BUILD
@@ -3,6 +3,7 @@ go_binary(
     srcs = ["main.go"],
     definitions = {
         "github.com/thought-machine/please/test/stamp/lib.GitRevision": "$SCM_REVISION",
+        "github.com/thought-machine/please/test/stamp/lib.GitDescribe": "$SCM_DESCRIBE",
     },
     stamp = True,
     deps = ["//test/stamp/lib"],
@@ -20,6 +21,7 @@ if CONFIG.OS == "linux":
         srcs = ["main.go"],
         definitions = {
             "github.com/thought-machine/please/test/stamp/lib.GitRevision": "$SCM_REVISION",
+            "github.com/thought-machine/please/test/stamp/lib.GitDescribe": "$SCM_DESCRIBE",
         },
         stamp = True,
         static = True,

--- a/test/stamp/lib/lib.go
+++ b/test/stamp/lib/lib.go
@@ -1,6 +1,9 @@
 package lib
 
-// GitRevision will be overridden at build time with the actual git revision.
+// vars that will be overridden at build time with actual git data.
 // N.B. Must be a variable not a constant - constants aren't linker symbols and
 //      hence can't be replaced in the same way.
-var GitRevision = "12345"
+var (
+	GitRevision = "12345"
+	GitDescribe = "12345"
+)

--- a/test/stamp/lib/lib.go
+++ b/test/stamp/lib/lib.go
@@ -4,6 +4,6 @@ package lib
 // N.B. Must be a variable not a constant - constants aren't linker symbols and
 //      hence can't be replaced in the same way.
 var (
-	GitRevision = "12345"
-	GitDescribe = "12345"
+	GitRevision = "12345-revision"
+	GitDescribe = "12345-describe"
 )

--- a/test/stamp/main.go
+++ b/test/stamp/main.go
@@ -10,4 +10,5 @@ import (
 
 func main() {
 	fmt.Println(lib.GitRevision)
+	fmt.Println(lib.GitDescribe)
 }

--- a/test/stamp/stamp_test.sh
+++ b/test/stamp/stamp_test.sh
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
 
-git_revision=$(git rev-parse HEAD)
-git_describe=$(git describe --always)
+unexpected="12345-revision
+12345-describe"
 
-expected="${git_revision}
-${git_describe}"
-
-if [ "`$DATA`" != "${expected}" ]; then
-    echo "`${DATA}` is not equal to ${expected}"
+if [ "`$DATA`" == "${unexpected}" ]; then
     echo "Stamped variable has not been replaced correctly."
     exit 1
 fi

--- a/test/stamp/stamp_test.sh
+++ b/test/stamp/stamp_test.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
-if [ "`$DATA`" = "12345" ]; then
+git_revision=$(git rev-parse HEAD)
+git_describe=$(git describe --always)
+
+expected="${git_revision}
+${git_describe}"
+
+if [ "`$DATA`" != "${expected}" ]; then
+    echo "`${DATA}` is not equal to ${expected}"
     echo "Stamped variable has not been replaced correctly."
     exit 1
 fi


### PR DESCRIPTION
Hello!

This PR adds an `SCM_DESCRIBE` environment variable that contains a "human-readable" identifier for the current git commit (https://git-scm.com/docs/git-describe) that is accessible from build targets that have `stamp = True` set.

We desire to use this alongside `SCM_REVISION` e.g.:
```
go_binary(
    ...
    definitions = {
        "github.com/my-user/my-project/pkg/version.BuildSCMVersion": "${SCM_REVISION}",
        "github.com/my-user/my-project/pkg/version.BuildHumanVersion": "${SCM_DESCRIBE}",
    },
    stamp = True,
    ...
)
```

This allows us to build binaries that can provide output in the format `<git describe --always> (SHA: <git rev-parse HEAD>)`:
```bash
$ my-binary version
Version: 1.2.3 (SHA: 6a6ce0a3930bc7e110d255308215991e4dd2543e)
# or a in-development version
$ my-binary version
Version: 1.2.3-1038-ge09a588f (SHA: ge09a588f930bc7110d255308215991e4dd2543e)
```
