### PR TITLE
Get absolute path to please_pex

### DIFF
--- a/tools/please_pex/pex/pex.go
+++ b/tools/please_pex/pex/pex.go
@@ -124,7 +124,11 @@ func (pw *Writer) Write(out, moduleDir string) error {
 	// Note that if the target contains its own test-runner, then we don't need to add anything.
 	if len(pw.testIncludes) > 0 {
 		f.Include = pw.testIncludes
-		if err := f.AddZipFile(os.Args[0]); err != nil {
+		pexPath, err := os.Executable() // get abspath to currently-running executable
+		if err != nil {
+			return err
+		}
+		if err := f.AddZipFile(pexPath); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
If `os.Args[0]` is a relative path (when using remote execution it's simply `please_pex`; the shell resolves it by looking it up in the $PATH) then reading from that path fails. Instead, we need to get the absolute path and use that.