### PR TITLE
Add support for TLS in remote execution

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -253,6 +253,7 @@ func DefaultConfiguration() *Configuration {
 	config.Test.Timeout = cli.Duration(10 * time.Minute)
 	config.Display.SystemStats = true
 	config.Remote.HomeDir = "~"
+	config.Remote.Secure = true
 	config.Go.GoTool = "go"
 	config.Go.CgoCCTool = "gcc"
 	config.Go.BuildIDTool = "go_buildid_replacer"
@@ -397,6 +398,7 @@ type Configuration struct {
 		DisplayURL   string       `help:"A URL to browse the remote server with (e.g. using buildbarn-browser). Only used when printing hashes."`
 		Timeout      cli.Duration `help:"Timeout for connections made to the remote server."`
 		ReadOnly     bool         `help:"If true, prevents this client from writing to the remote storage. Is overridden if being used for execution."`
+		Secure       bool         `help:"Whether to use TLS for communication or not."`
 		HomeDir      string       `help:"The home directory on the build machine."`
 		Platform     []string     `help:"Platform properties to request from remote workers, in the format key=value."`
 	} `help:"Settings related to remote execution & caching using the Google remote execution APIs. This section is still experimental and subject to change."`

--- a/src/remote/impl_test.go
+++ b/src/remote/impl_test.go
@@ -37,6 +37,7 @@ func newClientInstance(name string) *Client {
 	config.Remote.NumExecutors = 1
 	config.Remote.Instance = name
 	config.Remote.HomeDir = "~/.please"
+	config.Remote.Secure = false
 	state := core.NewBuildState(config)
 	state.Config.Remote.URL = "127.0.0.1:9987"
 	return New(state)

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -93,11 +93,11 @@ func (c *Client) init() {
 		// Create a copy of the state where we can modify the config
 		c.state = c.state.ForConfig()
 		c.state.Config.HomeDir = c.state.Config.Remote.HomeDir
-		// TODO(peterebden): Add support for TLS.
 		client, err := client.NewClient(context.Background(), c.instance, client.DialParams{
-			Service:    c.state.Config.Remote.URL,
-			CASService: c.state.Config.Remote.CASURL,
-			NoSecurity: true,
+			Service:            c.state.Config.Remote.URL,
+			CASService:         c.state.Config.Remote.CASURL,
+			NoSecurity:         !c.state.Config.Remote.Secure,
+			TransportCredsOnly: c.state.Config.Remote.Secure,
 		}, client.UseBatchOps(true), client.RetryTransient())
 		if err != nil {
 			return err


### PR DESCRIPTION
This is a fairly simple knob to allow switching on TLS. None of the more complex auth forms that the rex client supports are available right now.

Since none of this is stable yet I'm making it opt-out.