### PR TITLE
Display RPC bytes in/out

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -79,6 +79,8 @@ type RemoteClient interface {
 	Test(tid int, target *BuildTarget) (metadata *BuildMetadata, results, coverage []byte, err error)
 	// PrintHashes shows the hashes of a target.
 	PrintHashes(target *BuildTarget, isTest bool)
+	// DataRate returns an estimate of the current in/out RPC data rates in bytes per second.
+	DataRate() (int, int)
 }
 
 // A TargetHasher is a thing that knows how to create hashes for targets.

--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -10,6 +10,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dustin/go-humanize"
+
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"
 )
@@ -102,6 +104,10 @@ func (d *displayer) printLines() {
 		printStat("Mem use", d.state.Stats.Memory.UsedPercent, 1)
 		if d.state.Stats.NumWorkerProcesses > 0 {
 			printf("  ${BOLD_WHITE}Worker processes: %d${RESET}", d.state.Stats.NumWorkerProcesses)
+		}
+		if d.state.RemoteClient != nil {
+			in, out := d.state.RemoteClient.DataRate()
+			printf("  ${BOLD_WHITE}RPC data in: %s/s out: %s/s${RESET}", humanize.Bytes(uint64(in)), humanize.Bytes(uint64(out)))
 		}
 		printf("${ERASE_AFTER}\n")
 		d.lines++

--- a/src/remote/dialparams.go
+++ b/src/remote/dialparams.go
@@ -1,0 +1,19 @@
+// +build !bootstrap
+
+package remote
+
+import (
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
+	"google.golang.org/grpc"
+)
+
+// This is the real version that we use post-bootstrap.
+func (c *Client) dialParams() client.DialParams {
+	return client.DialParams{
+		Service:            c.state.Config.Remote.URL,
+		CASService:         c.state.Config.Remote.CASURL,
+		NoSecurity:         !c.state.Config.Remote.Secure,
+		TransportCredsOnly: c.state.Config.Remote.Secure,
+		DialOpts:           []grpc.DialOption{grpc.WithStatsHandler(newStatsHandler(c))},
+	}
+}

--- a/src/remote/dialparams_bootstrap.go
+++ b/src/remote/dialparams_bootstrap.go
@@ -1,0 +1,17 @@
+// +build bootstrap
+
+package remote
+
+import "github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
+
+// This is a special-cased version during bootstrap where we have to use the vanilla upstream
+// library which doesn't let us specify dial options.
+// TODO(peterebden): This should go away if we upstream this change.
+func (c *Client) dialParams() client.DialParams {
+	return client.DialParams{
+		Service:            c.state.Config.Remote.URL,
+		CASService:         c.state.Config.Remote.CASURL,
+		NoSecurity:         !c.state.Config.Remote.Secure,
+		TransportCredsOnly: c.state.Config.Remote.Secure,
+	}
+}

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -18,7 +18,6 @@ import (
 	"github.com/bazelbuild/remote-apis/build/bazel/semver"
 	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/genproto/googleapis/longrunning"
-	"google.golang.org/grpc"
 	_ "google.golang.org/grpc/encoding/gzip" // Registers the gzip compressor at init
 	"gopkg.in/op/go-logging.v1"
 
@@ -97,13 +96,7 @@ func (c *Client) init() {
 		// Create a copy of the state where we can modify the config
 		c.state = c.state.ForConfig()
 		c.state.Config.HomeDir = c.state.Config.Remote.HomeDir
-		client, err := client.NewClient(context.Background(), c.instance, client.DialParams{
-			Service:            c.state.Config.Remote.URL,
-			CASService:         c.state.Config.Remote.CASURL,
-			NoSecurity:         !c.state.Config.Remote.Secure,
-			TransportCredsOnly: c.state.Config.Remote.Secure,
-			DialOpts:           []grpc.DialOption{grpc.WithStatsHandler(newStatsHandler(c))},
-		}, client.UseBatchOps(true), client.RetryTransient())
+		client, err := client.NewClient(context.Background(), c.instance, c.dialParams(), client.UseBatchOps(true), client.RetryTransient())
 		if err != nil {
 			return err
 		}

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -585,6 +585,7 @@ func (c *Client) PrintHashes(target *core.BuildTarget, isTest bool) {
 	}
 }
 
+// DataRate returns an estimate of the current in/out RPC data rates in bytes per second.
 func (c *Client) DataRate() (int, int) {
 	return c.byteRateIn, c.byteRateOut
 }

--- a/src/remote/stats.go
+++ b/src/remote/stats.go
@@ -1,0 +1,99 @@
+package remote
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/stats"
+)
+
+// The length of time we keep stats around for.
+const windowDurationSeconds = 5
+const windowDuration = -windowDurationSeconds * time.Second
+
+// updateFrequency is the rate at which we update stats internally (which is independent of display updates)
+const updateFrequency = 1 * time.Second
+
+// A stat is a single statistic comprising an observation time and size value (in bytes)
+type stat struct {
+	Time time.Time
+	Val  int
+}
+
+// A statsHandler is an implementation of a grpc stats.Handler that calculates an estimate of
+// instantaneous performance.
+type statsHandler struct {
+	client        *Client
+	in, out       []stat
+	inmtx, outmtx sync.Mutex
+}
+
+func newStatsHandler(c *Client) *statsHandler {
+	h := statsHandler{client: c}
+	go h.update()
+	return h
+}
+
+func (h *statsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (h *statsHandler) HandleRPC(ctx context.Context, s stats.RPCStats) {
+	switch s.(type) {
+	case *stats.InPayload:
+		h.inmtx.Lock()
+		defer h.inmtx.Unlock()
+		h.in = append(h.in, stat{Time: s.RecvTime, Val: s.Length})
+	case *stats.OutPayload:
+		h.outmtx.Lock()
+		defer h.outmtx.Unlock()
+		h.out = append(h.out, stat{Time: s.SentTime, Val: s.Length})
+	}
+}
+
+func (h *statsHandler) TagConn(ctx context.Context, info *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (h *statsHandler) HandleConn(ctx context.Context, s stats.ConnStats) {
+}
+
+// update runs continually, updating the aggregated stats on the Client instance.
+func (h *statsHandler) update() {
+	for range time.NewTicker(updateFrequency) {
+		h.client.byteRateIn = h.updateStat(&h.in, &h.inmtx)
+		h.client.byteRateOut = h.updateStat(&h.out, &h.outmtx)
+	}
+}
+
+func (h *statsHandler) updateStat(stats *[]stat, mtx *sync.Mutex) float32 {
+	mtx.Lock()
+	defer mtx.Unlock()
+	s := *stats
+	idx := h.survivingStats(s, time.Now().Add(windowDuration))
+	if idx == 0 {
+		return // Nothing's changed
+	}
+	// Shuffle them all back by this much. We *could* just slice here but that has rather nasty
+	// allocation behaviour (in that we would be continually reallocating the underlying buffer)
+	copy(s, s[idx:])
+	*stats = s[:idx]
+	// Now recalculate the observed value
+	total := 0
+	for _, stat := range *stats {
+		total += stat.Val
+	}
+	return total / windowDurationSeconds
+}
+
+func (h *statsHandler) survivingStats(stats []stat, deadline time.Time) int {
+	// This assumes that we receive stats in time order, which seems reasonable; if it turns out not
+	// to be the case we could record the current time ourselves when we get them.
+	for i, stat := range stats {
+		if stat.Time.After(deadline) {
+			return i
+		}
+	}
+	return len(stats)
+}

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -443,7 +443,7 @@ go_get(
     name = "remote-apis-sdks",
     get = "github.com/bazelbuild/remote-apis-sdks/go/...",
     repo = "github.com/peterebden/remote-apis-sdks",
-    revision = "de86b298638b7ac24b09ac6bedfdee0c6384b5f6",
+    revision = "20174459d463931f5f373d2ad1fe0b80a18b6f47",
     deps = [
         ":annotations",
         ":bytestream",


### PR DESCRIPTION
This is a generic mechanism for measuring how much data is flowing, it complements rather than replaces #794 

Have bumped the sdks dep with a small change that allows us to specify the gRPC DialOptions. Haven't sent it upstream yet since I still have a couple open and not sure if they want more from me :)