### PR TITLE
Use aarch64 as the alternative arch spelling for arm64

### DIFF
--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -292,6 +292,8 @@ func (arch *Arch) XArch() string {
 		return "x86_64"
 	} else if arch.Arch == "x86" {
 		return "x86_32"
+	} else if arch.Arch == "arm64" {
+		return "aarch_64"
 	}
 	return arch.Arch
 }

--- a/tools/build_langserver/lsp/BUILD
+++ b/tools/build_langserver/lsp/BUILD
@@ -29,4 +29,6 @@ go_test(
         "//third_party/go:lsp",
         "//third_party/go:testify",
     ],
+    flaky = CONFIG.OS == 'freebsd',
 )
+

--- a/tools/build_langserver/lsp/BUILD
+++ b/tools/build_langserver/lsp/BUILD
@@ -22,6 +22,7 @@ go_test(
     name = "lsp_test",
     srcs = glob(["*_test.go"]),
     data = ["test_data"],
+    flaky = CONFIG.OS == "freebsd",
     deps = [
         ":lsp",
         "//src/cli",
@@ -29,6 +30,4 @@ go_test(
         "//third_party/go:lsp",
         "//third_party/go:testify",
     ],
-    flaky = CONFIG.OS == 'freebsd',
 )
-


### PR DESCRIPTION
Another one for #796 