### PR TITLE
Create a file for targets with stamp=True

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -586,6 +586,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
             test_only = test_only,
             revision = revision,
             strip = strip,
+            licences = licences,
         )
         outs += [getroot]
         srcs += [get_rule]
@@ -639,7 +640,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
 
 def _go_get_download(name:str, tag:str, get:str, repo:str='', patch:str=None, hashes:list=None,
                      test_only:bool&testonly=False, revision:str=None, strip:list=None,
-                     labels:list=[]):
+                     labels:list=[], licences:list=None):
     if hashes and not revision:
         log.warning("You shouldn't specify hashes on go_get without specifying revision as well")
     labels = [f'go_get:{get}@{revision}' if revision else f'go_get:{get}']
@@ -697,6 +698,7 @@ def _go_get_download(name:str, tag:str, get:str, repo:str='', patch:str=None, ha
         labels = labels + ['link:plz-out/go'],
         hashes = hashes,
         sandbox = False,
+        licences = licences,
     ), getroot
 
 

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -375,7 +375,7 @@ func prepareSources(graph *core.BuildGraph, target *core.BuildTarget) error {
 		}
 	}
 	if target.Stamp {
-		if err := fs.WriteFile(bytes.NewReader(core.StampFile(graph, target)), path.Join(target.TempDir(), target.StampFileName()), 0644); err != nil {
+		if err := fs.WriteFile(bytes.NewReader(core.StampFile(target)), path.Join(target.TmpDir(), target.StampFileName()), 0644); err != nil {
 			return err
 		}
 	}

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -374,6 +374,11 @@ func prepareSources(graph *core.BuildGraph, target *core.BuildTarget) error {
 			return err
 		}
 	}
+	if target.Stamp {
+		if err := fs.WriteFile(bytes.NewReader(core.StampFile(graph, target)), path.Join(target.TempDir(), target.StampFileName()), 0644); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -165,3 +165,12 @@ go_test(
         "//third_party/go:testify",
     ],
 )
+
+go_test(
+    name = "stamp_test",
+    srcs = ["stamp_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -172,6 +172,7 @@ func StampedBuildEnvironment(state *BuildState, target *BuildTarget, stamp []byt
 	if target.Stamp {
 		stampEnvOnce.Do(initStampEnv)
 		env = append(env, stampEnv...)
+		env = append(env, "STAMP_FILE="+target.StampFileName())
 		return append(env, "STAMP="+base64.RawURLEncoding.EncodeToString(stamp))
 	}
 	return env

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -440,6 +440,13 @@ func (label BuildLabel) Complete(match string) []flags.Completion {
 	return ret
 }
 
+// MarshalText implements the encoding.TextMarshaler interface, which makes BuildLabels
+// usable as map keys in JSON.
+// This implementation never returns an error.
+func (label BuildLabel) MarshalText() ([]byte, error) {
+	return []byte(label.String()), nil
+}
+
 // A packageKey is a cut-down version of BuildLabel that only contains the package part.
 // It's used to key maps and so forth that don't care about the target name.
 type packageKey struct {

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1170,6 +1170,11 @@ func (target *BuildTarget) PostBuildOutputFileName() string {
 	return ".build_output_" + target.Label.Name
 }
 
+// StampFileName returns the stamp filename for this target.
+func (target *BuildTarget) StampFileName() string {
+	return ".stamp_" + target.Label.Name
+}
+
 // NeedCoverage returns true if this target should output coverage during a test
 // for a particular invocation.
 func (target *BuildTarget) NeedCoverage(state *BuildState) bool {

--- a/src/core/stamp.go
+++ b/src/core/stamp.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+	"encoding/json"
+)
+
+// StampFile returns the contents of a stamp file, that is the data that would be written for
+// a target that is marked stamp=True.
+// This file contains information about its transitive dependencies that can be used to
+// embed information into the output (for example information from labels or licences).
+func StampFile(target *BuildTarget) []byte {
+	info := &stampInfo{
+		Targets: map[BuildLabel]targetInfo{},
+	}
+	populateStampInfo(target, info)
+	b, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		log.Fatalf("Failed to encode stamp file: %s", err)
+	}
+	return b
+}
+
+func populateStampInfo(target *BuildTarget, info *stampInfo) {
+	info.Targets[target.Label] = targetInfo{
+		Licences: target.Licences,
+		Labels:   target.Labels,
+	}
+	for _, dep := range target.Dependencies() {
+		if _, present := info.Targets[dep.Label]; !present {
+			populateStampInfo(dep, info)
+		}
+	}
+}
+
+type stampInfo struct {
+	Targets map[BuildLabel]targetInfo `json:"targets"`
+}
+
+type targetInfo struct {
+	Labels   []string `json:"labels,omitempty"`
+	Licences []string `json:"licences,omitempty"`
+}

--- a/src/core/stamp_test.go
+++ b/src/core/stamp_test.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStampFile(t *testing.T) {
+	t1 := NewBuildTarget(ParseBuildLabel("//src/core:core", ""))
+	t2 := NewBuildTarget(ParseBuildLabel("//src/fs:fs", ""))
+	t3 := NewBuildTarget(ParseBuildLabel("//third_party/go:errors", ""))
+	t1.AddLabel("go")
+	t3.AddLabel("go_get:github.com/pkg/errors")
+	t3.AddLicence("bsd-2-clause")
+	t1.AddDependency(t2.Label)
+	t1.resolveDependency(t2.Label, t2)
+	t1.AddDependency(t3.Label)
+	t1.resolveDependency(t3.Label, t3)
+	t2.AddDependency(t3.Label)
+	t2.resolveDependency(t3.Label, t3)
+	expected := []byte(`{
+  "targets": {
+    "//src/core:core": {
+      "labels": [
+        "go"
+      ]
+    },
+    "//src/fs:fs": {},
+    "//third_party/go:errors": {
+      "labels": [
+        "go_get:github.com/pkg/errors"
+      ],
+      "licences": [
+        "bsd-2-clause"
+      ]
+    }
+  }
+}`)
+	assert.Equal(t, expected, StampFile(t1))
+}

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -104,11 +104,16 @@ func (c *Client) digestMessage(msg proto.Message) *pb.Digest {
 // digestMessageContents is like DigestMessage but returns the serialised contents as well.
 func (c *Client) digestMessageContents(msg proto.Message) (*pb.Digest, []byte) {
 	b := mustMarshal(msg)
+	return c.digestBlob(b), b
+}
+
+// digestBlob digests a byteslice and returns the proto for it.
+func (c *Client) digestBlob(b []byte) *pb.Digest {
 	sum := c.sum(b)
 	return &pb.Digest{
 		Hash:      hex.EncodeToString(sum[:]),
 		SizeBytes: int64(len(b)),
-	}, b
+	}
 }
 
 // wrapActionErr wraps an error with information about the action related to it.


### PR DESCRIPTION
Thing we've wanted internally for some time, to be able to consume information about licences / labels transitively which is awkward or impossible when done through pre-build functions.

This shouldn't take a long time to construct, but users should ideally be setting `stamp` sparingly anyway.