### PR TITLE
Plumb context through from the main method

### DIFF
--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -4,6 +4,7 @@
 package build_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"testing"
@@ -48,7 +49,7 @@ func TestBuildLotsOfTargets(t *testing.T) {
 		}
 	}()
 
-	plz.RunHost(nil, state)
+	plz.RunHost(context.Background(), nil, state)
 }
 
 func addTarget(state *core.BuildState, i int) *core.BuildTarget {

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -8,6 +8,7 @@
 package build
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -30,7 +31,7 @@ var cache core.Cache
 func TestBuildTargetWithNoDeps(t *testing.T) {
 	state, target := newState("//package1:target1")
 	target.AddOutput("file1")
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(context.Background(), 1, state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 }
@@ -38,7 +39,7 @@ func TestBuildTargetWithNoDeps(t *testing.T) {
 func TestFailedBuildTarget(t *testing.T) {
 	state, target := newState("//package1:target1a")
 	target.Command = "false"
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(context.Background(), 1, state, target, false)
 	assert.Error(t, err)
 }
 
@@ -47,7 +48,7 @@ func TestBuildTargetWhichNeedsRebuilding(t *testing.T) {
 	// because there's no rule hash file.
 	state, target := newState("//package1:target2")
 	target.AddOutput("file2")
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(context.Background(), 1, state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 }
@@ -57,7 +58,7 @@ func TestBuildTargetWhichDoesntNeedRebuilding(t *testing.T) {
 	state, target := newState("//package1:target3")
 	target.AddOutput("file3")
 	assert.NoError(t, writeRuleHash(state, target))
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(context.Background(), 1, state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Reused, target.State())
 }
@@ -70,7 +71,7 @@ func TestModifiedBuildTargetStillNeedsRebuilding(t *testing.T) {
 	assert.NoError(t, writeRuleHash(state, target))
 	target.Command = "echo 'wibble wibble wibble' > $OUT"
 	target.RuleHash = nil // Have to force a reset of this
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(context.Background(), 1, state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 }
@@ -81,7 +82,7 @@ func TestSymlinkedOutputs(t *testing.T) {
 	target.AddOutput("file5")
 	target.AddSource(core.FileLabel{File: "src5", Package: "package1"})
 	target.Command = "ln -s $SRC $OUT"
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(context.Background(), 1, state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 }
@@ -95,7 +96,7 @@ func TestPreBuildFunction(t *testing.T) {
 		target.Command = "echo 'wibble wibble wibble' > $OUT"
 		return nil
 	})
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(context.Background(), 1, state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 }
@@ -109,7 +110,7 @@ func TestPostBuildFunction(t *testing.T) {
 		assert.Equal(t, "wibble wibble wibble", output)
 		return nil
 	})
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(context.Background(), 1, state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 	assert.Equal(t, []string{"file7"}, target.Outputs())
@@ -121,7 +122,7 @@ func TestCacheRetrieval(t *testing.T) {
 	target.AddOutput("file8")
 	target.Command = "false" // Will fail if we try to build it.
 	state.Cache = cache
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(context.Background(), 1, state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Cached, target.State())
 }
@@ -139,7 +140,7 @@ func TestPostBuildFunctionAndCache(t *testing.T) {
 		return nil
 	})
 	state.Cache = cache
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(context.Background(), 1, state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 	assert.True(t, called)
@@ -159,7 +160,7 @@ func TestPostBuildFunctionAndCache2(t *testing.T) {
 		return nil
 	})
 	state.Cache = cache
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(context.Background(), 1, state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Cached, target.State())
 	assert.True(t, called)
@@ -193,7 +194,7 @@ func TestCreatePlzOutGo(t *testing.T) {
 	target.AddLabel("link:plz-out/go/${PKG}/src")
 	target.AddOutput("file1.go")
 	assert.False(t, fs.PathExists("plz-out/go"))
-	assert.NoError(t, buildTarget(1, state, target, false))
+	assert.NoError(t, buildTarget(context.Background(), 1, state, target, false))
 	assert.True(t, fs.PathExists("plz-out/go/gopkg/src/file1.go"))
 }
 
@@ -307,10 +308,10 @@ func newPyFilegroup(state *core.BuildState, label, filename string) *core.BuildT
 // Fake cache implementation with hardcoded behaviour for the various tests above.
 type mockCache struct{}
 
-func (*mockCache) Store(target *core.BuildTarget, key []byte, metadata *core.BuildMetadata, files []string) {
+func (*mockCache) Store(ctx context.Context, target *core.BuildTarget, key []byte, metadata *core.BuildMetadata, files []string) {
 }
 
-func (*mockCache) Retrieve(target *core.BuildTarget, key []byte, outputs []string) *core.BuildMetadata {
+func (*mockCache) Retrieve(ctx context.Context, target *core.BuildTarget, key []byte, outputs []string) *core.BuildMetadata {
 	if target.Label.Name == "target8" {
 		ioutil.WriteFile("plz-out/gen/package1/file8", []byte("retrieved from cache"), 0664)
 		return &core.BuildMetadata{}
@@ -321,9 +322,9 @@ func (*mockCache) Retrieve(target *core.BuildTarget, key []byte, outputs []strin
 	return nil
 }
 
-func (*mockCache) Clean(target *core.BuildTarget) {}
-func (*mockCache) CleanAll()                      {}
-func (*mockCache) Shutdown()                      {}
+func (*mockCache) Clean(ctx context.Context, target *core.BuildTarget) {}
+func (*mockCache) CleanAll(ctx context.Context)                        {}
+func (*mockCache) Shutdown()                                           {}
 
 type fakeParser struct {
 }

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -14,6 +14,7 @@ package build
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
@@ -429,7 +430,7 @@ func RuntimeHash(state *core.BuildState, target *core.BuildTarget) ([]byte, erro
 
 // PrintHashes prints the various hashes for a target to stdout.
 // It's used by plz hash --detailed to show a breakdown of the input hashes of a target.
-func PrintHashes(state *core.BuildState, target *core.BuildTarget) {
+func PrintHashes(ctx context.Context, state *core.BuildState, target *core.BuildTarget) {
 	fmt.Printf("%s:\n", target.Label)
 	fmt.Printf("  Config: %s\n", b64(state.Hashes.Config))
 	fmt.Printf("    Rule: %s (pre-build)\n", b64(RuleHash(state, target, false, false)))
@@ -448,7 +449,7 @@ func PrintHashes(state *core.BuildState, target *core.BuildTarget) {
 		}
 	}
 	if state.RemoteClient != nil {
-		state.RemoteClient.PrintHashes(target, false)
+		state.RemoteClient.PrintHashes(ctx, target, false)
 	}
 }
 

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -3,9 +3,9 @@
 package cache
 
 import (
+	"context"
 	"sync"
 
-	"golang.org/x/net/context"
 	"gopkg.in/op/go-logging.v1"
 
 	"github.com/thought-machine/please/src/core"

--- a/src/cache/dir_cache_test.go
+++ b/src/cache/dir_cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"io/ioutil"
 	"os"
@@ -48,23 +49,23 @@ func inCompressedCache(target *core.BuildTarget) bool {
 func TestStoreAndRetrieve(t *testing.T) {
 	cache := makeCache(".plz-cache-test1", false)
 	target := makeTarget("//test1:target1", 20)
-	cache.Store(target, hash, &core.BuildMetadata{}, target.Outputs())
+	cache.Store(context.Background(), target, hash, &core.BuildMetadata{}, target.Outputs())
 	// Should now exist in cache at this path
 	assert.True(t, inCache(target))
-	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs()))
+	assert.NotNil(t, cache.Retrieve(context.Background(), target, hash, target.Outputs()))
 	// Should be able to store it again without problems
-	cache.Store(target, hash, &core.BuildMetadata{}, target.Outputs())
+	cache.Store(context.Background(), target, hash, &core.BuildMetadata{}, target.Outputs())
 	assert.True(t, inCache(target))
-	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs()))
+	assert.NotNil(t, cache.Retrieve(context.Background(), target, hash, target.Outputs()))
 }
 
 func TestCleanNoop(t *testing.T) {
 	cache := makeCache(".plz-cache-test2", false)
 	target1 := makeTarget("//test2:target1", 2000)
-	cache.Store(target1, hash, &core.BuildMetadata{}, target1.Outputs())
+	cache.Store(context.Background(), target1, hash, &core.BuildMetadata{}, target1.Outputs())
 	assert.True(t, inCache(target1))
 	target2 := makeTarget("//test2:target2", 2000)
-	cache.Store(target2, hash, &core.BuildMetadata{}, target2.Outputs())
+	cache.Store(context.Background(), target2, hash, &core.BuildMetadata{}, target2.Outputs())
 	assert.True(t, inCache(target2))
 	// Doesn't clean anything this time because the high water mark is sufficiently high
 	totalSize := cache.clean(20000, 1000)
@@ -76,10 +77,10 @@ func TestCleanNoop(t *testing.T) {
 func TestCleanNoop2(t *testing.T) {
 	cache := makeCache(".plz-cache-test3", false)
 	target1 := makeTarget("//test3:target1", 2000)
-	cache.Store(target1, hash, &core.BuildMetadata{}, target1.Outputs())
+	cache.Store(context.Background(), target1, hash, &core.BuildMetadata{}, target1.Outputs())
 	assert.True(t, inCache(target1))
 	target2 := makeTarget("//test3:target2", 2000)
-	cache.Store(target2, hash, &core.BuildMetadata{}, target2.Outputs())
+	cache.Store(context.Background(), target2, hash, &core.BuildMetadata{}, target2.Outputs())
 	assert.True(t, inCache(target2))
 	// Doesn't clean anything this time, the high water mark is lower but both targets have
 	// just been built.
@@ -92,7 +93,7 @@ func TestCleanNoop2(t *testing.T) {
 func TestCleanForReal(t *testing.T) {
 	cache := makeCache(".plz-cache-test4", false)
 	target1 := makeTarget("//test4:target1", 2000)
-	cache.Store(target1, hash, &core.BuildMetadata{}, target1.Outputs())
+	cache.Store(context.Background(), target1, hash, &core.BuildMetadata{}, target1.Outputs())
 	assert.True(t, inCache(target1))
 	target2 := makeTarget("//test4:target2", 2000)
 	writeFile(cachePath(target2, false), 2000)
@@ -110,7 +111,7 @@ func TestCleanForReal2(t *testing.T) {
 	writeFile(cachePath(target1, false), 2000)
 	assert.True(t, inCache(target1))
 	target2 := makeTarget("//test5:target2", 2000)
-	cache.Store(target2, hash, &core.BuildMetadata{}, target2.Outputs())
+	cache.Store(context.Background(), target2, hash, &core.BuildMetadata{}, target2.Outputs())
 	assert.True(t, inCache(target2))
 	// This time it should clean target1, because target2 has just been stored
 	totalSize := cache.clean(10000, 1000)
@@ -122,14 +123,14 @@ func TestCleanForReal2(t *testing.T) {
 func TestStoreAndRetrieveCompressed(t *testing.T) {
 	cache := makeCache(".plz-cache-test6", true)
 	target := makeTarget("//test6:target6", 20)
-	cache.Store(target, hash, &core.BuildMetadata{}, target.Outputs())
+	cache.Store(context.Background(), target, hash, &core.BuildMetadata{}, target.Outputs())
 	// Should now exist in cache at this path
 	assert.True(t, inCompressedCache(target))
-	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs()))
+	assert.NotNil(t, cache.Retrieve(context.Background(), target, hash, target.Outputs()))
 	// Should be able to store it again without problems
-	cache.Store(target, hash, &core.BuildMetadata{}, target.Outputs())
+	cache.Store(context.Background(), target, hash, &core.BuildMetadata{}, target.Outputs())
 	assert.True(t, inCompressedCache(target))
-	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs()))
+	assert.NotNil(t, cache.Retrieve(context.Background(), target, hash, target.Outputs()))
 }
 
 func TestCleanCompressed(t *testing.T) {
@@ -138,7 +139,7 @@ func TestCleanCompressed(t *testing.T) {
 	writeFile(cachePath(target1, true), 2000)
 	assert.True(t, inCompressedCache(target1))
 	target2 := makeTarget("//test7:target2", 2000)
-	cache.Store(target2, hash, &core.BuildMetadata{}, target2.Outputs())
+	cache.Store(context.Background(), target2, hash, &core.BuildMetadata{}, target2.Outputs())
 	assert.True(t, inCompressedCache(target2))
 	// Don't want to assert the size here since it depends on how well gzip compresses.
 	// It's a bit hard to know exactly what the sizes here should be too but we'll guess

--- a/src/cache/http_cache.go
+++ b/src/cache/http_cache.go
@@ -5,6 +5,7 @@ package cache
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -30,7 +31,7 @@ var mtime = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
 // nobody is the usual uid / gid of the 'nobody' user.
 const nobody = 65534
 
-func (cache *httpCache) Store(target *core.BuildTarget, key []byte, metadata *core.BuildMetadata, files []string) {
+func (cache *httpCache) Store(ctx context.Context, target *core.BuildTarget, key []byte, metadata *core.BuildMetadata, files []string) {
 	if cache.writable {
 		r, w := io.Pipe()
 		go cache.write(w, target, key, metadata, files)
@@ -110,7 +111,7 @@ func (cache *httpCache) storeFile(tw *tar.Writer, name string) error {
 	return err
 }
 
-func (cache *httpCache) Retrieve(target *core.BuildTarget, key []byte, files []string) *core.BuildMetadata {
+func (cache *httpCache) Retrieve(ctx context.Context, target *core.BuildTarget, key []byte, files []string) *core.BuildMetadata {
 	m, err := cache.retrieve(target, key)
 	if err != nil {
 		log.Warning("%s: Failed to retrieve files from HTTP cache: %s", target.Label, err)
@@ -175,11 +176,11 @@ func (cache *httpCache) retrieve(target *core.BuildTarget, key []byte) (*core.Bu
 	}
 }
 
-func (cache *httpCache) Clean(target *core.BuildTarget) {
+func (cache *httpCache) Clean(ctx context.Context, target *core.BuildTarget) {
 	// Not possible; this implementation can only clean for a hash.
 }
 
-func (cache *httpCache) CleanAll() {
+func (cache *httpCache) CleanAll(ctx context.Context) {
 	// Also not possible.
 }
 

--- a/src/cache/http_cache_test.go
+++ b/src/cache/http_cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -35,13 +36,13 @@ func TestStoreAndRetrieve(t *testing.T) {
 	cache := newHTTPCache(config)
 
 	key := []byte("test_key")
-	cache.Store(target, key, &core.BuildMetadata{}, target.Outputs())
+	cache.Store(context.Background(), target, key, &core.BuildMetadata{}, target.Outputs())
 
 	b, err := ioutil.ReadFile("plz-out/gen/pkg/name/testfile2")
 	assert.NoError(t, err)
 
 	// Remove the file before we retrieve
-	metadata := cache.Retrieve(target, key, nil)
+	metadata := cache.Retrieve(context.Background(), target, key, nil)
 	assert.NotNil(t, metadata)
 
 	b2, err := ioutil.ReadFile("plz-out/gen/pkg/name/testfile2")

--- a/src/cache/rex_cache.go
+++ b/src/cache/rex_cache.go
@@ -5,6 +5,7 @@ package cache
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"path"
 
@@ -22,18 +23,18 @@ func newRemoteCache(state *core.BuildState) *rexCache {
 	return &rexCache{client: state.RemoteClient, readonly: state.Config.Remote.ReadOnly}
 }
 
-func (rc *rexCache) Store(target *core.BuildTarget, key []byte, metadata *core.BuildMetadata, files []string) {
+func (rc *rexCache) Store(ctx context.Context, target *core.BuildTarget, key []byte, metadata *core.BuildMetadata, files []string) {
 	if !rc.readonly {
 		log.Debug("Storing %s in remote cache...", target.Label)
-		if err := rc.client.Store(target, metadata, files); err != nil {
+		if err := rc.client.Store(ctx, target, metadata, files); err != nil {
 			log.Warning("Error storing artifacts in remote cache: %s", err)
 		}
 	}
 }
 
-func (rc *rexCache) Retrieve(target *core.BuildTarget, key []byte, files []string) *core.BuildMetadata {
+func (rc *rexCache) Retrieve(ctx context.Context, target *core.BuildTarget, key []byte, files []string) *core.BuildMetadata {
 	log.Debug("Retrieving %s from remote cache...", target.Label)
-	metadata, err := rc.client.Retrieve(target)
+	metadata, err := rc.client.Retrieve(ctx, target)
 	if err != nil {
 		if remote.IsNotFound(err) {
 			log.Debug("Artifacts for %s [key %s] don't exist in remote cache", target.Label, hex.EncodeToString(key))
@@ -49,11 +50,11 @@ func (rc *rexCache) Retrieve(target *core.BuildTarget, key []byte, files []strin
 	return metadata
 }
 
-func (rc *rexCache) Clean(target *core.BuildTarget) {
+func (rc *rexCache) Clean(ctx context.Context, target *core.BuildTarget) {
 	// There is no API for this, so we just don't do it.
 }
 
-func (rc *rexCache) CleanAll() {
+func (rc *rexCache) CleanAll(ctx context.Context) {
 	// Similarly here.
 }
 

--- a/src/cache/stub.go
+++ b/src/cache/stub.go
@@ -6,11 +6,12 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thought-machine/please/src/core"
 )
 
-func newRPCCache(config *core.Configuration) (*httpCache, error) {
+func newRPCCache(ctx context.Context, config *core.Configuration) (*httpCache, error) {
 	return nil, fmt.Errorf("Config specifies RPC cache but it is not compiled")
 }

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -427,7 +428,7 @@ func (label BuildLabel) Complete(match string) []flags.Completion {
 	os.Setenv("PLZ_COMPLETE", match)
 	os.Unsetenv("GO_FLAGS_COMPLETION")
 	exec, _ := os.Executable()
-	out, _, err := process.New("").ExecWithTimeout(nil, "", os.Environ(), 10*time.Second, false, false, false, append([]string{exec}, os.Args[1:]...))
+	out, _, err := process.New("").ExecWithTimeout(context.Background(), nil, "", os.Environ(), 10*time.Second, false, false, false, append([]string{exec}, os.Args[1:]...))
 	if err != nil {
 		return nil
 	}

--- a/src/core/cache.go
+++ b/src/core/cache.go
@@ -1,24 +1,28 @@
 package core
 
+import (
+	"context"
+)
+
 // Cache is our general interface to caches for built targets.
 // The implementations are in //src/cache, but the interface is in this package because
 // it's passed around on the BuildState object.
 type Cache interface {
 	// Stores the results of a single build target.
-	Store(target *BuildTarget, key []byte, metadata *BuildMetadata, files []string)
+	Store(ctx context.Context, target *BuildTarget, key []byte, metadata *BuildMetadata, files []string)
 	// Retrieves the results of a single build target.
 	// If successful, the outputs will be placed into the output file tree and
 	// the returned metadata structure will be populated with whatever is stored
 	// (the only field that is guaranteed is standard output though, and only for targets
 	// that have post-build functions).
 	// If unsuccessful, it will return nil.
-	Retrieve(target *BuildTarget, key []byte, files []string) *BuildMetadata
+	Retrieve(ctx context.Context, target *BuildTarget, key []byte, files []string) *BuildMetadata
 	// Retrieves the results of a test run.
 	// Cleans any artifacts associated with this target from the cache, for any possible key.
 	// Some implementations may not honour this, depending on configuration etc.
-	Clean(target *BuildTarget)
+	Clean(ctx context.Context, target *BuildTarget)
 	// Cleans the entire cache.
-	CleanAll()
+	CleanAll(ctx context.Context)
 	// Shuts down the cache, blocking until any potentially pending requests are done.
 	Shutdown()
 }

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"crypto/sha1"
 	"crypto/sha256"
 	"fmt"
@@ -70,15 +71,15 @@ type Parser interface {
 // A RemoteClient is the interface to a remote execution service.
 type RemoteClient interface {
 	// Retrieve fetches remote results from the service.
-	Retrieve(target *BuildTarget) (*BuildMetadata, error)
+	Retrieve(ctx context.Context, target *BuildTarget) (*BuildMetadata, error)
 	// Store stores outputs of a target with the service.
-	Store(target *BuildTarget, metadata *BuildMetadata, files []string) error
+	Store(ctx context.Context, target *BuildTarget, metadata *BuildMetadata, files []string) error
 	// Build invokes a build of the target remotely
-	Build(tid int, target *BuildTarget) (*BuildMetadata, error)
+	Build(ctx context.Context, tid int, target *BuildTarget) (*BuildMetadata, error)
 	// Test invokes a test run of the target remotely.
-	Test(tid int, target *BuildTarget) (metadata *BuildMetadata, results, coverage []byte, err error)
+	Test(ctx context.Context, tid int, target *BuildTarget) (metadata *BuildMetadata, results, coverage []byte, err error)
 	// PrintHashes shows the hashes of a target.
-	PrintHashes(target *BuildTarget, isTest bool)
+	PrintHashes(ctx context.Context, target *BuildTarget, isTest bool)
 	// DataRate returns an estimate of the current in/out RPC data rates in bytes per second.
 	DataRate() (int, int)
 }

--- a/src/follow/grpc_test.go
+++ b/src/follow/grpc_test.go
@@ -63,7 +63,7 @@ func TestClientToServerCommunication(t *testing.T) {
 
 	clientState := core.NewDefaultBuildState()
 	results := clientState.Results()
-	connectClient(clientState, addr, retries, delay)
+	connectClient(context.Background(), clientState, addr, retries, delay)
 	// The client state should have synced up with the server's number of threads
 	assert.Equal(t, 5, clientState.Config.Please.NumThreads)
 
@@ -104,7 +104,7 @@ func TestWithOutput(t *testing.T) {
 	serverState := core.NewDefaultBuildState()
 	addr, shutdown := initialiseServer(serverState, 0)
 	clientState := core.NewDefaultBuildState()
-	connectClient(clientState, addr, retries, delay)
+	connectClient(context.Background(), clientState, addr, retries, delay)
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		serverState.LogBuildResult(0, l1, core.PackageParsed, fmt.Sprintf("Parsed %s", l1))
@@ -127,7 +127,7 @@ func TestResources(t *testing.T) {
 	addr, shutdown := initialiseServer(serverState, 0)
 	defer shutdown()
 	clientState := core.NewDefaultBuildState()
-	connectClient(clientState, addr, retries, delay)
+	connectClient(context.Background(), clientState, addr, retries, delay)
 	// Fortunately this is a lot less fiddly than the others, because we always
 	// receive updates eventually. On the downside it's hard to know when it'll
 	// be done since we can't observe the actual goroutines that are doing it.

--- a/src/follow/stub.go
+++ b/src/follow/stub.go
@@ -5,6 +5,7 @@
 package follow
 
 import (
+	"context"
 	"time"
 
 	"github.com/thought-machine/please/src/core"
@@ -16,7 +17,7 @@ func InitialiseServer(state *core.BuildState, port int) func() {
 }
 
 // ConnectClient is a stub that always returns false immediately.
-func ConnectClient(state *core.BuildState, url string, retries int, delay time.Duration) bool {
+func ConnectClient(ctx context.Context, state *core.BuildState, url string, retries int, delay time.Duration) bool {
 	return false
 }
 

--- a/src/please.go
+++ b/src/please.go
@@ -741,6 +741,7 @@ func newCache(ctx context.Context, state *core.BuildState) core.Cache {
 	return cache.NewCache(ctx, state)
 }
 
+// NewBuildState creates a new Build State based on the configuration and flags.
 func NewBuildState(config *core.Configuration, shouldBuild, shouldTest bool) *core.BuildState {
 	if opts.BuildFlags.NumThreads > 0 {
 		config.Please.NumThreads = opts.BuildFlags.NumThreads

--- a/src/please.go
+++ b/src/please.go
@@ -679,7 +679,7 @@ var buildFunctions = map[string]func(context.Context) int{
 		return toExitCode(success, state)
 	},
 	"filter": func(ctx context.Context) int {
-		return runQuery(ctx,false, opts.Query.Filter.Args.Targets, func(state *core.BuildState) {
+		return runQuery(ctx, false, opts.Query.Filter.Args.Targets, func(state *core.BuildState) {
 			query.Filter(state, state.ExpandOriginalLabels())
 		})
 	},

--- a/src/process/process_test.go
+++ b/src/process/process_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -9,33 +10,33 @@ import (
 )
 
 func TestExecWithTimeout(t *testing.T) {
-	out, _, err := New("").ExecWithTimeout(nil, "", nil, 10*time.Second, false, false, false, []string{"true"})
+	out, _, err := New("").ExecWithTimeout(context.Background(), nil, "", nil, 10*time.Second, false, false, false, []string{"true"})
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(out))
 }
 
 func TestExecWithTimeoutFailure(t *testing.T) {
-	out, _, err := New("").ExecWithTimeout(nil, "", nil, 10*time.Second, false, false, false, []string{"false"})
+	out, _, err := New("").ExecWithTimeout(context.Background(),nil, "", nil, 10*time.Second, false, false, false, []string{"false"})
 	assert.Error(t, err)
 	assert.Equal(t, 0, len(out))
 }
 
 func TestExecWithTimeoutDeadline(t *testing.T) {
-	out, _, err := New("").ExecWithTimeout(nil, "", nil, 1*time.Nanosecond, false, false, false, []string{"sleep", "10"})
+	out, _, err := New("").ExecWithTimeout(context.Background(),nil, "", nil, 1*time.Nanosecond, false, false, false, []string{"sleep", "10"})
 	assert.Error(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), "Timeout exceeded"))
 	assert.Equal(t, 0, len(out))
 }
 
 func TestExecWithTimeoutOutput(t *testing.T) {
-	out, stderr, err := New("").ExecWithTimeoutShell(nil, "", nil, 10*time.Second, false, "echo hello", false)
+	out, stderr, err := New("").ExecWithTimeoutShell(context.Background(), nil, "", nil, 10*time.Second, false, "echo hello", false)
 	assert.NoError(t, err)
 	assert.Equal(t, "hello\n", string(out))
 	assert.Equal(t, "hello\n", string(stderr))
 }
 
 func TestExecWithTimeoutStderr(t *testing.T) {
-	out, stderr, err := New("").ExecWithTimeoutShell(nil, "", nil, 10*time.Second, false, "echo hello 1>&2", false)
+	out, stderr, err := New("").ExecWithTimeoutShell(context.Background(), nil, "", nil, 10*time.Second, false, "echo hello 1>&2", false)
 	assert.NoError(t, err)
 	assert.Equal(t, "", string(out))
 	assert.Equal(t, "hello\n", string(stderr))

--- a/src/remote/impl_test.go
+++ b/src/remote/impl_test.go
@@ -40,7 +40,7 @@ func newClientInstance(name string) *Client {
 	config.Remote.Secure = false
 	state := core.NewBuildState(config)
 	state.Config.Remote.URL = "127.0.0.1:9987"
-	return New(state)
+	return New(context.Background(), state)
 }
 
 // A testServer implements the server interface for the various servers we test against.

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -110,7 +110,7 @@ func run(ctx context.Context, state *core.BuildState, label core.BuildLabel, arg
 	// Note that we don't connect stdin. It doesn't make sense for multiple processes.
 	// The process executor doesn't actually support not having a timeout, but the max is ~290 years so nobody
 	// should know the difference.
-	_, output, err := process.New("").ExecWithTimeout(target, "", env, time.Duration(math.MaxInt64), false, false, !quiet, args)
+	_, output, err := process.New("").ExecWithTimeout(ctx, target, "", env, time.Duration(math.MaxInt64), false, false, !quiet, args)
 	return toExitError(err, args, output)
 }
 

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -23,8 +23,8 @@ import (
 var log = logging.MustGetLogger("run")
 
 // Run implements the running part of 'plz run'.
-func Run(state *core.BuildState, label core.BuildLabel, args []string, env bool) {
-	run(context.Background(), state, label, args, false, false, env)
+func Run(ctx context.Context, state *core.BuildState, label core.BuildLabel, args []string, env bool) {
+	run(ctx, state, label, args, false, false, env)
 }
 
 // Parallel runs a series of targets in parallel.
@@ -61,10 +61,10 @@ func Parallel(ctx context.Context, state *core.BuildState, labels []core.BuildLa
 // Sequential runs a series of targets sequentially.
 // Returns a relevant exit code (i.e. if at least one subprocess exited unsuccessfully, it will be
 // that code, otherwise 0 if all were successful).
-func Sequential(state *core.BuildState, labels []core.BuildLabel, args []string, quiet, env bool) int {
+func Sequential(ctx context.Context, state *core.BuildState, labels []core.BuildLabel, args []string, quiet, env bool) int {
 	for _, label := range labels {
 		log.Notice("Running %s", label)
-		if err := run(context.Background(), state, label, args, true, quiet, env); err != nil {
+		if err := run(ctx, state, label, args, true, quiet, env); err != nil {
 			log.Error("%s", err)
 			return err.code
 		}

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -18,9 +18,9 @@ func init() {
 
 func TestSequential(t *testing.T) {
 	state, labels1, labels2 := makeState()
-	code := Sequential(state, labels1, nil, true, false)
+	code := Sequential(context.Background(), state, labels1, nil, true, false)
 	assert.Equal(t, 0, code)
-	code = Sequential(state, labels2, nil, false, false)
+	code = Sequential(context.Background(), state, labels2, nil, false, false)
 	assert.Equal(t, 1, code)
 }
 

--- a/src/watch/stub.go
+++ b/src/watch/stub.go
@@ -4,11 +4,15 @@
 
 package watch
 
-import "github.com/thought-machine/please/src/core"
+import (
+	"context"
+
+	"github.com/thought-machine/please/src/core"
+)
 
 // A CallbackFunc is supplied to Watch in order to trigger a build.
 type CallbackFunc func(*core.BuildState, []core.BuildLabel)
 
 // Watch is a stub implementation of the real function in watch.go, this one does nothing.
-func Watch(state *core.BuildState, labels core.BuildLabels, callback CallbackFunc) {
+func Watch(ctx context.Context, state *core.BuildState, labels core.BuildLabels, callback CallbackFunc) {
 }

--- a/src/watch/stub.go
+++ b/src/watch/stub.go
@@ -11,7 +11,7 @@ import (
 )
 
 // A CallbackFunc is supplied to Watch in order to trigger a build.
-type CallbackFunc func(*core.BuildState, []core.BuildLabel)
+type CallbackFunc func(context.Context, *core.BuildState, []core.BuildLabel) (bool, *core.BuildState)
 
 // Watch is a stub implementation of the real function in watch.go, this one does nothing.
 func Watch(ctx context.Context, state *core.BuildState, labels core.BuildLabels, callback CallbackFunc) {

--- a/tools/build_langserver/lsp/lsp.go
+++ b/tools/build_langserver/lsp/lsp.go
@@ -150,7 +150,7 @@ func (h *Handler) initialize(params *lsp.InitializeParams) (*lsp.InitializeResul
 	// This is a lot easier than trying to do clever partial parses later on, although
 	// eventually we may want that if we start dealing with truly large repos.
 	go func() {
-		plz.RunHost(core.WholeGraph, h.state)
+		plz.RunHost(context.Background(), core.WholeGraph, h.state)
 		log.Debug("initial parse complete")
 		h.buildPackageTree()
 		log.Debug("built completion package tree")


### PR DESCRIPTION
Open to comments / revision here.

There are a few odd things here (such as passing contexts into constructors as they make remote calls) but this seems pretty simple. I've tested it with "plz plz build" but see #806 - the repo doesn't fully build on my machine any more.

This is a precursor to adding tracing (e.g. OpenTracing) to all operations for visibility/fun (see similar functionality in Pants - https://github.com/pantsbuild/pants/pull/7342 )