### PR TITLE
Use the common process control code for plz run

### DIFF
--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -427,7 +427,7 @@ func (label BuildLabel) Complete(match string) []flags.Completion {
 	os.Setenv("PLZ_COMPLETE", match)
 	os.Unsetenv("GO_FLAGS_COMPLETION")
 	exec, _ := os.Executable()
-	out, _, err := process.New("").ExecWithTimeout(nil, "", os.Environ(), 10*time.Second, false, false, append([]string{exec}, os.Args[1:]...))
+	out, _, err := process.New("").ExecWithTimeout(nil, "", os.Environ(), 10*time.Second, false, false, false, append([]string{exec}, os.Args[1:]...))
 	if err != nil {
 		return nil
 	}

--- a/src/process/process_test.go
+++ b/src/process/process_test.go
@@ -9,19 +9,19 @@ import (
 )
 
 func TestExecWithTimeout(t *testing.T) {
-	out, _, err := New("").ExecWithTimeout(nil, "", nil, 10*time.Second, false, false, []string{"true"})
+	out, _, err := New("").ExecWithTimeout(nil, "", nil, 10*time.Second, false, false, false, []string{"true"})
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(out))
 }
 
 func TestExecWithTimeoutFailure(t *testing.T) {
-	out, _, err := New("").ExecWithTimeout(nil, "", nil, 10*time.Second, false, false, []string{"false"})
+	out, _, err := New("").ExecWithTimeout(nil, "", nil, 10*time.Second, false, false, false, []string{"false"})
 	assert.Error(t, err)
 	assert.Equal(t, 0, len(out))
 }
 
 func TestExecWithTimeoutDeadline(t *testing.T) {
-	out, _, err := New("").ExecWithTimeout(nil, "", nil, 1*time.Nanosecond, false, false, []string{"sleep", "10"})
+	out, _, err := New("").ExecWithTimeout(nil, "", nil, 1*time.Nanosecond, false, false, false, []string{"sleep", "10"})
 	assert.Error(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), "Timeout exceeded"))
 	assert.Equal(t, 0, len(out))

--- a/src/run/BUILD
+++ b/src/run/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//src/core",
         "//src/output",
+        "//src/process",
         "//third_party/go:errgroup",
         "//third_party/go:logging",
     ],


### PR DESCRIPTION
Seems this got missed out, but `plz run` is inventing bits of it itself, but misses the cleanup on terminate (so ctrl+c does not kill subprocesses, which can be pretty annoying / surprising).