### PR TITLE
Adding optional extra verification of outputs

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -254,6 +254,7 @@ func DefaultConfiguration() *Configuration {
 	config.Display.SystemStats = true
 	config.Remote.HomeDir = "~"
 	config.Remote.Secure = true
+	config.Remote.VerifyOutputs = true
 	config.Go.GoTool = "go"
 	config.Go.CgoCCTool = "gcc"
 	config.Go.BuildIDTool = "go_buildid_replacer"
@@ -390,17 +391,18 @@ type Configuration struct {
 		Upload          cli.URL      `help:"URL to upload test results to (in XML format)"`
 	}
 	Remote struct {
-		URL          string       `help:"URL for the remote server. If this is set but no executors are configured then it can still act as a remote cache."`
-		CASURL       string       `help:"URL for the CAS service, if it is different to the main one."`
-		NumExecutors int          `help:"Maximum number of remote executors to use simultaneously."`
-		Instance     string       `help:"Remote instance name to request; depending on the server this may be required."`
-		Name         string       `help:"A name for this worker instance. This is attached to artifacts uploaded to remote storage." example:"agent-001"`
-		DisplayURL   string       `help:"A URL to browse the remote server with (e.g. using buildbarn-browser). Only used when printing hashes."`
-		Timeout      cli.Duration `help:"Timeout for connections made to the remote server."`
-		ReadOnly     bool         `help:"If true, prevents this client from writing to the remote storage. Is overridden if being used for execution."`
-		Secure       bool         `help:"Whether to use TLS for communication or not."`
-		HomeDir      string       `help:"The home directory on the build machine."`
-		Platform     []string     `help:"Platform properties to request from remote workers, in the format key=value."`
+		URL           string       `help:"URL for the remote server. If this is set but no executors are configured then it can still act as a remote cache."`
+		CASURL        string       `help:"URL for the CAS service, if it is different to the main one."`
+		NumExecutors  int          `help:"Maximum number of remote executors to use simultaneously."`
+		Instance      string       `help:"Remote instance name to request; depending on the server this may be required."`
+		Name          string       `help:"A name for this worker instance. This is attached to artifacts uploaded to remote storage." example:"agent-001"`
+		DisplayURL    string       `help:"A URL to browse the remote server with (e.g. using buildbarn-browser). Only used when printing hashes."`
+		Timeout       cli.Duration `help:"Timeout for connections made to the remote server."`
+		ReadOnly      bool         `help:"If true, prevents this client from writing to the remote storage. Is overridden if being used for execution."`
+		Secure        bool         `help:"Whether to use TLS for communication or not."`
+		VerifyOutputs bool         `help:"Whether to verify all outputs are present after a cached remote execution action. Depending on your server implementation, you may require this to ensure files are really present."`
+		HomeDir       string       `help:"The home directory on the build machine."`
+		Platform      []string     `help:"Platform properties to request from remote workers, in the format key=value."`
 	} `help:"Settings related to remote execution & caching using the Google remote execution APIs. This section is still experimental and subject to change."`
 	Size  map[string]*Size `help:"Named sizes of targets; these are the definitions of what can be passed to the 'size' argument."`
 	Cover struct {


### PR DESCRIPTION
The API doesn't guarantee that all the blobs associated with a cached result actually exist. We should check that's the case if we're going to use one (since it'll be too late for us to rebuild if they turn out to be missing later).

It's guarded with a config flag though since I still think we'll end up with a server implementation that never evicts anything, in which case it's just a waste of time to re-check it.