### PR TITLE
Handle temp output names correctly

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,6 @@ env:
   GOPROXY: https://proxy.golang.org
 
 task:
-  install_script: pkg install -y bash protobuf go git python3
+  install_script: pkg install -y bash protobuf go git python3 && python3 -m ensurepip
   bashrc_script: touch ~/.bashrc
   build_script: PLZ_ARGS="-o cache.httpurl:http://$CIRRUS_HTTP_CACHE_HOST" ./bootstrap.sh --exclude pip --exclude py2 --exclude no_cirrus

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -358,7 +358,7 @@ func (c *Client) Retrieve(target *core.BuildTarget) (*core.BuildMetadata, error)
 	if err := c.downloadBlobs(ctx, func(ch chan<- *blob) error {
 		defer close(ch)
 		for _, file := range resp.OutputFiles {
-			filePath := path.Join(outDir, file.Path)
+			filePath := path.Join(outDir, target.GetRealOutput(file.Path))
 			addPerms := extraPerms(file)
 			if file.Contents != nil {
 				// Inlining must have been requested. Can write it directly.

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -266,6 +266,7 @@ func outputs(target *core.BuildTarget) (files, dirs []string) {
 	outs := target.Outputs()
 	files = make([]string, 0, len(outs))
 	for _, out := range outs {
+		out = target.GetTmpOutput(out)
 		if !strings.ContainsRune(path.Base(out), '.') && !strings.HasSuffix(out, "file") {
 			dirs = append(dirs, out)
 		} else {


### PR DESCRIPTION
we were updating env vars but not actual output declarations for remote execution, so we weren't getting back the right thing.