### PR TITLE
More rex fiddling

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -24,3 +24,11 @@ filegroup(
     binary = True,
     deps = ["//package:installed_files"],
 )
+
+# This is used as part of bootstrap, and is used from here to avoid subtle issues with remote execution.
+filegroup(
+    name = "jarcat_unzip",
+    srcs = ["//tools/jarcat:jarcat_unzip"],
+    binary = True,
+    visibility = ["//third_party/go:all"],
+)

--- a/build_defs/plz_e2e_test.build_defs
+++ b/build_defs/plz_e2e_test.build_defs
@@ -51,4 +51,5 @@ def plz_e2e_test(name:str, cmd:str, pre_cmd:str=None, expected_output:str=None,
         labels = ['e2e'] + (labels or []),
         no_test_output = True,
         sandbox = False,
+        local = True,
     )

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -410,18 +410,13 @@ func mustShortTargetHash(state *core.BuildState, target *core.BuildTarget) []byt
 	return core.CollapseHash(mustTargetHash(state, target))
 }
 
-// RuntimeHash returns the target hash, source hash, config hash & runtime file hash,
+// RuntimeHash returns the target hash, config hash & runtime file hash,
 // all rolled into one. Essentially this is one hash needed to determine if the runtime
 // state is consistent.
 func RuntimeHash(state *core.BuildState, target *core.BuildTarget) ([]byte, error) {
 	hash := append(RuleHash(state, target, true, false), RuleHash(state, target, true, true)...)
 	hash = append(hash, state.Hashes.Config...)
-	sh, err := sourceHash(state, target)
-	if err != nil {
-		return nil, err
-	}
 	h := sha1.New()
-	h.Write(sh)
 	for source := range core.IterRuntimeFiles(state.Graph, target, true) {
 		result, err := state.PathHasher.Hash(source.Src, false, true)
 		if err != nil {

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -194,7 +194,11 @@ func initStampEnv() {
 
 func toolPath(state *BuildState, tool BuildInput, abs bool) string {
 	if label := tool.Label(); label != nil {
-		return state.Graph.TargetOrDie(*label).toolPath(abs)
+		path := state.Graph.TargetOrDie(*label).toolPath(abs)
+		if !strings.Contains(path, "/") {
+			path = "./" + path
+		}
+		return path
 	} else if abs {
 		return tool.Paths(state.Graph)[0]
 	}

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -47,13 +47,15 @@ const MachineConfigFileName = "/etc/please/plzconfig"
 const UserConfigFileName = "~/.config/please/plzconfig"
 
 func readConfigFile(config *Configuration, filename string) error {
-	log.Debug("Reading config from %s...", filename)
+	log.Debug("Attempting to read config from %s...", filename)
 	if err := gcfg.ReadFileInto(config, filename); err != nil && os.IsNotExist(err) {
 		return nil // It's not an error to not have the file at all.
 	} else if gcfg.FatalOnly(err) != nil {
 		return err
 	} else if err != nil {
 		log.Warning("Error in config file: %s", err)
+	} else {
+		log.Debug("Read config from %s", filename)
 	}
 	return nil
 }

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -373,7 +373,7 @@ func (c *Client) buildMetadata(ar *pb.ActionResult, needStdout, needStderr bool)
 	return metadata, nil
 }
 
-// digestForFilename returns the digest for an output of the given name.
+// digestForFilename returns the digest for an output of the given name, or nil if it doesn't exist.
 func (c *Client) digestForFilename(ar *pb.ActionResult, name string) *pb.Digest {
 	for _, file := range ar.OutputFiles {
 		if file.Path == name {

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -120,7 +120,7 @@ func (c *Client) buildTestCommand(target *core.BuildTarget) (*pb.Command, error)
 		Arguments: []string{
 			c.bashPath, "--noprofile", "--norc", "-u", "-o", "pipefail", "-c", commandPrefix + cmd,
 		},
-		EnvironmentVariables: buildEnv(core.TestEnvironment(c.state, target, "")),
+		EnvironmentVariables: buildEnv(core.TestEnvironment(c.state, target, ".")),
 		OutputFiles:          files,
 		OutputDirectories:    dirs,
 		OutputPaths:          append(files, dirs...),

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -509,10 +509,12 @@ func (c *Client) execute(tid int, target *core.BuildTarget, command *pb.Command,
 					log.Debug("Server log available: %s: hash key %s", k, v.Digest.Hash)
 				}
 				var respErr error
-				if response.Status != nil && respErr != nil {
+				if response.Status != nil {
 					respErr = convertError(response.Status)
-					if url := c.actionURL(digest, false); url != "" {
-						respErr = fmt.Errorf("%s\nAction URL: %s", respErr, url)
+					if respErr != nil {
+						if url := c.actionURL(digest, false); url != "" {
+							respErr = fmt.Errorf("%s\nAction URL: %s", respErr, url)
+						}
 					}
 				}
 				if resp.Result == nil { // This is optional on failure.

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -267,7 +267,7 @@ func outputs(target *core.BuildTarget) (files, dirs []string) {
 	files = make([]string, 0, len(outs))
 	for _, out := range outs {
 		out = target.GetTmpOutput(out)
-		if !strings.ContainsRune(path.Base(out), '.') && !strings.HasSuffix(out, "file") {
+		if !strings.ContainsRune(path.Base(out), '.') && !strings.HasSuffix(out, "file") && !target.IsBinary {
 			dirs = append(dirs, out)
 		} else {
 			files = append(files, out)

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["PUBLIC"])
 
 # This is needed to break a circular dependency.
-package(jarcat_tool = "//tools/jarcat:jarcat_unzip")
+package(jarcat_tool = "//:jarcat_unzip")
 
 go_get(
     name = "logging",

--- a/tools/jarcat/BUILD
+++ b/tools/jarcat/BUILD
@@ -15,5 +15,5 @@ go_binary(
 go_binary(
     name = "jarcat_unzip",
     srcs = ["unzip_main.go"],
-    visibility = ["//third_party/go:all"],
+    visibility = ["PUBLIC"],
 )


### PR DESCRIPTION
This fixes a bunch of small issues. Was able to get Please to build remotely after these changes.

The change to RuntimeHash is kind of interesting - it's been that way since the dawn of time basically but I think it's always been wrong (it's hashing all the sources of the target to figure out if it needs to rerun the test, which should be unnecessary, we should only need to look at the output of the target, i.e. the test binary itself).

There's some slightly ugly stuff around one of the tools; it being in the working dir for remote execution causes a clash with `//third_party/go:tools`. That's kinda crap but the circumstances are specific enough (it's only in this repo where the tool is copied in that way) that I'm just doing a specific fix for now.