### PR TITLE
Delay uploading of sources until needed

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -79,8 +79,8 @@ type RemoteClient interface {
 	Test(tid int, target *BuildTarget) (metadata *BuildMetadata, results, coverage []byte, err error)
 	// PrintHashes shows the hashes of a target.
 	PrintHashes(target *BuildTarget, isTest bool)
-	// DataRate returns an estimate of the current in/out RPC data rates in bytes per second.
-	DataRate() (int, int)
+	// DataRate returns an estimate of the current in/out RPC data rates and totals so far in bytes per second.
+	DataRate() (int, int, int, int)
 }
 
 // A TargetHasher is a thing that knows how to create hashes for targets.

--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -106,7 +106,7 @@ func (d *displayer) printLines() {
 			printf("  ${BOLD_WHITE}Worker processes: %d${RESET}", d.state.Stats.NumWorkerProcesses)
 		}
 		if d.state.RemoteClient != nil {
-			in, out := d.state.RemoteClient.DataRate()
+			in, out, _, _ := d.state.RemoteClient.DataRate()
 			printf("  ${BOLD_WHITE}RPC data in: %6s/s out: %6s/s${RESET}", humanize.Bytes(uint64(in)), humanize.Bytes(uint64(out)))
 		}
 		printf("${ERASE_AFTER}\n")

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -60,6 +60,10 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, config *
 	if state.Cache != nil {
 		state.Cache.Shutdown()
 	}
+	if state.RemoteClient != nil {
+		_, _, in, out := state.RemoteClient.DataRate()
+		log.Info("Total remote RPC data in: %d out: %d", in, out)
+	}
 	state.CloseResults()
 }
 

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -68,7 +68,7 @@ type Client struct {
 	bashPath string
 
 	// Stats used to report RPC data rates
-	byteRateIn, byteRateOut int
+	byteRateIn, byteRateOut, totalBytesIn, totalBytesOut int
 }
 
 // New returns a new Client instance.
@@ -611,6 +611,6 @@ func (c *Client) PrintHashes(target *core.BuildTarget, isTest bool) {
 }
 
 // DataRate returns an estimate of the current in/out RPC data rates in bytes per second.
-func (c *Client) DataRate() (int, int) {
-	return c.byteRateIn, c.byteRateOut
+func (c *Client) DataRate() (int, int, int, int) {
+	return c.byteRateIn, c.byteRateOut, c.totalBytesIn, c.totalBytesOut
 }


### PR DESCRIPTION
Currently we simultaneously construct the request protos and upload sources to the CAS; we optimise the latter a bit by checking if they are already uploaded, but it still loads the server up with a lot of things to check for requests that end up being no-ops because they are cached anyway. This reorders that so we construct the protos but delay uploading sources until we know they are needed. Interestingly this sort of implies that well-optimised clients would never have a reason to let the server perform the cache check, because we'd always have done it ourselves first.

Also added some summary bytes in/out stats at the end. They're just logged quietly but is sort of useful to track totals rather than the instantaneous values in the display.