### PR TITLE
use lower case path instead to differentiate from env variable

### DIFF
--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -378,7 +378,7 @@ func LookPath(filename string, paths []string) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("%s not found in PATH %s", filename, strings.Join(paths, ":"))
+	return "", fmt.Errorf("%s not found in path %s", filename, strings.Join(paths, ":"))
 }
 
 // LookBuildPath is like LookPath but takes the config's build path into account.


### PR DESCRIPTION
"PATH" string causes to think that it's the shell path variable, so proposing the use of lowercase to differentiate