### PR TITLE
Do not do shell expansion for sh_cmd rule

### DIFF
--- a/rules/sh_rules.build_defs
+++ b/rules/sh_rules.build_defs
@@ -160,9 +160,9 @@ def sh_cmd(name:str, cmd:str|dict|list, srcs:list|dict=None, out:str="", shell:s
     """
     cmd = ' && '.join(cmd) if isinstance(cmd, list) else cmd
     if isinstance(cmd, str):
-        cmds = f'{{ cat > $OUT << EOF\n#!{shell}\n{cmd}\nEOF\n}}'
+        cmds = f'{{ cat > $OUT << "EOF"\n#!{shell}\n{cmd}\nEOF\n}}'
     elif isinstance(cmd, dict):
-        cmds = {k: f'{{ cat > $OUT << EOF\n#!{shell}\n{v}\nEOF\n}}' for k, v in cmd.items()}
+        cmds = {k: f'{{ cat > $OUT << "EOF"\n#!{shell}\n{v}\nEOF\n}}' for k, v in cmd.items()}
     return build_rule(
         name = name,
         outs = [out or name + '.sh'],

--- a/rules/sh_rules.build_defs
+++ b/rules/sh_rules.build_defs
@@ -148,7 +148,9 @@ def sh_cmd(name:str, cmd:str|dict|list, srcs:list|dict=None, out:str="", shell:s
 
     Args:
       name (str): Name of the rule.
-      cmd (str | dict): Command to write into the output script file.
+      cmd (str | dict): Command to write into the output script file. The commands are subject to
+                        shell expansion during build time, so if that is to be avoided the variables
+                        have to be escaped with \\\\\\$, i.e. \\\\\\${@}. 
       srcs (list | dict): Source files. Can be consumed by the generated command (but are not
                           written into the output in any other way).
       out (str): Name of the output file to create. Defaults to name + .sh.
@@ -160,9 +162,9 @@ def sh_cmd(name:str, cmd:str|dict|list, srcs:list|dict=None, out:str="", shell:s
     """
     cmd = ' && '.join(cmd) if isinstance(cmd, list) else cmd
     if isinstance(cmd, str):
-        cmds = f'{{ cat > $OUT << "EOF"\n#!{shell}\n{cmd}\nEOF\n}}'
+        cmds = f'{{ cat > $OUT << EOF\n#!{shell}\n{cmd}\nEOF\n}}'
     elif isinstance(cmd, dict):
-        cmds = {k: f'{{ cat > $OUT << "EOF"\n#!{shell}\n{v}\nEOF\n}}' for k, v in cmd.items()}
+        cmds = {k: f'{{ cat > $OUT << EOF\n#!{shell}\n{v}\nEOF\n}}' for k, v in cmd.items()}
     return build_rule(
         name = name,
         outs = [out or name + '.sh'],

--- a/test/sh_rules/BUILD
+++ b/test/sh_rules/BUILD
@@ -18,12 +18,14 @@ sh_test(
 
 sh_cmd(
     name = "sh_cmd",
-    cmd = ["TEST_VAR=\"$@\"",
-           "[ \"$TEST_VAR\" = \"test_value\" ] || (echo \"Expected a value expansion not to happen\" >&2 && exit 11)",]
+    cmd = [
+        "TEST_VAR=\"$@\"",
+        "[ \"$TEST_VAR\" = \"test_value\" ] || (echo \"Expected a value expansion not to happen\" >&2 && exit 11)",
+    ],
 )
 
 sh_test(
     name = "sh_cmd_test",
     src = ":sh_cmd",
-    flags = "test_value"
+    flags = "test_value",
 )

--- a/test/sh_rules/BUILD
+++ b/test/sh_rules/BUILD
@@ -19,8 +19,10 @@ sh_test(
 sh_cmd(
     name = "sh_cmd",
     cmd = [
-        "TEST_VAR=\"$@\"",
-        "[ \"$TEST_VAR\" = \"test_value\" ] || (echo \"Expected a value expansion not to happen\" >&2 && exit 11)",
+        "BUILD_TIME_EXPANSION_VAR=\"$OUT\"",
+        "NO_EXPANSION_VAR=\"\\\$@\"",
+        "[ \"\\\$BUILD_TIME_EXPANSION_VAR\" != \"\" ] || (echo \"Expected a build time var to be expanded.\" >&2 && exit 11)",
+        "[ \"\\\$NO_EXPANSION_VAR\" = \"test_value\" ] || (echo \"Expected a expansion not to happen\" >&2 && exit 11)",
     ],
 )
 

--- a/test/sh_rules/BUILD
+++ b/test/sh_rules/BUILD
@@ -15,3 +15,15 @@ sh_test(
     name = "sh_test",
     src = ":sh_binary",
 )
+
+sh_cmd(
+    name = "sh_cmd",
+    cmd = ["TEST_VAR=\"$@\"",
+           "[ \"$TEST_VAR\" = \"test_value\" ] || (echo \"Expected a value expansion not to happen\" >&2 && exit 11)",]
+)
+
+sh_test(
+    name = "sh_cmd_test",
+    src = ":sh_cmd",
+    flags = "test_value"
+)


### PR DESCRIPTION
sh_cmd rule looses any shell variable arguments specified as the cat is doing shell expansion.