### PR TITLE
Use a tempfile for writing Zip file to avoid having to exclude it

### DIFF
--- a/rules/sh_rules.build_defs
+++ b/rules/sh_rules.build_defs
@@ -61,15 +61,15 @@ def sh_binary(name:str, main:str|list&srcs, deps:list=None, visibility:list=None
     if deps:
         cmds = ' && '.join([
             # Use the same shebang as the original script
-            'head -1 $SRCS > _tmp.txt',
+            'head -1 $SRCS > $TMPDIR/_tmp.txt',
             # Inject bash code to untar the compressed files.
-            f'echo "{_SH_BINARY_TMPL_PREFIX}" >> _tmp.txt',
+            f'echo "{_SH_BINARY_TMPL_PREFIX}" >> $TMPDIR/_tmp.txt',
             # Inject the user defined script.
-            'cat $SRCS >> _tmp.txt',
+            'cat $SRCS >> $TMPDIR/_tmp.txt',
             # Inject a final exit so it doesn't try to execute the zipfile contents.
-            f'echo "{_SH_BINARY_TMPL_SUFFIX}" >> _tmp.txt',
+            f'echo "{_SH_BINARY_TMPL_SUFFIX}" >> $TMPDIR/_tmp.txt',
             # Compress the dependent files and dump out into the bash script.
-            '$TOOL z --include_other --suffix='' -n -i . -e $OUTS -e _tmp.txt -o $OUT --preamble_file _tmp.txt --strip_prefix ./',
+            '$TOOL z -d -n -i . -o $OUT --preamble_file $TMPDIR/_tmp.txt --strip_prefix ./',
         ])
     else:
         cmds = 'cp $SRCS $OUT'

--- a/tools/jarcat/BUILD
+++ b/tools/jarcat/BUILD
@@ -4,6 +4,7 @@ go_binary(
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",
+        "//src/fs",
         "//third_party/go:logging",
         "//tools/jarcat/ar",
         "//tools/jarcat/tar",

--- a/tools/jarcat/main.go
+++ b/tools/jarcat/main.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/op/go-logging.v1"
 
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/tools/jarcat/ar"
 	"github.com/thought-machine/please/tools/jarcat/tar"
 	"github.com/thought-machine/please/tools/jarcat/unzip"
@@ -229,13 +230,9 @@ func main() {
 	err = os.Rename(filename, opts.Zip.Out)
 	if err != nil {
 		// Fall back to copy
-		contents, err := ioutil.ReadFile(filename)
+		err = fs.CopyFile(filename, opts.Zip.Out, 0644)
 		if err != nil {
-			panic(fmt.Sprintf("unable to read the file we just wrote (%s): %s", filename, err))
-		}
-		err = ioutil.WriteFile(opts.Zip.Out, contents, 0644)
-		if err != nil {
-			panic(fmt.Sprintf("unable to write the file to the output location (%s): %s", opts.Zip.Out, err))
+			panic(fmt.Sprintf("unable to copy the file we just wrote (%s): %s", filename, err))
 		}
 		err = os.Remove(filename)
 		if err != nil {


### PR DESCRIPTION
This will simplify all other rules that use Jarcat as the preamble file and the output file are written to TMPDIR first.