### PR TITLE
Assorted small fixes for remote executing tests

### DIFF
--- a/src/core/command_replacements.go
+++ b/src/core/command_replacements.go
@@ -216,6 +216,8 @@ func checkAndReplaceSequence(state *BuildState, target, dep *BuildTarget, in str
 		panic(fmt.Sprintf("Rule %s can't $(exe %s), it's not executable", target.Label, dep.Label))
 	} else if runnable && len(dep.Outputs()) == 0 {
 		panic(fmt.Sprintf("Rule %s is tagged as binary but produces no output.", dep.Label))
+	} else if test && tool {
+		panic(fmt.Sprintf("Rule %s uses %s in its test command, but tools are not accessible at test time", target, dep))
 	}
 	if hash {
 		h, err := state.TargetHasher.OutputHash(dep)

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -121,10 +121,12 @@ func (c *Client) buildTestCommand(target *core.BuildTarget) (*pb.Command, error)
 	if target.NeedCoverage(c.state) {
 		files = append(files, core.CoverageFile)
 	}
-	if target.HasLabel(core.TestResultsDirLabel) {
-		dirs = []string{core.TestResultsFile}
-	} else {
-		files = append(files, core.TestResultsFile)
+	if !target.NoTestOutput {
+		if target.HasLabel(core.TestResultsDirLabel) {
+			dirs = []string{core.TestResultsFile}
+		} else {
+			files = append(files, core.TestResultsFile)
+		}
 	}
 	const commandPrefix = "export TMP_DIR=\"`pwd`\" TEST_DIR=\"`pwd`\" && "
 	cmd, err := core.ReplaceTestSequences(c.state, target, target.GetTestCommand(c.state))

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -344,7 +344,7 @@ func doTest(tid int, state *core.BuildState, target *core.BuildTarget, outputFil
 func doTestResults(tid int, state *core.BuildState, target *core.BuildTarget, outputFile string, runRemotely bool) (*core.BuildMetadata, []byte, *core.TestCoverage, error) {
 	if runRemotely {
 		metadata, results, coverage, err := state.RemoteClient.Test(tid, target)
-		cov, err2 := parseTestCoverage(target, coverage)
+		cov, err2 := parseRemoteCoverage(state, target, coverage)
 		if err == nil && err2 != nil {
 			log.Error("Error parsing coverage data: %s", err2)
 		}
@@ -356,6 +356,13 @@ func doTestResults(tid int, state *core.BuildState, target *core.BuildTarget, ou
 	stdout, err := prepareAndRunTest(tid, state, target)
 	coverage := parseCoverageFile(target, path.Join(target.TestDir(), core.CoverageFile))
 	return &core.BuildMetadata{Stdout: stdout}, nil, coverage, err
+}
+
+func parseRemoteCoverage(state *core.BuildState, target *core.BuildTarget, coverage []byte) (*core.TestCoverage, error) {
+	if !state.NeedCoverage {
+		return core.NewTestCoverage(), nil
+	}
+	return parseTestCoverage(target, coverage)
 }
 
 // prepareAndRunTest sets up a test directory and runs the test.


### PR DESCRIPTION
 - Handle NoTestOutput properly
 - Explicitly disallow using tools via replacements (this was never theoretically permitted, but we didn't check)
 - don't try to parse coverage if we're not covering
 - don't try to hash test inputs locally