### PR TITLE
Add a (currently hidden) --nodownload flag to not download remote execution outputs.

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -265,7 +265,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 	checkLicences(state, target)
 
 	if runRemotely {
-		if state.IsOriginalTarget(target.Label) || target.NeededForSubinclude {
+		if (state.IsOriginalTarget(target.Label) && state.DownloadOutputs) || target.NeededForSubinclude {
 			state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Downloading")
 			if _, err := state.RemoteClient.Retrieve(target); err != nil {
 				return fmt.Errorf("Failed to retrieve outputs for %s: %s", target.Label, err)

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -164,6 +164,8 @@ type BuildState struct {
 	PrepareOnly bool
 	// True if we're going to run a shell after builds are prepared.
 	PrepareShell bool
+	// True if we will download outputs during remote execution.
+	DownloadOutputs bool
 	// True if we only need to parse the initial package (i.e. don't search downwards
 	// through deps) - for example when doing `plz query print`.
 	ParsePackageOnly bool

--- a/src/please.go
+++ b/src/please.go
@@ -93,10 +93,11 @@ var opts struct {
 	Complete         string `long:"complete" hidden:"true" env:"PLZ_COMPLETE" description:"Provide completion options for this build target."`
 
 	Build struct {
-		Prepare bool     `long:"prepare" description:"Prepare build directory for these targets but don't build them."`
-		Shell   bool     `long:"shell" description:"Like --prepare, but opens a shell in the build directory with the appropriate environment variables."`
-		Rebuild bool     `long:"rebuild" description:"To force the optimisation and rebuild one or more targets."`
-		Args    struct { // Inner nesting is necessary to make positional-args work :(
+		Prepare    bool     `long:"prepare" description:"Prepare build directory for these targets but don't build them."`
+		Shell      bool     `long:"shell" description:"Like --prepare, but opens a shell in the build directory with the appropriate environment variables."`
+		Rebuild    bool     `long:"rebuild" description:"To force the optimisation and rebuild one or more targets."`
+		NoDownload bool     `long:"nodownload" hidden:"true" description:"Don't download outputs after building. Only applies when using remote build execution."`
+		Args       struct { // Inner nesting is necessary to make positional-args work :(
 			Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to build"`
 		} `positional-args:"true" required:"true"`
 	} `command:"build" description:"Builds one or more targets"`
@@ -770,6 +771,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	state.DebugTests = debugTests
 	state.ShowAllOutput = opts.OutputFlags.ShowAllOutput
 	state.ParsePackageOnly = opts.ParsePackageOnly
+	state.DownloadOutputs = !opts.Build.NoDownload
 	state.SetIncludeAndExclude(opts.BuildFlags.Include, opts.BuildFlags.Exclude)
 	if opts.BuildFlags.Arch.OS != "" {
 		state.OriginalArch = opts.BuildFlags.Arch


### PR DESCRIPTION
Useful to do big builds without it trying to download every single thing along the way.