### PR TITLE
Fix $(hash ) replacements for remote execution

### DIFF
--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -290,7 +290,7 @@ func newState(label string) (*core.BuildState, *core.BuildTarget) {
 	target.BuildTimeout = 100 * time.Second
 	state.Graph.AddTarget(target)
 	state.Parser = &fakeParser{}
-	state.TargetHasher = &TargetHasher{State: state}
+	state.TargetHasher = NewTargetHasher(state)
 	return state, target
 }
 

--- a/src/core/command_replacements_test.go
+++ b/src/core/command_replacements_test.go
@@ -270,3 +270,6 @@ type testHasher struct{}
 func (h *testHasher) OutputHash(target *BuildTarget) ([]byte, error) {
 	return base64.RawStdEncoding.DecodeString(testHash)
 }
+
+func (h *testHasher) SetHash(target *BuildTarget, hash []byte) {
+}

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -85,8 +85,6 @@ type RemoteClient interface {
 type TargetHasher interface {
 	// OutputHash calculates the output hash for a given build target.
 	OutputHash(target *BuildTarget) ([]byte, error)
-	// RefreshOutputHash is like OutputHash but always forces recomputation.
-	RefreshOutputHash(target *BuildTarget) ([]byte, error)
 	// SetHash sets the output hash for a given build target.
 	SetHash(target *BuildTarget, hash []byte)
 }

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -85,6 +85,10 @@ type RemoteClient interface {
 type TargetHasher interface {
 	// OutputHash calculates the output hash for a given build target.
 	OutputHash(target *BuildTarget) ([]byte, error)
+	// RefreshOutputHash is like OutputHash but always forces recomputation.
+	RefreshOutputHash(target *BuildTarget) ([]byte, error)
+	// SetHash sets the output hash for a given build target.
+	SetHash(target *BuildTarget, hash []byte)
 }
 
 // A BuildState tracks the current state of the build & related data.

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -131,7 +131,7 @@ func IterSources(graph *BuildGraph, target *BuildTarget, includeTools bool) <-ch
 	done := map[string]bool{}
 	tmpDir := target.TmpDir()
 	go func() {
-		for input := range IterInputs(graph, target, includeTools) {
+		for input := range IterInputs(graph, target, includeTools, false) {
 			fullPaths := input.FullPaths(graph)
 			for i, sourcePath := range input.Paths(graph) {
 				if tmpPath := path.Join(tmpDir, sourcePath); !done[tmpPath] {
@@ -146,7 +146,7 @@ func IterSources(graph *BuildGraph, target *BuildTarget, includeTools bool) <-ch
 }
 
 // IterInputs iterates all the inputs for a target.
-func IterInputs(graph *BuildGraph, target *BuildTarget, includeTools bool) <-chan BuildInput {
+func IterInputs(graph *BuildGraph, target *BuildTarget, includeTools, sourcesOnly bool) <-chan BuildInput {
 	ch := make(chan BuildInput)
 	done := map[BuildLabel]bool{}
 	var inner func(dependency *BuildTarget)
@@ -190,7 +190,9 @@ func IterInputs(graph *BuildGraph, target *BuildTarget, includeTools bool) <-cha
 				ch <- src
 			}
 		}
-		inner(target)
+		if !sourcesOnly {
+			inner(target)
+		}
 		close(ch)
 	}()
 	return ch

--- a/src/please.go
+++ b/src/please.go
@@ -801,7 +801,7 @@ func runPlease(state *core.BuildState, targets []core.BuildLabel) {
 		state.RemoteClient = remote.New(state)
 	}
 	state.Cache = newCache(state)
-	state.TargetHasher = &build.TargetHasher{State: state}
+	state.TargetHasher = build.NewTargetHasher(state)
 
 	// Run the display
 	state.Results() // important this is called now, don't ask...

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -266,12 +266,14 @@ func (c *Client) uploadInputs(ch chan<- *blob, target *core.BuildTarget, isTest,
 			return nil, err
 		}
 	}
-	if isTest && target.Stamp && ch != nil {
+	if !isTest && target.Stamp {
 		stamp := core.StampFile(target)
 		digest := c.digestBlob(stamp)
-		ch <- &blob{
-			Digest: digest,
-			Data:   stamp,
+		if ch != nil {
+			ch <- &blob{
+				Digest: digest,
+				Data:   stamp,
+			}
 		}
 		d := b.Dir(".")
 		d.Files = append(d.Files, &pb.FileNode{

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -237,9 +237,9 @@ func (c *Client) digestDir(dir string, children []*pb.Directory) (*pb.Directory,
 }
 
 // uploadInputs finds and uploads a set of inputs from a target.
-func (c *Client) uploadInputs(ch chan<- *blob, target *core.BuildTarget, isTest, useTargetPackage bool) (*pb.Directory, error) {
+func (c *Client) uploadInputs(ch chan<- *blob, target *core.BuildTarget, isTest, isFilegroup bool) (*pb.Directory, error) {
 	b := newDirBuilder(c)
-	for input := range c.iterInputs(target, isTest) {
+	for input := range c.iterInputs(target, isTest, isFilegroup) {
 		if l := input.Label(); l != nil {
 			if o := c.targetOutputs(*l); o == nil {
 				if c.remoteExecution {
@@ -248,7 +248,7 @@ func (c *Client) uploadInputs(ch chan<- *blob, target *core.BuildTarget, isTest,
 				}
 			} else {
 				pkgName := l.PackageName
-				if useTargetPackage {
+				if isFilegroup {
 					pkgName = target.Label.PackageName
 				} else if isTest && *l == target.Label {
 					// At test time the target itself is put at the root rather than in the normal dir.
@@ -279,7 +279,7 @@ func (c *Client) uploadInputs(ch chan<- *blob, target *core.BuildTarget, isTest,
 			Digest: digest,
 		})
 	}
-	if useTargetPackage {
+	if isFilegroup {
 		b.Root(ch)
 		return b.Dir(target.Label.PackageName), nil
 	}
@@ -341,9 +341,9 @@ func (c *Client) uploadInput(b *dirBuilder, ch chan<- *blob, input core.BuildInp
 }
 
 // iterInputs yields all the input files needed for a target.
-func (c *Client) iterInputs(target *core.BuildTarget, isTest bool) <-chan core.BuildInput {
+func (c *Client) iterInputs(target *core.BuildTarget, isTest, isFilegroup bool) <-chan core.BuildInput {
 	if !isTest {
-		return core.IterInputs(c.state.Graph, target, true)
+		return core.IterInputs(c.state.Graph, target, true, isFilegroup)
 	}
 	ch := make(chan core.BuildInput)
 	go func() {

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -6,6 +6,7 @@ package remote
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path"
@@ -298,6 +299,8 @@ func (c *Client) Build(tid int, target *core.BuildTarget) (*core.BuildMetadata, 
 	if err != nil {
 		return metadata, err
 	}
+	hash, _ := hex.DecodeString(c.digestMessage(ar).Hash)
+	c.state.TargetHasher.SetHash(target, hash)
 	return metadata, c.wrapActionErr(c.setOutputs(target.Label, ar), digest)
 }
 

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -300,7 +300,9 @@ func (c *Client) Build(tid int, target *core.BuildTarget) (*core.BuildMetadata, 
 		return metadata, err
 	}
 	hash, _ := hex.DecodeString(c.digestMessage(ar).Hash)
-	c.state.TargetHasher.SetHash(target, hash)
+	if c.state.TargetHasher != nil {
+		c.state.TargetHasher.SetHash(target, hash)
+	}
 	return metadata, c.wrapActionErr(c.setOutputs(target.Label, ar), digest)
 }
 


### PR DESCRIPTION
Bit fiddly since at the point it does that we're way too far away from the remote executor.
Solved by storing the hashes (what's a bit more memory between friends)