### PR TITLE
Use the new Remote Asset API for remote_file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/peterebden/ar v0.0.0-20181115090543-a0ae3a11a518
 	github.com/peterebden/gcfg v1.3.0
 	github.com/peterebden/go-cli-init v1.0.0
+	github.com/peterebden/go-sri v1.0.0
 	github.com/peterebden/tools v0.0.0-20190805132753-b2a0db951d2a
 	github.com/pkg/xattr v0.4.0
 	github.com/shirou/gopsutil v2.18.12+incompatible
@@ -31,7 +32,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/streamrail/concurrent-map v0.0.0-20160823150647-8bf1e9bacbf6
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.4.0
 	github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e
 	github.com/ulikunitz/xz v0.5.6
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5
@@ -41,7 +42,6 @@ require (
 	google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6
 	google.golang.org/grpc v1.26.0
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
-	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/peterebden/gcfg v1.3.0 h1:cXPrg3yRF5HTK3tBfIk+AJy10BZKRnBbb34FHklJzn8
 github.com/peterebden/gcfg v1.3.0/go.mod h1:VDdZttqmD3nudN3emvXYhkgOqqyYhWjnPIcEoIxNlTE=
 github.com/peterebden/go-cli-init v1.0.0 h1:HfcOHuyuyvHsaQZApuk44LpRc+EF/MDAI6u5/sthJGg=
 github.com/peterebden/go-cli-init v1.0.0/go.mod h1:u3NE4dP66iHWwbq8eqlXRNZqVMMuqJbkPn3MGKht0ME=
+github.com/peterebden/go-sri v1.0.0 h1:Ew88r4WD4H5K/UgsHxzhm0du8iUSH1uRIp2uscYeqe8=
+github.com/peterebden/go-sri v1.0.0/go.mod h1:KIRxtog35NfDWec5LV/iBqqfOEPcMpePZLc7EPE6goQ=
 github.com/peterebden/tools v0.0.0-20190805132753-b2a0db951d2a h1:R4xz7BkSIQOS5CFmaadk2gwwOzy/u2Jvnimf1NHD2LY=
 github.com/peterebden/tools v0.0.0-20190805132753-b2a0db951d2a/go.mod h1:rOzwC5Mel4JH+jDIo1rSQc21HWzWSvje4R5QnHPukvY=
 github.com/phpdave11/gofpdi v1.0.7/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
@@ -249,6 +251,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e h1:T5PdfK/M1xyrHwynxMIVMWLS7f/qHwfslZphxtGnw7s=

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -743,7 +743,7 @@ func fetchRemoteFile(state *core.BuildState, target *core.BuildTarget) error {
 	httpClient.Timeout = time.Duration(state.Config.Build.Timeout) // Can't set this when we init the client because config isn't loaded then.
 	var err error
 	for _, src := range target.Sources {
-		if e := fetchOneRemoteFile(state, target, src.STring()); e != nil {
+		if e := fetchOneRemoteFile(state, target, src.String()); e != nil {
 			err = multierror.Append(err, e)
 		} else {
 			return nil

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -743,7 +743,7 @@ func fetchRemoteFile(state *core.BuildState, target *core.BuildTarget) error {
 	httpClient.Timeout = time.Duration(state.Config.Build.Timeout) // Can't set this when we init the client because config isn't loaded then.
 	var err error
 	for _, src := range target.Sources {
-		if e := fetchOneRemoteFile(state, target, string(src.(core.URLLabel))); e != nil {
+		if e := fetchOneRemoteFile(state, target, src.STring()); e != nil {
 			err = multierror.Append(err, e)
 		} else {
 			return nil

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -350,6 +350,15 @@ func (target *BuildTarget) allSourcePaths(graph *BuildGraph, full buildPathsFunc
 	return ret
 }
 
+// AllURLs returns all the URLs for this target. This should only be called if the target is a remote file.
+func (target *BuildTarget) AllURLs() []string {
+	ret := make([]string, len(target.Sources))
+	for i, s := range target.Sources {
+		ret[i] = string(s.(URLLabel))
+	}
+	return ret
+}
+
 // DeclaredDependencies returns all the targets this target declared any kind of dependency on (including sources and tools).
 func (target *BuildTarget) DeclaredDependencies() []BuildLabel {
 	ret := make(BuildLabels, len(target.dependencies))

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -350,11 +350,14 @@ func (target *BuildTarget) allSourcePaths(graph *BuildGraph, full buildPathsFunc
 	return ret
 }
 
-// AllURLs returns all the URLs for this target. This should only be called if the target is a remote file.
-func (target *BuildTarget) AllURLs() []string {
+// AllURLs returns all the URLs for this target.
+// This should only be called if the target is a remote file.
+// The URLs will have any embedded environment variables expanded according to the given config.
+func (target *BuildTarget) AllURLs(config *Configuration) []string {
+	env := GeneralBuildEnvironment(config)
 	ret := make([]string, len(target.Sources))
 	for i, s := range target.Sources {
-		ret[i] = string(s.(URLLabel))
+		ret[i] = os.Expand(string(s.(URLLabel)), env.ReplaceEnvironment)
 	}
 	return ret
 }

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -490,6 +490,17 @@ func TestAllLocalSources(t *testing.T) {
 	assert.Equal(t, []string{"src/core/target1.go"}, target.AllLocalSources())
 }
 
+func TestAllURLs(t *testing.T) {
+	target := makeTarget("//src/core:remote1", "")
+	target.IsRemoteFile = true
+	target.AddSource(URLLabel("https://github.com/thought-machine/please"))
+	target.AddSource(URLLabel("https://github.com/thought-machine/pleasings"))
+	assert.Equal(t, []string{
+		"https://github.com/thought-machine/please",
+		"https://github.com/thought-machine/pleasings",
+	}, target.AllURLs())
+}
+
 func TestCheckSecrets(t *testing.T) {
 	target := makeTarget("//src/core:target1", "")
 	assert.NoError(t, target.CheckSecrets())

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -491,6 +491,7 @@ func TestAllLocalSources(t *testing.T) {
 }
 
 func TestAllURLs(t *testing.T) {
+	config := DefaultConfiguration()
 	target := makeTarget("//src/core:remote1", "")
 	target.IsRemoteFile = true
 	target.AddSource(URLLabel("https://github.com/thought-machine/please"))
@@ -498,7 +499,7 @@ func TestAllURLs(t *testing.T) {
 	assert.Equal(t, []string{
 		"https://github.com/thought-machine/please",
 		"https://github.com/thought-machine/pleasings",
-	}, target.AllURLs())
+	}, target.AllURLs(config))
 }
 
 func TestCheckSecrets(t *testing.T) {

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -397,6 +397,7 @@ type Configuration struct {
 	Remote struct {
 		URL           string       `help:"URL for the remote server."`
 		CASURL        string       `help:"URL for the CAS service, if it is different to the main one."`
+		AssetURL      string       `help:"URL for the remote asset server."`
 		NumExecutors  int          `help:"Maximum number of remote executors to use simultaneously."`
 		Instance      string       `help:"Remote instance name to request; depending on the server this may be required."`
 		Name          string       `help:"A name for this worker instance. This is attached to artifacts uploaded to remote storage." example:"agent-001"`

--- a/src/remote/BUILD
+++ b/src/remote/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//third_party/go:bytestream",
         "//third_party/go:errgroup",
         "//third_party/go:grpc",
+        "//third_party/go:grpc-middleware",
         "//third_party/go:logging",
         "//third_party/go:longrunning",
         "//third_party/go:protobuf",

--- a/src/remote/BUILD
+++ b/src/remote/BUILD
@@ -37,6 +37,7 @@ go_test(
         "//third_party/go:protobuf",
         "//third_party/go:remote-apis",
         "//third_party/go:rpcstatus",
+        "//third_party/go:sri",
         "//third_party/go:testify",
     ],
 )

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -153,7 +153,7 @@ func (c *Client) buildTestCommand(target *core.BuildTarget) (*pb.Command, error)
 func (c *Client) getCommand(target *core.BuildTarget) string {
 	if target.IsRemoteFile {
 		// This isn't a real command, but it suits us to construct a pseudo-version of one.
-		cmd := "fetch " + strings.Join(target.AllURLs(), " ") + " & verify " + strings.Join(target.Hashes, " ")
+		cmd := "fetch " + strings.Join(target.AllURLs(c.state.Config), " ") + " & verify " + strings.Join(target.Hashes, " ")
 		if target.IsBinary {
 			return cmd + " binary"
 		}

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -152,14 +152,10 @@ func (c *Client) buildTestCommand(target *core.BuildTarget) (*pb.Command, error)
 // getCommand returns the appropriate command to use for a target.
 func (c *Client) getCommand(target *core.BuildTarget) string {
 	if target.IsRemoteFile {
-		// TODO(peterebden): we should handle this using the Remote Fetch API once that's available.
-		urls := make([]string, len(target.Sources))
-		for i, s := range target.Sources {
-			urls[i] = "curl -fsSLo $OUT " + s.String()
-		}
-		cmd := strings.Join(urls, " || ")
+		// This isn't a real command, but it suits us to construct a pseudo-version of one.
+		cmd := "fetch " + strings.Join(target.AllURLs(), " ") + " & verify " + strings.Join(target.Hashes, " ")
 		if target.IsBinary {
-			return "(" + cmd + ") && chmod +x $OUT"
+			return cmd + " binary"
 		}
 		return cmd
 	}
@@ -238,6 +234,9 @@ func (c *Client) digestDir(dir string, children []*pb.Directory) (*pb.Directory,
 
 // uploadInputs finds and uploads a set of inputs from a target.
 func (c *Client) uploadInputs(ch chan<- *blob, target *core.BuildTarget, isTest, isFilegroup bool) (*pb.Directory, error) {
+	if target.IsRemoteFile {
+		return &pb.Directory{}, nil
+	}
 	b := newDirBuilder(c)
 	for input := range c.iterInputs(target, isTest, isFilegroup) {
 		if l := input.Label(); l != nil {

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -15,9 +15,12 @@ import (
 	"time"
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
+	fpb "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/bazelbuild/remote-apis/build/bazel/semver"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/genproto/googleapis/longrunning"
 	"google.golang.org/grpc"
 	_ "google.golang.org/grpc/encoding/gzip" // Registers the gzip compressor at init
@@ -42,12 +45,13 @@ var apiVersion = semver.SemVer{Major: 2}
 //
 // It provides a higher-level interface over the specific RPCs available.
 type Client struct {
-	client     *client.Client
-	initOnce   sync.Once
-	state      *core.BuildState
-	reqTimeout time.Duration
-	err        error // for initialisation
-	instance   string
+	client      *client.Client
+	fetchClient fpb.FetchClient
+	initOnce    sync.Once
+	state       *core.BuildState
+	reqTimeout  time.Duration
+	err         error // for initialisation
+	instance    string
 
 	// Stored output directories from previously executed targets.
 	// This isn't just a cache - it is needed for cases where we don't actually
@@ -71,6 +75,7 @@ type Client struct {
 
 	// Stats used to report RPC data rates
 	byteRateIn, byteRateOut, totalBytesIn, totalBytesOut int
+	stats                                                *statsHandler
 }
 
 // New returns a new Client instance.
@@ -82,6 +87,7 @@ func New(state *core.BuildState) *Client {
 		reqTimeout: time.Duration(state.Config.Remote.Timeout),
 		outputs:    map[core.BuildLabel]*pb.Directory{},
 	}
+	c.stats = newStatsHandler(c)
 	go c.CheckInitialised() // Kick off init now, but we don't have to wait for it.
 	return c
 }
@@ -94,75 +100,91 @@ func (c *Client) CheckInitialised() error {
 
 // init is passed to the sync.Once to do the actual initialisation.
 func (c *Client) init() {
-	c.err = func() error {
-		// Create a copy of the state where we can modify the config
-		c.state = c.state.ForConfig()
-		c.state.Config.HomeDir = c.state.Config.Remote.HomeDir
-		client, err := client.NewClient(context.Background(), c.instance, client.DialParams{
-			Service:            c.state.Config.Remote.URL,
-			CASService:         c.state.Config.Remote.CASURL,
-			NoSecurity:         !c.state.Config.Remote.Secure,
-			TransportCredsOnly: c.state.Config.Remote.Secure,
-			DialOpts: []grpc.DialOption{
-				grpc.WithStatsHandler(newStatsHandler(c)),
-				// Set an arbitrarily large (400MB) max message size so it isn't a limitation.
-				grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(419430400)),
-			},
-		}, client.UseBatchOps(true), client.RetryTransient())
-		if err != nil {
-			return err
-		}
-		c.client = client
-		// Query the server for its capabilities. This tells us whether it is capable of
-		// execution, caching or both.
-		ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
-		defer cancel()
-		resp, err := c.client.GetCapabilities(ctx)
-		if err != nil {
-			return err
-		}
-		if lessThan(&apiVersion, resp.LowApiVersion) || lessThan(resp.HighApiVersion, &apiVersion) {
-			return fmt.Errorf("Unsupported API version; we require %s but server only supports %s - %s", printVer(&apiVersion), printVer(resp.LowApiVersion), printVer(resp.HighApiVersion))
-		}
-		caps := resp.CacheCapabilities
-		if caps == nil {
-			return fmt.Errorf("Cache capabilities not supported by server (we do not support execution-only servers)")
-		}
-		if err := c.chooseDigest(caps.DigestFunction); err != nil {
-			return err
-		}
-		if caps.ActionCacheUpdateCapabilities != nil {
-			c.cacheWritable = caps.ActionCacheUpdateCapabilities.UpdateEnabled
-		}
-		c.maxBlobBatchSize = caps.MaxBatchTotalSizeBytes
-		if c.maxBlobBatchSize == 0 {
-			// No limit was set by the server, assume we are implicitly limited to 4MB (that's
-			// gRPC's limit which most implementations do not seem to override). Round it down a
-			// bit to allow a bit of serialisation overhead etc.
-			c.maxBlobBatchSize = 4000000
-		}
-		// Look this up just once now.
-		bash, err := core.LookBuildPath("bash", c.state.Config)
-		c.bashPath = bash
-		c.canBatchBlobReads = c.checkBatchReadBlobs()
-		log.Debug("Remote execution client initialised for storage")
-		// Now check if it can do remote execution
-		if resp.ExecutionCapabilities == nil {
-			log.Fatalf("Remote execution is configured but the build server doesn't support it")
-		}
-		if err := c.chooseDigest([]pb.DigestFunction_Value{resp.ExecutionCapabilities.DigestFunction}); err != nil {
-			return err
-		} else if !resp.ExecutionCapabilities.ExecEnabled {
-			return fmt.Errorf("Remote execution not enabled for this server")
-		}
-		c.remoteExecution = true
-		c.platform = convertPlatform(c.state.Config)
-		log.Debug("Remote execution client initialised for execution")
-		return nil
-	}()
+	var g errgroup.Group
+	g.Go(c.initExec)
+	g.Go(c.initFetch)
+	c.err = g.Wait()
 	if c.err != nil {
 		log.Error("Error setting up remote execution client: %s", c.err)
 	}
+}
+
+// initExec initialiases the remote execution client.
+func (c *Client) initExec() error {
+	// Create a copy of the state where we can modify the config
+	c.state = c.state.ForConfig()
+	c.state.Config.HomeDir = c.state.Config.Remote.HomeDir
+	client, err := client.NewClient(context.Background(), c.instance, client.DialParams{
+		Service:            c.state.Config.Remote.URL,
+		CASService:         c.state.Config.Remote.CASURL,
+		NoSecurity:         !c.state.Config.Remote.Secure,
+		TransportCredsOnly: c.state.Config.Remote.Secure,
+		DialOpts: []grpc.DialOption{
+			grpc.WithStatsHandler(c.stats),
+			// Set an arbitrarily large (400MB) max message size so it isn't a limitation.
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(419430400)),
+		},
+	}, client.UseBatchOps(true), client.RetryTransient())
+	if err != nil {
+		return err
+	}
+	c.client = client
+	// Query the server for its capabilities. This tells us whether it is capable of
+	// execution, caching or both.
+	ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+	defer cancel()
+	resp, err := c.client.GetCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if lessThan(&apiVersion, resp.LowApiVersion) || lessThan(resp.HighApiVersion, &apiVersion) {
+		return fmt.Errorf("Unsupported API version; we require %s but server only supports %s - %s", printVer(&apiVersion), printVer(resp.LowApiVersion), printVer(resp.HighApiVersion))
+	}
+	caps := resp.CacheCapabilities
+	if caps == nil {
+		return fmt.Errorf("Cache capabilities not supported by server (we do not support execution-only servers)")
+	}
+	if err := c.chooseDigest(caps.DigestFunction); err != nil {
+		return err
+	}
+	if caps.ActionCacheUpdateCapabilities != nil {
+		c.cacheWritable = caps.ActionCacheUpdateCapabilities.UpdateEnabled
+	}
+	c.maxBlobBatchSize = caps.MaxBatchTotalSizeBytes
+	if c.maxBlobBatchSize == 0 {
+		// No limit was set by the server, assume we are implicitly limited to 4MB (that's
+		// gRPC's limit which most implementations do not seem to override). Round it down a
+		// bit to allow a bit of serialisation overhead etc.
+		c.maxBlobBatchSize = 4000000
+	}
+	// Look this up just once now.
+	bash, err := core.LookBuildPath("bash", c.state.Config)
+	c.bashPath = bash
+	c.canBatchBlobReads = c.checkBatchReadBlobs()
+	log.Debug("Remote execution client initialised for storage")
+	// Now check if it can do remote execution
+	if resp.ExecutionCapabilities == nil {
+		return fmt.Errorf("Remote execution is configured but the build server doesn't support it")
+	}
+	if err := c.chooseDigest([]pb.DigestFunction_Value{resp.ExecutionCapabilities.DigestFunction}); err != nil {
+		return err
+	} else if !resp.ExecutionCapabilities.ExecEnabled {
+		return fmt.Errorf("Remote execution not enabled for this server")
+	}
+	c.remoteExecution = true
+	c.platform = convertPlatform(c.state.Config)
+	log.Debug("Remote execution client initialised for execution")
+	return nil
+}
+
+// initFetch initialises the remote fetch server.
+func (c *Client) initFetch() error {
+	conn, err := grpc.Dial(c.state.Config.Remote.AssetURL, grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor()))
+	if err != nil {
+		return fmt.Errorf("Failed to connect to the remote fetch server: %s", err)
+	}
+	c.fetchClient = fpb.NewFetchClient(conn)
+	return nil
 }
 
 // chooseDigest selects a digest function that we will use.w

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -583,7 +583,7 @@ func (c *Client) DataRate() (int, int, int, int) {
 // fetchRemoteFile sends a request to fetch a file using the remote asset API.
 func (c *Client) fetchRemoteFile(tid int, target *core.BuildTarget, actionDigest *pb.Digest) (*core.BuildMetadata, *pb.ActionResult, error) {
 	c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Downloading...")
-	urls := target.AllURLs()
+	urls := target.AllURLs(c.state.Config)
 	req := &fpb.FetchBlobRequest{
 		InstanceName: c.instance,
 		Timeout:      ptypes.DurationProto(target.BuildTimeout),

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -180,6 +180,9 @@ func (c *Client) initExec() error {
 
 // initFetch initialises the remote fetch server.
 func (c *Client) initFetch() error {
+	if c.state.Config.Remote.AssetURL == "" {
+		return fmt.Errorf("You must specify remote.asseturl in configuration to use remote execution")
+	}
 	tlsOption := func() grpc.DialOption {
 		if c.state.Config.Remote.Secure {
 			return grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, ""))

--- a/src/remote/remote_test.go
+++ b/src/remote/remote_test.go
@@ -173,6 +173,18 @@ func TestExecutePostBuildFunction(t *testing.T) {
 	assert.Equal(t, []string{"somefile"}, target.Outputs())
 }
 
+func TestExecuteFetch(t *testing.T) {
+	c := newClient()
+	target := core.NewBuildTarget(core.BuildLabel{PackageName: "package", Name: "remote1"})
+	target.IsRemoteFile = true
+	target.AddSource(core.URLLabel("https://get.please.build/linux_amd64/14.2.0/please_14.2.0.tar.gz"))
+	target.AddOutput("please_14.2.0.tar.gz")
+	target.Hashes = []string{"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"}
+	target.BuildTimeout = time.Minute
+	_, err := c.Build(0, target)
+	assert.NoError(t, err)
+}
+
 func TestExecuteTest(t *testing.T) {
 	c := newClientInstance("test")
 	target := core.NewBuildTarget(core.BuildLabel{PackageName: "package", Name: "target3"})

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -455,3 +455,12 @@ func dirSize(dir *pb.Directory) (size int64) {
 	}
 	return size
 }
+
+// subresourceIntegrity returns a string corresponding to a target's hashes in the Subresource Integrity format.
+func subresourceIntegrity(hashes []string) string {
+	ret := make([]string, len(hashes))
+	for i, h := range hashes {
+		ret[i] = strings.Replace(h, ":", "-", -1)
+	}
+	return strings.Join(ret, " ")
+}

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -439,7 +439,8 @@ go_get(
 go_get(
     name = "remote-apis",
     get = "github.com/bazelbuild/remote-apis/build/...",
-    revision = "b5123b1bb2853393c7b9aa43236db924d7e32d61",
+    repo = "github.com/sstriker/remote-apis",
+    revision = "32f1ba13a666302556060d7642aba95bf68c1acb",
     deps = [
         ":annotations",
         ":grpc",

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -439,8 +439,7 @@ go_get(
 go_get(
     name = "remote-apis",
     get = "github.com/bazelbuild/remote-apis/build/...",
-    repo = "github.com/sstriker/remote-apis",
-    revision = "32f1ba13a666302556060d7642aba95bf68c1acb",
+    revision = "2846a67ac8feb5001e9f704b66f5acc1e90f1ade",
     deps = [
         ":annotations",
         ":grpc",

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -602,3 +602,10 @@ go_get(
         ":go-isatty",
     ],
 )
+
+go_get(
+    name = "sri",
+    get = "github.com/peterebden/go-sri",
+    revision = "v1.0.0",
+    test_only = True,
+)


### PR DESCRIPTION
This puts more onus on the implementation (since now they have to have another service, or one that implements it in the same endpoint) but seems to be the future direction of these APIs.
It's also nicer than us trying to make up some bash / curl command for these.