### PR TITLE
Support named data on build rules

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -3,7 +3,7 @@
 
 # Do not change the order of arguments to this function unless you feel like
 # updating all of targets.go to match it.
-def build_rule(name:str, cmd:str|dict='', test_cmd:str|dict='', srcs:list|dict=None, data:list=None, outs:list|dict=None,
+def build_rule(name:str, cmd:str|dict='', test_cmd:str|dict='', srcs:list|dict=None, data:list|dict=None, outs:list|dict=None,
                deps:list=None, exported_deps:list=None, secrets:list|dict=None, tools:list|dict=None, labels:list=None,
                visibility:list=CONFIG.DEFAULT_VISIBILITY, hashes:list=None, binary:bool=False, test:bool=False,
                test_only:bool=CONFIG.DEFAULT_TESTONLY, building_description:str=None, needs_transitive_deps:bool=False,

--- a/rules/c_rules.build_defs
+++ b/rules/c_rules.build_defs
@@ -223,7 +223,7 @@ def c_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compile
 
 
 def c_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
-           pkg_config_libs:list=[], pkg_config_cflags:list=[], deps:list=[], worker:str='', data:list=[], visibility:list=None, flags:str='',
+           pkg_config_libs:list=[], pkg_config_cflags:list=[], deps:list=[], worker:str='', data:list|dict=[], visibility:list=None, flags:str='',
            labels:list&features&tags=[], flaky:bool|int=0, test_outputs:list=None, size:str=None, timeout:int=0,
            sandbox:bool=None):
     """Defines a C test target.

--- a/rules/cc_rules.build_defs
+++ b/rules/cc_rules.build_defs
@@ -544,7 +544,7 @@ def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[],
 
 def cc_test(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[],
             linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[],
-            pkg_config_cflags:list=[], deps:list=[], worker:str='', data:list=[],
+            pkg_config_cflags:list=[], deps:list=[], worker:str='', data:list|dict=[],
             visibility:list=[], flags:str='', labels:list&features&tags=[], flaky:bool|int=0,
             test_outputs:list=[], size:str=None, timeout:int=0,
             sandbox:bool=None, write_main:bool=False, linkstatic:bool=False, _c=False):

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -340,7 +340,7 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
     )
 
 
-def go_test(name:str, srcs:list, data:list=None, deps:list=[], worker:str='', visibility:list=None,
+def go_test(name:str, srcs:list, data:list|dict=None, deps:list=[], worker:str='', visibility:list=None,
             flags:str='', sandbox:bool=None, cgo:bool=False,
             external:bool=False, timeout:int=0, flaky:bool|int=0, test_outputs:list=None,
             labels:list&features&tags=None, size:str=None, static:bool=CONFIG.GO_DEFAULT_STATIC,

--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -173,7 +173,7 @@ def java_runtime_image(name:str, main_module:str, main_class:str, modules:list, 
       modules (list): Modules to be included in the runtime image.
       out (str): Name of the folder that contains the runtime image and the binary contained by it. Defaults to 'name'.
       deps (list): Dependencies of this rule.
-      data (list): Runtime data files for this rule.
+      data (list): Deprecated, has no effect.
       visibility (list): Visibility declaration of this rule.
       jlink_args (str): Arguments to pass to the JVM in the run script.
     """
@@ -191,7 +191,6 @@ def java_runtime_image(name:str, main_module:str, main_class:str, modules:list, 
     return build_rule(
         name=name,
         deps=deps,
-        data=data,
         outs=[out],
         cmd=cmd,
         needs_transitive_deps=True,
@@ -215,7 +214,7 @@ def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, dep
       out (str): Name of output .jar file. Defaults to name + .jar.
       srcs (list): Source files to compile.
       deps (list): Dependencies of this rule.
-      data (list): Runtime data files for this rule.
+      data (list): Deprecated, has no effect.
       visibility (list): Visibility declaration of this rule.
       jvm_args (str): Arguments to pass to the JVM in the run script.
       self_executable (bool): True to make the jar self executable.
@@ -241,7 +240,6 @@ def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, dep
     return build_rule(
         name=name,
         deps=deps,
-        data=data,
         outs=[out or name + '.jar'],
         srcs=[manifest],
         cmd=cmd,
@@ -257,7 +255,7 @@ def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, dep
 
 
 def java_test(name:str, srcs:list, resources:list=None, resources_root:str=None,
-              data:list=None, deps:list=None, worker:str='',
+              data:list|dict=None, deps:list=None, worker:str='',
               labels:list&features&tags=[], visibility:list=None, flags:str='',
               sandbox:bool=None, timeout:int=0, flaky:bool|int=0, test_outputs:list=None, size:str=None,
               test_package:str=CONFIG.DEFAULT_TEST_PACKAGE, jvm_args:str=''):

--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -124,7 +124,7 @@ def genrule(name:str, cmd:str|list|dict, srcs:list|dict=None, out:str=None, outs
 
 
 def gentest(name:str, test_cmd:str|dict, labels:list&features&tags=None, cmd:str|dict=None, srcs:list|dict=None, outs:list=None,
-            deps:list=None, tools:list|dict=None, data:list=None, visibility:list=None, timeout:int=0,
+            deps:list=None, tools:list|dict=None, data:list|dict=None, visibility:list=None, timeout:int=0,
             needs_transitive_deps:bool=False, flaky:bool|int=0, secrets:list|dict=None, no_test_output:bool=False,
             test_outputs:list=None, output_is_complete:bool=True, requires:list=None,
             sandbox:bool=None, size:str=None, local:bool=False):
@@ -150,7 +150,7 @@ def gentest(name:str, test_cmd:str|dict, labels:list&features&tags=None, cmd:str
       tools (list): Tools used to build this rule; similar to srcs but are not copied to the temporary
                     build directory. Should be accessed via $(exe //path/to:tool) or similar.
       secrets (list | dict): Secrets available to this rule while building.
-      data (list): Runtime data files for the test.
+      data (list | dict): Runtime data files for the test.
       visibility (list): Visibility declaration of this rule.
       timeout (int): Length of time in seconds to allow the test to run for before killing it.
       needs_transitive_deps (bool): True if building the rule requires all transitive dependencies to

--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -192,7 +192,7 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
     )
 
 
-def python_test(name:str, srcs:list, data:list=[], resources:list=[], deps:list=[], worker:str='',
+def python_test(name:str, srcs:list, data:list|dict=[], resources:list=[], deps:list=[], worker:str='',
                 labels:list&features&tags=[], size:str=None, flags:str='', visibility:list=None,
                 sandbox:bool=None, timeout:int=0, flaky:bool|int=0,
                 test_outputs:list=None, zip_safe:bool=None, interpreter:str=None, site:bool=False):

--- a/rules/sh_rules.build_defs
+++ b/rules/sh_rules.build_defs
@@ -88,7 +88,7 @@ def sh_binary(name:str, main:str|list&srcs, deps:list=None, visibility:list=None
     )
 
 
-def sh_test(name:str, src:str=None, labels:list&features&tags=None, data:list=None, deps:list=None, worker:str='',
+def sh_test(name:str, src:str=None, labels:list&features&tags=None, data:list|dict=None, deps:list=None, worker:str='',
             size:str=None, visibility:list=None, flags:str='', flaky:bool|int=0, test_outputs:list=None, timeout:int=0,
             sandbox:bool=None):
     """Generates a shell test. Note that these aren't packaged in a useful way.
@@ -150,7 +150,7 @@ def sh_cmd(name:str, cmd:str|dict|list, srcs:list|dict=None, out:str="", shell:s
       name (str): Name of the rule.
       cmd (str | dict): Command to write into the output script file. The commands are subject to
                         shell expansion during build time, so if that is to be avoided the variables
-                        have to be escaped with \\\\\\$, i.e. \\\\\\${@}. 
+                        have to be escaped with \\\\\\$, i.e. \\\\\\${@}.
       srcs (list | dict): Source files. Can be consumed by the generated command (but are not
                           written into the output in any other way).
       out (str): Name of the output file to create. Defaults to name + .sh.

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -229,7 +229,7 @@ func ruleHash(state *core.BuildState, target *core.BuildTarget, runtime bool) []
 	if runtime {
 		// Similarly, we only hash the current command here again.
 		h.Write([]byte(target.GetTestCommand(state)))
-		for _, datum := range target.Data {
+		for _, datum := range target.AllData() {
 			h.Write([]byte(datum.String()))
 		}
 		hashOptionalBool(h, target.TestSandbox)

--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -53,6 +53,7 @@ var KnownFields = map[string]bool{
 
 	// These only contribute to the runtime hash, not at build time.
 	"Data":              true,
+	"namedData":         true,
 	"TestSandbox":       true,
 	"ContainerSettings": true,
 

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -153,7 +153,13 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) Bui
 		}
 	}
 	if len(target.Data) > 0 {
-		env = append(env, "DATA="+strings.Join(target.AllData(state.Graph), " "))
+		env = append(env, "DATA="+strings.Join(target.AllDataPaths(state.Graph), " "))
+	}
+	if target.namedData != nil {
+		for name, data := range target.namedData {
+			paths := target.SourcePaths(state.Graph, data)
+			env = append(env, "DATA_"+strings.ToUpper(name)+"="+strings.Join(paths, " "))
+		}
 	}
 	// Bit of a hack for gcov which needs access to its .gcno files.
 	if target.HasLabel("cc") {

--- a/src/core/command_replacements_test.go
+++ b/src/core/command_replacements_test.go
@@ -91,7 +91,7 @@ func TestReplacementsForTest(t *testing.T) {
 
 func TestDataReplacementForTest(t *testing.T) {
 	target := makeTarget("//path/to:target1", "cat $(location test_data.txt)", nil)
-	target.Data = append(target.Data, FileLabel{File: "test_data.txt", Package: "path/to"})
+	target.AddDatum(FileLabel{File: "test_data.txt", Package: "path/to"})
 
 	expected := "cat path/to/test_data.txt"
 	cmd, _ := ReplaceTestSequences(state, target, target.Command)

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -256,7 +256,7 @@ func IterRuntimeFiles(graph *BuildGraph, target *BuildTarget, absoluteOuts bool)
 		for _, out := range target.Outputs() {
 			pushOut(path.Join(outDir, out), out)
 		}
-		for _, data := range target.Data {
+		for _, data := range target.AllData() {
 			fullPaths := data.FullPaths(graph)
 			for i, dataPath := range data.Paths(graph) {
 				pushOut(fullPaths[i], dataPath)
@@ -296,7 +296,7 @@ func IterInputPaths(graph *BuildGraph, target *BuildTarget) <-chan string {
 			}
 
 			// Now yield all the data deps of this rule.
-			for _, data := range target.Data {
+			for _, data := range target.AllData() {
 				// If the label is nil add any input paths contained here.
 				if label := data.Label(); label == nil {
 					for _, sourcePath := range data.FullPaths(graph) {

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -157,7 +157,7 @@ func populateTarget(s *scope, t *core.BuildTarget, args []pyObject) {
 	}
 	addMaybeNamed(s, "tools", args[9], t.AddTool, t.AddNamedTool, true, true)
 	addMaybeNamed(s, "system_srcs", args[32], t.AddSource, nil, true, false)
-	addMaybeNamed(s, "data", args[4], t.AddDatum, nil, false, false)
+	addMaybeNamed(s, "data", args[4], t.AddDatum, t.AddNamedDatum, false, false)
 	addMaybeNamedOutput(s, "outs", args[5], t.AddOutput, t.AddNamedOutput, t, false)
 	addMaybeNamedOutput(s, "optional_outs", args[35], t.AddOptionalOutput, nil, t, true)
 	addMaybeNamedOutput(s, "test_outputs", args[31], t.AddTestOutput, nil, t, false)

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -350,7 +350,7 @@ func (c *Client) iterInputs(target *core.BuildTarget, isTest, isFilegroup bool) 
 	ch := make(chan core.BuildInput)
 	go func() {
 		ch <- target.Label
-		for _, datum := range target.Data {
+		for _, datum := range target.AllData() {
 			ch <- datum
 		}
 		close(ch)

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -96,7 +96,7 @@ func startWatching(watcher *fsnotify.Watcher, state *core.BuildState, labels []c
 		for _, source := range target.AllSources() {
 			addSource(watcher, state, source, dirs, files)
 		}
-		for _, datum := range target.Data {
+		for _, datum := range target.AllData() {
 			addSource(watcher, state, datum, dirs, files)
 		}
 		for _, dep := range target.Dependencies() {


### PR DESCRIPTION
This has been missing parity with things like SRCS and TOOLS for ages. We have some motivating use cases where people have worked around with lots of $(location) stuff but it would be better to just support this directly.