### PR TITLE
Upload outputs for local targets once built.

### DIFF
--- a/src/remote/remote_test.go
+++ b/src/remote/remote_test.go
@@ -1,8 +1,6 @@
 package remote
 
 import (
-	"context"
-	"encoding/hex"
 	"os"
 	"path"
 	"testing"
@@ -109,7 +107,7 @@ func TestExecuteTest(t *testing.T) {
 	target.IsTest = true
 	target.IsBinary = true
 	target.SetState(core.Building)
-	err := c.Store(target, &core.BuildMetadata{}, target.Outputs())
+	err := c.Store(target)
 	assert.NoError(t, err)
 	c.state.Graph.AddTarget(target)
 	_, results, coverage, err := c.Test(0, target)
@@ -127,7 +125,7 @@ func TestExecuteTestWithCoverage(t *testing.T) {
 	target.TestCommand = "$TEST"
 	target.IsTest = true
 	target.IsBinary = true
-	err := c.Store(target, &core.BuildMetadata{}, target.Outputs())
+	err := c.Store(target)
 	assert.NoError(t, err)
 	target.SetState(core.Built)
 	c.state.Graph.AddTarget(target)
@@ -197,118 +195,10 @@ func TestUpdateHashFilename(t *testing.T) {
 	)
 }
 
-// Store stores a set of artifacts for a single build target.
-// TODO(peterebden): this has been moved out of the "real" code because it's no longer needed, but
-//                   is useful for testing the rest of it. Find a way of having useful tests
-//                   without so much custom code.
-func (c *Client) Store(target *core.BuildTarget, metadata *core.BuildMetadata, files []string) error {
+// Store is a small hack that stores a target's outputs for testing only.
+func (c *Client) Store(target *core.BuildTarget) error {
 	if err := c.CheckInitialised(); err != nil {
 		return err
 	}
-	ar := &pb.ActionResult{
-		// We never cache any failed actions so ExitCode is implicitly 0.
-		ExecutionMetadata: &pb.ExecutedActionMetadata{
-			Worker:                       c.state.Config.Remote.Name,
-			OutputUploadStartTimestamp:   toTimestamp(time.Now()),
-			ExecutionStartTimestamp:      toTimestamp(metadata.StartTime),
-			ExecutionCompletedTimestamp:  toTimestamp(metadata.EndTime),
-			InputFetchStartTimestamp:     toTimestamp(metadata.InputFetchStartTime),
-			InputFetchCompletedTimestamp: toTimestamp(metadata.InputFetchEndTime),
-		},
-	}
-	outDir := target.OutDir()
-	if err := c.uploadBlobs(func(ch chan<- *blob) error {
-		defer close(ch)
-		for _, filename := range files {
-			file := path.Join(outDir, filename)
-			info, err := os.Lstat(file)
-			if err != nil {
-				return err
-			} else if mode := info.Mode(); mode&os.ModeDir != 0 {
-				// It's a directory, needs special treatment
-				root, children, err := c.digestDir(file, nil)
-				if err != nil {
-					return err
-				}
-				digest, contents := c.digestMessageContents(&pb.Tree{
-					Root:     root,
-					Children: children,
-				})
-				ch <- &blob{
-					Digest: digest,
-					Data:   contents,
-				}
-				ar.OutputDirectories = append(ar.OutputDirectories, &pb.OutputDirectory{
-					Path:       filename,
-					TreeDigest: digest,
-				})
-				continue
-			} else if mode&os.ModeSymlink != 0 {
-				target, err := os.Readlink(file)
-				if err != nil {
-					return err
-				}
-				// TODO(peterebden): Work out if we need to give a shit about
-				//                   OutputDirectorySymlinks or not. Seems like we shouldn't
-				//                   need to care since symlinks don't know the type of thing
-				//                   they point to?
-				ar.OutputFileSymlinks = append(ar.OutputFileSymlinks, &pb.OutputSymlink{
-					Path:   filename,
-					Target: target,
-				})
-				continue
-			}
-			// It's a real file, bung it onto the channel.
-			h, err := c.state.PathHasher.Hash(file, false, true)
-			if err != nil {
-				return err
-			}
-			digest := &pb.Digest{
-				SizeBytes: info.Size(),
-				Hash:      hex.EncodeToString(h),
-			}
-			ch <- &blob{
-				File:   file,
-				Digest: digest,
-			}
-			ar.OutputFiles = append(ar.OutputFiles, &pb.OutputFile{
-				Path:         filename,
-				Digest:       digest,
-				IsExecutable: target.IsBinary,
-			})
-		}
-		if len(metadata.Stdout) > 0 {
-			h := c.sum(metadata.Stdout)
-			digest := &pb.Digest{
-				SizeBytes: int64(len(metadata.Stdout)),
-				Hash:      hex.EncodeToString(h[:]),
-			}
-			ch <- &blob{
-				Data:   metadata.Stdout,
-				Digest: digest,
-			}
-			ar.StdoutDigest = digest
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-	// OK, now the blobs are uploaded, we also need to upload the Action itself.
-	_, digest, err := c.uploadAction(target, metadata.Test)
-	if err != nil {
-		return err
-	} else if !metadata.Test {
-		if err := c.setOutputs(target.Label, ar); err != nil {
-			return err
-		}
-	}
-	// Now we can use that to upload the result itself.
-	ctx, cancel := context.WithTimeout(context.Background(), c.reqTimeout)
-	defer cancel()
-	_, err = c.client.UpdateActionResult(ctx, &pb.UpdateActionResultRequest{
-		InstanceName: c.instance,
-		ActionDigest: digest,
-		ActionResult: ar,
-	})
-	return err
+	return c.uploadLocalTarget(target)
 }


### PR DESCRIPTION
This means that there's half a hope of doing something useful with a target marked `local = True`.

Have found a rather nice way of taking more advantage of the SDK to remove even more of my code.