### PR TITLE
Allow short date retrieval

### DIFF
--- a/src/parse/asp/exec.go
+++ b/src/parse/asp/exec.go
@@ -282,10 +282,12 @@ func execGitShow(s *scope, args []pyObject) pyObject {
 	case "%T": // tree hash
 	case "%P": // parent hashes
 	case "%an": // author name
+	case "%ad": // author date (format respects --date option)
 	case "%ae": // author email
 	case "%at": // author date, UNIX timestamp
-	case "%cn": // committer name
+	case "%cd": // committer date (format respects --date option)
 	case "%ce": // committer email
+	case "%cn": // committer name
 	case "%ct": // committer date, UNIX timestamp
 	case "%D": // ref names without the " (", ")" wrapping.
 	case "%e": // encoding
@@ -308,6 +310,7 @@ func execGitShow(s *scope, args []pyObject) pyObject {
 		pyString("git"),
 		pyString("show"),
 		pyString("-s"),
+		pyString("--date=short"),
 		pyString(fmt.Sprintf("--format=%s", formatVerb)),
 	}
 


### PR DESCRIPTION
This minor change adds two more options to `git_show` in order to retrieve the author and committer date formatted according to the `--date` parameter. Currently this is hard-coded to be `short` but as nothing else uses it, I felt we didn't need to add the parameter to `git_show` itself.