### PR TITLE
Add support for downloading remote outputs when building a local target.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/Songmu/prompter v0.0.0-20181014095714-d227c68538bd
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/bazelbuild/buildtools v0.0.0-20190228125936-4bcdbd1064fc
-	github.com/bazelbuild/remote-apis v0.0.0-20191119143007-b5123b1bb285
+	github.com/bazelbuild/remote-apis v0.0.0-20200127100703-2846a67ac8fe
 	github.com/bazelbuild/remote-apis-sdks v0.0.0-20200117155253-d02017f96d3b
 	github.com/coreos/go-semver v0.2.0
 	github.com/djherbis/atime v1.0.0
@@ -23,7 +23,7 @@ require (
 	github.com/manifoldco/promptui v0.3.2
 	github.com/peterebden/ar v0.0.0-20181115090543-a0ae3a11a518
 	github.com/peterebden/gcfg v1.3.0
-	github.com/peterebden/go-cli-init v1.0.0
+	github.com/peterebden/go-cli-init v1.2.0
 	github.com/peterebden/go-sri v1.0.0
 	github.com/peterebden/tools v0.0.0-20190805132753-b2a0db951d2a
 	github.com/pkg/xattr v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/bazelbuild/remote-apis v0.0.0-20191104140458-e77c4eb2ca48 h1:bgj+Oufa
 github.com/bazelbuild/remote-apis v0.0.0-20191104140458-e77c4eb2ca48/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/bazelbuild/remote-apis v0.0.0-20191119143007-b5123b1bb285 h1:OPH+hf+ICw8WEp2CV2ncfdyWPC30Cmw8b5NKun0n5IQ=
 github.com/bazelbuild/remote-apis v0.0.0-20191119143007-b5123b1bb285/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
+github.com/bazelbuild/remote-apis v0.0.0-20200127100703-2846a67ac8fe h1:psm84nneek82/tb3AFg3k6lBL8bCAd6g0C1Onv7p6kM=
+github.com/bazelbuild/remote-apis v0.0.0-20200127100703-2846a67ac8fe/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20191119014045-9f0428c343a9 h1:KU66ZTme1RxNuBPyseaHmSHZKQMM52yrCDhGhMCqOUU=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20191119014045-9f0428c343a9/go.mod h1:qgVeF5etXayzvt6OKXzeSg9Y0QDXfeH9H4EWKo/MNLM=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20191125202410-a21ff57ff57c h1:8zx14LG5/YyL54A3R/oIOG5TsilYs7EnVLlVMWXjHOU=
@@ -203,6 +205,8 @@ github.com/peterebden/gcfg v1.3.0 h1:cXPrg3yRF5HTK3tBfIk+AJy10BZKRnBbb34FHklJzn8
 github.com/peterebden/gcfg v1.3.0/go.mod h1:VDdZttqmD3nudN3emvXYhkgOqqyYhWjnPIcEoIxNlTE=
 github.com/peterebden/go-cli-init v1.0.0 h1:HfcOHuyuyvHsaQZApuk44LpRc+EF/MDAI6u5/sthJGg=
 github.com/peterebden/go-cli-init v1.0.0/go.mod h1:u3NE4dP66iHWwbq8eqlXRNZqVMMuqJbkPn3MGKht0ME=
+github.com/peterebden/go-cli-init v1.2.0 h1:rQBiOoBenaD8t2L9Ds+KwFm/Pi1fF6UZ3Cy5Zs2MMdA=
+github.com/peterebden/go-cli-init v1.2.0/go.mod h1:sZ1OlmpWqJHtdqnJ4dc9TDl/nzvrJ/pt3cEvrsSfhm8=
 github.com/peterebden/go-sri v1.0.0 h1:Ew88r4WD4H5K/UgsHxzhm0du8iUSH1uRIp2uscYeqe8=
 github.com/peterebden/go-sri v1.0.0/go.mod h1:KIRxtog35NfDWec5LV/iBqqfOEPcMpePZLc7EPE6goQ=
 github.com/peterebden/tools v0.0.0-20190805132753-b2a0db951d2a h1:R4xz7BkSIQOS5CFmaadk2gwwOzy/u2Jvnimf1NHD2LY=

--- a/src/BUILD.plz
+++ b/src/BUILD.plz
@@ -17,7 +17,6 @@ go_binary(
         "//src/ide/intellij",
         "//src/output",
         "//src/plz",
-        "//src/remote",
         "//src/query",
         "//src/run",
         "//src/scm",

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -126,6 +126,17 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 		if target.IsHashFilegroup {
 			updateHashFilegroupPaths(state, target)
 		}
+		// Ensure we have downloaded any previous dependencies if that's relevant.
+		if state.Config.NumRemoteExecutors() > 0 {
+			for _, dep := range target.Dependencies() {
+				if dep.State() == core.BuiltRemotely {
+					if err := state.RemoteClient.Download(dep); err != nil {
+						return err
+					}
+				}
+			}
+		}
+
 		// We don't record rule hashes for filegroups since we know the implementation and the check
 		// is just "are these the same file" which we do anyway, and it means we don't have to worry
 		// about two rules outputting the same file.

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -543,8 +543,8 @@ type targetHasher struct {
 	mutex  sync.RWMutex
 }
 
-// NewTargetHasher returns a new TargetHasher
-func NewTargetHasher(state *core.BuildState) core.TargetHasher {
+// newTargetHasher returns a new TargetHasher
+func newTargetHasher(state *core.BuildState) core.TargetHasher {
 	return &targetHasher{
 		State:  state,
 		hashes: map[*core.BuildTarget][]byte{},

--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -32,12 +32,10 @@ func TestBuildLotsOfTargets(t *testing.T) {
 	pkg := core.NewPackage("pkg")
 	state.Graph.AddPackage(pkg)
 
-	go func() {
-		for i := 1; i <= size; i++ {
-			addTarget(state, i)
-		}
-		state.TaskDone(true) // Initial target adding counts as one.
-	}()
+	for i := 1; i <= size; i++ {
+		addTarget(state, i)
+	}
+	state.TaskDone(true) // Initial target adding counts as one.
 
 	results := state.Results()
 	// Consume and discard any results

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -290,7 +290,7 @@ func newState(label string) (*core.BuildState, *core.BuildTarget) {
 	target.BuildTimeout = 100 * time.Second
 	state.Graph.AddTarget(target)
 	state.Parser = &fakeParser{}
-	state.TargetHasher = NewTargetHasher(state)
+	state.TargetHasher = newTargetHasher(state)
 	return state, target
 }
 

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -290,7 +290,7 @@ func newState(label string) (*core.BuildState, *core.BuildTarget) {
 	target.BuildTimeout = 100 * time.Second
 	state.Graph.AddTarget(target)
 	state.Parser = &fakeParser{}
-	state.TargetHasher = newTargetHasher(state)
+	Init(state)
 	return state, target
 }
 
@@ -363,7 +363,7 @@ func TestMain(m *testing.M) {
 	// Move ourselves to the root of the test data tree
 	wd, _ := os.Getwd()
 	core.RepoRoot = path.Join(wd, "src/build/test_data")
-	Init(nil)
+	Init(core.NewDefaultBuildState())
 	if err := os.Chdir(core.RepoRoot); err != nil {
 		panic(err)
 	}

--- a/src/build/filegroup.go
+++ b/src/build/filegroup.go
@@ -26,6 +26,7 @@ func Init(state *core.BuildState) {
 	theFilegroupBuilder = &filegroupBuilder{
 		built: map[string]bool{},
 	}
+	state.TargetHasher = newTargetHasher(state)
 }
 
 // A filegroupBuilder is a singleton that we have that builds all filegroups.

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -73,6 +73,8 @@ type RemoteClient interface {
 	Build(tid int, target *BuildTarget) (*BuildMetadata, error)
 	// Test invokes a test run of the target remotely.
 	Test(tid int, target *BuildTarget) (metadata *BuildMetadata, results [][]byte, coverage []byte, err error)
+	// Download downloads the outputs for the given target that has already been built remotely.
+	Download(target *BuildTarget) error
 	// PrintHashes shows the hashes of a target.
 	PrintHashes(target *BuildTarget, isTest bool)
 	// DataRate returns an estimate of the current in/out RPC data rates and totals so far in bytes per second.

--- a/src/please.go
+++ b/src/please.go
@@ -30,7 +30,6 @@ import (
 	"github.com/thought-machine/please/src/output"
 	"github.com/thought-machine/please/src/plz"
 	"github.com/thought-machine/please/src/query"
-	"github.com/thought-machine/please/src/remote"
 	"github.com/thought-machine/please/src/run"
 	"github.com/thought-machine/please/src/scm"
 	"github.com/thought-machine/please/src/test"
@@ -797,9 +796,6 @@ func runPlease(state *core.BuildState, targets []core.BuildLabel) {
 			!targets[0].IsAllSubpackages() && targets[0] != core.BuildLabelStdin))
 	streamTests := opts.Test.StreamResults || opts.Cover.StreamResults
 	pretty := prettyOutput(opts.OutputFlags.InteractiveOutput, opts.OutputFlags.PlainOutput, opts.OutputFlags.Verbosity) && state.NeedBuild && !streamTests
-	if state.Config.Remote.URL != "" {
-		state.RemoteClient = remote.New(state)
-	}
 	state.Cache = newCache(state)
 
 	// Run the display

--- a/src/please.go
+++ b/src/please.go
@@ -801,7 +801,6 @@ func runPlease(state *core.BuildState, targets []core.BuildLabel) {
 		state.RemoteClient = remote.New(state)
 	}
 	state.Cache = newCache(state)
-	state.TargetHasher = build.NewTargetHasher(state)
 
 	// Run the display
 	state.Results() // important this is called now, don't ask...

--- a/src/plz/BUILD
+++ b/src/plz/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//src/follow",
         "//src/fs",
         "//src/parse",
+        "//src/remote",
         "//src/test",
         "//src/utils",
         "//third_party/go:logging",

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -12,6 +12,7 @@ import (
 	"github.com/thought-machine/please/src/follow"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/parse"
+	"github.com/thought-machine/please/src/remote"
 	"github.com/thought-machine/please/src/test"
 	"github.com/thought-machine/please/src/utils"
 )
@@ -26,6 +27,9 @@ var log = logging.MustGetLogger("plz")
 func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, config *core.Configuration, arch cli.Arch) {
 	parse.InitParser(state)
 	build.Init(state)
+	if state.Config.Remote.URL != "" {
+		state.RemoteClient = remote.New(state)
+	}
 
 	if config.Events.Port != 0 && state.NeedBuild {
 		shutdown := follow.InitialiseServer(state, config.Events.Port)

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -240,17 +240,37 @@ func (c *Client) Build(tid int, target *core.BuildTarget) (*core.BuildMetadata, 
 	// Also anything needed for subinclude needs to be local.
 	if (c.state.IsOriginalTarget(target.Label) && c.state.DownloadOutputs && !c.state.NeedTests) || target.NeededForSubinclude {
 		c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Downloading")
-		if err := removeOutputs(target); err != nil {
-			return nil, err
+		if err := c.download(target, digest, ar); err != nil {
+			return metadata, err
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), c.reqTimeout)
-		defer cancel()
-		if err := c.client.DownloadActionOutputs(ctx, ar, target.OutDir()); err != nil {
-			return metadata, c.wrapActionErr(err, digest)
-		}
-		c.recordAttrs(target, digest)
 	}
 	return metadata, nil
+}
+
+// Download downloads outputs for the given target.
+func (c *Client) Download(target *core.BuildTarget) error {
+	command, digest, err := c.buildAction(target, false)
+	if err != nil {
+		return fmt.Errorf("Failed to create action for %s: %s", target, err)
+	}
+	_, ar := c.retrieveResults(target, command, digest, false)
+	if ar == nil {
+		return fmt.Errorf("Failed to retrieve action result for %s", target)
+	}
+	return c.download(target, digest, ar)
+}
+
+func (c *Client) download(target *core.BuildTarget, digest *pb.Digest, ar *pb.ActionResult) error {
+	if err := removeOutputs(target); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), c.reqTimeout)
+	defer cancel()
+	if err := c.client.DownloadActionOutputs(ctx, ar, target.OutDir()); err != nil {
+		return c.wrapActionErr(err, digest)
+	}
+	c.recordAttrs(target, digest)
+	return nil
 }
 
 // Test executes a remote test of the given target.
@@ -286,17 +306,16 @@ func (c *Client) Test(tid int, target *core.BuildTarget) (metadata *core.BuildMe
 	return metadata, results, coverage, execErr
 }
 
-// execute submits an action to the remote executor and monitors its progress.
-// The returned ActionResult may be nil on failure.
-func (c *Client) execute(tid int, target *core.BuildTarget, command *pb.Command, digest *pb.Digest, timeout time.Duration, isTest, needStdout bool) (*core.BuildMetadata, *pb.ActionResult, error) {
+// retrieveResults retrieves target results from where it can (either from the local cache or from remote).
+// It returns nil if it cannot be retrieved.
+func (c *Client) retrieveResults(target *core.BuildTarget, command *pb.Command, digest *pb.Digest, needStdout bool) (*core.BuildMetadata, *pb.ActionResult) {
 	// First see if this execution is cached locally
 	if metadata, ar := c.retrieveLocalResults(target, digest); metadata != nil {
 		log.Debug("Got locally cached results for %s %s", target.Label, c.actionURL(digest, true))
-		return metadata, ar, nil
+		return metadata, ar
 	}
 	// Now see if it is cached on the remote server
-	c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Checking remote...")
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), c.reqTimeout)
 	defer cancel()
 	if ar, err := c.client.GetActionResult(ctx, &pb.GetActionResultRequest{
 		InstanceName: c.instance,
@@ -309,10 +328,20 @@ func (c *Client) execute(tid int, target *core.BuildTarget, command *pb.Command,
 			err := c.verifyActionResult(target, command, digest, ar, c.state.Config.Remote.VerifyOutputs)
 			if err == nil {
 				c.locallyCacheResults(target, digest, metadata, ar)
-				return metadata, ar, nil
+				return metadata, ar
 			}
 			log.Debug("Remotely cached results for %s were missing some outputs, forcing a rebuild: %s", target.Label, err)
 		}
+	}
+	return nil, nil
+}
+
+// execute submits an action to the remote executor and monitors its progress.
+// The returned ActionResult may be nil on failure.
+func (c *Client) execute(tid int, target *core.BuildTarget, command *pb.Command, digest *pb.Digest, timeout time.Duration, isTest, needStdout bool) (*core.BuildMetadata, *pb.ActionResult, error) {
+	c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Checking remote...")
+	if metadata, ar := c.retrieveResults(target, command, digest, needStdout); metadata != nil {
+		return metadata, ar, nil
 	}
 	// We didn't actually upload the inputs before, so we must do so now.
 	command, digest, err := c.uploadAction(target, isTest)
@@ -326,7 +355,7 @@ func (c *Client) execute(tid int, target *core.BuildTarget, command *pb.Command,
 	} else if target.IsRemoteFile {
 		return c.fetchRemoteFile(tid, target, digest)
 	}
-	ctx, cancel = context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	stream, err := c.client.Execute(ctx, &pb.ExecuteRequest{
 		InstanceName:    c.instance,


### PR DESCRIPTION
Currently it fails if a local target depends on anything that was built remotely. This fixes.