### PR TITLE
Quote all build variables that could have spaces in them

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,7 +15,7 @@ genrule(
     srcs = ["bootstrap.sh"],
     outs = ["bootstrap.sh"],
     binary = True,
-    cmd = "sed 's/EXCLUDES=\"\"/EXCLUDES=\"%s\"/' $SRC > $OUT" % CONFIG.get("EXCLUDETEST", ""),
+    cmd = "sed 's/EXCLUDES=\"\"/EXCLUDES=\"%s\"/' $SRC > \"$OUT\"" % CONFIG.get("EXCLUDETEST", ""),
 )
 
 filegroup(

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,7 +14,7 @@ PLZ_ARGS="${PLZ_ARGS:-}"
 
 # Now invoke Go to run Please to build itself.
 notice "Building Please..."
-go run -tags bootstrap src/please.go $PLZ_ARGS --profile bootstrap -v4 -p build //src:please --log_file plz-out/log/bootstrap_build.log
+go run -tags bootstrap src/please.go $PLZ_ARGS --profile bootstrap build //src:please --log_file plz-out/log/bootstrap_build.log
 # Use it to build the rest of the tools that come with it.
 notice "Building the tools..."
 plz-out/bin/src/please $PLZ_ARGS build //package:installed_files --log_file plz-out/log/tools_build.log

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,7 +14,7 @@ PLZ_ARGS="${PLZ_ARGS:-}"
 
 # Now invoke Go to run Please to build itself.
 notice "Building Please..."
-go run -tags bootstrap src/please.go $PLZ_ARGS --profile bootstrap build //src:please --log_file plz-out/log/bootstrap_build.log
+go run -tags bootstrap src/please.go $PLZ_ARGS --profile bootstrap -v4 -p build //src:please --log_file plz-out/log/bootstrap_build.log
 # Use it to build the rest of the tools that come with it.
 notice "Building the tools..."
 plz-out/bin/src/please $PLZ_ARGS build //package:installed_files --log_file plz-out/log/tools_build.log

--- a/build_defs/BUILD
+++ b/build_defs/BUILD
@@ -14,7 +14,7 @@ genrule(
     name = "version",
     srcs = ["//:version"],
     outs = ["version.build_defs"],
-    cmd = "echo \"VERSION = '`cat $SRCS`'\" > $OUT",
+    cmd = "echo \"VERSION = '`cat $SRCS`'\" > \"$OUT\"",
     visibility = ["PUBLIC"],
 )
 

--- a/build_defs/cc_embed_binary.build_defs
+++ b/build_defs/cc_embed_binary.build_defs
@@ -42,7 +42,7 @@ def cc_embed_binary(name:str, src:str, deps:list=[], visibility:list=None,
             'export ENCODED_FILENAME="${SRCS//[\\/\\.]/_}"',
             f'export BINARY_NAME="{name}"',
             f'export NAMESPACE="{namespace}"',
-            f'echo "{hdr_contents}" > $OUT',
+            f'echo "{hdr_contents}" > "$OUT"',
         ]),
         visibility = visibility,
         building_description = 'Writing header...',
@@ -60,11 +60,11 @@ def cc_embed_binary(name:str, src:str, deps:list=[], visibility:list=None,
             f'echo "{_CC_DARWIN_ASM_CONTENTS}" > embedded.asm',
             '$TOOLS_ASM -fmacho64 embedded.asm -o ${OUTS/.a/.o}',
             '$TOOLS_JARCAT ar --srcs ${OUTS/.a/.o}',
-            '$TOOLS_AR s $OUTS',
+            '$TOOLS_AR s "$OUTS"',
         ])
         tools['asm'] = [CONFIG.ASM_TOOL]
     else:
-        cmd = '$TOOLS_LD -r --format binary %s -o ${OUTS/.a/.o} $SRC && $TOOLS_JARCAT ar --srcs ${OUTS/.a/.o} && $TOOLS_AR s $OUTS' % CONFIG.DEFAULT_LDFLAGS
+        cmd = '$TOOLS_LD -r --format binary %s -o "${OUTS/.a/.o}" $SRC && $TOOLS_JARCAT ar --srcs "${OUTS/.a/.o}" && $TOOLS_AR s "$OUTS"' % CONFIG.DEFAULT_LDFLAGS
         tools['ld'] = [CONFIG.LD_TOOL]
 
     lib_rule = build_rule(

--- a/build_defs/go_bindata.build_defs
+++ b/build_defs/go_bindata.build_defs
@@ -2,7 +2,7 @@ def go_bindata(name, srcs, input_dir=None, prefix='$PKG', out=None,
                memcopy=False, metadata=False, compress=False, visibility=None,
                test_only=False):
     """Defines a rule that invokes go-bindata to embed data into Go code."""
-    cmd = '$TOOL -o $OUT %s %s %s -pkg %s %s %s' % (
+    cmd = '"$TOOL" -o "$OUT" %s %s %s -pkg %s %s %s' % (
         '' if memcopy else '-nomemcopy',
         '' if metadata else '-nometadata',
         '' if compress else '-nocompress',

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -12,7 +12,7 @@ for src in glob(
         name = src.replace(".", "_"),
         srcs = ["template.html", src],
         outs = [src],
-        cmd = "$TOOL $SRCS > $OUT",
+        cmd = '"$TOOL" $SRCS > "$OUT"',
         tools = [":templater"],
     )
     deps += [templated_rule]
@@ -20,7 +20,7 @@ for src in glob(
 genrule(
     name = "rules",
     outs = ["rules.json"],
-    cmd = "$TOOL query rules > $OUT",
+    cmd = '"$TOOL" query rules > "$OUT"',
     tools = ["//src:please"],
 )
 
@@ -34,9 +34,9 @@ genrule(
     ],
     outs = ["lexicon.html"],
     cmd = [
-        "$TOOLS_LEX > lexicon.html",
-        "$TOOLS_TMPL docs/template.html lexicon.html > tmp.html",
-        "mv tmp.html $OUT",
+        '"$TOOLS_LEX" > lexicon.html',
+        '"$TOOLS_TMPL" docs/template.html lexicon.html > tmp.html',
+        'mv tmp.html "$OUT"',
     ],
     tools = {
         "lex": [":lexicon_templater"],
@@ -54,7 +54,7 @@ genrule(
         "grammar": ["grammar.txt"],
     },
     outs = ["language.html"],
-    cmd = "$TOOLS_TEMPLATE $SRCS_HTML | $TOOLS_GRAMMAR > $OUT",
+    cmd = '"$TOOLS_TEMPLATE" $SRCS_HTML | "$TOOLS_GRAMMAR" > "$OUT"',
     tools = {
         "grammar": [":grammar_templater"],
         "template": [":templater"],

--- a/docs/basics.html
+++ b/docs/basics.html
@@ -92,7 +92,7 @@
               srcs = ['docs.txt'],
               outs = [f'docs_{language}.txt'],
               tools = ['//tools:translate_tool'],
-              cmd = f'$TOOL -i $SRC --language {language} > $OUT',
+              cmd = f'$TOOL -i $SRC --language {language} > "$OUT"',
           )
 
           genrule(
@@ -100,7 +100,7 @@
               srcs = [lang_docs],
               outs = [f'docs_{language}.html'],
               tools = ['//tools:html_doc_tool'],
-              cmd = '$TOOL --src $SRC --out $OUT',
+              cmd = '$TOOL --src $SRC --out "$OUT"',
               visibility = ['PUBLIC'],
           )
       </code></pre>

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -4,7 +4,7 @@ genrule(
     name = "builtin_rules",
     srcs = build_defs,
     outs = [build_def + ".gob" for build_def in build_defs],
-    cmd = "$TOOL -o $TMP_DIR $SRCS",
+    cmd = '"$TOOL" -o "$TMP_DIR" $SRCS',
     tools = ["//src/parse/asp/main:compiler"],
 )
 

--- a/rules/cc_rules.build_defs
+++ b/rules/cc_rules.build_defs
@@ -107,7 +107,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
 
     if _interfaces:
         # Generate the module interface file
-        xflags = ['-fmodules-ts --precompile -x c++-module -o $OUT' if CONFIG.CC_MODULES_CLANG else '-fmodules -fmodule-output=$OUT']
+        xflags = ['-fmodules-ts --precompile -x c++-module -o "$OUT"' if CONFIG.CC_MODULES_CLANG else '-fmodules -fmodule-output="$OUT"']
         cmds, tools = _library_cmds(_c, compiler_flags + xflags, pkg_config_libs, pkg_config_cflags, archive=False)
         interface_rule = build_rule(
             name = name,
@@ -159,7 +159,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
             tag = 'a',
             srcs = {'srcs': a_rules},
             outs = [name + '.a'],
-            cmd = '$TOOLS_JARCAT ar --combine && $TOOLS_AR s $OUT',
+            cmd = '"$TOOLS_JARCAT" ar --combine && "$TOOLS_AR" s "$OUT"',
             building_description = 'Archiving...',
             test_only = test_only,
             labels = labels,
@@ -340,7 +340,7 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
         name = name,
         deps = deps,
         outs = [f'lib{name}.a'],
-        cmd = '$TOOLS_JARCAT ar --find && $TOOLS_AR s $OUT',
+        cmd = '"$TOOLS_JARCAT" ar --find && "$TOOLS_AR" s "$OUT"',
         needs_transitive_deps = True,
         output_is_complete = True,
         visibility = visibility,
@@ -689,7 +689,7 @@ def _library_cmds(c, compiler_flags, pkg_config_libs, pkg_config_cflags, extra_f
     opt_flags = _build_flags(compiler_flags, pkg_config_libs, pkg_config_cflags, c=c)
     cmd_template = '$TOOLS_CC -c -I . ${SRCS_SRCS} %s %s'
     if archive:
-        cmd_template += ' && $TOOLS_JARCAT ar -r && $TOOLS_AR s $OUT'
+        cmd_template += ' && "$TOOLS_JARCAT" ar -r && "$TOOLS_AR" s "$OUT"'
     cmds = {
         'dbg': cmd_template % (dbg_flags, extra_flags),
         'opt': cmd_template % (opt_flags, extra_flags),
@@ -708,11 +708,11 @@ def _binary_cmds(c, linker_flags, pkg_config_libs, extra_flags='', shared=False,
     dbg_flags = _binary_build_flags(linker_flags, pkg_config_libs, shared, alwayslink, c=c, dbg=True)
     opt_flags = _binary_build_flags(linker_flags, pkg_config_libs, shared, alwayslink, c=c, dbg=False)
     cmds = {
-        'dbg': f'$TOOL -o $OUT {dbg_flags} {extra_flags}',
-        'opt': f'$TOOL -o $OUT {opt_flags} {extra_flags}',
+        'dbg': f'"$TOOL" -o "$OUT" {dbg_flags} {extra_flags}',
+        'opt': f'"$TOOL" -o "$OUT" {opt_flags} {extra_flags}',
     }
     if CONFIG.CPP_COVERAGE:
-        cmds['cover'] = f'$TOOL -o $OUT {dbg_flags} {extra_flags} {_COVERAGE_FLAGS} -lgcov'
+        cmds['cover'] = f'"$TOOL" -o "$OUT" {dbg_flags} {extra_flags} {_COVERAGE_FLAGS} -lgcov'
     return cmds, [CONFIG.LD_TOOL if CONFIG.LINK_WITH_LD_TOOL else
                   CONFIG.CC_TOOL if c else CONFIG.CPP_TOOL]
 

--- a/rules/config_rules.build_defs
+++ b/rules/config_rules.build_defs
@@ -41,7 +41,7 @@ def config_setting(name:str, values:dict, visibility:list=None):
     return build_rule(
         name = name,
         outs = [name],
-        cmd = 'echo true > $OUT' if on else 'echo false > $OUT',
+        cmd = 'echo true > "$OUT"' if on else 'echo false > "$OUT"',
         visibility = visibility,
         labels = ['config:on' if on else 'config:off'],
     )

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -6,9 +6,9 @@ rules to Go packages.
 
 # This links all the .a files up one level. This is necessary for some Go tools to find them.
 _LINK_PKGS_CMD = ' '.join([
-    'for FN in `find . -name "*.a" | sort`; do ',
-    'DN=${FN%/*}; BN=${FN##*/}; if [ "${DN##*/}" == "${BN%.a}" ]; then ',
-    'ln -s $TMP_DIR/$FN ${DN%/*}; fi; done'
+    'for FN in `find . -name "*.a" | sort`; do',
+    'DN=${FN%/*}; BN=${FN##*/}; if [ "${DN##*/}" == "${BN%.a}" ]; then',
+    'ln -s "$TMP_DIR"/$FN ${DN%/*}; fi; done'
 ])
 
 
@@ -59,7 +59,7 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
             },
             outs = [name + '.abi'],
             building_description = 'Creating ABI...',
-            cmd = 'eval `$TOOL env` && $TOOL tool asm -trimpath $TMP_DIR -I ${GOROOT}/pkg/include -D GOOS_${OS} -D GOARCH_${ARCH} -gensymabis -o $OUT $SRCS_ASM',
+            cmd = 'eval `"$TOOL" env` && "$TOOL" tool asm -trimpath "$TMP_DIR" -I ${GOROOT}/pkg/include -D GOOS_${OS} -D GOARCH_${ARCH} -gensymabis -o "$OUT" $SRCS_ASM',
             tools=[CONFIG.GO_TOOL],
             test_only = test_only,
         )
@@ -84,7 +84,7 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
             },
             outs = [name + '.o'],
             building_description = 'Assembling...',
-            cmd = 'eval `$TOOL env` && $TOOL tool asm -trimpath $TMP_DIR -I ${GOROOT}/pkg/include -D GOOS_${GOOS} -D GOARCH_${GOARCH} -o $OUT $SRCS_ASM',
+            cmd = 'eval `"$TOOL" env` && "$TOOL" tool asm -trimpath "$TMP_DIR" -I ${GOROOT}/pkg/include -D GOOS_${GOOS} -D GOARCH_${GOARCH} -o "$OUT" $SRCS_ASM',
             tools=[CONFIG.GO_TOOL],
             test_only = test_only,
         )
@@ -96,7 +96,7 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
             },
             outs=[out],
             tools=[CONFIG.GO_TOOL],
-            cmd = 'cp $SRCS_LIB $OUT && chmod +w $OUT && $TOOL tool pack r $OUT $SRCS_ASM',
+            cmd = 'cp $SRCS_LIB "$OUT" && chmod +w "$OUT" && "$TOOL" tool pack r "$OUT" $SRCS_ASM',
             visibility = visibility,
             building_description = 'Packing...',
             requires = ['go'],
@@ -199,14 +199,14 @@ def cgo_library(name:str, srcs:list, go_srcs:list=[], c_srcs:list=[], hdrs:list=
         },
         cmd = ' && '.join([
             (f'OUT_DIR="$TMP_DIR/{subdir}"') if subdir else 'OUT_DIR="$TMP_DIR"',
-            'mkdir -p $OUT_DIR',
+            'mkdir -p "$OUT_DIR"',
             'cd $PKG_DIR/' + subdir,
-            '$TOOL tool cgo -objdir $OUT_DIR -importpath ${PKG_DIR#*src/} *.go',
+            '$TOOL tool cgo -objdir "$OUT_DIR" -importpath ${PKG_DIR#*src/} *.go',
             # Remove the .o file which BSD sed gets upset about in the next command
-            'rm -f $OUT_DIR/_cgo_.o $OUT_DIR/_cgo_main.c',
+            'rm -f "$OUT_DIR"/_cgo_.o "$OUT_DIR"/_cgo_main.c',
             # cgo leaves absolute paths in these files which we must get rid of :(
-            'find $OUT_DIR -type f -maxdepth 1 | xargs sed -i -e "s|$TMP_DIR/||g"',
-            'cd $TMP_DIR',
+            'find "$OUT_DIR" -type f -maxdepth 1 | xargs sed -i -e "s|"$TMP_DIR"/||g"',
+            'cd "$TMP_DIR"',
             f'ls {subdir2}*.c {subdir2}*.go',
         ]),
         tools = [CONFIG.GO_TOOL],
@@ -257,9 +257,9 @@ def _merge_cgo_obj(name, a_rule, o_rule=None, visibility=None, test_only=False, 
                    linker_flags:list=[], deps=None, provides=None, out=None, labels:list=[]):
     """Defines a rule to merge a cgo object into a Go library."""
     if o_rule:
-        cmd = 'cp $SRCS_A $OUT && chmod +w $OUT && $TOOLS_AR x $SRCS_O && $TOOLS_GO tool pack r $OUT *.o'
+        cmd = 'cp $SRCS_A "$OUT" && chmod +w "$OUT" && "$TOOLS_AR" x $SRCS_O && "$TOOLS_GO" tool pack r "$OUT" *.o'
     else:
-        cmd = 'cp $SRCS_A $OUT && chmod +w $OUT && $TOOLS_AR x $PKG_DIR/*#c.a && $TOOLS_GO tool pack r $OUT *.o'
+        cmd = 'cp $SRCS_A "$OUT" && chmod +w "$OUT" && "$TOOLS_AR" x $PKG_DIR/*#c.a && "$TOOLS_GO" tool pack r "$OUT" *.o'
 
     return build_rule(
         name = name,
@@ -466,9 +466,9 @@ def go_test_main(name:str, srcs:list, test_only:bool=False,
         outs = [name + '_main.go'],
         deps = deps,
         cmd = {
-            'dbg': f'$TOOLS -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS',
-            'opt': f'$TOOLS -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS',
-            'cover': f'$TOOLS -d . -o $OUT -i "{CONFIG.GO_IMPORT_PATH}" $SRCS ',
+            'dbg': f'"$TOOLS" -o "$OUT" -i "{CONFIG.GO_IMPORT_PATH}" $SRCS',
+            'opt': f'"$TOOLS" -o "$OUT" -i "{CONFIG.GO_IMPORT_PATH}" $SRCS',
+            'cover': f'"$TOOLS" -d . -o "$OUT" -i "{CONFIG.GO_IMPORT_PATH}" $SRCS ',
         },
         needs_transitive_deps = True,  # Need all dependencies to template coverage variables
         requires = ['go', 'go_src'],
@@ -598,14 +598,14 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
 
     # Now compile it in a separate step.
     cmd = [
-        'export GOPATH=$(find $TMP_DIR \( -name src -o -name pkg \) -exec dirname {} \; | sort | uniq | tr "\\n" ":") GO111MODULE="off"',
-        '$TOOLS_GO install -toolexec "$TOOLS_BUILDID" -gcflags "-trimpath $TMP_DIR" -asmflags "-trimpath $TMP_DIR" ' + ' '.join(all_installs or install),
+        'export GOPATH="$(find \"$TMP_DIR\" \( -name src -o -name pkg \) -exec dirname {} \; | sort | uniq | tr \'\\n\' \':\')" GO111MODULE="off"',
+        '"$TOOLS_GO" install -toolexec "$TOOLS_BUILDID" -gcflags "-trimpath \\\"$TMP_DIR\\\"" -asmflags "-trimpath \\\"$TMP_DIR\\\"" ' + ' '.join(all_installs or install),
     ]
     if package_name():
         cmd += [
             # The outputs tend to end up in subdirectories (Go seems to match them to the location the source came from)
             'rm -rf bin' if binary else 'rm -rf pkg',
-            'mv $PKG_DIR/bin .' if binary else 'mv $PKG_DIR/pkg .',
+            'mv "$PKG_DIR/bin" .' if binary else 'mv "$PKG_DIR/pkg" .',
         ]
     if binary:
         outs = ['bin/' + name]
@@ -679,7 +679,7 @@ def _go_get_download(name:str, tag:str, get:str, repo:str='', patch:str=None, ha
         cmd += ['find . -name .git | xargs rm -rf']
         tools = [CONFIG.GO_TOOL]
     if patch:
-        cmd += [f'patch -s -d {subdir} -p1 < $TMP_DIR/$SRCS_PATCH']
+        cmd += [f'patch -s -d {subdir} -p1 < "$TMP_DIR"/$SRCS_PATCH']
     if strip:
         cmd += [f'rm -rf {subdir}/{s}' for s in strip]
     return build_rule(
@@ -720,7 +720,7 @@ def _go_github_repo_cmd(name, get, repo, revision):
     )
     return [
         'rm -rf src/' + out,
-        '$TOOL x $SRCS_GET',
+        '"$TOOL" x $SRCS_GET',
         f'mv {dest}*/ src/{out}',
     ], [remote_rule], [CONFIG.JARCAT_TOOL]
 
@@ -755,13 +755,13 @@ def _replace_test_package(name, output, static, definitions, cgo):
 
 def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True, abi=False):
     """Returns the commands to run for building a Go library."""
-    filter_cmd = 'export SRCS="$(${TOOLS_FILTER} ${SRCS})"; ' if filter_srcs else ''
+    filter_cmd = 'export SRCS="$(\"${TOOLS_FILTER}\" ${SRCS})"; ' if filter_srcs else ''
     # Invokes the Go compiler.
     complete_flag = '-complete ' if complete else ''
-    out_cmd = ' -o $OUTS_O -symabis $SRCS_ABI -asmhdr $OUTS_H' if abi else ' -o $OUT'
+    out_cmd = ' -o "$OUTS_O" -symabis $SRCS_ABI -asmhdr "$OUTS_H"' if abi else ' -o "$OUT"'
     _GOPATH = ' '.join(
-        ['-I %s -I %s/pkg/%s_%s' % (p, p, CONFIG.GOOS, CONFIG.GOARCH) for p in CONFIG.GOPATH.split(':')])
-    compile_cmd = f'$TOOLS_GO tool compile -trimpath $TMP_DIR {complete_flag}{_GOPATH} $(for i in $(find $TMP_DIR -name pkg -type d); do echo -n " -I $i/{CONFIG.GOOS}_{CONFIG.GOARCH} "; done) -pack {out_cmd}'
+        ['-I "%s" -I "%s/pkg/%s_%s"' % (p, p, CONFIG.GOOS, CONFIG.GOARCH) for p in CONFIG.GOPATH.split(':')])
+    compile_cmd = f'"$TOOLS_GO" tool compile -trimpath "$TMP_DIR" {complete_flag}{_GOPATH} $(for i in $(find "$TMP_DIR" -name pkg -type d); do echo -n " -I \"$i\"/{CONFIG.GOOS}_{CONFIG.GOARCH} "; done) -pack {out_cmd}'
     # Annotates files for coverage.
     cover_cmd = 'for SRC in $SRCS; do BN=$(basename $SRC); go tool cover -mode=set -var=GoCover_${BN//[.-]/_} $SRC > _tmp.go && mv -f _tmp.go $SRC; done'
     prefix = ('export SRCS="$PKG_DIR/*.go"; ' + _LINK_PKGS_CMD) if all_srcs else _LINK_PKGS_CMD
@@ -779,8 +779,8 @@ def _go_binary_cmds(static=False, ldflags='', pkg_config='', definitions=None, g
     """Returns the commands to run for linking a Go binary."""
 
     _GOPATH = ' '.join(
-        ['-I %s -I %s/pkg/%s_%s' % (p, p, CONFIG.GOOS, CONFIG.GOARCH) for p in CONFIG.GOPATH.split(':')])
-    _link_cmd = f'$TOOLS_GO tool link -tmpdir $TMP_DIR -extld $TOOLS_LD %s $(find $TMP_DIR -type d -print | grep  "pkg/{CONFIG.GOOS}_{CONFIG.GOARCH}$" | sed -e "s/^/-L /" | tr "\\n" " ") -o $OUT ' % _GOPATH.replace('-I ', '-L ')
+        ['-I "%s" -I "%s/pkg/%s_%s"' % (p, p, CONFIG.GOOS, CONFIG.GOARCH) for p in CONFIG.GOPATH.split(':')])
+    _link_cmd = f'"$TOOLS_GO" tool link -tmpdir "$TMP_DIR" -extld "$TOOLS_LD" %s $(find "$TMP_DIR" -type d -print | grep "pkg/{CONFIG.GOOS}_{CONFIG.GOARCH}$" | sed -e "s/^/-L /" | tr "\\n" " ") -o "$OUT" ' % _GOPATH.replace('-I ', '-L ')
     prefix = _LINK_PKGS_CMD + _go_import_path_cmd(CONFIG.GO_IMPORT_PATH)
 
     linkerdefs = []
@@ -825,9 +825,9 @@ def _go_import_path_cmd(import_path):
     elif import_path.startswith('/'):
         raise ConfigError('GO_IMPORT_PATH cannot start with a /')
     elif '/' in import_path:
-        return ' && mkdir -p %s && ln -s $TMP_DIR %s' % (dirname(import_path), import_path)
+        return ' && mkdir -p %s && ln -s "$TMP_DIR" %s' % (dirname(import_path), import_path)
     else:
-        return ' && ln -s $TMP_DIR ' + import_path
+        return ' && ln -s "$TMP_DIR" ' + import_path
 
 
 def _collect_linker_flags(static):

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -599,7 +599,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
     # Now compile it in a separate step.
     cmd = [
         'export GOPATH="$(find \"$TMP_DIR\" \( -name src -o -name pkg \) -exec dirname {} \; | sort | uniq | tr \'\\n\' \':\')" GO111MODULE="off"',
-        '"$TOOLS_GO" install -toolexec "$TOOLS_BUILDID" -gcflags "-trimpath \\\"$TMP_DIR\\\"" -asmflags "-trimpath \\\"$TMP_DIR\\\"" ' + ' '.join(all_installs or install),
+        '"$TOOLS_GO" install -toolexec "\\\"$TOOLS_BUILDID\\\"" -gcflags "-trimpath \\\"$TMP_DIR\\\"" -asmflags "-trimpath \\\"$TMP_DIR\\\"" ' + ' '.join(all_installs or install),
     ]
     if package_name():
         cmd += [
@@ -780,7 +780,7 @@ def _go_binary_cmds(static=False, ldflags='', pkg_config='', definitions=None, g
 
     _GOPATH = ' '.join(
         ['-I "%s" -I "%s/pkg/%s_%s"' % (p, p, CONFIG.GOOS, CONFIG.GOARCH) for p in CONFIG.GOPATH.split(':')])
-    _link_cmd = f'"$TOOLS_GO" tool link -tmpdir "$TMP_DIR" -extld "$TOOLS_LD" %s $(find "$TMP_DIR" -type d -print | grep "pkg/{CONFIG.GOOS}_{CONFIG.GOARCH}$" | sed -e "s/^/-L /" | tr "\\n" " ") -o "$OUT" ' % _GOPATH.replace('-I ', '-L ')
+    _link_cmd = f'"$TOOLS_GO" tool link -tmpdir "$TMP_DIR" -extld "$TOOLS_LD" %s $(find "$TMP_DIR" -type d -print | grep "pkg/{CONFIG.GOOS}_{CONFIG.GOARCH}$" | sed -e "s/^/-L \\\"/" | tr "\\n" "\\\" ") -o "$OUT" ' % _GOPATH.replace('-I ', '-L ')
     prefix = _LINK_PKGS_CMD + _go_import_path_cmd(CONFIG.GO_IMPORT_PATH)
 
     linkerdefs = []

--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -58,15 +58,15 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=None
             srcflag = '--src_dir' if src_dir else ''
             javac_cmd = f'$(worker {CONFIG.JAVAC_WORKER}) {javac_flags} {mflag} {srcflag}'
         else:
-            find = r'`find $TMP_DIR -name "*.jar" | tr \\\\n :`'
+            find = r'`find "$TMP_DIR" -name "*.jar" | tr \\\\n :`'
             srcflag = '$SRCS' if srcs else '`find $SRCS -name "*.java"`'
-            javac_cmd = f'mkdir -p _tmp/META-INF && $TOOLS_JAVAC {javac_flags} -classpath .:{find} -d _tmp {srcflag}'
+            javac_cmd = f'mkdir -p _tmp/META-INF && "$TOOLS_JAVAC" {javac_flags} -classpath .:{find} -d _tmp {srcflag}'
 
         cmd = ' && '.join([
             javac_cmd,
             'find _tmp -name "*.class" | sed -e "s|_tmp/|${PKG} |g" -e "s/\\.class/.java/g" | sort > _tmp/META-INF/please_sourcemap',
             'cd _tmp',
-            '$TOOLS_JARCAT z -d -o $OUT -i .',
+            '"$TOOLS_JARCAT" z -d -o "$OUT" -i .',
         ])
 
         src_dir_label = []
@@ -184,7 +184,7 @@ def java_runtime_image(name:str, main_module:str, main_class:str, modules:list, 
     if not modules:
         raise Exception('You cannot assemble a java runtime image without specifying any modules.')
     out = out or name
-    depflags = r'`find $TMP_DIR -name "*.jar" | tr \\\\n :`'
+    depflags = r'`find "$TMP_DIR" -name "*.jar" | tr \\\\n :`'
     modules = ','.join(modules)
     cmd = f"$TOOL --module-path {depflags}:{CONFIG.JAVA_HOME}/jmods --add-modules {modules} --launcher {name}={main_module}/{main_class} --output {out} {jlink_args}"
 

--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -314,7 +314,7 @@ def system_library(name:str, srcs:list, deps:list=None, hashes:list=None,
         system_srcs = srcs,
         outs = [basename(src) for src in srcs],
         deps = deps,
-        cmd = 'cp $SRCS .',
+        cmd = 'cp "$SRCS" .',
         hashes = hashes,
         visibility = visibility,
         test_only = test_only,
@@ -357,9 +357,9 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
             labels = labels,
         )
         if strip_prefix:
-            cmd = '$TOOL x $SRCS -o $OUT -s ' + strip_prefix
+            cmd = '"$TOOL" x $SRCS -o "$OUT" -s ' + strip_prefix
         else:
-            cmd = '$TOOL x $SRCS -o $OUT'
+            cmd = '"$TOOL" x $SRCS -o "$OUT"'
         return build_rule(
             name = name,
             srcs = [remote_rule],
@@ -453,7 +453,7 @@ def tarball(name:str, srcs:list, out:str=None, deps:list=None, subdir:str=None, 
         name = name,
         srcs = [tar_rule],
         outs = [out or (name + '.tar.xz')],
-        cmd = 'xz -zc -T 0 $SRCS > $OUT',
+        cmd = 'xz -zc -T 0 $SRCS > "$OUT"',
         visibility = visibility,
         labels = labels + ['tar'],
         output_is_complete = True,

--- a/rules/proto_rules.build_defs
+++ b/rules/proto_rules.build_defs
@@ -55,7 +55,7 @@ def proto_library(name:str, srcs:list, deps:list=[], visibility:list=None, label
     tools['protoc'] = [CONFIG.PROTOC_TOOL]
     cmd = '$TOOLS_PROTOC ' + ' '.join(flags)
     if root_dir:
-        cmd = 'export RD="%s"; cd $RD; %s ${SRCS//$RD\\//} && cd $TMP_DIR' % (root_dir, cmd.replace('$TMP_DIR', '.'))
+        cmd = 'export RD="%s"; cd $RD; %s ${SRCS//$RD\\//} && cd "$TMP_DIR"' % (root_dir, cmd.replace('$TMP_DIR', '.'))
     else:
         cmd += ' ${SRCS}'
     cmds = [cmd, '(mv -f ${PKG_DIR}/* .; true)']
@@ -277,7 +277,7 @@ def proto_languages():
                 pkg_config_libs = ['protobuf'],
                 compiler_flags = ['-I$PKG_DIR'],
             ),
-            protoc_flags = ['--cpp_out=$TMP_DIR'],
+            protoc_flags = ['--cpp_out="$TMP_DIR"'],
         ),
         'java': proto_language(
             language = 'java',
@@ -290,7 +290,7 @@ def proto_languages():
                 test_only = test_only,
                 labels = ['proto'],
             ),
-            protoc_flags = ['--java_out=$TMP_DIR'],
+            protoc_flags = ['--java_out="$TMP_DIR"'],
             deps = [CONFIG.PROTO_JAVA_DEP],
         ),
         'go': proto_language(
@@ -303,7 +303,7 @@ def proto_languages():
                 deps = deps,
                 test_only = test_only,
             ),
-            protoc_flags = ['--go_out=paths=source_relative:$TMP_DIR', '--plugin=protoc-gen-go=$TOOLS_GO'],
+            protoc_flags = ['--go_out=paths=source_relative:"$TMP_DIR"', '--plugin=protoc-gen-go=$TOOLS_GO'],
             tools = [CONFIG.PROTOC_GO_PLUGIN],
             deps = [CONFIG.PROTO_GO_DEP],
             pre_build = _go_path_mapping(False),
@@ -319,7 +319,7 @@ def proto_languages():
                 requires = ['js'],
                 output_is_complete = False,
             ),
-            protoc_flags = ['--js_out=import_style=commonjs,binary:$TMP_DIR'],
+            protoc_flags = ['--js_out=import_style=commonjs,binary:"$TMP_DIR"'],
             deps = [CONFIG.PROTO_JS_DEP],
         ),
         'py': proto_language(
@@ -327,7 +327,7 @@ def proto_languages():
             proto_language = 'python',
             extensions = ['_pb2.py'],
             func = python_library,
-            protoc_flags = ['--python_out=$TMP_DIR'],
+            protoc_flags = ['--python_out="$TMP_DIR"'],
             deps = [CONFIG.PROTO_PYTHON_DEP],
         ),
     }
@@ -349,7 +349,7 @@ def grpc_languages():
                 pkg_config_libs = ['grpc++', 'grpc', 'protobuf'],
                 compiler_flags = ['-I$PKG_DIR', '-Wno-unused-parameter'],  # Generated gRPC code is not robust to this.
             ),
-            protoc_flags = ['--cpp_out=$TMP_DIR', '--plugin=protoc-gen-grpc-cc=$TOOLS_CC', '--grpc-cc_out=$TMP_DIR'],
+            protoc_flags = ['--cpp_out="$TMP_DIR"', '--plugin=protoc-gen-grpc-cc="$TOOLS_CC"', '--grpc-cc_out="$TMP_DIR"'],
             tools = [CONFIG.GRPC_CC_PLUGIN],
         ),
         'py': proto_language(
@@ -357,7 +357,7 @@ def grpc_languages():
             proto_language = 'python',
             extensions = ['_pb2.py', '_pb2_grpc.py'],
             func = python_library,
-            protoc_flags = ['--python_out=$TMP_DIR', '--plugin=protoc-gen-grpc-python=$TOOLS_PY', '--grpc-python_out=$TMP_DIR'],
+            protoc_flags = ['--python_out="$TMP_DIR"', '--plugin=protoc-gen-grpc-python="$TOOLS_PY"', '--grpc-python_out="$TMP_DIR"'],
             tools = [CONFIG.GRPC_PYTHON_PLUGIN],
             deps = [CONFIG.PROTO_PYTHON_DEP, CONFIG.GRPC_PYTHON_DEP],
         ),
@@ -372,7 +372,7 @@ def grpc_languages():
                 test_only = test_only,
                 labels = ['proto'],
             ),
-            protoc_flags = ['--java_out=$TMP_DIR', '--plugin=protoc-gen-grpc-java=$TOOLS_JAVA', '--grpc-java_out=$TMP_DIR'],
+            protoc_flags = ['--java_out="$TMP_DIR"', '--plugin=protoc-gen-grpc-java="$TOOLS_JAVA"', '--grpc-java_out="$TMP_DIR"'],
             tools = [CONFIG.GRPC_JAVA_PLUGIN],
             deps = [CONFIG.GRPC_JAVA_DEP, CONFIG.PROTO_JAVA_DEP],
         ),
@@ -386,7 +386,7 @@ def grpc_languages():
                 deps = deps,
                 test_only = test_only,
             ),
-            protoc_flags = ['--go_out=paths=source_relative:$TMP_DIR', '--plugin=protoc-gen-go=$TOOLS_GO'],
+            protoc_flags = ['--go_out=paths=source_relative:"$TMP_DIR"', '--plugin=protoc-gen-go="$TOOLS_GO"'],
             tools = [CONFIG.PROTOC_GO_PLUGIN],
             deps = [CONFIG.PROTO_GO_DEP, CONFIG.GRPC_GO_DEP],
             pre_build = _go_path_mapping(True),
@@ -403,7 +403,7 @@ def grpc_languages():
                 requires = ['js'],
                 output_is_complete = False,
             ),
-            protoc_flags = ['--js_out=import_style=commonjs,binary:$TMP_DIR'],
+            protoc_flags = ['--js_out=import_style=commonjs,binary:"$TMP_DIR"'],
             deps = [CONFIG.PROTO_JS_DEP],
         ),
     }
@@ -439,8 +439,8 @@ def protoc_binary(name, version, hashes=None, deps=None, visibility=None):
         tools = [CONFIG.JARCAT_TOOL],
         cmd = '$TOOL x $SRCS --strip_prefix include',
         labels = [
-            'protoc:-I$TMP_DIR/' + package_name(),
-            'protoc:-I$TMP_DIR',
+            'protoc:-I"$TMP_DIR"/' + package_name(),
+            'protoc:-I"$TMP_DIR"',
         ],
     )
     return genrule(

--- a/rules/sh_rules.build_defs
+++ b/rules/sh_rules.build_defs
@@ -61,18 +61,18 @@ def sh_binary(name:str, main:str|list&srcs, deps:list=None, visibility:list=None
     if deps:
         cmds = ' && '.join([
             # Use the same shebang as the original script
-            'head -1 $SRCS > $TMPDIR/_tmp.txt',
+            'head -1 "$SRCS" > "$TMPDIR"/_tmp.txt',
             # Inject bash code to untar the compressed files.
-            f'echo "{_SH_BINARY_TMPL_PREFIX}" >> $TMPDIR/_tmp.txt',
+            f'echo "{_SH_BINARY_TMPL_PREFIX}" >> "$TMPDIR"/_tmp.txt',
             # Inject the user defined script.
-            'cat $SRCS >> $TMPDIR/_tmp.txt',
+            'cat $SRCS >> "$TMPDIR"/_tmp.txt',
             # Inject a final exit so it doesn't try to execute the zipfile contents.
-            f'echo "{_SH_BINARY_TMPL_SUFFIX}" >> $TMPDIR/_tmp.txt',
+            f'echo "{_SH_BINARY_TMPL_SUFFIX}" >> "$TMPDIR"/_tmp.txt',
             # Compress the dependent files and dump out into the bash script.
-            '$TOOL z -d -n -i . -o $OUT --preamble_file $TMPDIR/_tmp.txt --strip_prefix ./',
+            '"$TOOL" z -d -n -i . -o "$OUT" --preamble_file "$TMPDIR"/_tmp.txt --strip_prefix ./',
         ])
     else:
-        cmds = 'cp $SRCS $OUT'
+        cmds = 'cp $SRCS "$OUT"'
 
     return build_rule(
         name = name,
@@ -119,7 +119,7 @@ def sh_test(name:str, src:str=None, labels:list&features&tags=None, data:list|di
         data=data,
         deps=deps,
         outs=[name + '.sh'],
-        cmd='mv ${SRC} ${OUT}',
+        cmd='mv "${SRC}" "${OUT}"',
         test_cmd=test_cmd,
         visibility=visibility,
         labels=labels,
@@ -162,9 +162,9 @@ def sh_cmd(name:str, cmd:str|dict|list, srcs:list|dict=None, out:str="", shell:s
     """
     cmd = ' && '.join(cmd) if isinstance(cmd, list) else cmd
     if isinstance(cmd, str):
-        cmds = f'{{ cat > $OUT << EOF\n#!{shell}\n{cmd}\nEOF\n}}'
+        cmds = f'{{ cat > "$OUT" << EOF\n#!{shell}\n{cmd}\nEOF\n}}'
     elif isinstance(cmd, dict):
-        cmds = {k: f'{{ cat > $OUT << EOF\n#!{shell}\n{v}\nEOF\n}}' for k, v in cmd.items()}
+        cmds = {k: f'{{ cat > "$OUT" << EOF\n#!{shell}\n{v}\nEOF\n}}' for k, v in cmd.items()}
     return build_rule(
         name = name,
         outs = [out or name + '.sh'],

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -95,15 +95,15 @@ def new_http_archive(name:str, urls:list, build_file:str=None, build_file_conten
         hashes = hashes,
     )
     if strip_prefix:
-        cmd = '$TOOL x $SRCS_REMOTE -o $OUT -s ' + strip_prefix
+        cmd = '$TOOL x $SRCS_REMOTE -o "$OUT" -s ' + strip_prefix
     else:
-        cmd = '$TOOL x $SRCS_REMOTE -o $OUT'
+        cmd = '$TOOL x $SRCS_REMOTE -o "$OUT"'
     if strip_build:
         cmd += ' && find . -name BUILD | xargs rm -f'
     if build_file:
-        cmd += ' && mv $SRCS_BUILD $OUT/' + CONFIG.BUILD_FILE_NAMES[0]
+        cmd += ' && mv $SRCS_BUILD "$OUT/' + CONFIG.BUILD_FILE_NAMES[0] + '"'
     elif build_file_content:
-        cmd += ' && cat > $OUT/%s << EOF\n%s\nEOF' % (CONFIG.BUILD_FILE_NAMES[0], build_file_content)
+        cmd += ' && cat > "$OUT"/%s << EOF\n%s\nEOF' % (CONFIG.BUILD_FILE_NAMES[0], build_file_content)
 
     extract_rule = build_rule(
         name = name,

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -5,7 +5,7 @@ genrule(
         "version": ["//:version"],
     },
     outs = ["versioned.go"],
-    cmd = "sed \"s/1.0.9999/`cat $SRCS_VERSION`/\" $SRCS_GO > $OUT",
+    cmd = "sed \"s/1.0.9999/`cat $SRCS_VERSION`/\" $SRCS_GO > \"$OUT\"",
 )
 
 go_library(

--- a/src/help/BUILD
+++ b/src/help/BUILD
@@ -44,7 +44,7 @@ go_test(
 genrule(
     name = "config_json",
     outs = ["config.json"],
-    cmd = "$TOOL > $OUTS",
+    cmd = '"$TOOL" > "$OUTS"',
     tools = ["//src/help/config:config_help"],
 )
 

--- a/src/parse/asp/fuzz/BUILD
+++ b/src/parse/asp/fuzz/BUILD
@@ -2,7 +2,7 @@ genrule(
     name = "build",
     srcs = ["fuzz.go"],
     outs = ["fuzz.zip"],
-    cmd = "export GOPATH=$TMP_DIR:$TMP_DIR/third_party/go; $TOOL -o $OUT parse/asp/fuzz",
+    cmd = 'export GOPATH=$TMP_DIR:$TMP_DIR/third_party/go; "$TOOL" -o "$OUT" parse/asp/fuzz',
     labels = ["manual"],  # This is really quite slow to compile and has poor incrementality.
     needs_transitive_deps = True,
     requires = [

--- a/test/BUILD
+++ b/test/BUILD
@@ -385,7 +385,7 @@ genrule(
     name = "symlink_gen",
     srcs = ["symlink_test.txt"],
     outs = ["symlink_test.txt"],
-    cmd = "ln -s $SRCS $OUTS",
+    cmd = 'ln -s $SRCS "$OUTS"',
 )
 
 gentest(
@@ -434,7 +434,7 @@ sh_test(
 genrule(
     name = "pass_env",
     outs = ["pass_env.sh"],
-    cmd = "echo \"export USER='$USER'\" > $OUT",
+    cmd = "echo \"export USER='$USER'\" > \"$OUT\"",
     pass_env = ["USER"],
 )
 

--- a/test/cc_rules/clang/BUILD
+++ b/test/cc_rules/clang/BUILD
@@ -24,7 +24,7 @@ cc_embed_binary(
 genrule(
     name = "embedded_file_3_gen",
     outs = ["embedded_file_3.txt"],
-    cmd = "echo \"testing message 3\" > $OUT",
+    cmd = "echo \"testing message 3\" > \"$OUT\"",
 )
 
 c_embed_binary(

--- a/test/cc_rules/gcc/BUILD
+++ b/test/cc_rules/gcc/BUILD
@@ -12,7 +12,7 @@ cc_embed_binary(
 genrule(
     name = "embedded_file_3_gen",
     outs = ["embedded_file_3.txt"],
-    cmd = "echo \"testing message 3\" > $OUT",
+    cmd = "echo \"testing message 3\" > \"$OUT\"",
 )
 
 cc_embed_binary(

--- a/test/completions/BUILD
+++ b/test/completions/BUILD
@@ -3,20 +3,20 @@
 genrule(
     name = "library",
     outs = ["lib.txt"],
-    cmd = "touch $OUT",
+    cmd = 'touch "$OUT"',
 )
 
 genrule(
     name = "binary",
     outs = ["bin.sh"],
     binary = True,
-    cmd = "touch $OUT",
+    cmd = 'touch "$OUT"',
 )
 
 gentest(
     name = "test",
     outs = ["test.sh"],
-    cmd = "touch $OUT",
+    cmd = 'touch "$OUT"',
     labels = ["manual"],
     test_cmd = "true",
 )

--- a/test/cross_compile/BUILD
+++ b/test/cross_compile/BUILD
@@ -3,7 +3,7 @@ subinclude("//build_defs:plz_e2e_test")
 genrule(
     name = "record_arch",
     outs = ["arch.txt"],
-    cmd = "echo ${OS}_${ARCH} > $OUT",
+    cmd = 'echo ${OS}_${ARCH} > "$OUT"',
 )
 
 sh_test(
@@ -48,7 +48,7 @@ genrule(
     name = "location",
     srcs = [":record_arch"],
     outs = ["arch_location.txt"],
-    cmd = "echo '$(location :record_arch)' > $OUT",
+    cmd = "echo '$(location :record_arch)' > \"$OUT\"",
 )
 
 sh_test(

--- a/test/cross_compile/lib/BUILD
+++ b/test/cross_compile/lib/BUILD
@@ -11,7 +11,7 @@ go_binary(
 genrule(
     name = "generated",
     outs = ["gen.txt"],
-    cmd = "$TOOL > $OUT",
+    cmd = '"$TOOL" > "$OUT"',
     tools = [":generator"],
 )
 

--- a/test/filegroup/BUILD
+++ b/test/filegroup/BUILD
@@ -4,7 +4,7 @@ genrule(
     name = "gen",
     outs = ["gen.txt"],
     # This being nondeterministic would normally be a bad idea, but here makes the test work better.
-    cmd = "dd if=/dev/urandom of=$OUT bs=10000 count=1",
+    cmd = 'dd if=/dev/urandom of="$OUT" bs=10000 count=1',
     visibility = ["//test/filegroup/many:all"],
 )
 

--- a/test/moar/BUILD
+++ b/test/moar/BUILD
@@ -5,13 +5,13 @@ package(default_visibility = ["//test/..."])
 genrule(
     name = "test_require_py",
     outs = ["test_require.py"],
-    cmd = "touch $OUT",
+    cmd = 'touch "$OUT"',
 )
 
 genrule(
     name = "test_require_go",
     outs = ["test_require.go"],
-    cmd = "touch $OUT",
+    cmd = 'touch "$OUT"',
 )
 
 filegroup(
@@ -48,14 +48,14 @@ filegroup(
 genrule(
     name = "provided",
     outs = ["provided.txt"],
-    cmd = "echo \"hello\" > $OUT",
+    cmd = 'echo "hello" > "$OUT"',
 )
 
 gentest(
     name = "require_test",
     srcs = [":provider"],
     outs = ["require_test.txt"],
-    cmd = "cat $SRCS > $OUT",
+    cmd = 'cat $SRCS > "$OUT"',
     no_test_output = True,
     requires = ["wibble"],
     test_cmd = "[ \"`cat $TEST`\" == \"hello\" ]",

--- a/test/parse_test/BUILD
+++ b/test/parse_test/BUILD
@@ -2,14 +2,14 @@
 genrule(
     name = "test_require_py",
     outs = ["test_require.py"],
-    cmd = "touch $OUT",
+    cmd = 'touch "$OUT"',
     test_only = True,
 )
 
 genrule(
     name = "test_require_go",
     outs = ["test_require.go"],
-    cmd = "touch $OUT",
+    cmd = 'touch "$OUT"',
     test_only = True,
 )
 
@@ -50,7 +50,7 @@ genrule(
 
 genrule(
     name = "_gen_output",
-    cmd = "echo -n \"kittens\" > $OUT",
+    cmd = 'echo -n "kittens" > "$OUT"',
     deps = [
         ":_gen_output_name",
     ],

--- a/test/secrets/BUILD
+++ b/test/secrets/BUILD
@@ -3,7 +3,7 @@
 gentest(
     name = "test_root_file",
     outs = ["test_root_file.sh"],
-    cmd = "echo \"#!$SECRETS\nexec true\" > $OUT",
+    cmd = 'echo "#!$SECRETS\nexec true" > "$OUT"',
     no_test_output = True,
     secrets = ["/bin/sh"],
     test_cmd = "$TEST",
@@ -11,7 +11,7 @@ gentest(
 
 tildes_replaced_test = r'''
 echo "[ \"$SECRETS_AD_SECRETS\" = \"/bin/sh $SECRETS_HOME/.bashrc\" ] || \
-(echo "Failed: $SECRETS_HOME $SECRETS_AD_SECRETS"; exit 1)" > $OUT'''
+(echo "Failed: $SECRETS_HOME $SECRETS_AD_SECRETS"; exit 1)" > "$OUT"'''
 
 gentest(
     name = "test_tildes_replaced",

--- a/tools/build_langserver/lsp/test_data/build_defs/go_bindata.build_defs
+++ b/tools/build_langserver/lsp/test_data/build_defs/go_bindata.build_defs
@@ -2,7 +2,7 @@ def go_bindata(name, srcs, input_dir=None, prefix='$PKG', out=None,
                memcopy=False, metadata=False, compress=False, visibility=None,
                test_only=False):
     """Defines a rule that invokes go-bindata to embed data into Go code."""
-    cmd = '$TOOL -o $OUT %s %s %s -pkg %s %s %s' % (
+    cmd = '"$TOOL" -o "$OUT" %s %s %s -pkg %s %s %s' % (
         '' if memcopy else '-nomemcopy',
         '' if metadata else '-nometadata',
         '' if compress else '-nocompress',

--- a/tools/please_go_test/gotest/BUILD
+++ b/tools/please_go_test/gotest/BUILD
@@ -32,7 +32,7 @@ genrule(
     name = "test_excluded_archive",
     srcs = ["test_data/core.a"],
     outs = ["test_data/x/core.a"],
-    cmd = "cp $SRC $OUT",
+    cmd = 'cp $SRC "$OUT"',
 )
 
 go_test(

--- a/tools/please_pex/BUILD
+++ b/tools/please_pex/BUILD
@@ -53,7 +53,7 @@ genrule(
         "mv third_party/python .bootstrap",
         # A little cleanup.
         "rm -rf third_party .bootstrap/xmlrunner/extra .bootstrap/coverage/htmlfiles .bootstrap/.*.pex.zip",
-        "$TOOL z -d -i .bootstrap -o $OUTS --preamble_file $(location :pex_main)",
+        '"$TOOL" z -d -i .bootstrap -o "$OUTS" --preamble_file $(location :pex_main)',
     ],
     tools = ["//tools/jarcat"],
     visibility = ["PUBLIC"],


### PR DESCRIPTION
This fixes #849 (to the extent that Pleasings and other repos will also need to be updated).
```
$ mkdir 'c d'                            
mkdir: created directory 'c d'
$ cd c\ d
$ [c d] ~/go/src/github.com/thought-machine/please/plz-out/gen/package/please --noupdate initWrote config template to /home/mike/x/c d/.plzconfig, you're now ready to go!

Also wrote wrapper script to pleasew; users can invoke that directly to run Please, even without it installed.
$ [c d] ~/go/src/github.com/thought-machine/please/plz-out/gen/package/please --noupdate build
Build finished; total time 40ms, incrementality 100.0%. Outputs:
$ [c d] touch BUILD   
$ [c d] ~/go/src/github.com/thought-machine/please/plz-out/gen/package/please --noupdate build   
Build finished; total time 210ms, incrementality 0.0%. Outputs:
//:pleasings:
  plz-out/gen/pleasings
```

Have also tested by running the bootstrap and confirmed everything builds.