### PR TITLE
Fix over-eager triggering of tests

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -61,7 +61,7 @@ func Build(tid int, state *core.BuildState, label core.BuildLabel, remote bool) 
 			state.AddPendingBuild(reverseDep.Label, false)
 		}
 	}
-	if target.IsTest && state.NeedTests && state.IsOriginalTarget(target.Label) && state.ShouldInclude(target) {
+	if target.IsTest && state.NeedTests && ((state.IsOriginalTarget(target.Label) && state.ShouldInclude(target)) || state.IsExactOriginalTarget(target.Label)) {
 		state.AddPendingTest(target.Label)
 	}
 }

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -61,7 +61,7 @@ func Build(tid int, state *core.BuildState, label core.BuildLabel, remote bool) 
 			state.AddPendingBuild(reverseDep.Label, false)
 		}
 	}
-	if target.IsTest && state.NeedTests {
+	if target.IsTest && state.NeedTests && state.IsOriginalTarget(target.Label) && state.ShouldInclude(target) {
 		state.AddPendingTest(target.Label)
 	}
 }

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -353,6 +353,12 @@ func (state *BuildState) IsOriginalTarget(label BuildLabel) bool {
 	return state.isOriginalTarget(label, false)
 }
 
+// IsExactOriginalTarget returns true if a target is an original target, specified exactly
+// (i.e. not via a :all label).
+func (state *BuildState) IsExactOriginalTarget(label BuildLabel) bool {
+	return state.isOriginalTarget(label, true)
+}
+
 // isOriginalTarget implementsIsOriginalTarget, optionally allowing disabling matching :all labels.
 func (state *BuildState) isOriginalTarget(label BuildLabel, exact bool) bool {
 	for _, original := range state.OriginalTargets {

--- a/test/manual_label/BUILD
+++ b/test/manual_label/BUILD
@@ -1,0 +1,12 @@
+gentest(
+    name = "failing_test",
+    test_cmd = "false",
+    labels = ["manual"],
+)
+
+gentest(
+    name = "passing_test",
+    test_cmd = "true",
+    no_test_output = True,
+    deps = [":failing_test"],
+)

--- a/test/manual_label/BUILD
+++ b/test/manual_label/BUILD
@@ -1,12 +1,12 @@
 gentest(
     name = "failing_test",
-    test_cmd = "false",
     labels = ["manual"],
+    test_cmd = "false",
 )
 
 gentest(
     name = "passing_test",
-    test_cmd = "true",
     no_test_output = True,
+    test_cmd = "true",
     deps = [":failing_test"],
 )


### PR DESCRIPTION
If something that is one of the original targets depends on a test that is not, the test gets tested because the current logic is basically "it is a test and we are testing therefore test". This filters it a bit so we can skip tests that are depended on but not part of the original target set.