### PR TITLE
Prohibit subinclude of :all or /...

### DIFF
--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -263,6 +263,7 @@ func subincludeTarget(s *scope, l core.BuildLabel) *core.BuildTarget {
 		// This is a subinclude in the same package, check the target exists.
 		s.NAssert(s.contextPkg.Target(l.Name) == nil, "Target :%s is not defined in this package; it has to be defined before the subinclude() call", l.Name)
 	}
+	s.NAssert(l.IsAllTargets() || l.IsAllSubpackages(), "Can't pass :all or /... to subinclude()")
 	t := s.state.WaitForBuiltTarget(l, pkgLabel)
 	// This is not quite right, if you subinclude from another subinclude we can basically
 	// lose track of it later on. It's hard to know what better to do at this point though.

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -291,3 +291,8 @@ func TestDoubleIndex(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, 1, s.Lookup("y"))
 }
+
+func TestSubincludeAll(t *testing.T) {
+	_, err := parseFile("src/parse/asp/test_data/interpreter/subinclude_all.build")
+	assert.Error(t, err)
+}

--- a/src/parse/asp/test_data/interpreter/subinclude_all.build
+++ b/src/parse/asp/test_data/interpreter/subinclude_all.build
@@ -1,0 +1,1 @@
+subinclude("@pleasings//python:all")


### PR DESCRIPTION
Small one for #859 ; error out explicitly if someone passes :all to subinclude() rather than waiting forever for a target that never arrives.