### PR TITLE
Fix some data races in logging code

### DIFF
--- a/src/cli/logging.go
+++ b/src/cli/logging.go
@@ -106,6 +106,7 @@ type LogBackend struct {
 	passthrough                                                           bool
 }
 
+// Log implements the logging.Backend interface.
 func (backend *LogBackend) Log(level logging.Level, calldepth int, rec *logging.Record) error {
 	backend.mutex.Lock()
 	defer backend.mutex.Unlock()

--- a/src/cli/logging_test.go
+++ b/src/cli/logging_test.go
@@ -12,9 +12,9 @@ import (
 func TestLineWrap(t *testing.T) {
 	newLogBackend(logging.NewLogBackend(os.Stderr, "", 0))
 	backend := CurrentBackend
-	backend.Cols = 80
+	backend.cols = 80
 	backend.maxLines = 2
-	backend.InteractiveRows = 2
+	backend.interactiveRows = 2
 
 	s := backend.lineWrap(strings.Repeat("a", 40))
 	assert.Equal(t, strings.Repeat("a", 40), strings.Join(s, "\n"))

--- a/src/cli/logging_test.go
+++ b/src/cli/logging_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -9,9 +10,11 @@ import (
 )
 
 func TestLineWrap(t *testing.T) {
-	backend := NewLogBackend(2)
+	newLogBackend(logging.NewLogBackend(os.Stderr, "", 0))
+	backend := CurrentBackend
 	backend.Cols = 80
 	backend.maxLines = 2
+	backend.InteractiveRows = 2
 
 	s := backend.lineWrap(strings.Repeat("a", 40))
 	assert.Equal(t, strings.Repeat("a", 40), strings.Join(s, "\n"))


### PR DESCRIPTION
Basically it's not safe to swap the logger backend concurrently. Although this race seems to be benign, it's annoying, and we shouldn't.

Certain amount of general cleanup & trying to encapsulate what's going on with the logger, although it's a bit crazy still.