### PR TITLE
Revisit how we handle binary rules

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -517,7 +517,7 @@ func (c *Client) buildEnv(target *core.BuildTarget, env []string, sandbox bool) 
 	if target != nil && target.PostBuildFunction != nil && c.targetOutputs(target.Label) != nil {
 		env = append(env, "_CREATE_OUTPUT_DIRS=false")
 	}
-	if target.IsBinary {
+	if target != nil && target.IsBinary {
 		env = append(env, "_BINARY=true")
 	}
 	sort.Strings(env) // Proto says it must be sorted (not just consistently ordered :( )


### PR DESCRIPTION
Adding the `&& chmod +x $OUTS` bit is breaking some cases.
Instead if it comes back as the outputs not being binary, just update all the files so they are.