### PR TITLE
Allow the user to bring their own test runner

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -179,7 +179,6 @@ func ReadConfigFiles(filenames []string, profiles []string) (*Configuration, err
 
 	// We can only verify options by reflection (we need struct tags) so run them quickly through this.
 	return config, config.ApplyOverrides(map[string]string{
-		"python.testrunner":  config.Python.TestRunner,
 		"build.hashfunction": config.Build.HashFunction,
 	})
 }
@@ -436,7 +435,7 @@ type Configuration struct {
 		PipFlags            string  `help:"Additional flags to pass to pip invocations in pip_library rules." var:"PIP_FLAGS"`
 		PexTool             string  `help:"The tool that's invoked to build pexes. Defaults to please_pex in the install directory." var:"PEX_TOOL"`
 		DefaultInterpreter  string  `help:"The interpreter used for python_binary and python_test rules when none is specified on the rule itself. Defaults to python but you could of course set it to, say, pypy." var:"DEFAULT_PYTHON_INTERPRETER"`
-		TestRunner          string  `help:"The test runner used to discover & run Python tests; one of unittest, pytest or behave." var:"PYTHON_TEST_RUNNER" options:"unittest,pytest,behave"`
+		TestRunner          string  `help:"The test runner used to discover & run Python tests; one of unittest, pytest or behave, or a custom import path to bring your own." var:"PYTHON_TEST_RUNNER"`
 		TestRunnerBootstrap string  `help:"Target providing test-runner library and its transitive dependencies. Injects plz-provided bootstraps if not given." var:"PYTHON_TEST_RUNNER_BOOTSTRAP"`
 		ModuleDir           string  `help:"Defines a directory containing modules from which they can be imported at the top level.\nBy default this is empty but by convention we define our pip_library rules in third_party/python and set this appropriately. Hence any of those third-party libraries that try something like import six will have it work as they expect, even though it's actually in a different location within the .pex." var:"PYTHON_MODULE_DIR"`
 		DefaultPipRepo      cli.URL `help:"Defines a location for a pip repo to download wheels from.\nBy default pip_library uses PyPI (although see below on that) but you may well want to use this define another location to upload your own wheels to.\nIs overridden by the repo argument to pip_library." var:"PYTHON_DEFAULT_PIP_REPO"`

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -145,10 +145,10 @@ func TestConfigOverrideURL(t *testing.T) {
 
 func TestConfigOverrideOptions(t *testing.T) {
 	config := DefaultConfiguration()
-	err := config.ApplyOverrides(map[string]string{"python.testrunner": "pytest"})
+	err := config.ApplyOverrides(map[string]string{"build.hashfunction": "sha256"})
 	assert.NoError(t, err)
-	assert.Equal(t, "pytest", config.Python.TestRunner)
-	err = config.ApplyOverrides(map[string]string{"python.testrunner": "junit"})
+	assert.Equal(t, "sha256", config.Build.HashFunction)
+	err = config.ApplyOverrides(map[string]string{"build/hashfunction": "md5"})
 	assert.Error(t, err)
 }
 

--- a/src/core/test_data/testrunner_bad.plzconfig
+++ b/src/core/test_data/testrunner_bad.plzconfig
@@ -1,2 +1,2 @@
-[python]
-testrunner = junit
+[build]
+hashfunction = md5

--- a/src/core/test_data/testrunner_good.plzconfig
+++ b/src/core/test_data/testrunner_good.plzconfig
@@ -1,2 +1,4 @@
+[build]
+hashfunction = sha256
 [python]
 testrunner = pytest

--- a/test/python_rules/custom_runner/BUILD
+++ b/test/python_rules/custom_runner/BUILD
@@ -1,0 +1,15 @@
+package(
+    python_test_runner = "test.python_rules.custom_runner.runner.run",
+    python_test_runner_bootstrap = "//test/python_rules/custom_runner:runner",
+)
+
+python_library(
+    name = "runner",
+    srcs = ["runner.py"],
+    deps = ["//third_party/python:pytest"],
+)
+
+python_test(
+    name = "custom_runner_test",
+    srcs = ["custom_runner_test.py"],
+)

--- a/test/python_rules/custom_runner/BUILD
+++ b/test/python_rules/custom_runner/BUILD
@@ -6,7 +6,10 @@ package(
 python_library(
     name = "runner",
     srcs = ["runner.py"],
-    deps = ["//third_party/python:pytest"],
+    deps = [
+        "//third_party/python:coverage",
+        "//third_party/python:pytest",
+    ],
 )
 
 python_test(

--- a/test/python_rules/custom_runner/custom_runner_test.py
+++ b/test/python_rules/custom_runner/custom_runner_test.py
@@ -1,0 +1,2 @@
+def test_custom_runner():
+    pass

--- a/test/python_rules/custom_runner/runner.py
+++ b/test/python_rules/custom_runner/runner.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+
+
+def run(test_names, args):
+    """Custom test runner entry point.
+
+    This is fairly minimal and serves mostly to demonstrate how to define this as an
+    entry point.
+
+    Args:
+      test_names: The names of the original test modules to be run (i.e. the things that were
+                  srcs to the python_test rule).
+      args: Any command-line arguments, not including sys.argv[0].
+    """
+    results_file = os.getenv('RESULTS_FILE', 'test.results')
+    os.mkdir(results_file)
+    args += ['--junitxml', os.path.join(results_file, 'results.xml')] + test_names
+    if os.environ.get('DEBUG'):
+        args.append('--pdb')
+    return pytest.main(args)

--- a/tools/please_pex/BUILD
+++ b/tools/please_pex/BUILD
@@ -2,6 +2,7 @@ filegroup(
     name = "pex_data",
     srcs = [
         "behave.py",
+        "custom.py",
         "pex_main.py",
         "pex_run.py",
         "pytest.py",

--- a/tools/please_pex/custom.py
+++ b/tools/please_pex/custom.py
@@ -1,0 +1,8 @@
+import importlib
+
+
+def run_tests(args):
+    """Runs tests using a custom test runner that is selected by the user."""
+    runner, _, name = "__TEST_RUNNER__".rpartition('.')
+    mod = importlib.import_module(runner)
+    return getattr(mod, name)(TEST_NAMES, args)

--- a/tools/please_pex/custom.py
+++ b/tools/please_pex/custom.py
@@ -3,6 +3,10 @@ import importlib
 
 def run_tests(args):
     """Runs tests using a custom test runner that is selected by the user."""
-    runner, _, name = "__TEST_RUNNER__".rpartition('.')
-    mod = importlib.import_module(runner)
-    return getattr(mod, name)(TEST_NAMES, args)
+    runner = "__TEST_RUNNER__"
+    mod_name, _, name = runner.rpartition('.')
+    mod = importlib.import_module(mod_name)
+    f = getattr(mod, name)
+    if not callable(f):
+        raise TypeError('Specified test runner %s is not callable, should be a function taking two arguments' % runner)
+    return f(TEST_NAMES, args)

--- a/tools/please_pex/pex_main.go
+++ b/tools/please_pex/pex_main.go
@@ -19,7 +19,7 @@ var opts = struct {
 	TestSrcs           []string      `long:"test_srcs" env:"SRCS" env-delim:" " description:"Test source files"`
 	Test               bool          `short:"t" long:"test" description:"True if we're to build a test"`
 	Interpreter        string        `short:"i" long:"interpreter" env:"TOOLS_INTERPRETER" description:"Python interpreter to use"`
-	TestRunner         string        `short:"r" long:"test_runner" choice:"unittest" choice:"pytest" choice:"behave" default:"unittest" description:"Test runner to use"`
+	TestRunner         string        `short:"r" long:"test_runner" default:"unittest" description:"Test runner to use"`
 	Shebang            string        `short:"s" long:"shebang" description:"Explicitly set shebang to this"`
 	Site               bool          `short:"S" long:"site" description:"Allow the pex to import site at startup"`
 	ZipSafe            bool          `long:"zip_safe" description:"Marks this pex as zip-safe"`


### PR DESCRIPTION
Basically the `test_runner_bootstrap` thing still defines whatever dependencies are needed, and you can set `test_runner` to a module path to have it import and use that.