### PR TITLE
Fix remote subincludes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/bazelbuild/buildtools v0.0.0-20190228125936-4bcdbd1064fc
 	github.com/bazelbuild/remote-apis v0.0.0-20200127100703-2846a67ac8fe
-	github.com/bazelbuild/remote-apis-sdks v0.0.0-20200117155253-d02017f96d3b
+	github.com/bazelbuild/remote-apis-sdks v0.0.0-20200316225911-4b8acdce5908
 	github.com/coreos/go-semver v0.2.0
 	github.com/djherbis/atime v1.0.0
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/bazelbuild/remote-apis-sdks v0.0.0-20191125202410-a21ff57ff57c h1:8zx
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20191125202410-a21ff57ff57c/go.mod h1:qgVeF5etXayzvt6OKXzeSg9Y0QDXfeH9H4EWKo/MNLM=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20200117155253-d02017f96d3b h1:Vy+DZZyPUNv2Ki15vJ+JdJRPg4LzJm52i8//9pfqPEU=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20200117155253-d02017f96d3b/go.mod h1:sAMybttCdA6S0dbSG/xluhJY6D3qlEkAkgfcyOyRee4=
+github.com/bazelbuild/remote-apis-sdks v0.0.0-20200316225911-4b8acdce5908 h1:P4asBf0pXW2R7bBEnIgoL49a+/jYof/5zqoUkIxROmI=
+github.com/bazelbuild/remote-apis-sdks v0.0.0-20200316225911-4b8acdce5908/go.mod h1:sAMybttCdA6S0dbSG/xluhJY6D3qlEkAkgfcyOyRee4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -710,7 +710,7 @@ func (state *BuildState) QueueTarget(label, dependent BuildLabel, rescan, forceB
 	if !target.SyncUpdateState(Inactive, Semiactive) && !rescan && !forceBuild {
 		return nil
 	}
-	target.NeededForSubinclude = forceBuild
+	target.NeededForSubinclude = target.NeededForSubinclude || forceBuild
 	if state.NeedBuild || forceBuild {
 		if target.SyncUpdateState(Semiactive, Active) {
 			state.AddActiveTarget()

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -631,7 +631,13 @@ func (state *BuildState) WaitForPackage(label BuildLabel) *Package {
 // WaitForBuiltTarget blocks until the given label is available as a build target and has been successfully built.
 func (state *BuildState) WaitForBuiltTarget(l, dependent BuildLabel) *BuildTarget {
 	if t := state.Graph.Target(l); t != nil {
-		if state := t.State(); state >= Built && state != Failed {
+		if s := t.State(); s >= Built && s != Failed {
+			// Ensure we have downloaded its outputs if needed.
+			// This is a bit fiddly but works around the case where we already built it but
+			// didn't download, and now have found we need to.
+			if state.RemoteClient != nil {
+				state.RemoteClient.Download(t)
+			}
 			return t
 		}
 	}

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -274,6 +274,8 @@ func (c *Client) Download(target *core.BuildTarget) error {
 		_, ar := c.retrieveResults(target, command, digest, false)
 		if ar == nil {
 			return fmt.Errorf("Failed to retrieve action result for %s", target)
+		} else if c.outputsExist(target, digest) {
+			return nil
 		}
 		return c.reallyDownload(target, digest, ar)
 	})

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -289,6 +289,7 @@ func (c *Client) download(target *core.BuildTarget, digest *pb.Digest, ar *pb.Ac
 }
 
 func (c *Client) reallyDownload(target *core.BuildTarget, digest *pb.Digest, ar *pb.ActionResult) error {
+	log.Debug("Downloading outputs for %s", target)
 	if err := removeOutputs(target); err != nil {
 		return err
 	}
@@ -298,6 +299,7 @@ func (c *Client) reallyDownload(target *core.BuildTarget, digest *pb.Digest, ar 
 		return c.wrapActionErr(err, digest)
 	}
 	c.recordAttrs(target, digest)
+	log.Debug("Downloaded outputs for %s", target)
 	return nil
 }
 

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -453,7 +453,7 @@ go_get(
     name = "remote-apis-sdks",
     get = "github.com/bazelbuild/remote-apis-sdks/go/...",
     repo = "github.com/peterebden/remote-apis-sdks",
-    revision = "fea5ad5ed463082753f542d5610cea615ca10d47",
+    revision = "16b8c03a1b365b4c36c6544b5d03bda429cee2e2",
     deps = [
         ":annotations",
         ":bytestream",

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -453,7 +453,7 @@ go_get(
     name = "remote-apis-sdks",
     get = "github.com/bazelbuild/remote-apis-sdks/go/...",
     repo = "github.com/peterebden/remote-apis-sdks",
-    revision = "7d27474f58852792800a8bc930eb81d4d729f023",
+    revision = "fea5ad5ed463082753f542d5610cea615ca10d47",
     deps = [
         ":annotations",
         ":bytestream",


### PR DESCRIPTION
Fixes some cases where they get built in parallel with other things (especially when they are independently built & subincluded... ugh).

Also take advantage of SDK retryability for Execute. Made a little extension to it to support progress messages (which we can't do with the existing one, and my scheme of attaching interceptors doesn't work since they attach their own).