### PR TITLE
Fix exclude call

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -574,7 +574,7 @@ func (state *BuildState) expandOriginalPseudoTarget(label BuildLabel) BuildLabel
 	ret := BuildLabels{}
 	addPackage := func(pkg *Package) {
 		for _, target := range pkg.AllTargets() {
-			if target.ShouldInclude(state.Include, state.Exclude) && (!state.NeedTests || target.IsTest) {
+			if state.ShouldInclude(target) && (!state.NeedTests || target.IsTest) {
 				ret = append(ret, target.Label)
 			}
 		}


### PR DESCRIPTION
Such as `plz test //test/... --exclude //test/cross_compile:x86_test`, ends up moaning about that target not having built (which obviously it won't have).