### PR TITLE
Bind test code to 127.0.0.1

### DIFF
--- a/src/cache/http_cache_test.go
+++ b/src/cache/http_cache_test.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	os.Chdir("src/cache/test_data")
 	// Split up the listen and serve parts to avoid race conditions.
-	lis, err := net.Listen("tcp", ":8989")
+	lis, err := net.Listen("tcp", "127.0.0.1:8989")
 	if err != nil {
 		log.Fatalf("%s", err)
 	}

--- a/src/follow/grpc_server.go
+++ b/src/follow/grpc_server.go
@@ -32,15 +32,15 @@ const buffering = 1000
 // It dies on any errors.
 // The returned function should be called to shut down once the server is no longer required.
 func InitialiseServer(state *core.BuildState, port int) func() {
-	_, f := initialiseServer(state, port)
+	_, f := initialiseServer(state, "", port)
 	return f
 }
 
 // initialiseServer sets up the gRPC server on the given port.
 // It's split out from the above for testing purposes.
-func initialiseServer(state *core.BuildState, port int) (string, func()) {
+func initialiseServer(state *core.BuildState, host string, port int) (string, func()) {
 	// TODO(peterebden): TLS support
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		log.Fatalf("%s", err)
 	}

--- a/src/follow/grpc_test.go
+++ b/src/follow/grpc_test.go
@@ -46,7 +46,7 @@ func TestClientToServerCommunication(t *testing.T) {
 	config := core.DefaultConfiguration()
 	config.Please.NumThreads = 5
 	serverState := core.NewBuildState(config)
-	addr, shutdown := initialiseServer(serverState, 0)
+	addr, shutdown := initialiseServer(serverState, "127.0.0.1", 0)
 
 	// This is a bit awkward. We want to assert that we receive a matching set of
 	// build events, but it's difficult to build strong synchronisation into this
@@ -102,7 +102,7 @@ func TestClientToServerCommunication(t *testing.T) {
 
 func TestWithOutput(t *testing.T) {
 	serverState := core.NewDefaultBuildState()
-	addr, shutdown := initialiseServer(serverState, 0)
+	addr, shutdown := initialiseServer(serverState, "127.0.0.1", 0)
 	clientState := core.NewDefaultBuildState()
 	connectClient(clientState, addr, retries, delay)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -124,7 +124,7 @@ func TestWithOutput(t *testing.T) {
 func TestResources(t *testing.T) {
 	serverState := core.NewDefaultBuildState()
 	go UpdateResources(serverState)
-	addr, shutdown := initialiseServer(serverState, 0)
+	addr, shutdown := initialiseServer(serverState, "127.0.0.1", 0)
 	defer shutdown()
 	clientState := core.NewDefaultBuildState()
 	connectClient(clientState, addr, retries, delay)

--- a/src/remote/impl_test.go
+++ b/src/remote/impl_test.go
@@ -447,7 +447,7 @@ func (f testFunction) Call(t *core.BuildTarget, o string) error { return nil }
 
 func TestMain(m *testing.M) {
 	server.Reset()
-	lis, err := net.Listen("tcp", ":9987")
+	lis, err := net.Listen("tcp", "127.0.0.1:9987")
 	if err != nil {
 		log.Fatalf("Failed to listen on %s: %v", lis.Addr(), err)
 	}


### PR DESCRIPTION
Avoids annoying popup dialogs on OSX (and is of course more correct)