### PR TITLE
Extend remote execution test to run more tests

### DIFF
--- a/.circleci/rex_test.sh
+++ b/.circleci/rex_test.sh
@@ -19,4 +19,4 @@ plz run parallel -p -v notice --colour --detach //test/remote:run_elan //test/re
 # Test we can rebuild plz itself.
 plz build --profile ci_remote -p -v notice --colour //src:please
 # Check we can actually run some tests
-plz test --profile ci_remote -p -v notice --colour //src/core:all
+plz test --profile ci_remote -p -v notice --colour --exclude e2e

--- a/.circleci/rex_test.sh
+++ b/.circleci/rex_test.sh
@@ -19,4 +19,4 @@ plz run parallel -p -v notice --colour --detach //test/remote:run_elan //test/re
 # Test we can rebuild plz itself.
 plz build --profile ci_remote -p -v notice --colour //src:please
 # Check we can actually run some tests
-plz test --profile ci_remote -p -v notice --colour --exclude e2e
+plz test --profile ci_remote -p -v notice --colour //src/...


### PR DESCRIPTION
It is currently running more quickly than I expected - ~1 min per run, which leaves it a lot of time (it's basically free as long as it's faster than the darwin build which is 4-5 mins). So add more tests!