### PR TITLE
Convert trace writing to be done on-the-fly rather than at the end

### DIFF
--- a/src/output/trace.go
+++ b/src/output/trace.go
@@ -20,7 +20,7 @@ var log = logging.MustGetLogger("output")
 type traceWriter struct {
 	b     *bufio.Writer
 	f     *os.File
-	first bool  // have we written the first record
+	first bool // have we written the first record
 }
 
 // newTraceWriter returns a new traceWriter writing to the given file.
@@ -50,7 +50,7 @@ func (tw *traceWriter) Close() error {
 		return nil
 	} else if _, err := tw.b.Write([]byte{'\n', ']', '\n'}); err != nil {
 		return err
-    } else if err := tw.b.Flush(); err != nil {
+	} else if err := tw.b.Flush(); err != nil {
 		return err
 	}
 	return tw.f.Close()

--- a/src/output/trace.go
+++ b/src/output/trace.go
@@ -46,7 +46,9 @@ func newTraceWriter(filename string) *traceWriter {
 
 // Close closes this write and any associated files.
 func (tw *traceWriter) Close() error {
-	if _, err := tw.b.Write([]byte{'\n', ']', '\n'}); err != nil {
+	if tw.b == nil {
+		return nil
+	} else if _, err := tw.b.Write([]byte{'\n', ']', '\n'}); err != nil {
 		return err
     } else if err := tw.b.Flush(); err != nil {
 		return err


### PR DESCRIPTION
Main advantage is not having to hold all the traces in-memory (then doubling that or worse when writing to the file).

Also using the slightly simpler array format which is more robust (Chrome will allow a missing trailing ] if needed so you can analyse a partial trace) and we don't write anything useful in the object format anyway. We write traces out one line at a time which makes the file much friendlier (having 80 million characters on one line is not easy to deal with in an editor, or grep etc).

Down side is that JSON mangling is a little manual but I can live with that.