### PR TITLE
Put resources in the same jar as java_library sources

### DIFF
--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -1,7 +1,7 @@
 """Built-in rules to compile Java code."""
 
 
-def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=None, resources_root:str=None,
+def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], resources_root:str=None,
                  deps:list=[], modular:bool=False, exported_deps:list=None, visibility:list=None,
                  test_only:bool&testonly=False, javac_flags:list&javacopts=None, labels:list=[]):
     """Compiles Java source to a .jar which can be collected by other rules.
@@ -25,19 +25,17 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=None
       javac_flags (list): List of flags passed to javac.
       labels (list): Additional labels to apply to this rule.
     """
+    resources_cmd = 'true'
+    if resources:
+        # TODO(macripps): Check this actually matches the documented behaviour, as it's not clear it does
+        if resources_root:
+            resources_cmd = f'$(for SRC in $SRCS_RESOURCES; do DEST=${SRC#"{resources_root}"};mkdir -p $(dirname "_tmp/$DEST");cp "$SRC" "_tmp/$DEST"; done)'
+        else:
+            resources_cmd = '$(for SRC in $SRCS_RESOURCES; do mkdir -p $(dirname "_tmp/$SRC");cp "$SRC" "_tmp/$SRC"; done)'
+
     if srcs and src_dir:
         raise ParseError('You cannot pass both srcs and src_dir to java_library')
     if srcs or src_dir:
-        if resources:
-            # Split up resources into a separate rule so we don't have to try to build them here.
-            res_rule = java_library(
-                name = '_%s#res' % name,
-                resources = resources,
-                resources_root = resources_root,
-                test_only=test_only,
-            )
-            deps += [res_rule]
-
         if javac_flags:
             # See http://bazel.io/blog/2015/06/25/ErrorProne.html for more info about this flag;
             # it doesn't mean anything to us so we must filter it out.
@@ -46,12 +44,12 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=None
         else:
             javac_flags = CONFIG.JAVAC_TEST_FLAGS if test_only else CONFIG.JAVAC_FLAGS
 
-        javac_flags = '-encoding utf8 ' + javac_flags
+        javac_flags = '-g -encoding utf8 ' + javac_flags
 
         if CONFIG.JAVA_RELEASE_LEVEL:
             javac_flags = f'--release {CONFIG.JAVA_RELEASE_LEVEL} ' + javac_flags
         else:
-            javac_flags = f'-encoding utf8 -source {CONFIG.JAVA_SOURCE_LEVEL} -target {CONFIG.JAVA_TARGET_LEVEL} -g ' + javac_flags
+            javac_flags = f'-source {CONFIG.JAVA_SOURCE_LEVEL} -target {CONFIG.JAVA_TARGET_LEVEL} ' + javac_flags
 
         if not CONFIG.JAVAC_TOOL:
             mflag = '--modular' if modular else ''
@@ -65,6 +63,7 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=None
         cmd = ' && '.join([
             javac_cmd,
             'find _tmp -name "*.class" | sed -e "s|_tmp/|${PKG} |g" -e "s/\\.class/.java/g" | sort > _tmp/META-INF/please_sourcemap',
+            resources_cmd,
             'cd _tmp',
             '"$TOOLS_JARCAT" z -d -o "$OUT" -i .',
         ])
@@ -75,7 +74,12 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=None
 
         return build_rule(
             name=name,
-            srcs=srcs or [src_dir],
+            srcs={
+                # To ensure we don't pass the resources to the compiler,
+                # this key has to match the magic constant in build_step.go
+                'WORKER': srcs or [src_dir],
+                'RESOURCES': resources,
+            },
             deps=deps,
             exported_deps=exported_deps,
             outs=[name + '.jar'],
@@ -89,27 +93,6 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=None
                 'javac': [CONFIG.JAVAC_TOOL or CONFIG.JAVAC_WORKER],
                 'jarcat': [CONFIG.JARCAT_TOOL],
             },
-        )
-    elif resources:
-        # TODO(agenticarus): Turn `resources` into a first-class construct, and just use them in `deps` normally.
-        # Can't run javac since there are no java files.
-        if resources_root:
-            cmd = 'cd ${PKG_DIR}/%s && $TOOL z -d -o ${OUT} -i .' % resources_root
-        else:
-            cmd = '$TOOL z -d -o ${OUTS} -i .'
-        return build_rule(
-            name=name,
-            srcs=resources,
-            deps=deps,
-            exported_deps=exported_deps,
-            outs=[name + '.jar'],
-            visibility=visibility,
-            cmd=cmd,
-            building_description="Linking...",
-            requires=['java'],
-            labels = labels + ['rule:test_resources' if test_only else 'rule:resources'],
-            test_only=test_only,
-            tools=[CONFIG.JARCAT_TOOL],
         )
     else:
         # If input is only jar files (as maven_jar produces in some cases) we simply collect them

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -36,7 +36,7 @@ var errStop = fmt.Errorf("stopping build")
 var httpClient http.Client
 var httpClientOnce sync.Once
 
-var MAGIC_SOURCES_WORKER_KEY = "WORKER"
+var magicSourcesWorkerKey = "WORKER"
 
 // Build implements the core logic for building a single target.
 func Build(tid int, state *core.BuildState, label core.BuildLabel, remote bool) {
@@ -834,7 +834,7 @@ func buildMaybeRemotely(state *core.BuildState, target *core.BuildTarget, inputH
 	// If they don't do this, send all sources.
 
 	var workerSources []string
-	workerSourceInputs, present := target.NamedSources[MAGIC_SOURCES_WORKER_KEY]
+	workerSourceInputs, present := target.NamedSources[magicSourcesWorkerKey]
 	if !present {
 		workerSources = target.AllSourcePaths(state.Graph)
 	} else {

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -36,6 +36,8 @@ var errStop = fmt.Errorf("stopping build")
 var httpClient http.Client
 var httpClientOnce sync.Once
 
+var MAGIC_SOURCES_WORKER_KEY = "WORKER"
+
 // Build implements the core logic for building a single target.
 func Build(tid int, state *core.BuildState, label core.BuildLabel, remote bool) {
 	target := state.Graph.TargetOrDie(label)
@@ -827,11 +829,23 @@ func buildMaybeRemotely(state *core.BuildState, target *core.BuildTarget, inputH
 		return nil, err
 	}
 	log.Debug("Sending remote build request for %s to %s; opts %s", target.Label, workerCmd, workerArgs)
+
+	// Allow callers to specify only a subset of sources to send to the worker
+	// If they don't do this, send all sources.
+
+	var workerSources []string
+	workerSourceInputs, present := target.NamedSources[MAGIC_SOURCES_WORKER_KEY]
+	if !present {
+		workerSources = target.AllSourcePaths(state.Graph)
+	} else {
+		workerSources = target.SourcePaths(state.Graph, workerSourceInputs)
+	}
+
 	resp, err := worker.BuildRemotely(state, target, workerCmd, &worker.Request{
 		Rule:    target.Label.String(),
 		Labels:  target.Labels,
 		TempDir: path.Join(core.RepoRoot, target.TmpDir()),
-		Sources: target.AllSourcePaths(state.Graph),
+		Sources: workerSources,
 		Options: opts,
 	})
 	if err != nil {

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -89,6 +89,7 @@ func BuildEnvironment(state *BuildState, target *BuildTarget, tmpDir string) Bui
 	// Named source groups if the target declared any.
 	for name, srcs := range target.NamedSources {
 		paths := target.SourcePaths(state.Graph, srcs)
+		// TODO(macripps): Quote these to prevent spaces from breaking everything (consider joining with NUL or sth?)
 		env = append(env, "SRCS_"+strings.ToUpper(name)+"="+strings.Join(paths, " "))
 	}
 	// Named output groups similarly.

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -448,7 +448,7 @@ func printBuildResults(state *core.BuildState, duration time.Duration) {
 	// Print this stuff so we always see it.
 	printf("Build finished; total time %s, incrementality %.1f%%.", duration, incrementality)
 	if state.RemoteClient != nil && !state.DownloadOutputs {
-		fmt.Printf("\n")  // Outputs are not downloaded so do not print them out.
+		fmt.Printf("\n") // Outputs are not downloaded so do not print them out.
 		return
 	}
 	fmt.Printf(" Outputs:\n")

--- a/test/java_rules/issue_877/BUILD
+++ b/test/java_rules/issue_877/BUILD
@@ -30,5 +30,8 @@ plz_e2e_test(
     data = [
         ":issue_877",
     ],
+    labels = [
+        "java",
+    ],
     expect_output_contains = "some.txt",
 )

--- a/test/java_rules/issue_877/BUILD
+++ b/test/java_rules/issue_877/BUILD
@@ -30,8 +30,8 @@ plz_e2e_test(
     data = [
         ":issue_877",
     ],
+    expect_output_contains = "some.txt",
     labels = [
         "java",
     ],
-    expect_output_contains = "some.txt",
 )

--- a/test/java_rules/issue_877/BUILD
+++ b/test/java_rules/issue_877/BUILD
@@ -1,0 +1,34 @@
+# Tests for Java Library including resources
+
+subinclude("//build_defs:plz_e2e_test")
+
+java_library(
+    name = "issue_877",
+    srcs = [
+        "MyClass.java",
+    ],
+    resources = [
+        "some.txt",
+        # TODO(macripps): Add this once we work out better quoting support (see build_env.go).
+        # "file with space.txt",
+    ],
+    # Ensure resources end up at root of jar
+    resources_root = "test/java_rules/issue_877",
+)
+
+java_binary(
+    name = "issue_877_main",
+    main_class = "MyClass",
+    deps = [
+        ":issue_877",
+    ],
+)
+
+plz_e2e_test(
+    name = "issue_877_test",
+    cmd = "unzip -l test/java_rules/issue_877/issue_877.jar",
+    data = [
+        ":issue_877",
+    ],
+    expect_output_contains = "some.txt",
+)

--- a/test/java_rules/issue_877/MyClass.java
+++ b/test/java_rules/issue_877/MyClass.java
@@ -1,0 +1,10 @@
+import java.net.URL;
+
+public class MyClass {
+    public static void main(String... args) {
+        URL res = MyClass.class.getResource("some.txt");
+        if (res == null) {
+            System.exit(1);
+        }
+    }
+}

--- a/test/java_rules/issue_877/some.txt
+++ b/test/java_rules/issue_877/some.txt
@@ -1,0 +1,1 @@
+This is a sample file that should be included in the java library as a resource.


### PR DESCRIPTION
This addresses the requested issue #877. We make a slight change to the way sources for workers are specified (to allow us to not send these resources to it), and now copy the resources directly into the output tree (in _tmp).

Added an end-to-end test that passes, would value some greater check on (in particular) the change to resources_root calculation - I'm not convinced the previous documentation was correct but now seems to do the right thing.

```
Archive:  plz-out/gen/test/java_rules/issue_877/issue_877.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  01-01-2001 00:00   META-INF/
       39  01-01-2001 00:00   META-INF/please_sourcemap
      615  01-01-2001 00:00   MyClass.class
       81  01-01-2001 00:00   some.txt
```

Previously this would have created a whole new Jar file just to contain the `some.txt` file.