### PR TITLE
Strip a trailing : character from GOPATH population for go_get.

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -600,7 +600,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
 
     # Now compile it in a separate step.
     cmd = [
-        'export GOPATH="$(find \"$TMP_DIR\" \( -name src -o -name pkg \) -exec dirname {} \; | sort | uniq | tr \'\\n\' \':\')" GO111MODULE="off"',
+        'export GOPATH="$(find \"$TMP_DIR\" \( -name src -o -name pkg \) -exec dirname {} \; | sort | uniq | tr \'\\n\' \':\' | sed \'s/:$//\')" GO111MODULE="off"',
         '"$TOOLS_GO" install -toolexec "\\\"$TOOLS_BUILDID\\\"" -gcflags "-trimpath \\\"$TMP_DIR\\\"" -asmflags "-trimpath \\\"$TMP_DIR\\\"" ' + ' '.join(all_installs or install),
     ]
     if package_name():


### PR DESCRIPTION
The previous implementaton still added a : character from the GOPATH when rendering, which breaks old version of go install, etc. Consult https://go-review.googlesource.com/c/go/+/65151/ for more context.