### PR TITLE
Revert #889

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -10,7 +10,7 @@ def build_rule(name:str, cmd:str|dict='', test_cmd:str|dict='', srcs:list|dict=N
                output_is_complete:bool=False, _=None, sandbox:bool=CONFIG.BUILD_SANDBOX,
                test_sandbox:bool=CONFIG.TEST_SANDBOX, no_test_output:bool=False, flaky:bool|int=0, build_timeout:int|str=0,
                test_timeout:int|str=0, pre_build:function=None, post_build:function=None, requires:list=None, provides:dict=None,
-               licences:list=CONFIG.DEFAULT_LICENCES, test_outputs:list=None, system_srcs:list=None, stamp:bool|str=False,
+               licences:list=CONFIG.DEFAULT_LICENCES, test_outputs:list=None, system_srcs:list=None, stamp:bool=False,
                tag:str='', optional_outs:list=None, progress:bool=False, size:str=None, _urls:list=None,
                internal_deps:list=None, pass_env:list=None, local:bool=False):
     pass

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -285,7 +285,7 @@ def _merge_cgo_obj(name, a_rule, o_rule=None, visibility=None, test_only=False, 
 
 def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=[],
               visibility:list=None, test_only:bool&testonly=False, static:bool=CONFIG.GO_DEFAULT_STATIC,
-              filter_srcs:bool=True, definitions:str|list|dict=None, stamp:bool|str=False):
+              filter_srcs:bool=True, definitions:str|list|dict=None, stamp:bool=False):
     """Compiles a Go binary.
 
     Args:
@@ -307,10 +307,8 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
                      when calling the Go linker.  If set to a list, pass each value as a
                      definition to the linker.  If set to a dict, each key/value pair is
                      used to contruct the list of definitions passed to the linker.
-      stamp (bool|str): Allows this rule to gain access to information about SCM revision etc
-                        via env vars. These can be useful to pass into `definitions`.
-                        Can be True for SCM and rule env vars or 'scm' or 'target' to just get one
-                        or the other. By default neither are available.
+      stamp (bool): Allows this rule to gain access to information about SCM revision etc
+                    via env vars. These can be useful to pass into `definitions`.
     """
     lib = go_library(
         name=f'_{name}#lib',

--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -161,7 +161,7 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
             'pex': [CONFIG.PEX_TOOL],
         },
         test_only=test_only,
-        stamp='target',  # Used to derive a unique cache-directory for zip-unsafe binaries.
+        stamp=True,  # Used to derive a unique cache-directory for zip-unsafe binaries.
     )
     # This rule concatenates the .pex with all the other precompiled zip files from dependent rules.
     cmd = '$TOOL z -i . -s .pex.zip -s .whl --preamble_from="$SRC" --include_other --add_init_py --strict'
@@ -265,7 +265,7 @@ def python_test(name:str, srcs:list, data:list|dict=[], resources:list=[], deps:
             'interpreter': [interpreter or CONFIG.DEFAULT_PYTHON_INTERPRETER],
             'pex': [CONFIG.PEX_TOOL],
         },
-        stamp = 'target',
+        stamp = True,
     )
 
     # If there are resources specified, they have to get built into the pex.

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -241,7 +241,6 @@ func ruleHash(state *core.BuildState, target *core.BuildTarget, runtime bool) []
 	// change the hash of every single other target everywhere.
 	// Might consider removing this the next time we peturb the hashing strategy.
 	hashOptionalBool(h, target.Stamp)
-	hashOptionalBool(h, target.StampScm)
 	hashOptionalBool(h, target.IsFilegroup)
 	hashOptionalBool(h, target.IsHashFilegroup)
 	hashOptionalBool(h, target.IsRemoteFile)

--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -50,7 +50,6 @@ var KnownFields = map[string]bool{
 	"NamedSecrets":                true,
 	"TestOutputs":                 true,
 	"Stamp":                       true,
-	"StampScm":                    true,
 
 	// These only contribute to the runtime hash, not at build time.
 	"Data":              true,

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -176,11 +176,9 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) Bui
 // Optionally includes a stamp if the target is marked as such.
 func StampedBuildEnvironment(state *BuildState, target *BuildTarget, stamp []byte, tmpDir string) BuildEnv {
 	env := BuildEnvironment(state, target, tmpDir)
-	if target.StampScm {
+	if target.Stamp {
 		stampEnvOnce.Do(initStampEnv)
 		env = append(env, stampEnv...)
-	}
-	if target.Stamp {
 		env = append(env, "STAMP_FILE="+target.StampFileName())
 		return append(env, "STAMP="+base64.RawURLEncoding.EncodeToString(stamp))
 	}

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -118,8 +118,6 @@ type BuildTarget struct {
 	// If true, the rule is given an env var at build time that contains the hash of its
 	// transitive dependencies, which can be used to identify the output in a predictable way.
 	Stamp bool
-	// If true, the rule is given env vars at build time for SCM_REVISION, SCM_DESCRIBE, etc.
-	StampScm bool `print:"false"`
 	// If true, the target must be run locally (i.e. is not compatible with remote execution).
 	Local bool
 	// If true, the target is needed for a subinclude and therefore we will have to make sure its

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -64,14 +64,7 @@ func createTarget(s *scope, args []pyObject) *core.BuildTarget {
 	}
 
 	target.BuildTimeout = sizeAndTimeout(s, size, args[24], s.state.Config.Build.Timeout)
-	switch t := args[33].(type) {
-	case pyBool:
-		target.Stamp = bool(t)
-		target.StampScm = bool(t)
-	case pyString:
-		target.Stamp = string(t) == "target"
-		target.StampScm = string(t) == "scm"
-	}
+	target.Stamp = isTruthy(33)
 	target.IsHashFilegroup = args[1] == hashFilegroupCommand
 	target.IsFilegroup = args[1] == filegroupCommand || target.IsHashFilegroup
 	if desc := args[16]; desc != nil && desc != None {

--- a/src/query/print.go
+++ b/src/query/print.go
@@ -66,16 +66,6 @@ var specialFields = map[string]func(*printer) (string, bool){
 	"data": func(p *printer) (string, bool) {
 		return p.genericPrint(reflect.ValueOf(p.target.AllData()))
 	},
-	"stamp": func(p *printer) (string, bool) {
-		if p.target.Stamp && p.target.StampScm {
-			return p.genericPrint(reflect.ValueOf(p.target.Stamp))
-		} else if p.target.Stamp {
-			return p.genericPrint(reflect.ValueOf("target"))
-		} else if p.target.StampScm {
-			return p.genericPrint(reflect.ValueOf("scm"))
-		}
-		return "", false
-	},
 }
 
 // fieldPrecedence defines a specific ordering for fields.

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -106,7 +106,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 // stampedBuildEnvironment returns a build environment, optionally with a stamp if the
 // target requires one.
 func (c *Client) stampedBuildEnvironment(target *core.BuildTarget, inputRoot *pb.Directory) []string {
-	if !target.Stamp && !target.StampScm {
+	if !target.Stamp {
 		return core.BuildEnvironment(c.state, target, ".")
 	}
 	// We generate the stamp ourselves from the input root.


### PR DESCRIPTION
This reverts commit e7d65660b52737571b5b099f212bc9b8c5ffc155.

Turns out we still have heaps of places that use SCM info in stamps which this will not help. Instead will have to find a solution to make remote execution behave like local execution, which I think will be fiddlier but will not require modifying build rules to take advantage of.