### PR TITLE
Remote stamp lookups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/bazelbuild/buildtools v0.0.0-20190228125936-4bcdbd1064fc
 	github.com/bazelbuild/remote-apis v0.0.0-20200127100703-2846a67ac8fe
-	github.com/bazelbuild/remote-apis-sdks v0.0.0-20200316225911-4b8acdce5908
+	github.com/bazelbuild/remote-apis-sdks v0.0.0-20200331142530-d833149cbc0b
 	github.com/coreos/go-semver v0.2.0
 	github.com/djherbis/atime v1.0.0
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/bazelbuild/remote-apis-sdks v0.0.0-20200117155253-d02017f96d3b h1:Vy+
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20200117155253-d02017f96d3b/go.mod h1:sAMybttCdA6S0dbSG/xluhJY6D3qlEkAkgfcyOyRee4=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20200316225911-4b8acdce5908 h1:P4asBf0pXW2R7bBEnIgoL49a+/jYof/5zqoUkIxROmI=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20200316225911-4b8acdce5908/go.mod h1:sAMybttCdA6S0dbSG/xluhJY6D3qlEkAkgfcyOyRee4=
+github.com/bazelbuild/remote-apis-sdks v0.0.0-20200331142530-d833149cbc0b h1:o4t5Pn6LtX9rFOsgh6EMiLTEPw7oene6rXAyRh2vV2k=
+github.com/bazelbuild/remote-apis-sdks v0.0.0-20200331142530-d833149cbc0b/go.mod h1:sAMybttCdA6S0dbSG/xluhJY6D3qlEkAkgfcyOyRee4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -72,6 +72,17 @@ func (c *Client) buildAction(target *core.BuildTarget, isTest, stamp bool) (*pb.
 	return command, actionDigest, nil
 }
 
+// buildStampedAndUnstampedAction builds both a stamped and unstamped version of the action for a target, if it
+// needs stamping, otherwise it returns the same one twice.
+func (c *Client) buildStampedAndUnstampedAction(target *core.BuildTarget) (command *pb.Command, stamped, unstamped *pb.Digest, err error) {
+	command, unstampedDigest, err := c.buildAction(target, false, false)
+	if !target.Stamp || err != nil {
+		return command, unstampedDigest, unstampedDigest, err
+	}
+	command, stampedDigest, err := c.buildAction(target, false, true)
+	return command, stampedDigest, unstampedDigest, err
+}
+
 // buildCommand builds the command for a single target.
 func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory, isTest, stamp bool) (*pb.Command, error) {
 	if isTest {

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -34,7 +34,7 @@ func (c *Client) uploadAction(target *core.BuildTarget, isTest bool) (*pb.Comman
 		}
 		inputRootChunker, _ := chunker.NewFromProto(inputRoot, int(c.client.ChunkMaxSize))
 		ch <- inputRootChunker
-		command, err = c.buildCommand(target, inputRoot, isTest)
+		command, err = c.buildCommand(target, inputRoot, isTest, target.Stamp)
 		if err != nil {
 			return err
 		}
@@ -53,13 +53,13 @@ func (c *Client) uploadAction(target *core.BuildTarget, isTest bool) (*pb.Comman
 }
 
 // buildAction creates a build action for a target and returns the command and the action digest digest. No uploading is done.
-func (c *Client) buildAction(target *core.BuildTarget, isTest bool) (*pb.Command, *pb.Digest, error) {
+func (c *Client) buildAction(target *core.BuildTarget, isTest, stamp bool) (*pb.Command, *pb.Digest, error) {
 	inputRoot, err := c.uploadInputs(nil, target, isTest)
 	if err != nil {
 		return nil, nil, err
 	}
 	inputRootDigest := c.digestMessage(inputRoot)
-	command, err := c.buildCommand(target, inputRoot, isTest)
+	command, err := c.buildCommand(target, inputRoot, isTest, stamp)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -73,7 +73,7 @@ func (c *Client) buildAction(target *core.BuildTarget, isTest bool) (*pb.Command
 }
 
 // buildCommand builds the command for a single target.
-func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory, isTest bool) (*pb.Command, error) {
+func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory, isTest, stamp bool) (*pb.Command, error) {
 	if isTest {
 		return c.buildTestCommand(target)
 	}
@@ -96,23 +96,22 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 		Arguments: []string{
 			c.bashPath, "--noprofile", "--norc", "-u", "-o", "pipefail", "-c", commandPrefix + cmd,
 		},
-		EnvironmentVariables: c.buildEnv(target, c.stampedBuildEnvironment(target, inputRoot), target.Sandbox),
+		EnvironmentVariables: c.buildEnv(target, c.stampedBuildEnvironment(target, inputRoot, stamp), target.Sandbox),
 		OutputFiles:          files,
 		OutputDirectories:    dirs,
 		OutputPaths:          append(files, dirs...),
 	}, err
 }
 
-// stampedBuildEnvironment returns a build environment, optionally with a stamp if the
-// target requires one.
-func (c *Client) stampedBuildEnvironment(target *core.BuildTarget, inputRoot *pb.Directory) []string {
-	if !target.Stamp {
+// stampedBuildEnvironment returns a build environment, optionally with a stamp if stamp is true.
+func (c *Client) stampedBuildEnvironment(target *core.BuildTarget, inputRoot *pb.Directory, stamp bool) []string {
+	if !stamp {
 		return core.BuildEnvironment(c.state, target, ".")
 	}
 	// We generate the stamp ourselves from the input root.
 	// TODO(peterebden): it should include the target properties too...
-	stamp := c.sum(mustMarshal(inputRoot))
-	return core.StampedBuildEnvironment(c.state, target, stamp, ".")
+	hash := c.sum(mustMarshal(inputRoot))
+	return core.StampedBuildEnvironment(c.state, target, hash, ".")
 }
 
 // buildTestCommand builds a command for a target when testing.

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -448,7 +448,7 @@ func (c *Client) verifyActionResult(target *core.BuildTarget, command *pb.Comman
 
 // uploadLocalTarget uploads the outputs of a target that was built locally.
 func (c *Client) uploadLocalTarget(target *core.BuildTarget) error {
-	m, ar, err := tree.ComputeOutputsToUpload(target.OutDir(), target.Outputs(), int(c.client.ChunkMaxSize), &filemetadata.NoopFileMetadataCache{})
+	m, ar, err := tree.ComputeOutputsToUpload(target.OutDir(), target.Outputs(), int(c.client.ChunkMaxSize), filemetadata.NewNoopCache())
 	if err != nil {
 		return err
 	}

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -235,11 +235,7 @@ func (c *Client) Build(tid int, target *core.BuildTarget) (*core.BuildMetadata, 
 	if err := c.CheckInitialised(); err != nil {
 		return nil, err
 	}
-	command, digest, err := c.buildAction(target, false)
-	if err != nil {
-		return nil, err
-	}
-	metadata, ar, err := c.execute(tid, target, command, digest, target.BuildTimeout, false, target.PostBuildFunction != nil)
+	metadata, ar, digest, err := c.build(tid, target)
 	if err != nil {
 		return metadata, err
 	}
@@ -265,10 +261,30 @@ func (c *Client) Build(tid int, target *core.BuildTarget) (*core.BuildMetadata, 
 	return metadata, nil
 }
 
+// build implements the actual build of a target.
+func (c *Client) build(tid int, target *core.BuildTarget) (*core.BuildMetadata, *pb.ActionResult, *pb.Digest, error) {
+	needStdout := target.PostBuildFunction != nil
+	// If we're gonna stamp the target, first check the unstamped equivalent that we store results under.
+	// This implements the rules of stamp whereby we don't force rebuilds every time e.g. the SCM revision changes.
+	if target.Stamp {
+		if command, digest, err := c.buildAction(target, false, target.Stamp); err == nil {
+			if metadata, ar := c.maybeRetrieveResults(tid, target, command, digest, needStdout); metadata != nil {
+				return metadata, ar, digest, nil
+			}
+		}
+	}
+	command, digest, err := c.buildAction(target, false, target.Stamp)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	metadata, ar, err := c.execute(tid, target, command, digest, target.BuildTimeout, false, needStdout)
+	return metadata, ar, digest, err
+}
+
 // Download downloads outputs for the given target.
 func (c *Client) Download(target *core.BuildTarget) error {
 	return c.download(target, func() error {
-		command, digest, err := c.buildAction(target, false)
+		command, digest, err := c.buildAction(target, false, target.Stamp)
 		if err != nil {
 			return fmt.Errorf("Failed to create action for %s: %s", target, err)
 		}
@@ -312,7 +328,7 @@ func (c *Client) Test(tid int, target *core.BuildTarget) (metadata *core.BuildMe
 	if err := c.CheckInitialised(); err != nil {
 		return nil, nil, nil, err
 	}
-	command, digest, err := c.buildAction(target, true)
+	command, digest, err := c.buildAction(target, true, false)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -369,14 +385,23 @@ func (c *Client) retrieveResults(target *core.BuildTarget, command *pb.Command, 
 	return nil, nil
 }
 
+// maybeRetrieveResults is like retrieveResults but only retrieves if we aren't forcing a rebuild of the target
+// (i.e. not if we're doing plz build --rebuild).
+func (c *Client) maybeRetrieveResults(tid int, target *core.BuildTarget, command *pb.Command, digest *pb.Digest, needStdout bool) (*core.BuildMetadata, *pb.ActionResult) {
+	if !(c.state.ForceRebuild && (c.state.IsOriginalTarget(target.Label) || c.state.IsOriginalTarget(target.Label.Parent()))) {
+		c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Checking remote...")
+		if metadata, ar := c.retrieveResults(target, command, digest, needStdout); metadata != nil {
+			return metadata, ar
+		}
+	}
+	return nil, nil
+}
+
 // execute submits an action to the remote executor and monitors its progress.
 // The returned ActionResult may be nil on failure.
 func (c *Client) execute(tid int, target *core.BuildTarget, command *pb.Command, digest *pb.Digest, timeout time.Duration, isTest, needStdout bool) (*core.BuildMetadata, *pb.ActionResult, error) {
-	c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Checking remote...")
-	if !(c.state.ForceRebuild && (c.state.IsOriginalTarget(target.Label) || c.state.IsOriginalTarget(target.Label.Parent()))) {
-		if metadata, ar := c.retrieveResults(target, command, digest, needStdout); metadata != nil {
-			return metadata, ar, nil
-		}
+	if metadata, ar := c.maybeRetrieveResults(tid, target, command, digest, needStdout); metadata != nil {
+		return metadata, ar, nil
 	}
 	// We didn't actually upload the inputs before, so we must do so now.
 	command, digest, err := c.uploadAction(target, isTest)
@@ -538,7 +563,7 @@ func (c *Client) PrintHashes(target *core.BuildTarget, isTest bool) {
 	fmt.Printf("Remote execution hashes:\n")
 	inputRootDigest := c.digestMessage(inputRoot)
 	fmt.Printf("  Input: %7d bytes: %s\n", inputRootDigest.SizeBytes, inputRootDigest.Hash)
-	cmd, _ := c.buildCommand(target, inputRoot, isTest)
+	cmd, _ := c.buildCommand(target, inputRoot, isTest, target.Stamp)
 	commandDigest := c.digestMessage(cmd)
 	fmt.Printf("Command: %7d bytes: %s\n", commandDigest.SizeBytes, commandDigest.Hash)
 	if c.state.Config.Remote.DisplayURL != "" {

--- a/src/remote/remote_test.go
+++ b/src/remote/remote_test.go
@@ -156,7 +156,7 @@ func TestNoAbsolutePaths(t *testing.T) {
 	target.AddOutput("remote_test")
 	target.AddSource(core.FileLabel{Package: "package", File: "file"})
 	target.AddTool(tool.Label)
-	cmd, _ := c.buildCommand(target, &pb.Directory{}, false)
+	cmd, _ := c.buildCommand(target, &pb.Directory{}, false, false)
 	testDir := os.Getenv("TEST_DIR")
 	for _, env := range cmd.EnvironmentVariables {
 		assert.False(t, path.IsAbs(env.Value), "Env var %s has an absolute path: %s", env.Name, env.Value)
@@ -173,7 +173,7 @@ func TestNoAbsolutePaths2(t *testing.T) {
 	target := core.NewBuildTarget(core.BuildLabel{PackageName: "package", Name: "target5"})
 	target.AddOutput("remote_test")
 	target.AddTool(core.SystemPathLabel{Path: []string{os.Getenv("TMP_DIR")}, Name: "remote_test"})
-	cmd, _ := c.buildCommand(target, &pb.Directory{}, false)
+	cmd, _ := c.buildCommand(target, &pb.Directory{}, false, false)
 	for _, env := range cmd.EnvironmentVariables {
 		assert.False(t, path.IsAbs(env.Value), "Env var %s has an absolute path: %s", env.Name, env.Value)
 		assert.NotContains(t, env.Value, core.OutDir, "Env var %s contains %s: %s", env.Name, core.OutDir, env.Value)

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -453,7 +453,7 @@ go_get(
     name = "remote-apis-sdks",
     get = "github.com/bazelbuild/remote-apis-sdks/go/...",
     repo = "github.com/peterebden/remote-apis-sdks",
-    revision = "16b8c03a1b365b4c36c6544b5d03bda429cee2e2",
+    revision = "d9c747b11b80d75575c2560bb62f89f5bd519c3b",
     deps = [
         ":annotations",
         ":bytestream",


### PR DESCRIPTION
Implements special lookup logic for targets with `stamp = True`.

Background: stamped targets get access to the current SCM revision and a couple of other things. That doesn't force a rebuild when it changes though, only if we otherwise would because the actual inputs have changed (which keeps these targets from building every commit). However this wasn't happening for remote execution; this adds some special-casing for that logic.

_Technically_ this means there is an incrementality issue where if you had a target that successfully built remotely without being stamped, then you turned it on, it would not rebuild. I think that's a weird enough situation that we don't need to care though (and arguably it sort of mirrors the "doesn't force rebuild" logic of it anyway).