### PR TITLE
Allow symlinks in jarcat tar archives

### DIFF
--- a/src/fs/copy.go
+++ b/src/fs/copy.go
@@ -9,7 +9,7 @@ import (
 // Falls back to a copy if link fails and fallback is true.
 func copyOrLinkFile(from, to string, fromMode, toMode os.FileMode, link, fallback bool) error {
 	if link {
-		if (fromMode&os.ModeSymlink) != 0 {
+		if (fromMode & os.ModeSymlink) != 0 {
 			// Don't try to hard-link to a symlink, that doesn't work reliably across all platforms.
 			// Instead recreate an equivalent symlink in the new location.
 			dest, err := os.Readlink(from)

--- a/src/fs/copy.go
+++ b/src/fs/copy.go
@@ -3,33 +3,28 @@ package fs
 import (
 	"os"
 	"path"
-	"runtime"
 )
 
 // CopyOrLinkFile either copies or hardlinks a file based on the link argument.
 // Falls back to a copy if link fails and fallback is true.
-func CopyOrLinkFile(from, to string, mode os.FileMode, link, fallback bool) error {
+func copyOrLinkFile(from, to string, fromMode, toMode os.FileMode, link, fallback bool) error {
 	if link {
-		if err := os.Link(from, to); err == nil || !fallback {
-			return err
-		} else if runtime.GOOS != "linux" && os.IsNotExist(err) {
-			// There is an awkward issue on several non-Linux platforms where links to
-			// symlinks actually try to link to the target rather than the link itself.
-			// In that case we try to recreate a similar symlink at the destination.
-			if info, err := os.Lstat(from); err == nil && (info.Mode()&os.ModeSymlink) != 0 {
-				dest, err := os.Readlink(from)
-				if err != nil {
-					return err
-				}
-				return os.Symlink(dest, to)
+		if (fromMode&os.ModeSymlink) != 0 {
+			// Don't try to hard-link to a symlink, that doesn't work reliably across all platforms.
+			// Instead recreate an equivalent symlink in the new location.
+			dest, err := os.Readlink(from)
+			if err != nil {
+				return err
 			}
-			return err
+			return os.Symlink(dest, to)
 		}
+		return os.Link(from, to)
 	}
-	return CopyFile(from, to, mode)
+	return CopyFile(from, to, toMode)
 }
 
 // RecursiveCopy copies either a single file or a directory.
+// 'mode' is the mode of the destination file.
 func RecursiveCopy(from string, to string, mode os.FileMode) error {
 	return recursiveCopyOrLinkFile(from, to, mode, false, false)
 }
@@ -37,22 +32,28 @@ func RecursiveCopy(from string, to string, mode os.FileMode) error {
 // RecursiveLink hardlinks either a single file or a directory.
 // Note that you can't hardlink directories so the behaviour is much the same as a recursive copy.
 // If it can't link then it falls back to a copy.
+// 'mode' is the mode of the destination file.
 func RecursiveLink(from string, to string, mode os.FileMode) error {
 	return recursiveCopyOrLinkFile(from, to, mode, true, true)
 }
 
 // recursiveCopyOrLinkFile recursively copies or links a file or directory.
+// 'mode' is the mode of the destination file.
 // If 'link' is true then we'll hardlink files instead of copying them.
 // If 'fallback' is true then we'll fall back to a copy if linking fails.
 func recursiveCopyOrLinkFile(from string, to string, mode os.FileMode, link, fallback bool) error {
-	if info, err := os.Stat(from); err == nil && info.IsDir() {
+	info, err := os.Lstat(from)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
 		return WalkMode(from, func(name string, isDir bool, fileMode os.FileMode) error {
 			dest := path.Join(to, name[len(from):])
 			if isDir {
 				return os.MkdirAll(dest, DirPermissions)
 			}
-			return CopyOrLinkFile(name, dest, mode, link, fallback)
+			return copyOrLinkFile(name, dest, fileMode, mode, link, fallback)
 		})
 	}
-	return CopyOrLinkFile(from, to, mode, link, fallback)
+	return copyOrLinkFile(from, to, info.Mode(), mode, link, fallback)
 }

--- a/src/fs/copy.go
+++ b/src/fs/copy.go
@@ -7,7 +7,7 @@ import (
 
 // CopyOrLinkFile either copies or hardlinks a file based on the link argument.
 // Falls back to a copy if link fails and fallback is true.
-func copyOrLinkFile(from, to string, fromMode, toMode os.FileMode, link, fallback bool) error {
+func CopyOrLinkFile(from, to string, fromMode, toMode os.FileMode, link, fallback bool) error {
 	if link {
 		if (fromMode & os.ModeSymlink) != 0 {
 			// Don't try to hard-link to a symlink, that doesn't work reliably across all platforms.
@@ -52,8 +52,8 @@ func recursiveCopyOrLinkFile(from string, to string, mode os.FileMode, link, fal
 			if isDir {
 				return os.MkdirAll(dest, DirPermissions)
 			}
-			return copyOrLinkFile(name, dest, fileMode, mode, link, fallback)
+			return CopyOrLinkFile(name, dest, fileMode, mode, link, fallback)
 		})
 	}
-	return copyOrLinkFile(from, to, info.Mode(), mode, link, fallback)
+	return CopyOrLinkFile(from, to, info.Mode(), mode, link, fallback)
 }

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -518,20 +518,20 @@ func (c *Client) buildEnv(target *core.BuildTarget, env []string, sandbox bool) 
 		env = append(env, "SANDBOX=true")
 	}
 	if target != nil {
-	// This is an awkward little hack; the protocol says we always create directories for declared
-	// outputs, which (mostly by luck) is the same as plz would normally do. However targets that
-	// have post-build functions that detect their outputs do not get this on the first run since
-	// they don't *have* any at that point, but can then fail on the second because now they do,
-	// which is very hard to debug since it doesn't happen locally where we only run once.
-	// For now resolve with this hack; it is not nice but the whole protocol does not well support
-	// what we want to do here.
+		// This is an awkward little hack; the protocol says we always create directories for declared
+		// outputs, which (mostly by luck) is the same as plz would normally do. However targets that
+		// have post-build functions that detect their outputs do not get this on the first run since
+		// they don't *have* any at that point, but can then fail on the second because now they do,
+		// which is very hard to debug since it doesn't happen locally where we only run once.
+		// For now resolve with this hack; it is not nice but the whole protocol does not well support
+		// what we want to do here.
 		if target.PostBuildFunction != nil && c.targetOutputs(target.Label) != nil {
 			env = append(env, "_CREATE_OUTPUT_DIRS=false")
 		}
 		if target.IsBinary {
 			env = append(env, "_BINARY=true")
 		}
-		env = append(env, "_TARGET=" + target.Label.String())
+		env = append(env, "_TARGET="+target.Label.String())
 	}
 	sort.Strings(env) // Proto says it must be sorted (not just consistently ordered :( )
 	vars := make([]*pb.Command_EnvironmentVariable, len(env))

--- a/src/test/surefire.go
+++ b/src/test/surefire.go
@@ -18,7 +18,7 @@ func CopySurefireXMLFilesToDir(state *core.BuildState, surefireDir string) {
 					if !isDir {
 						if bytes, _ := ioutil.ReadFile(path); looksLikeJUnitXMLTestResults(bytes) {
 							surefireResult := filepath.Join(surefireDir, filepath.Base(path))
-							if err := fs.CopyOrLinkFile(path, surefireResult, 0644, true, true); err != nil {
+							if err := fs.RecursiveLink(path, surefireResult, 0644); err != nil {
 								log.Errorf("Error linking %s to %s - %s", surefireResult, path, err)
 							}
 						}

--- a/tools/jarcat/tar/tar.go
+++ b/tools/jarcat/tar/tar.go
@@ -96,7 +96,7 @@ func write(w io.Writer, output string, srcs []string, prefix string, flatten boo
 				return err
 			}
 			// only copy content of regular files
-			if ! info.Mode().IsRegular() {
+			if !info.Mode().IsRegular() {
 				return nil
 			}
 			f, err := os.Open(path)

--- a/tools/jarcat/tar/test_data/symlink/link.txt
+++ b/tools/jarcat/tar/test_data/symlink/link.txt
@@ -1,0 +1,1 @@
+./source.txt

--- a/tools/jarcat/tar/test_data/symlink/source.txt
+++ b/tools/jarcat/tar/test_data/symlink/source.txt
@@ -1,0 +1,1 @@
+symlink file


### PR DESCRIPTION
Avoid error `CRITICAL: Error writing tarball: archive/tar: write too long` when sources of `tarball()` contains symlinks.