### PR TITLE
Fix creation of links not to symlink directly to directories

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -744,19 +744,20 @@ func buildLinksOfType(state *core.BuildState, target *core.BuildTarget, prefix s
 
 // linkIfNotExists creates dest as a link to src if it doesn't already exist.
 func linkIfNotExists(src, dest string, f linkFunc) {
-	if !fs.PathExists(dest) {
-		fs.Walk(src, func(name string, isDir bool) error {
-			if !isDir {
-				fullDest := path.Join(dest, name[len(src):])
-				if err := fs.EnsureDir(fullDest); err != nil {
-					log.Warning("Failed to create directory for %s: %s", fullDest, err)
-				} else if err := f(src, fullDest); err != nil && !os.IsExist(err) {
-					log.Warning("Failed to create %s: %s", fullDest, err)
-				}
-			}
-			return nil
-		})
+	if fs.PathExists(dest) {
+		return
 	}
+	fs.Walk(src, func(name string, isDir bool) error {
+		if !isDir {
+			fullDest := path.Join(dest, name[len(src):])
+			if err := fs.EnsureDir(fullDest); err != nil {
+				log.Warning("Failed to create directory for %s: %s", fullDest, err)
+			} else if err := f(src, fullDest); err != nil && !os.IsExist(err) {
+				log.Warning("Failed to create %s: %s", fullDest, err)
+			}
+		}
+		return nil
+	})
 }
 
 // fetchRemoteFile fetches a remote file from a URL.

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -745,11 +745,17 @@ func buildLinksOfType(state *core.BuildState, target *core.BuildTarget, prefix s
 // linkIfNotExists creates dest as a link to src if it doesn't already exist.
 func linkIfNotExists(src, dest string, f linkFunc) {
 	if !fs.PathExists(dest) {
-		if err := fs.EnsureDir(dest); err != nil {
-			log.Warning("Failed to create directory for %s: %s", dest, err)
-		} else if err := f(src, dest); err != nil && !os.IsExist(err) {
-			log.Warning("Failed to create %s: %s", dest, err)
-		}
+		fs.Walk(src, func(name string, isDir bool) error {
+			if !isDir {
+				fullDest := path.Join(dest, name[len(src):])
+				if err := fs.EnsureDir(fullDest); err != nil {
+					log.Warning("Failed to create directory for %s: %s", fullDest, err)
+				} else if err := f(src, fullDest); err != nil && !os.IsExist(err) {
+					log.Warning("Failed to create %s: %s", fullDest, err)
+				}
+			}
+			return nil
+		})
 	}
 }
 


### PR DESCRIPTION
Subtle bugs abound involving go_gets in multiple directories with similar but differing `get` stanzas.

Instead link to all the files in the directory individually as we do in other cases. This has the side effect of making it work for hardlinks as well.