### PR TITLE
Simplify embedding of GPG key for updates

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,7 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.2-0.20191028172631-481baca67f93 h1:VvBteXw2zOXEgm0o3PgONTWf+bhUGsCaiNn3pbkU9LA=
 github.com/google/go-cmp v0.3.2-0.20191028172631-481baca67f93/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=

--- a/src/update/BUILD
+++ b/src/update/BUILD
@@ -1,11 +1,6 @@
 go_library(
     name = "update",
-    srcs = [
-        "clean.go",
-        "update.go",
-        "verify.go",
-        ":pubkey",
-    ],
+    srcs = glob(["*.go"], exclude=["*_test.go"]),
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",
@@ -16,11 +11,6 @@ go_library(
         "//third_party/go:semver",
         "//third_party/go:xz",
     ],
-)
-
-go_bindata(
-    name = "pubkey",
-    srcs = ["pubkey.gpg.asc"],
 )
 
 go_test(

--- a/src/update/BUILD
+++ b/src/update/BUILD
@@ -1,6 +1,9 @@
 go_library(
     name = "update",
-    srcs = glob(["*.go"], exclude=["*_test.go"]),
+    srcs = glob(
+        ["*.go"],
+        exclude = ["*_test.go"],
+    ),
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",

--- a/src/update/clean.go
+++ b/src/update/clean.go
@@ -1,5 +1,3 @@
-// +build !bootstrap
-
 package update
 
 import (

--- a/src/update/pubkey.go
+++ b/src/update/pubkey.go
@@ -1,3 +1,7 @@
+package update
+
+// pubkey is the public key we verify Please releases with.
+const pubkey = `
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1
 
@@ -1371,3 +1375,4 @@ uNxTgSvMxQsHlb3pcogZz+55KdvKmiR/7WIZYruE3azmUmm4w+HGWXOCufbyID95
 fW5YgZzvJHjbMkW/gh+zWrAb8LUnqlnV
 =11fD
 -----END PGP PUBLIC KEY BLOCK-----
+`

--- a/src/update/stub.go
+++ b/src/update/stub.go
@@ -1,9 +1,0 @@
-// +build bootstrap
-
-package update
-
-import "github.com/thought-machine/please/src/core"
-
-// CheckAndUpdate is a stub implementation that does nothing.
-func CheckAndUpdate(config *core.Configuration, updatesEnabled, updateCommand, forceUpdate, verify bool) {
-}

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -1,5 +1,3 @@
-// +build !bootstrap
-
 // Package update contains code for Please auto-updating itself.
 // At startup, Please can check a version set in the config file. If that doesn't
 // match the version of the current binary, it will download the appropriate

--- a/src/update/verify.go
+++ b/src/update/verify.go
@@ -1,5 +1,3 @@
-// +build !bootstrap
-
 package update
 
 import (
@@ -22,7 +20,7 @@ const identity = "Please Releases <releases@please.build>"
 // verifySignature verifies an OpenPGP detached signature of a file.
 // It returns true if the signature is correct according to our key.
 func verifySignature(signed, signature io.Reader) bool {
-	entities, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(MustAsset("pubkey.gpg.asc")))
+	entities, err := openpgp.ReadArmoredKeyRing(strings.NewReader(pubkey))
 	if err != nil {
 		log.Fatalf("%s", err) // Shouldn't happen
 	}


### PR DESCRIPTION
Basically just drop it in a Go file instead of going through the embedding malarkey.

Not 100% a fan but as part of the march towards making Go tooling happier it seems on balance worth it.