### PR TITLE
Swap bootstrap tags for flags in core

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -341,7 +341,7 @@ def go_binary(name:str, srcs:list=[], asm_srcs:list=[], out:str=None, deps:list=
 
 
 def go_test(name:str, srcs:list, data:list|dict=None, deps:list=[], worker:str='', visibility:list=None,
-            flags:str='', sandbox:bool=None, cgo:bool=False,
+            flags:str='', sandbox:bool=None, cgo:bool=False, filter_srcs:bool=True,
             external:bool=False, timeout:int=0, flaky:bool|int=0, test_outputs:list=None,
             labels:list&features&tags=None, size:str=None, static:bool=CONFIG.GO_DEFAULT_STATIC,
             definitions:str|list|dict=None):
@@ -357,6 +357,7 @@ def go_test(name:str, srcs:list, data:list|dict=None, deps:list=[], worker:str='
       flags (str): Flags to apply to the test invocation.
       sandbox (bool): Sandbox the test on Linux to restrict access to namespaces such as network.
       cgo (bool): True if this test depends on a cgo_library.
+      filter_srcs (bool): If True, filters source files through Go's standard build constraints.
       external (bool): True if this test is external to the library it's testing, i.e. it uses the
                        feature of Go that allows it to be in the same directory with a _test suffix.
       timeout (int): Timeout in seconds to allow the test to run for.
@@ -382,6 +383,7 @@ def go_test(name:str, srcs:list, data:list|dict=None, deps:list=[], worker:str='
         out = name + ('_lib.a' if cgo else '.a'),
         deps = deps,
         test_only = True,
+        filter_srcs = filter_srcs,
         _all_srcs = not external,
         _link_extra = False,
         complete = False,

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -13,12 +13,14 @@ go_library(
     srcs = glob(
         ["*.go"],
         exclude = [
+            "stub.go",
             "*_test.go",
             "version.go",
         ],
     ) + [
         ":version",
     ],
+    filter_srcs = False,  # Fix to make tags work until we have #532
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -42,6 +42,7 @@ go_test(
     name = "config_test",
     srcs = ["config_test.go"],
     data = glob(["test_data/*.plzconfig*"]),
+    filter_srcs = False,  # As above
     deps = [
         ":core",
         "//src/cli",

--- a/src/core/config_flags.go
+++ b/src/core/config_flags.go
@@ -1,4 +1,4 @@
-// +build !bootstrap
+// +build please
 
 package core
 

--- a/src/core/stub.go
+++ b/src/core/stub.go
@@ -1,5 +1,3 @@
-// +build bootstrap
-
 package core
 
 import "github.com/jessevdk/go-flags"


### PR DESCRIPTION
More Go compliancy.

A simpler option from the perspective of this repo would be to fork go-flags and merge the required patches there. I'm still holding off doing that until there is more clarity on upstream status since it's a pretty sweeping change (and I wouldn't have time to maintain the fork anyway)