### PR TITLE
Istanbul fixes

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -96,8 +96,8 @@ func ReadConfigFiles(filenames []string, profiles []string) (*Configuration, err
 	}
 	setBuildPath(&config.Build.Path, config.Build.PassEnv)
 	setDefault(&config.Build.PassEnv)
-	setDefault(&config.Cover.FileExtension, ".go", ".py", ".java", ".js", ".cc", ".h", ".c")
-	setDefault(&config.Cover.ExcludeExtension, ".pb.go", "_pb2.py", ".pb.cc", ".pb.h", "_test.py", "_test.go", "_pb.go", "_bindata.go", "_test_main.cc")
+	setDefault(&config.Cover.FileExtension, ".go", ".py", ".java", ".tsx", ".ts", ".js", ".cc", ".h", ".c")
+	setDefault(&config.Cover.ExcludeExtension, ".pb.go", "_pb2.py", ".spec.tsx", ".spec.ts", ".spec.js", ".pb.cc", ".pb.h", "_test.py", "_test.go", "_pb.go", "_bindata.go", "_test_main.cc")
 	setDefault(&config.Proto.Language, "cc", "py", "java", "go", "js")
 	setDefault(&config.Parse.BuildDefsDir, "build_defs")
 

--- a/src/test/coverage_test.go
+++ b/src/test/coverage_test.go
@@ -209,13 +209,13 @@ func TestIstanbulCoverage2(t *testing.T) {
 	lines := coverage.Files["common/js/components/Table/Table.js"]
 	// This exercises a slightly more complex example with multiple overlapping statements.
 	assertLine(t, lines, 15, core.Covered)
-	assertLine(t, lines, 16, core.Covered)
-	assertLine(t, lines, 17, core.Covered)
-	assertLine(t, lines, 18, core.Covered)
-	assertLine(t, lines, 19, core.Covered)
-	assertLine(t, lines, 20, core.Covered)
-	assertLine(t, lines, 21, core.Covered)
-	assertLine(t, lines, 22, core.Covered)
+	assertLine(t, lines, 16, core.Uncovered)
+	assertLine(t, lines, 17, core.Uncovered)
+	assertLine(t, lines, 18, core.Uncovered)
+	assertLine(t, lines, 19, core.Uncovered)
+	assertLine(t, lines, 20, core.Uncovered)
+	assertLine(t, lines, 21, core.Uncovered)
+	assertLine(t, lines, 22, core.Uncovered)
 	assertLine(t, lines, 23, core.Covered)
 }
 

--- a/src/test/istanbul_coverage.go
+++ b/src/test/istanbul_coverage.go
@@ -58,7 +58,7 @@ func (file *istanbulFile) toLineCoverage() []core.LineCoverage {
 		}
 		s := file.StatementMap[statement]
 		for i := s.Start.Line; i <= s.End.Line; i++ {
-			if val > ret[i-1] {
+			if ret[i-1] != core.Uncovered {
 				ret[i-1] = val // -1 because 1-indexed
 			}
 		}
@@ -84,6 +84,8 @@ func sanitiseFileName(target *core.BuildTarget, filename string) string {
 	} else if s := sanitiseFileNameDir(filename, target.TmpDir(), true); s != "" {
 		return s
 	} else if s := sanitiseFileNameDir(filename, target.TestDir(), true); s != "" {
+		return s
+	} else if s := sanitiseFileNameDir(filename, core.SandboxDir, false); s != "" {
 		return s
 	}
 	return filename


### PR DESCRIPTION
**What does this PR do?**

* It adds new TypeScript related extensions to the default cover configuration
* Fixes istanbul related code
  * Uncovered lines can't be marked as such after being first marked as covered. The current logic prevents this as the `Covered` const is higher. This solution allows the coverage of lines to be updated until a statement finally marks them as uncovered. For instance, istanbul will mark an `if` statement as covered if reached, but statements within it as uncovered if not
  * Corrects an istanbul test as a result of the fix above. See snapshots below
  * Sanitises file names properly if coverage is run within a sandbox

The first two statements and respective counts in the `istanbul_coverage_2.json` file below show how lines 16-22 are actually uncovered.

![Screenshot 2020-04-21 at 19 58 43](https://user-images.githubusercontent.com/15216823/79903281-b4700100-840a-11ea-84ec-00847ce4da3e.png)

![Screenshot 2020-04-21 at 19 59 40](https://user-images.githubusercontent.com/15216823/79903292-b8038800-840a-11ea-9909-f11d59ad310b.png)


