### PR TITLE
Remove the `--unique` flag to `plz query deps` and make it the default.

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -251,7 +251,6 @@ var opts struct {
 
 	Query struct {
 		Deps struct {
-			Unique bool `long:"unique" short:"u" description:"Only output each dependency once"`
 			Hidden bool `long:"hidden" short:"h" description:"Output internal / hidden dependencies too"`
 			Level  int  `long:"level" default:"-1" description:"Levels of the dependencies to retrieve."`
 			Args   struct {
@@ -516,7 +515,7 @@ var buildFunctions = map[string]func() int{
 	},
 	"deps": func() int {
 		return runQuery(true, opts.Query.Deps.Args.Targets, func(state *core.BuildState) {
-			query.Deps(state, state.ExpandOriginalTargets(), opts.Query.Deps.Unique, opts.Query.Deps.Hidden, opts.Query.Deps.Level)
+			query.Deps(state, state.ExpandOriginalTargets(), opts.Query.Deps.Hidden, opts.Query.Deps.Level)
 		})
 	},
 	"revdeps": func() int {

--- a/src/query/deps.go
+++ b/src/query/deps.go
@@ -6,16 +6,15 @@ import (
 )
 
 // Deps prints all transitive dependencies of a set of targets.
-func Deps(state *core.BuildState, labels []core.BuildLabel, unique, hidden bool, targetLevel int) {
+func Deps(state *core.BuildState, labels []core.BuildLabel, hidden bool, targetLevel int) {
 	done := map[core.BuildLabel]bool{}
 	for _, label := range labels {
-		printTarget(state, state.Graph.TargetOrDie(label), "", done, unique, hidden, 0, targetLevel)
+		printTarget(state, state.Graph.TargetOrDie(label), "", done, hidden, 0, targetLevel)
 	}
 }
 
-func printTarget(state *core.BuildState, target *core.BuildTarget, indent string, done map[core.BuildLabel]bool,
-	unique, hidden bool, currentLevel int, targetLevel int) {
-	if unique && done[target.Label] {
+func printTarget(state *core.BuildState, target *core.BuildTarget, indent string, done map[core.BuildLabel]bool, hidden bool, currentLevel int, targetLevel int) {
+	if done[target.Label] {
 		return
 	}
 
@@ -28,9 +27,7 @@ func printTarget(state *core.BuildState, target *core.BuildTarget, indent string
 			done[parent.Label] = true
 		}
 	}
-	if !unique {
-		indent = indent + "  "
-	}
+	indent = indent + "  "
 
 	// access the level of dependency, as default is -1 which prints out everything
 	if targetLevel != -1 && currentLevel == targetLevel {
@@ -40,6 +37,6 @@ func printTarget(state *core.BuildState, target *core.BuildTarget, indent string
 	currentLevel++
 
 	for _, dep := range target.Dependencies() {
-		printTarget(state, dep, indent, done, unique, hidden, currentLevel, targetLevel)
+		printTarget(state, dep, indent, done, hidden, currentLevel, targetLevel)
 	}
 }


### PR DESCRIPTION
This has been overdue for ages. The non-unique version produces way too much output on non-trivial trees to be useful.

I considered keeping a flag for it but I'm not convinced it's ever really useful; running it on what we would consider a pretty minimal server with 134 unique dependencies, it took 8 minutes before I got bored and killed the process.