### PR TITLE
Add include_dependees flag to query changes

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -337,6 +337,7 @@ var opts struct {
 		} `command:"rules" description:"Prints built-in rules to stdout as JSON"`
 		Changes struct {
 			Since           string `short:"s" long:"since" default:"origin/master" description:"Revision to compare against"`
+			IncludeDependees string `long:"include_dependees" hidden:"true" default:"transitive" choice:"transitive" description:"Transitional flag to help moving to v15. Has no effect at present."`
 			CheckoutCommand string `long:"checkout_command" hidden:"true" description:"Deprecated, has no effect."`
 			CurrentCommand  string `long:"current_revision_command" hidden:"true" description:"Deprecated, has no effect."`
 			Args            struct {

--- a/src/please.go
+++ b/src/please.go
@@ -336,11 +336,11 @@ var opts struct {
 			} `positional-args:"true"`
 		} `command:"rules" description:"Prints built-in rules to stdout as JSON"`
 		Changes struct {
-			Since           string `short:"s" long:"since" default:"origin/master" description:"Revision to compare against"`
+			Since            string `short:"s" long:"since" default:"origin/master" description:"Revision to compare against"`
 			IncludeDependees string `long:"include_dependees" hidden:"true" default:"transitive" choice:"transitive" description:"Transitional flag to help moving to v15. Has no effect at present."`
-			CheckoutCommand string `long:"checkout_command" hidden:"true" description:"Deprecated, has no effect."`
-			CurrentCommand  string `long:"current_revision_command" hidden:"true" description:"Deprecated, has no effect."`
-			Args            struct {
+			CheckoutCommand  string `long:"checkout_command" hidden:"true" description:"Deprecated, has no effect."`
+			CurrentCommand   string `long:"current_revision_command" hidden:"true" description:"Deprecated, has no effect."`
+			Args             struct {
 				Files cli.StdinStrings `positional-arg-name:"files" description:"Deprecated, no longer necessary."`
 			} `positional-args:"true"`
 		} `command:"changes" description:"Calculates the difference between two different states of the build graph"`


### PR DESCRIPTION
This will ease the transition to v15; users can start using --include-dependees=transitive now and on upgrade things will continue to work as expected.