### PR TITLE
Fix sub-package problems in new glob implementation

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -82,5 +82,6 @@ accept = ASL
 accept = MPL-2.0
 accept = LGPL
 accept = Artistic License
+accept = ISC
 # Not really a licence, but Bazel projects commonly describe things this way.
 accept = notice

--- a/src/fs/glob_test.go
+++ b/src/fs/glob_test.go
@@ -36,7 +36,7 @@ func TestCannotGlobThirdFile(t *testing.T) {
 }
 
 func TestCanGlobFileAtRootWithDoubleStar(t *testing.T) {
-	files, err := glob(buildFileNames, "src/fs/test_data/test_subfolder1", "**/*.txt", false, nil)
+	files, err := glob("src/fs/test_data/test_subfolder1", "**/*.txt", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"src/fs/test_data/test_subfolder1/a.txt"}, files)
 }
@@ -51,7 +51,7 @@ func TestIsGlob(t *testing.T) {
 }
 
 func TestGlobPlusPlus(t *testing.T) {
-	files, err := glob(buildFileNames, "src/fs/test_data/test_subfolder++", "**/*.txt", false, nil)
+	files, err := glob("src/fs/test_data/test_subfolder++", "**/*.txt", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"src/fs/test_data/test_subfolder++/test.txt"}, files)
 }
@@ -60,4 +60,15 @@ func TestGlobExcludes(t *testing.T) {
 	files := Glob(buildFileNames, "src/fs", []string{"test_data/**/*.txt"}, nil, []string{"test.txt"}, false)
 	expected := []string{"test_data/test_subfolder1/a.txt"}
 	assert.Equal(t, expected, files)
+}
+
+func TestGlobExcludesSubPackages(t *testing.T) {
+	files := Glob(buildFileNames, "src/fs", []string{"**/*.txt", "**/*.py"}, nil, nil, false)
+	expected := []string{
+		"test_data/test_subfolder++/test.txt",
+		"test_data/test_subfolder1/a.txt",
+		"test_data/test_subfolder3/test.py",
+		"test_data/test.txt",
+	}
+	assert.ElementsMatch(t, expected, files)
 }

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -178,6 +178,7 @@ go_get(
     name = "spew",
     get = "github.com/davecgh/go-spew/spew",
     patch = "spew_omit_empty.patch",
+    licences = ["ISC"],
     revision = "ecdeabc65495df2dec95d7c4a4c3e021903035e5",
 )
 
@@ -187,11 +188,37 @@ go_get(
     install = [
         "assert",
         "require",
-        "vendor/github.com/davecgh/go-spew/spew",
-        "vendor/github.com/pmezard/go-difflib/difflib",
+        "vendor/...",
     ],
-    revision = "f390dcf405f7b83c997eac1b06768bb9f44dec18",
-    deps = [":spew"],
+    licences = ["MIT"],
+    revision = "v1.4.0",
+    deps = [
+        ":difflib",
+        ":spew",
+        ":objx",
+        ":yaml.v2",
+    ],
+)
+
+go_get(
+    name = "difflib",
+    get = "github.com/pmezard/go-difflib/...",
+    licences = ["BSD 3-Clause"],
+    revision = "792786c7400a136282c1664665ae0a8db921c6c2",
+)
+
+go_get(
+    name = "objx",
+    get = "github.com/stretchr/objx",
+    licences = ["MIT"],
+    revision = "1a9d0bb9f541897e62256577b352fdbc1fb4fd94",
+)
+
+go_get(
+    name = "yaml.v2",
+    get = "gopkg.in/yaml.v2",
+    licences = ["Apache 2.0"],
+    revision = "v2.2.4",
 )
 
 go_get(


### PR DESCRIPTION
The new glob implementation was only checking the matched files to find the build files to determine any sub packages below the root path. This change makes it check all files. 