### PR TITLE
Add an option for authenticating using a pre-shared token.

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -408,8 +408,8 @@ type Configuration struct {
 		Instance      string       `help:"Remote instance name to request; depending on the server this may be required."`
 		Name          string       `help:"A name for this worker instance. This is attached to artifacts uploaded to remote storage." example:"agent-001"`
 		DisplayURL    string       `help:"A URL to browse the remote server with (e.g. using buildbarn-browser). Only used when printing hashes."`
+		TokenFile     string       `help:"A file containing a token that is attached to outgoing RPCs to authenticate them. This is somewhat bespoke; we are still investigating further options for authentication."`
 		Timeout       cli.Duration `help:"Timeout for connections made to the remote server."`
-		ReadOnly      bool         `help:"If true, prevents this client from writing to the remote storage. Is overridden if being used for execution."`
 		Secure        bool         `help:"Whether to use TLS for communication or not."`
 		VerifyOutputs bool         `help:"Whether to verify all outputs are present after a cached remote execution action. Depending on your server implementation, you may require this to ensure files are really present."`
 		HomeDir       string       `help:"The home directory on the build machine."`

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -478,5 +478,5 @@ func (cred tokenCredProvider) GetRequestMetadata(ctx context.Context, uri ...str
 }
 
 func (cred tokenCredProvider) RequireTransportSecurity() bool {
-	return false  // Allow these to be provided over an insecure channel; this facilitates e.g. service meshes like Istio.
+	return false // Allow these to be provided over an insecure channel; this facilitates e.g. service meshes like Istio.
 }

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -463,3 +463,20 @@ func updateHashFilename(name string, digest *pb.Digest) string {
 	b, _ := hex.DecodeString(digest.Hash)
 	return before + "-" + base64.RawURLEncoding.EncodeToString(b) + ext
 }
+
+// preSharedToken returns a gRPC credential provider for a pre-shared token.
+func preSharedToken(token string) tokenCredProvider {
+	return tokenCredProvider{
+		"authorization": "Bearer " + strings.TrimSpace(token),
+	}
+}
+
+type tokenCredProvider map[string]string
+
+func (cred tokenCredProvider) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	return cred, nil
+}
+
+func (cred tokenCredProvider) RequireTransportSecurity() bool {
+	return false  // Allow these to be provided over an insecure channel; this facilitates e.g. service meshes like Istio.
+}


### PR DESCRIPTION
It would be conceptually nice to use the CredentialsFile option on the SDK, but after quite some experimentation I can't find anything able to validate that on the server side.
Unsure what is wrong there... but also we have some use cases involving Istio where we wouldn't necessarily have TLS from the client's perspective so that wouldn't be an option anyway.