### PR TITLE
Make SHA-256 the default hash function 

### DIFF
--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -250,10 +250,10 @@ func TestFileGroupBinDir(t *testing.T) {
 func TestOutputHash(t *testing.T) {
 	state, target := newState("//package3:target1")
 	target.AddOutput("file1")
-	target.Hashes = []string{"6c6d66a0852b49cdeeb0e183b4f10b0309c5dd4a"}
+	target.Hashes = []string{"634b027b1b69e1242d40d53e312b3b4ac7710f55be81f289b549446ef6778bee"}
 	b, err := state.TargetHasher.OutputHash(target)
 	assert.NoError(t, err)
-	assert.Equal(t, "6c6d66a0852b49cdeeb0e183b4f10b0309c5dd4a", hex.EncodeToString(b))
+	assert.Equal(t, "634b027b1b69e1242d40d53e312b3b4ac7710f55be81f289b549446ef6778bee", hex.EncodeToString(b))
 }
 
 func TestCheckRuleHashes(t *testing.T) {

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -239,7 +239,7 @@ func DefaultConfiguration() *Configuration {
 	config.Build.FallbackConfig = "opt" // Optimised builds as a fallback on any target that doesn't have a matching one set
 	config.Build.PleaseSandboxTool = "please_sandbox"
 	config.Build.Xattrs = true
-	config.Build.HashFunction = "sha1" // will likely be changed to sha256 at some future date.
+	config.Build.HashFunction = "sha256"
 	config.BuildConfig = map[string]string{}
 	config.BuildEnv = map[string]string{}
 	config.Cache.HTTPWriteable = true


### PR DESCRIPTION
This is not technically a breaking change but will leave for v15 since it will force a rebuild of everything.

We support this on a per-target basis atm but it's preferable to make it the default so that `plz hash` uses them without any extra flag gymnastics, and it avoids the whole remote execution issue (where most servers are likely to only support SHA256)