### PR TITLE
Make plz hash --update a bit more robust.

### DIFF
--- a/src/parse/asp/util.go
+++ b/src/parse/asp/util.go
@@ -12,7 +12,7 @@ func FindTarget(statements []*Statement, name string) (target *Statement) {
 		if arg := FindArgument(stmt, "name"); arg != nil && arg.Value.Val != nil && arg.Value.Val.String != "" && strings.Trim(arg.Value.Val.String, `"`) == name {
 			target = stmt
 		}
-		return false  // FindArgument is recursive so we never need to visit more deeply.
+		return false // FindArgument is recursive so we never need to visit more deeply.
 	})
 	return
 }
@@ -51,7 +51,7 @@ func FindArgument(statement *Statement, args ...string) (argument *CallArgument)
 				break
 			}
 		}
-		return false  // CallArguments can't contain other arguments so no point recursing further.
+		return false // CallArguments can't contain other arguments so no point recursing further.
 	})
 	return
 }


### PR DESCRIPTION
This makes the search recursive so it can deal with things like
```
rule = remote_file(
    name = "stuff",
    hashes = ["blahblah"],
)
```
which the old implementation was easily confused by.

It's a *little* slow in large BUILD files but I think people would rather have it work... and obviously the hashing is pretty slow anyway.