### PR TITLE
Download data of targets recursively

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -275,8 +275,12 @@ func (c *Client) downloadData(target *core.BuildTarget) error {
 	var g errgroup.Group
 	for _, datum := range target.AllData() {
 		if l := datum.Label(); l != nil {
+			t := c.state.Graph.TargetOrDie(*l)
 			g.Go(func() error {
-				return c.Download(c.state.Graph.TargetOrDie(*l))
+				if err := c.Download(t); err != nil {
+					return err
+				}
+				return c.downloadData(t)
 			})
 		}
 	}

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -262,16 +262,25 @@ func (c *Client) Build(tid int, target *core.BuildTarget) (*core.BuildMetadata, 
 			}); err != nil {
 				return metadata, err
 			}
-			for _, datum := range target.AllData() {
-				if l := datum.Label(); l != nil {
-					if err := c.Download(c.state.Graph.TargetOrDie(*l)); err != nil {
-						return metadata, err
-					}
-				}
-			}
+		}
+		if err := c.downloadData(target); err != nil {
+			return metadata, err
 		}
 	}
 	return metadata, nil
+}
+
+// downloadData downloads all the runtime data for a target, recursively.
+func (c *Client) downloadData(target *core.BuildTarget) error {
+	var g errgroup.Group
+	for _, datum := range target.AllData() {
+		if l := datum.Label(); l != nil {
+			g.Go(func() error {
+				return c.Download(c.state.Graph.TargetOrDie(*l))
+			})
+		}
+	}
+	return g.Wait()
 }
 
 // Run runs a target on the remote executors.


### PR DESCRIPTION
I'm not totally wowed about this but we have motivating cases that won't work without.

Presumably it will be rare to have data that also has data except in cases where you do actually need this.