### PR TITLE
CI tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
      working_directory: ~/please
      docker:
        - image: thoughtmachine/please_ubuntu:20200226
+     resource_class: large
      environment:
        PLZ_ARGS: "-p --profile ci"
      steps:
@@ -49,6 +50,7 @@ jobs:
      working_directory: ~/please
      docker:
        - image: thoughtmachine/please_ubuntu_alt:20200226
+     resource_class: large
      environment:
        PLZ_ARGS: "-p --profile ci"
        PLZ_COVER: "cover"
@@ -139,6 +141,7 @@ jobs:
      working_directory: ~/please
      docker:
        - image: thoughtmachine/please_ubuntu:20200326
+     resource_class: large
      steps:
        - checkout
        - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,20 @@ jobs:
            key: python-linux-alt-{{ checksum "third_party/python/BUILD" }}
            paths: [ ".plz-cache/third_party/python" ]
 
+   lint:
+     working_directory: ~/please
+     docker:
+       - image: thoughtmachine/please_ubuntu:20200226
+     environment:
+       PLZ_ARGS: "-p --profile ci"
+     steps:
+       - checkout
+       - restore_cache:
+           key: go-linux-main-v3-{{ checksum "third_party/go/BUILD" }}
+       - run:
+           name: Lint
+           command: ./pleasew lint
+
    build-darwin:
       macos:
         xcode: "9.0"
@@ -173,6 +187,10 @@ workflows:
     jobs:
       - build-linux
       - build-linux-alt
+      - lint:
+          filters:
+            branches:
+              ignore: master
       - build-darwin:
           requires:
             - build-linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,8 @@ jobs:
      steps:
        - checkout
        - restore_cache:
+           key: go-mod-linux-v4-{{ checksum "go.mod" }}
+       - restore_cache:
            key: go-linux-main-v3-{{ checksum "third_party/go/BUILD" }}
        - run:
            name: Lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,6 @@ jobs:
        - store_test_results:
            path: plz-out/results
        - run:
-           name: Lint
-           command: plz-out/bin/src/please lint
-       - run:
            name: Package
            command: ./plz-out/bin/src/please build //package:all //tools/misc:gen_release //docs:tarball -p
        - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
            key: python-linux-main-{{ checksum "third_party/python/BUILD" }}
        - run:
            name: Bootstrap & Build
-           command: ./bootstrap.sh --exclude no_circleci --test_results_file plz-out/results/please/test_results.xml
+           command: ./bootstrap.sh --test_results_file plz-out/results/please/test_results.xml
        - store_test_results:
            path: plz-out/results
        - run:
@@ -64,7 +64,7 @@ jobs:
            key: python-linux-alt-{{ checksum "third_party/python/BUILD" }}
        - run:
            name: Bootstrap & Build
-           command: ./bootstrap.sh --exclude no_circleci --test_results_file plz-out/results/please/test_results.xml
+           command: ./bootstrap.sh --test_results_file plz-out/results/please/test_results.xml
        - store_test_results:
            path: plz-out/results
        - store_artifacts:
@@ -112,7 +112,7 @@ jobs:
            command: ./.circleci/setup_osx.sh
        - run:
            name: Bootstrap & Build
-           command: ./bootstrap.sh --exclude no_circleci --test_results_file plz-out/results/please/test_results.xml
+           command: ./bootstrap.sh --test_results_file plz-out/results/please/test_results.xml
        - store_test_results:
            path: plz-out/results
        - store_artifacts:

--- a/src/follow/BUILD
+++ b/src/follow/BUILD
@@ -20,9 +20,7 @@ go_library(
 go_test(
     name = "grpc_test",
     srcs = ["grpc_test.go"],
-    # Doesn't seem to work on CircleCI - the client is inexplicably unable to connect
-    # to the server, even though that's running. Maybe something related to its network config?
-    labels = ["no_circleci"],
+    labels = ["manual"],  # Having many issues with this test. Feature is soon to be removed.
     deps = [
         ":follow",
         "//src/cli",

--- a/tools/misc/buildify.sh
+++ b/tools/misc/buildify.sh
@@ -1,2 +1,8 @@
-#!/bin/sh
-exec plz-out/bin/src/please run -p -- //third_party/go:buildifier $@ `git ls-files | grep BUILD$`
+#!/usr/bin/env bash
+
+plz="plz-out/bin/src/please"
+if [ ! -f $plz ]; then
+    plz="./pleasew"
+fi
+
+exec $plz run -p -- //third_party/go:buildifier $@ `git ls-files | grep BUILD$`

--- a/tools/misc/lint.sh
+++ b/tools/misc/lint.sh
@@ -3,6 +3,10 @@
 plz="plz-out/bin/src/please"
 BLACKLIST="src/parse/asp/main|//test|tools/please_pex|third_party"
 
+if [ ! -f $plz ]; then
+    plz="./pleasew"
+fi
+
 # gofmt and go vet
 for TARGET in `$plz query alltargets --include go_src --hidden | grep -v "_test#lib" | grep -v "#main" | grep -v proto | grep -Ev $BLACKLIST`; do
     DIR=`echo $TARGET | cut -f 1 -d ':' | cut -c 3-`


### PR DESCRIPTION
 - Breaks lint out into a separate step
 - Experiment with a bigger resource class to see if builds are a bit faster (the default is 2CPUs but we can definitely make use of more)
 - Disable annoying test (which was already off on circleci but keeps failing on cirrus) - it is to be deleted soon anyway
 - Remove no_circleci since there now aren't any such tests left \o/