### PR TITLE
Improve Windows compatibility of pexes

### DIFF
--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -270,6 +270,12 @@ pip_library(
 )
 
 pip_library(
+    name = "portalocker",
+    version = "1.7.0",
+    licences = ["PSF"],
+)
+
+pip_library(
     name = "pytz",
     test_only = True,
     version = "2018.4",

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -252,6 +252,12 @@ python_wheel(
     deps = [":six"],
 )
 
+python_wheel(
+    name = "portalocker",
+    version = "1.7.0",
+    hashes = ["9fa00efa3102a84ed5281de63189de813f0f83fd"],
+)
+
 pip_library(
     name = "numpy",
     test_only = True,
@@ -267,12 +273,6 @@ pip_library(
         ":numpy",
         ":protobuf",
     ],
-)
-
-pip_library(
-    name = "portalocker",
-    version = "1.7.0",
-    licences = ["PSF"],
 )
 
 pip_library(

--- a/tools/please_pex/BUILD
+++ b/tools/please_pex/BUILD
@@ -49,7 +49,6 @@ genrule(
         "//third_party/python:packaging",
         "//third_party/python:importlib_metadata",
         "//third_party/python:zipp",
-        "//third_party/python:portalocker",
     ],
     outs = ["please_pex"],
     binary = True,

--- a/tools/please_pex/BUILD
+++ b/tools/please_pex/BUILD
@@ -41,6 +41,7 @@ genrule(
         "//third_party/python:behave",
         "//third_party/python:parse",
         "//third_party/python:parse_type",
+        "//third_party/python:portalocker",
         "//third_party/python:traceback2",
         "//third_party/python:enum34",
         "//third_party/python:win_unicode_console",

--- a/tools/please_pex/BUILD
+++ b/tools/please_pex/BUILD
@@ -48,6 +48,7 @@ genrule(
         "//third_party/python:packaging",
         "//third_party/python:importlib_metadata",
         "//third_party/python:zipp",
+        "//third_party/python:portalocker",
     ],
     outs = ["please_pex"],
     binary = True,

--- a/tools/please_pex/pex_main.py
+++ b/tools/please_pex/pex_main.py
@@ -6,7 +6,6 @@ import os
 import runpy
 import sys
 
-import portalocker
 
 PY_VERSION = sys.version_info
 
@@ -276,7 +275,7 @@ def explode_zip():
     This is primarily used for binary extensions which can't be imported directly from
     inside a zipfile.
     """
-    import contextlib
+    import contextlib, portalocker
 
     @contextlib.contextmanager
     def pex_lockfile(basepath, uniquedir):


### PR DESCRIPTION
Basically uses portalocker instead of fcntl so pexes don't blow up at import time.

Obviously this does not particularly help with pexes having appropriately-architectured binary bits, but for a pure-Python one it should work rather better.