### PR TITLE
Shut up glog

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -106,7 +106,9 @@ func (c *Client) CheckInitialised() error {
 // init is passed to the sync.Once to do the actual initialisation.
 func (c *Client) init() {
 	// Disable all logging from glog (which is transitively called from remote-apis-sdks)
-	flag.CommandLine.Parse([]string{"-v", "0", "-log_dir", "/dev/null"})
+	if err := flag.CommandLine.Parse([]string{"-v", "0", "-log_dir", "/dev/null"}); err != nil {
+		log.Warning("%s", err)
+	}
 	var g errgroup.Group
 	g.Go(c.initExec)
 	if c.state.Config.Remote.AssetURL != "" {

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -6,7 +6,6 @@ package remote
 import (
 	"context"
 	"encoding/hex"
-	"flag"
 	"fmt"
 	"path"
 	"strings"
@@ -105,10 +104,6 @@ func (c *Client) CheckInitialised() error {
 
 // init is passed to the sync.Once to do the actual initialisation.
 func (c *Client) init() {
-	// Disable all logging from glog (which is transitively called from remote-apis-sdks)
-	if err := flag.CommandLine.Parse([]string{"-v", "0"}); err != nil {
-		log.Warning("%s", err)
-	}
 	var g errgroup.Group
 	g.Go(c.initExec)
 	if c.state.Config.Remote.AssetURL != "" {

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -106,7 +106,7 @@ func (c *Client) CheckInitialised() error {
 // init is passed to the sync.Once to do the actual initialisation.
 func (c *Client) init() {
 	// Disable all logging from glog (which is transitively called from remote-apis-sdks)
-	if err := flag.CommandLine.Parse([]string{"-v", "0", "-log_dir", "/dev/null"}); err != nil {
+	if err := flag.CommandLine.Parse([]string{"-v", "0"}); err != nil {
 		log.Warning("%s", err)
 	}
 	var g errgroup.Group

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -507,8 +507,8 @@ go_get(
 go_get(
     name = "glog",
     get = "github.com/golang/glog",
-    revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
     patch = "glog_disable.patch",
+    revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
 )
 
 go_get(

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -508,6 +508,7 @@ go_get(
     name = "glog",
     get = "github.com/golang/glog",
     revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
+    patch = "glog_disable.patch",
 )
 
 go_get(

--- a/third_party/go/glog_disable.patch
+++ b/third_party/go/glog_disable.patch
@@ -1,0 +1,20 @@
+diff --git a/glog.go b/glog.go
+index 54bd7af..fda9853 100644
+--- a/glog.go
++++ b/glog.go
+@@ -669,6 +669,7 @@ func (l *loggingT) printWithFileLine(s severity, file string, line int, alsoToSt
+ 
+ // output writes the data to the log files and releases the buffer.
+ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoToStderr bool) {
++	return
+ 	l.mu.Lock()
+ 	if l.traceLocation.isSet() {
+ 		if l.traceLocation.match(file, line) {
+@@ -997,6 +998,7 @@ type Verbose bool
+ // V is at least the value of -v, or of -vmodule for the source file containing the
+ // call, the V call will log.
+ func V(level Level) Verbose {
++	return Verbose(false)
+ 	// This function tries hard to be cheap unless there's work to do.
+ 	// The fast path is two atomic loads and compares.
+ 


### PR DESCRIPTION
Turns out I'm still getting a bunch of annoying log files in /tmp. Can't figure out why `-v 0` wasn't sufficient to shut it up, so going back to a patch.