### PR TITLE
Fix TestFileGroupBinDir when umask is not defualt

### DIFF
--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -241,10 +241,15 @@ func TestFileGroupBinDir(t *testing.T) {
 	assert.True(t, fs.FileExists("plz-out/bin/package1/package2/file1.py"))
 	assert.True(t, fs.IsDirectory("plz-out/bin/package1/package2/"))
 
-	// Ensure correct permission on directory
+	// Ensure permissions on directory are not modified
 	info, err := os.Stat("plz-out/bin/package1/package2/")
 	assert.NoError(t, err)
-	assert.Equal(t, os.FileMode(0755), info.Mode().Perm())
+    compare_dir := "plz-out/bin/package1/package2_cmp/"
+    os.Mkdir(compare_dir, core.DirPermissions)
+    info_cmp, err := os.Stat(compare_dir)
+    assert.NoError(t, err)
+
+    assert.Equal(t, info_cmp.Mode().Perm(), info.Mode().Perm())
 }
 
 func TestOutputHash(t *testing.T) {


### PR DESCRIPTION
TestFileGroupBinDir failed if umask did not have the usual value 0022.
The test is verifying that when please creates a new directory, it won't
modify its permissions.
So instead of comparing against a specific set
of permissions (which depend on the environment) it's simpler to create
a new dir on the spot and check that its permissions are the same for
the directories that please created.