### PR TITLE
Add conditional logic for parsing go 1.14 output

### DIFF
--- a/src/test/go_results.go
+++ b/src/test/go_results.go
@@ -86,7 +86,7 @@ func parseGoTestResults(data []byte) (core.TestSuite, error) {
 				output := strings.Join(outputLines, "\n")
 				testCase.Executions = append(testCase.Executions, core.TestExecution{
 					Failure: &core.TestResultFailure{
-						Traceback: string(output),
+						Traceback: output,
 					},
 					Stderr:   strings.Join(testOutput, ""),
 					Duration: &duration,

--- a/src/test/test_data/go_test_fail_1_14.txt
+++ b/src/test/test_data/go_test_fail_1_14.txt
@@ -1,0 +1,11 @@
+=== RUN   TestSomething
+    TestSomething: my_test.go:8: This thing is also here
+    TestSomething: my_test.go:9: This test is skipped
+--- SKIP: TestSomething (0.00s)
+=== RUN   TestPass
+    TestPass: my_test.go:13: This is passing
+--- PASS: TestPass (0.00s)
+=== RUN   TestFail
+    TestFail: my_test.go:17: This test is going to fail.
+--- FAIL: TestFail (0.00s)
+FAIL

--- a/src/test/test_data/go_test_skip_1_14.txt
+++ b/src/test/test_data/go_test_skip_1_14.txt
@@ -1,0 +1,11 @@
+=== RUN   TestSomething
+    TestSomething: my_test.go:8: This thing is also here
+    TestSomething: my_test.go:9: This test is skipped
+--- SKIP: TestSomething (0.00s)
+=== RUN   TestPass
+    TestPass: my_test.go:13: This is passing
+--- PASS: TestPass (0.00s)
+=== RUN   TestFail
+    TestFail: my_test.go:17: This test is going to fail.
+--- FAIL: TestFail (0.00s)
+FAIL


### PR DESCRIPTION
Go 1.14 slightly changes the format of the output of `go test`, such that test output occurs before the test result line, instead of afterwards. This PR adds some additional logic to the test package to take these differences into account.