### PR TITLE
Support --num_runs meaningfully for remote execution

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -161,6 +161,9 @@ func (c *Client) buildTestCommand(target *core.BuildTarget) (*pb.Command, error)
 	}
 	const commandPrefix = "export TMP_DIR=\"`pwd`\" TEST_DIR=\"`pwd`\" && "
 	cmd, err := core.ReplaceTestSequences(c.state, target, target.GetTestCommand(c.state))
+	if len(c.state.TestArgs) != 0 {
+		cmd += " " + strings.Join(c.state.TestArgs, " ")
+	}
 	return &pb.Command{
 		Platform: &pb.Platform{
 			Properties: []*pb.Platform_Property{

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -441,8 +441,10 @@ func (c *Client) maybeRetrieveResults(tid int, target *core.BuildTarget, command
 // execute submits an action to the remote executor and monitors its progress.
 // The returned ActionResult may be nil on failure.
 func (c *Client) execute(tid int, target *core.BuildTarget, command *pb.Command, digest *pb.Digest, timeout time.Duration, isTest, needStdout bool) (*core.BuildMetadata, *pb.ActionResult, error) {
-	if metadata, ar := c.maybeRetrieveResults(tid, target, command, digest, needStdout); metadata != nil {
-		return metadata, ar, nil
+	if !isTest || c.state.NumTestRuns == 1 {
+		if metadata, ar := c.maybeRetrieveResults(tid, target, command, digest, needStdout); metadata != nil {
+			return metadata, ar, nil
+		}
 	}
 	// We didn't actually upload the inputs before, so we must do so now.
 	command, digest, err := c.uploadAction(target, isTest, false)


### PR DESCRIPTION
Basically don't allow it to be cached (otherwise you immediately get the cached results back n times). Also honour test args.