### PR TITLE
Always write the test coverage file from go tests

### DIFF
--- a/tools/please_go_test/gotest/write_test_main.go
+++ b/tools/please_go_test/gotest/write_test_main.go
@@ -21,15 +21,17 @@ type testDescr struct {
 	Examples  []*doc.Example
 	CoverVars []CoverVar
 	Imports   []string
+	Coverage  bool
 }
 
 // WriteTestMain templates a test main file from the given sources to the given output file.
 // This mimics what 'go test' does, although we do not currently support benchmarks or examples.
-func WriteTestMain(pkgDir, importPath string, sources []string, output string, coverVars []CoverVar) error {
+func WriteTestMain(pkgDir, importPath string, sources []string, output string, coverage bool, coverVars []CoverVar) error {
 	testDescr, err := parseTestSources(sources)
 	if err != nil {
 		return err
 	}
+	testDescr.Coverage = coverage
 	testDescr.CoverVars = coverVars
 	if len(testDescr.Functions) > 0 || len(testDescr.Examples) > 0 {
 		// Can't set this if there are no test functions, it'll be an unused import.
@@ -152,7 +154,7 @@ var examples = []testing.InternalExample{
 {{end}}
 }
 
-{{if .CoverVars}}
+{{if .Coverage}}
 
 // Only updated by init functions, so no need for atomicity.
 var (
@@ -192,7 +194,7 @@ func coverRegisterFile(fileName string, counter []uint32, pos []uint32, numStmts
 var testDeps = testdeps.TestDeps{}
 
 func main() {
-{{if .CoverVars}}
+{{if .Coverage}}
 	testing.RegisterCover(testing.Cover{
 		Mode: "set",
 		Counters: coverCounters,

--- a/tools/please_go_test/gotest/write_test_main_test.go
+++ b/tools/please_go_test/gotest/write_test_main_test.go
@@ -51,6 +51,7 @@ func TestWriteTestMain(t *testing.T) {
 		"",
 		[]string{"tools/please_go_test/gotest/test_data/test/example_test.go"},
 		"test.go",
+		false,
 		[]CoverVar{},
 	)
 	assert.NoError(t, err)
@@ -67,6 +68,7 @@ func TestWriteTestMainWithCoverage(t *testing.T) {
 		"",
 		[]string{"tools/please_go_test/gotest/test_data/test/example_test.go"},
 		"test.go",
+		true,
 		[]CoverVar{{
 			Dir:        "tools/please_go_test/gotest/test_data",
 			ImportPath: "core",

--- a/tools/please_go_test/plz_go_test.go
+++ b/tools/please_go_test/plz_go_test.go
@@ -35,7 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error scanning for coverage: %s", err)
 	}
-	if err = gotest.WriteTestMain(opts.Package, opts.ImportPath, opts.Args.Sources, opts.Output, coverVars); err != nil {
+	if err = gotest.WriteTestMain(opts.Package, opts.ImportPath, opts.Args.Sources, opts.Output, opts.Dir != "", coverVars); err != nil {
 		log.Fatalf("Error writing test main: %s", err)
 	}
 	os.Exit(0)


### PR DESCRIPTION
Even if we don't find any variables. Confuses things like rex a bit less.