### PR TITLE
show skip message in plz test output if detailed output is enabled

### DIFF
--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -284,10 +284,10 @@ func printTestResults(state *core.BuildState, failedTargets []core.BuildLabel, f
 					}
 					format := fmt.Sprintf("%%-%ds", width+1)
 					for _, result := range target.Results.TestCases {
-						printf("    %s\n", formatTestCase(result, fmt.Sprintf(format, result.Name)))
+						printf("    %s\n", formatTestCase(result, fmt.Sprintf(format, result.Name), detailed))
 						if len(result.Executions) > 1 {
 							for run, execution := range result.Executions {
-								printf("        RUN %d: %s\n", run+1, formatTestExecution(execution))
+								printf("        RUN %d: %s\n", run+1, formatTestExecution(execution, detailed))
 								if state.ShowTestOutput {
 									showExecutionOutput(execution)
 								}
@@ -320,7 +320,7 @@ func showExecutionOutput(execution core.TestExecution) {
 	}
 }
 
-func formatTestCase(result core.TestCase, name string) string {
+func formatTestCase(result core.TestCase, name string, detailed bool) string {
 	if len(result.Executions) == 0 {
 		return fmt.Sprintf("%s (No results)", formatTestName(result, name))
 	}
@@ -338,7 +338,7 @@ func formatTestCase(result core.TestCase, name string) string {
 	} else if len(result.Failures()) > 0 {
 		outcome = result.Failures()[0]
 	}
-	return fmt.Sprintf("%s %s", formatTestName(result, name), formatTestExecution(outcome))
+	return fmt.Sprintf("%s %s", formatTestName(result, name), formatTestExecution(outcome, detailed))
 }
 
 func formatTestName(testCase core.TestCase, name string) string {
@@ -357,7 +357,7 @@ func formatTestName(testCase core.TestCase, name string) string {
 	return testCase.Name
 }
 
-func formatTestExecution(execution core.TestExecution) string {
+func formatTestExecution(execution core.TestExecution, detailed bool) string {
 	if execution.Error != nil {
 		return "${BOLD_CYAN}ERROR${RESET}"
 	}
@@ -365,8 +365,12 @@ func formatTestExecution(execution core.TestExecution) string {
 		return fmt.Sprintf("${BOLD_RED}FAIL${RESET} %s", maybeToString(execution.Duration))
 	}
 	if execution.Skip != nil {
+		if detailed {
+			return fmt.Sprintf("${BOLD_YELLOW}SKIP\n        Reason:${RESET} %s", execution.Skip.Message)
+		}
 		// Not usually interesting to have a duration when we did no work.
 		return "${BOLD_YELLOW}SKIP${RESET}"
+
 	}
 	return fmt.Sprintf("${BOLD_GREEN}PASS${RESET} %s", maybeToString(execution.Duration))
 }


### PR DESCRIPTION
Show skip message for skipped tests if `--detailed` flag is passed into `plz test`

Example output:

```
plz test //src/test:all --detailed
//src/test:coverage_test 12 tests run in 0s; 12 passed [cached]
    TestCoverageNotRequired   PASS  0s
    TestTargetIsRecorded      PASS  0s
    TestPythonResults         PASS  0s
    TestGoResults             PASS  0s
    TestGoResults2            PASS  0s
    TestGoResults3            PASS  0s
    TestParseBlocks           PASS  0s
    TestGcovParsing           PASS  0s
    TestIstanbulCoverage      PASS  0s
    TestIstanbulCoverage2     PASS  0s
    TestIncrementalStats      PASS  0s
    TestGetDirectoryCoverage  PASS  0s
//src/test:results_test 19 tests run in 0s; 18 passed, 1 skipped [cached]
    TestGoFailure                  PASS  0s
    TestGoPassed                   PASS  0s
    TestGoMultipleFailure          PASS  0s
    TestGoSkipped                  PASS  0s
    TestGoSkippedMessage           PASS  0s
    TestGoSkippedMessage114        PASS  0s
    TestGoFailedTraceback          PASS  0s
    TestGoFailedTracebackGo114     PASS  0s
    TestGoSubtests                 PASS  0s
    TestBuckXML                    SKIP
        Reason: TestBuckXML: results_test.go:110: This format matches nothing we generate or care about
    TestJUnitXML                   PASS  0s
    TestKarmaXML                   PASS  0s
    TestUnitTestXML                PASS  0s
    TestSkip                       PASS  0s
    TestGoSuite                    PASS  0s
    TestGoIgnoreUnknownOutput      PASS  0s
    TestGoFailIfUnknownTestPasses  PASS  0s
    TestParseGoFileWithNoTests     PASS  0s
    TestParseGoFileWithLogging     PASS  0s
//src/test:xml_results_test 2 tests run in 0s; 2 passed [cached]
    TestParseJUnitXMLResults_oneSuccessfulTest  PASS  0s
    TestUpload                                  PASS  0s
3 test targets and 33 tests run in 0s; 32 passed, 1 skipped. Total time 190ms.
```