### PR TITLE
Update IsOriginalTarget checks a bit

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -65,7 +65,7 @@ func Build(tid int, state *core.BuildState, label core.BuildLabel, remote bool) 
 			state.AddPendingBuild(reverseDep.Label, false)
 		}
 	}
-	if target.IsTest && state.NeedTests && ((state.IsOriginalTarget(target.Label) && state.ShouldInclude(target)) || state.IsExactOriginalTarget(target.Label)) {
+	if target.IsTest && state.NeedTests && state.IsOriginalTarget(target) {
 		if state.TestSequentially {
 			state.AddPendingTest(target.Label, 1)
 		} else {
@@ -161,7 +161,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 	}
 
 	state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Preparing...")
-	if state.PrepareOnly && state.IsOriginalTarget(target.Label) {
+	if state.PrepareOnly && state.IsOriginalTarget(target) {
 		return prepareOnly(tid, state, target)
 	}
 
@@ -688,7 +688,7 @@ func calculateAndCheckRuleHash(state *core.BuildState, target *core.BuildTarget)
 		return nil, err
 	}
 	if err = checkRuleHashes(state, target, hash); err != nil {
-		if state.NeedHashesOnly && (state.IsOriginalTarget(target.Label) || state.IsOriginalTarget(target.Label.Parent())) {
+		if state.NeedHashesOnly && state.IsOriginalTargetOrParent(target) {
 			return nil, errStop
 		} else if state.VerifyHashes {
 			return nil, err

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -101,7 +101,7 @@ func needsBuilding(state *core.BuildState, target *core.BuildTarget, postBuild b
 		}
 	}
 	// Maybe we've forced a rebuild. Do this last; might be interesting to see if it needed building anyway.
-	return state.ForceRebuild && (state.IsOriginalTarget(target.Label) || state.IsOriginalTarget(target.Label.Parent()))
+	return state.ShouldRebuild(target)
 }
 
 // b64 base64 encodes a string of bytes for printing.

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -390,8 +390,12 @@ func (state *BuildState) CloseResults() {
 
 // IsOriginalTarget returns true if a target is an original target, ie. one specified on the command line.
 func (state *BuildState) IsOriginalTarget(target *BuildTarget) bool {
+	return state.isOriginalTarget(target, false)
+}
+
+func (state *BuildState) isOriginalTarget(target *BuildTarget, exact bool) bool {
 	for _, original := range state.OriginalTargets {
-		if original == target.Label || (original.IsAllTargets() && original.PackageName == target.Label.PackageName && state.ShouldInclude(target)) {
+		if original == target.Label || (!exact && original.IsAllTargets() && original.PackageName == target.Label.PackageName && state.ShouldInclude(target)) {
 			return true
 		}
 	}
@@ -638,7 +642,7 @@ func (state *BuildState) expandOriginalPseudoTarget(label BuildLabel) BuildLabel
 func (state *BuildState) ExpandVisibleOriginalTargets() BuildLabels {
 	ret := BuildLabels{}
 	for _, target := range state.ExpandOriginalTargets() {
-		if !target.HasParent() || state.IsOriginalTarget(state.Graph.TargetOrDie(target)) {
+		if !target.HasParent() || state.isOriginalTarget(state.Graph.TargetOrDie(target), true) {
 			ret = append(ret, target)
 		}
 	}

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -729,6 +729,12 @@ func (state *BuildState) ShouldDownload(target *BuildTarget) bool {
 	return (state.IsOriginalTarget(target.Label) && state.DownloadOutputs && !state.NeedTests) || target.NeededForSubinclude
 }
 
+// ShouldRebuild returns true if we should force a rebuild of this target (i.e. the user
+// has done plz build --rebuild where we would not otherwise build it).
+func (state *BuildState) ShouldRebuild(target *BuildTarget) bool {
+	return state.ForceRebuild && (state.IsOriginalTarget(target.Label) || state.IsOriginalTarget(target.Label.Parent()))
+}
+
 // ensureDownloaded ensures that a target has been downloaded when built remotely.
 // If remote execution is not enabled it has no effect.
 func (state *BuildState) ensureDownloaded(target *BuildTarget) {

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -423,7 +423,7 @@ func (c *Client) retrieveResults(target *core.BuildTarget, command *pb.Command, 
 // maybeRetrieveResults is like retrieveResults but only retrieves if we aren't forcing a rebuild of the target
 // (i.e. not if we're doing plz build --rebuild).
 func (c *Client) maybeRetrieveResults(tid int, target *core.BuildTarget, command *pb.Command, digest *pb.Digest, needStdout bool) (*core.BuildMetadata, *pb.ActionResult) {
-	if !(c.state.ForceRebuild && (c.state.IsOriginalTarget(target.Label) || c.state.IsOriginalTarget(target.Label.Parent()))) {
+	if !c.state.ShouldRebuild(target) {
 		c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Checking remote...")
 		if metadata, ar := c.retrieveResults(target, command, digest, needStdout); metadata != nil {
 			return metadata, ar


### PR DESCRIPTION
Centralises the logic about checking :all against --include etc. Currently this doesn't happen consistently.