### PR TITLE
Fix go test parsing

### DIFF
--- a/src/test/go_results.go
+++ b/src/test/go_results.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	parser "github.com/jstemmer/go-junit-report/parser"
+	parser "github.com/peterebden/go-junit-report/parser"
 
 	"github.com/thought-machine/please/src/core"
 )
@@ -34,7 +34,6 @@ func fromGoJunitReport(report *parser.Report) core.TestSuite {
 		for _, test := range pkg.Tests {
 			coreTestCase := core.TestCase{Name: test.Name}
 			testOutput := strings.Join(test.Output, "\n")
-
 			if test.Result == parser.PASS {
 				coreTestCase.Executions = append(coreTestCase.Executions, core.TestExecution{
 					Stderr:   testOutput,

--- a/src/test/results_test.go
+++ b/src/test/results_test.go
@@ -181,3 +181,11 @@ func TestParseGoFileWithLogging(t *testing.T) {
 	assert.Equal(t, 3, results.Passes())
 	assert.Equal(t, 0, results.Failures())
 }
+
+func TestParseGoFileWithAssertion(t *testing.T) {
+	results, err := parseTestResultsFile("src/test/test_data/go_test_assertion.txt")
+	assert.NoError(t, err)
+	assert.Equal(t, 6, len(results.TestCases))
+	assert.NotNil(t, results.TestCases[3].Executions[0].Error)
+	assert.Contains(t, results.TestCases[3].Executions[0].Error.Message, "expected: core.BuildLabels")
+}

--- a/src/test/test_data/go_test_assertion.txt
+++ b/src/test/test_data/go_test_assertion.txt
@@ -1,0 +1,28 @@
+=== RUN   TestExpandOriginalTargets
+--- PASS: TestExpandOriginalTargets (0.00s)
+=== RUN   TestExpandOriginalTestTargets
+--- PASS: TestExpandOriginalTestTargets (0.00s)
+=== RUN   TestExpandVisibleOriginalTargets
+    TestExpandVisibleOriginalTargets: state_test.go:56: 
+        	Error Trace:	state_test.go:56
+        	Error:      	Not equal: 
+        	            	expected: core.BuildLabels{core.BuildLabel{PackageName:"src/core", Name:"_target1#zip", Subrepo:""}, core.BuildLabel{PackageName:"src/core", Name:"target1", Subrepo:""}}
+        	            	actual  : core.BuildLabels{core.BuildLabel{PackageName:"src/core", Name:"target1", Subrepo:""}}
+        	            	
+        	            	Diff:
+        	            	--- Expected
+        	            	+++ Actual
+        	            	@@ -1,3 +1,2 @@
+        	            	-(core.BuildLabels) (len=2) {
+        	            	- (core.BuildLabel) //src/core:_target1#zip,
+        	            	+(core.BuildLabels) (len=1) {
+        	            	  (core.BuildLabel) //src/core:target1
+        	Test:       	TestExpandVisibleOriginalTargets
+--- FAIL: TestExpandVisibleOriginalTargets (0.00s)
+=== RUN   TestExpandOriginalSubTargets
+--- PASS: TestExpandOriginalSubTargets (0.00s)
+=== RUN   TestExpandOriginalTargetsOrdering
+--- PASS: TestExpandOriginalTargetsOrdering (0.00s)
+=== RUN   TestComparePendingTasks
+--- PASS: TestComparePendingTasks (0.00s)
+FAIL

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -640,7 +640,7 @@ go_get(
 
 go_get(
     name = "go-junit-report",
-    get = "github.com/jstemmer/go-junit-report/...",
+    get = "github.com/peterebden/go-junit-report/parser",
     licences = ["MIT"],
-    revision = "984a47ca6b0a7d704c4b589852051b4d7865aa17",
+    revision = "7884553bc963d73b0d1e2fbd55dfa8df5ae9f010",
 )


### PR DESCRIPTION
Basically the lib is overwriting most of the useful test output which makes it quite hard to see what's gone on in your test :)
The fix appears to be fairly straightforward, fortunately; I've done it on a fork for now.