### PR TITLE
Fix plz test when more than one test argument is provided

### DIFF
--- a/src/test/results.go
+++ b/src/test/results.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
@@ -83,7 +84,8 @@ func LoadPreviousFailures(filename string) ([]core.BuildLabel, []string) {
 	args := []string{}
 	for _, suite := range junit.TestSuites {
 		if suite.Failures > 0 {
-			labels = append(labels, core.ParseBuildLabel(suite.Name, "")) // These always have complete labels
+			labels = append(labels, core.NewBuildLabel(
+				strings.Replace(suite.Package, ".", "/", -1), suite.Name))
 			for _, c := range suite.TestCases {
 				if c.Failure != nil || c.Error != nil {
 					args = append(args, c.Name)

--- a/tools/please_go_test/gotest/write_test_main.go
+++ b/tools/please_go_test/gotest/write_test_main.go
@@ -135,6 +135,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
     "testing/internal/testdeps"
 
@@ -208,7 +209,8 @@ func main() {
 {{end}}
     testVar := os.Getenv("TESTS")
     if testVar != "" {
-        args = append(args, "-test.run", testVar)
+		testVar = strings.Replace(testVar, " ", "|", -1)
+		args = append(args, "-test.run", testVar)
     }
     os.Args = append(args, os.Args[1:]...)
 	m := testing.MainStart(testDeps, tests, nil, examples)


### PR DESCRIPTION
I've fixed the `LoadPreviousFailures` method to use the correct build label and thus resolve the issue with `plz test --failed` not working.

There was also a problem with `plz test` not working when a target was provided along with more than one test argument. (It works when a single argument is provided)
