### PR TITLE
Output package check fix

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -690,21 +690,21 @@ func (target *BuildTarget) CheckTargetOwnsBuildOutputs(state *BuildState) error 
 	}
 
 	for _, output := range target.outputs {
+		targetPackage := target.Label.PackageName
+		out := filepath.Join(targetPackage, output)
+
+		if fs.IsPackage(state.Config.Parse.BuildFileName, out) {
+			return fmt.Errorf("trying to output file %s, but that directory is another package", out)
+		}
+
 		// If the output is just a file in the package root, we don't need to check anything else.
 		if filepath.Dir(output) == "." {
 			continue
 		}
 
-		targetPackage := target.Label.PackageName
-		out := filepath.Join(target.Label.PackageName, output)
-
 		pkg := FindOwningPackage(state, out)
 		if targetPackage != pkg.PackageName {
 			return fmt.Errorf("trying to output file %s, but that directory belongs to another package (%s)", out, pkg.PackageName)
-		}
-
-		if fs.IsPackage(state.Config.Parse.BuildFileName, out) {
-			return fmt.Errorf("trying to output file %s, but that directory is another package", out)
 		}
 	}
 	return nil

--- a/src/core/package.go
+++ b/src/core/package.go
@@ -235,22 +235,21 @@ func FindOwningPackages(state *BuildState, files []string) []BuildLabel {
 	ret := make([]BuildLabel, len(files))
 	for i, file := range files {
 		ret[i] = FindOwningPackage(state, file)
+		if ret[i].PackageName == "" {
+			log.Fatalf("No BUILD file owns file %s", file)
+		}
 	}
 	return ret
 }
 
 // FindOwningPackage returns a build label identifying the package that owns a given file.
 func FindOwningPackage(state *BuildState, file string) BuildLabel {
-	f := file
+	f := path.Dir(file)
 	for f != "." {
-		f = path.Dir(f)
 		if fs.IsPackage(state.Config.Parse.BuildFileName, f) {
-			if f == "." {
-				return BuildLabel{PackageName: "", Name: "all"}
-			}
 			return BuildLabel{PackageName: f, Name: "all"}
 		}
+		f = path.Dir(f)
 	}
-	log.Fatalf("No BUILD file owns file %s", file)
-	return BuildLabel{}
+	return BuildLabel{PackageName: "", Name: "all"}
 }


### PR DESCRIPTION
When the pleasings subrepo is included, it is in the // package however not all repos have a BUILD file there. This rule is synthetic so it belongs to a package that doesn't really exist on the filesystem. This means that we were getting a panic when trying to check this sub-repo rule owns it's outputs. 

This PR makes the FindPackage function return package "" instead of panicking when it can't find a BUILD file effectively adding an imaginary BUILD file in the repo root. 