### PR TITLE
Only print failures once

### DIFF
--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -206,7 +206,12 @@ func processResult(state *core.BuildState, result *core.BuildResult, buildingTar
 
 func printTestResults(state *core.BuildState, failedTargets []core.BuildLabel, failedTargetsMap map[core.BuildLabel]error, duration time.Duration, detailed bool) {
 	if len(failedTargets) > 0 {
+		done := map[core.BuildLabel]bool{}
 		for _, failed := range failedTargets {
+			if done[failed] {
+				continue
+			}
+			done[failed] = true
 			target := state.Graph.TargetOrDie(failed)
 			if target.Results.Failures() == 0 && target.Results.Errors() == 0 {
 				if target.Results.TimedOut {


### PR DESCRIPTION
Looks like the targets have all failure messages aggregated onto them, and we also print each target once per failed run, so given `-n 3` we get 9 failures instead of 3.