### PR TITLE
Don't complain about empty coverage output

### DIFF
--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -370,7 +370,7 @@ func doTestResults(tid int, state *core.BuildState, target *core.BuildTarget, ru
 }
 
 func parseRemoteCoverage(state *core.BuildState, target *core.BuildTarget, coverage []byte, run int) (*core.TestCoverage, error) {
-	if !state.NeedCoverage {
+	if !state.NeedCoverage || len(coverage) == 0 {
 		return core.NewTestCoverage(), nil
 	}
 	return parseTestCoverage(target, coverage, run)


### PR DESCRIPTION
This mimics the behaviour when running locally (there is no equivalent to `no_test_output`, if the test doesn't produce a coverage file we just assume it doesn't know how and carry on)