### PR TITLE
Don't try to download artifacts for targets that were built locally

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -322,6 +322,9 @@ func (c *Client) build(tid int, target *core.BuildTarget) (*core.BuildMetadata, 
 
 // Download downloads outputs for the given target.
 func (c *Client) Download(target *core.BuildTarget) error {
+	if target.Local {
+		return nil // No download needed since this target was built locally
+	}
 	return c.download(target, func() error {
 		command, digest, err := c.buildAction(target, false, target.Stamp)
 		if err != nil {


### PR DESCRIPTION
It won't work since they don't have an action result, and the files must be available locally anyway.