### PR TITLE
A start on Java toolchains

### DIFF
--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -1,7 +1,12 @@
 """Built-in rules to compile Java code."""
 
-def java_toolchain(name : str, sdk_url : str, visibility:list = ["PUBLIC"]) -> str:
+def java_toolchain(name : str, sdk_url : str|dict, visibility:list = ["PUBLIC"]) -> str:
     current_package = package_name()
+
+    sdk_url = sdk_url if isinstance(sdk_url, str) else sdk_url[CONFIG.OS]
+
+    if not sdk_url:
+        raise ParseError(f"No java sdk_url defined for platform {CONFIG.OS}")
 
     download = remote_file(
         name=f"_{name}#download",

--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -506,6 +506,60 @@ def _jarcat_cmd(main_class=None, preamble=None, manifest=None):
         cmd += ' --manifest "$SRCS"'
     return cmd, {'jarcat': [CONFIG.JARCAT_TOOL]}
 
+# This function is exposed as java_toolchain unless Bazel compatibility is enabled in which case it is exposed as
+# please_java_toolchain. This is to avoid namespace conflicts with Bazel's java_toolchain rule. 
+def _java_toolchain(name : str, jdk_url : str|dict, visibility:list = ["PUBLIC"]) -> str:
+    """Downloads the JDK and sets up build rule metadata so the language rules can use the toolchain"""
+    current_package = package_name()
+
+    jdk_url = jdk_url if isinstance(jdk_url, str) else jdk_url[CONFIG.OS]
+
+    if not jdk_url:
+        raise ParseError(f"No java jdk_url defined for platform {CONFIG.OS}")
+
+    download = remote_file(
+        name=f"_{name}#download",
+        url = jdk_url,
+        visibility = visibility,
+    )
+
+    javac = sh_cmd(
+        name=f"_{name}#javac",
+        cmd=f"$(location //{current_package}:{name})/bin/javac \\\$@",
+        visibility = visibility,
+        deps = [f"//{current_package}:{name}"],
+    )
+
+    java = sh_cmd(
+        name=f"_{name}#java",
+        cmd=f"$(location //{current_package}:{name})/bin/java \\\$@",
+        visibility = visibility,
+        deps = [f"//{current_package}:{name}"],
+    )
+
+    md = {
+        "deps": [f"//{current_package}:{name}"],
+        "javac": f"//{current_package}" + javac,
+        "java": f"//{current_package}" + java,
+    }
+
+    return build_rule(
+        name = name,
+        srcs = [download],
+        outs = [name],
+        tools = [CONFIG.JARCAT_TOOL],
+        cmd = " && ".join([
+            '"$TOOL" x $SRCS -o extract_dir',
+            'mkdir $OUT && mkdir $OUT/bin',
+            'mv $(find extract_dir -name javac) $OUT/bin',
+            'mv $(find extract_dir -name java) $OUT/bin',
+            'mv $(find extract_dir -name lib) $OUT',
+        ]),
+        building_description = 'Extracting...',
+        metadata = md,
+        binary = True,
+        visibility = visibility,
+    )
 
 if CONFIG.BAZEL_COMPATIBILITY:
     def java_toolchain(javac=None, source_version=None, target_version=None):
@@ -530,55 +584,7 @@ if CONFIG.BAZEL_COMPATIBILITY:
             test_only = test_only,
             visibility = visibility,
         )
+
+    please_java_toolchain = _java_toolchain
 else:
-    def java_toolchain(name : str, sdk_url : str|dict, visibility:list = ["PUBLIC"]) -> str:
-        current_package = package_name()
-
-        sdk_url = sdk_url if isinstance(sdk_url, str) else sdk_url[CONFIG.OS]
-
-        if not sdk_url:
-            raise ParseError(f"No java sdk_url defined for platform {CONFIG.OS}")
-
-        download = remote_file(
-            name=f"_{name}#download",
-            url = sdk_url,
-            visibility = visibility,
-        )
-
-        javac = sh_cmd(
-            name=f"_{name}#javac",
-            cmd=f"$(location //{current_package}:{name})/bin/javac \\\$@",
-            visibility = visibility,
-            deps = [f"//{current_package}:{name}"],
-        )
-
-        java = sh_cmd(
-            name=f"_{name}#java",
-            cmd=f"$(location //{current_package}:{name})/bin/java \\\$@",
-            visibility = visibility,
-            deps = [f"//{current_package}:{name}"],
-        )
-
-        md = {
-            "deps": [f"//{current_package}:{name}"],
-            "javac": f"//{current_package}" + javac,
-            "java": f"//{current_package}" + java,
-        }
-
-        return build_rule(
-            name = name,
-            srcs = [download],
-            outs = [name],
-            tools = [CONFIG.JARCAT_TOOL],
-            cmd = " && ".join([
-                '"$TOOL" x $SRCS -o extract_dir',
-                'mkdir $OUT && mkdir $OUT/bin',
-                'mv $(find extract_dir -name javac) $OUT/bin',
-                'mv $(find extract_dir -name java) $OUT/bin',
-                'mv $(find extract_dir -name lib) $OUT',
-            ]),
-            building_description = 'Extracting...',
-            metadata = md,
-            binary = True,
-            visibility = visibility,
-        )
+    java_toolchain = _java_toolchain

--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -1,9 +1,55 @@
 """Built-in rules to compile Java code."""
 
+def java_toolchain(name : str, sdk_url : str, visibility:list = ["PUBLIC"]) -> str:
+    current_package = package_name()
+
+    download = remote_file(
+        name=f"_{name}#download",
+        url = sdk_url,
+        visibility = visibility,
+    )
+
+    javac = sh_cmd(
+        name=f"_{name}#javac",
+        cmd=f"$(location //{current_package}:{name})/bin/javac \\\$@",
+        visibility = visibility,
+        deps = [f"//{current_package}:{name}"],
+    )
+
+    java = sh_cmd(
+        name=f"_{name}#java",
+        cmd=f"$(location //{current_package}:{name})/bin/java \\\$@",
+        visibility = visibility,
+        deps = [f"//{current_package}:{name}"],
+    )
+
+    md = {
+        "deps": [f"//{current_package}:{name}"],
+        "javac": f"//{current_package}" + javac,
+        "java": f"//{current_package}" + java,
+    }
+
+    return build_rule(
+        name = name,
+        srcs = [download],
+        outs = [name],
+        tools = [CONFIG.JARCAT_TOOL],
+        cmd = " && ".join([
+            '"$TOOL" x $SRCS -o extract_dir',
+            'mkdir $OUT && mkdir $OUT/bin',
+            'mv $(find extract_dir -name javac) $OUT/bin',
+            'mv $(find extract_dir -name java) $OUT/bin',
+            'mv $(find extract_dir -name lib) $OUT',
+        ]),
+        building_description = 'Extracting...',
+        metadata = md,
+        binary = True,
+        visibility = visibility,
+    )
 
 def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], resources_root:str=None,
                  deps:list=[], modular:bool=False, exported_deps:list=None, visibility:list=None,
-                 test_only:bool&testonly=False, javac_flags:list&javacopts=None, labels:list=[]):
+                 test_only:bool&testonly=False, javac_flags:list&javacopts=None, labels:list=[], toolchain:str=''):
     """Compiles Java source to a .jar which can be collected by other rules.
 
     Args:
@@ -25,9 +71,11 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], 
       javac_flags (list): List of flags passed to javac.
       labels (list): Additional labels to apply to this rule.
     """
+    toolchain = toolchain if toolchain else CONFIG.JAVA_TOOLCHAIN
+
     resources_cmd = 'true'
     if resources:
-        # TODO(macripps): Check this actually matches the documented behaviour, as it's not clear it does
+        # TODO(jpoole): Check this actually matches the documented behaviour, as it's not clear it does
         if resources_root:
             resources_cmd = f'$(for SRC in $SRCS_RESOURCES; do DEST=${SRC#"{resources_root}"};mkdir -p $(dirname "_tmp/$DEST");cp "$SRC" "_tmp/$DEST"; done)'
         else:
@@ -51,14 +99,26 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], 
         else:
             javac_flags = f'-source {CONFIG.JAVA_SOURCE_LEVEL} -target {CONFIG.JAVA_TARGET_LEVEL} ' + javac_flags
 
-        if not CONFIG.JAVAC_TOOL:
+        javac = CONFIG.JAVAC_TOOL
+
+        # Override old config if we have a toolchain c configured
+        if toolchain:
+            jdk_info = get_rule_metadata(toolchain)
+
+            deps += jdk_info.deps
+            javac = jdk_info.javac
+
+        if javac:
+            find = r'`find "$TMP_DIR" -name "*.jar" | tr \\\\n :`'
+            srcflag = '`find $SRCS_WORKER -name "*.java"`' if src_dir else '$SRCS_WORKER'
+            javac_cmd = f'mkdir -p _tmp/META-INF && "$TOOLS_JAVAC" {javac_flags} -classpath .:{find} -d _tmp {srcflag}'
+        else:
+            # TODO(jpoole): add worker to toolchain (probably need to just invoke the jar with the correct version of java)
+            javac = CONFIG.JAVAC_WORKER
             mflag = '--modular' if modular else ''
             srcflag = '--src_dir' if src_dir else ''
             javac_cmd = f'$(worker {CONFIG.JAVAC_WORKER}) {javac_flags} {mflag} {srcflag}'
-        else:
-            find = r'`find "$TMP_DIR" -name "*.jar" | tr \\\\n :`'
-            srcflag = '$SRCS_WORKER' if srcs else '`find $SRCS_WORKER -name "*.java"`'
-            javac_cmd = f'mkdir -p _tmp/META-INF && "$TOOLS_JAVAC" {javac_flags} -classpath .:{find} -d _tmp {srcflag}'
+
 
         cmd = ' && '.join([
             javac_cmd,
@@ -88,7 +148,7 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], 
             labels = labels + ['rule:java_test_library' if test_only else 'rule:java_library'] + src_dir_label,
             test_only=test_only,
             tools={
-                'javac': [CONFIG.JAVAC_TOOL or CONFIG.JAVAC_WORKER],
+                'javac': [javac],
                 'jarcat': [CONFIG.JARCAT_TOOL],
             },
         )
@@ -257,10 +317,10 @@ def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, dep
 
 
 def java_test(name:str, srcs:list, resources:list=None, resources_root:str=None,
-              data:list|dict=None, deps:list=None, worker:str='',
+              data:list|dict=[], deps:list=None, worker:str='',
               labels:list&features&tags=[], visibility:list=None, flags:str='',
               sandbox:bool=None, timeout:int=0, flaky:bool|int=0, test_outputs:list=None, size:str=None,
-              test_package:str=CONFIG.DEFAULT_TEST_PACKAGE, jvm_args:str=''):
+              test_package:str=CONFIG.DEFAULT_TEST_PACKAGE, jvm_args:str='', toolchain:str=''):
     """Defines a Java test.
 
     Args:
@@ -284,6 +344,8 @@ def java_test(name:str, srcs:list, resources:list=None, resources_root:str=None,
       test_package (str): Java package to scan for test classes to run.
       jvm_args (str): Arguments to pass to the JVM in the run script.
     """
+    toolchain = toolchain if toolchain else CONFIG.JAVA_TOOLCHAIN
+
     lib_rule = java_library(
         name=f'_{name}#lib',
         srcs=srcs,
@@ -292,13 +354,23 @@ def java_test(name:str, srcs:list, resources:list=None, resources_root:str=None,
         deps=deps,
         test_only=True,
         labels=labels + ["rule:java_test"],
+        toolchain = toolchain,
         # Deliberately not visible outside this package.
     )
     # As above, would be nicer if we could make the jars self-executing again.
     cmd, tools = _jarcat_cmd('build.please.main.TestMain')
     tools['junit'] = [CONFIG.JUNIT_RUNNER]
+
+    data = {'data': data}
+    java_cmd = 'java'
+    if toolchain:
+        toolchain_info = get_rule_metadata(toolchain)
+        data['java'] = [toolchain_info.java]
+        data['data'] += toolchain_info.deps
+        java_cmd = '$DATA_JAVA'
+
     cmd = 'ln -s `which $TOOLS_JUNIT` . && ' + cmd
-    test_cmd = f'java -Dbuild.please.testpackage={test_package} {jvm_args} -jar $(location :{name}) {flags}'
+    test_cmd = f'{java_cmd} -Dbuild.please.testpackage={test_package} {jvm_args} -jar $(location :{name}) {flags}'
 
     deps = [lib_rule]
     if worker:

--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -2,7 +2,8 @@
 
 def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], resources_root:str=None,
                  deps:list=[], modular:bool=False, exported_deps:list=None, visibility:list=None,
-                 test_only:bool&testonly=False, javac_flags:list&javacopts=None, labels:list=[], toolchain:str=''):
+                 test_only:bool&testonly=False, javac_flags:list&javacopts=None, labels:list=[],
+                 toolchain:str=CONFIG.JAVA_TOOLCHAIN):
     """Compiles Java source to a .jar which can be collected by other rules.
 
     Args:
@@ -23,9 +24,8 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], 
       test_only (bool): If True, this rule can only be depended on by tests.
       javac_flags (list): List of flags passed to javac.
       labels (list): Additional labels to apply to this rule.
+      toolchain (str): A label identifying a java_toolchain rule which will be used to build this java library.
     """
-    toolchain = toolchain if toolchain else CONFIG.JAVA_TOOLCHAIN
-
     resources_cmd = 'true'
     if resources:
         # TODO(jpoole): Check this actually matches the documented behaviour, as it's not clear it does
@@ -142,7 +142,7 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], 
 
 def java_module(name:str, srcs:list=None, src_dir:str=None, resources:list=None, resources_root:str=None,
                 deps:list=None, visibility:list=None, test_only:bool&testonly=False, javac_flags:list&javacopts=None,
-                toolchain:str=''):
+                toolchain:str=CONFIG.JAVA_TOOLCHAIN):
     """Compiles Java source to a modular .jar which can be collected by other rules.
 
     Args:
@@ -161,6 +161,7 @@ def java_module(name:str, srcs:list=None, src_dir:str=None, resources:list=None,
       visibility (list): Visibility declaration of this rule.
       test_only (bool): If True, this rule can only be depended on by tests.
       javac_flags (list): List of flags passed to javac.
+      toolchain (str): A label identifying a java_toolchain rule which will be used to build this java module.
     """
     return java_library(
         name = name,
@@ -221,7 +222,7 @@ def java_runtime_image(name:str, main_module:str, main_class:str, modules:list, 
 
 def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, deps:list=[],
                 data:list=None, visibility:list=None, jvm_args:str=None,
-                self_executable:bool=False, manifest:str=None, toolchain:str=''):
+                self_executable:bool=False, manifest:str=None, toolchain:str=CONFIG.JAVA_TOOLCHAIN):
     """Compiles a .jar from a set of Java libraries.
 
     Args:
@@ -236,6 +237,7 @@ def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, dep
       self_executable (bool): True to make the jar self executable.
       manifest (str): Manifest file to put into the jar. Can't be passed at the same time as
                       main_class.
+      toolchain (str): A label identifying a java_toolchain rule which will be used to build this java binary.
     """
     if main_class and manifest:
         raise ParseError("Can't pass both main_class and manifest to java_binary")
@@ -276,7 +278,7 @@ def java_test(name:str, srcs:list, resources:list=None, resources_root:str=None,
               data:list|dict=[], deps:list=None, worker:str='',
               labels:list&features&tags=[], visibility:list=None, flags:str='',
               sandbox:bool=None, timeout:int=0, flaky:bool|int=0, test_outputs:list=None, size:str=None,
-              test_package:str=CONFIG.DEFAULT_TEST_PACKAGE, jvm_args:str='', toolchain:str=''):
+              test_package:str=CONFIG.DEFAULT_TEST_PACKAGE, jvm_args:str='', toolchain:str=CONFIG.JAVA_TOOLCHAIN):
     """Defines a Java test.
 
     Args:
@@ -299,9 +301,8 @@ def java_test(name:str, srcs:list, resources:list=None, resources_root:str=None,
       size (str): Test size (enormous, large, medium or small).
       test_package (str): Java package to scan for test classes to run.
       jvm_args (str): Arguments to pass to the JVM in the run script.
+      toolchain (str): A label identifying a java_toolchain rule which will be used to run this java test.
     """
-    toolchain = toolchain if toolchain else CONFIG.JAVA_TOOLCHAIN
-
     lib_rule = java_library(
         name=f'_{name}#lib',
         srcs=srcs,

--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -1,57 +1,5 @@
 """Built-in rules to compile Java code."""
 
-def java_toolchain(name : str, sdk_url : str|dict, visibility:list = ["PUBLIC"]) -> str:
-    current_package = package_name()
-
-    sdk_url = sdk_url if isinstance(sdk_url, str) else sdk_url[CONFIG.OS]
-
-    if not sdk_url:
-        raise ParseError(f"No java sdk_url defined for platform {CONFIG.OS}")
-
-    download = remote_file(
-        name=f"_{name}#download",
-        url = sdk_url,
-        visibility = visibility,
-    )
-
-    javac = sh_cmd(
-        name=f"_{name}#javac",
-        cmd=f"$(location //{current_package}:{name})/bin/javac \\\$@",
-        visibility = visibility,
-        deps = [f"//{current_package}:{name}"],
-    )
-
-    java = sh_cmd(
-        name=f"_{name}#java",
-        cmd=f"$(location //{current_package}:{name})/bin/java \\\$@",
-        visibility = visibility,
-        deps = [f"//{current_package}:{name}"],
-    )
-
-    md = {
-        "deps": [f"//{current_package}:{name}"],
-        "javac": f"//{current_package}" + javac,
-        "java": f"//{current_package}" + java,
-    }
-
-    return build_rule(
-        name = name,
-        srcs = [download],
-        outs = [name],
-        tools = [CONFIG.JARCAT_TOOL],
-        cmd = " && ".join([
-            '"$TOOL" x $SRCS -o extract_dir',
-            'mkdir $OUT && mkdir $OUT/bin',
-            'mv $(find extract_dir -name javac) $OUT/bin',
-            'mv $(find extract_dir -name java) $OUT/bin',
-            'mv $(find extract_dir -name lib) $OUT',
-        ]),
-        building_description = 'Extracting...',
-        metadata = md,
-        binary = True,
-        visibility = visibility,
-    )
-
 def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], resources_root:str=None,
                  deps:list=[], modular:bool=False, exported_deps:list=None, visibility:list=None,
                  test_only:bool&testonly=False, javac_flags:list&javacopts=None, labels:list=[], toolchain:str=''):
@@ -106,7 +54,7 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], 
 
         javac = CONFIG.JAVAC_TOOL
 
-        # Override old config if we have a toolchain c configured
+        # Override old config if we have a toolchain configured
         if toolchain:
             jdk_info = get_rule_metadata(toolchain)
 
@@ -193,7 +141,8 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], 
 
 
 def java_module(name:str, srcs:list=None, src_dir:str=None, resources:list=None, resources_root:str=None,
-                deps:list=None, visibility:list=None, test_only:bool&testonly=False, javac_flags:list&javacopts=None):
+                deps:list=None, visibility:list=None, test_only:bool&testonly=False, javac_flags:list&javacopts=None,
+                toolchain:str=''):
     """Compiles Java source to a modular .jar which can be collected by other rules.
 
     Args:
@@ -224,6 +173,7 @@ def java_module(name:str, srcs:list=None, src_dir:str=None, resources:list=None,
         test_only = test_only,
         javac_flags = javac_flags,
         modular = True,
+        toolchain = toolchain,
     )
 
 
@@ -271,7 +221,7 @@ def java_runtime_image(name:str, main_module:str, main_class:str, modules:list, 
 
 def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, deps:list=[],
                 data:list=None, visibility:list=None, jvm_args:str=None,
-                self_executable:bool=False, manifest:str=None):
+                self_executable:bool=False, manifest:str=None, toolchain:str=''):
     """Compiles a .jar from a set of Java libraries.
 
     Args:
@@ -294,6 +244,7 @@ def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, dep
             name = f'_{name}#lib',
             srcs = srcs,
             deps = deps,
+            toolchain = toolchain,
         )
         deps += [lib_rule]
     if self_executable:
@@ -577,5 +528,57 @@ if CONFIG.BAZEL_COMPATIBILITY:
             deps = deps,
             exported_deps = exports,
             test_only = test_only,
+            visibility = visibility,
+        )
+else:
+    def java_toolchain(name : str, sdk_url : str|dict, visibility:list = ["PUBLIC"]) -> str:
+        current_package = package_name()
+
+        sdk_url = sdk_url if isinstance(sdk_url, str) else sdk_url[CONFIG.OS]
+
+        if not sdk_url:
+            raise ParseError(f"No java sdk_url defined for platform {CONFIG.OS}")
+
+        download = remote_file(
+            name=f"_{name}#download",
+            url = sdk_url,
+            visibility = visibility,
+        )
+
+        javac = sh_cmd(
+            name=f"_{name}#javac",
+            cmd=f"$(location //{current_package}:{name})/bin/javac \\\$@",
+            visibility = visibility,
+            deps = [f"//{current_package}:{name}"],
+        )
+
+        java = sh_cmd(
+            name=f"_{name}#java",
+            cmd=f"$(location //{current_package}:{name})/bin/java \\\$@",
+            visibility = visibility,
+            deps = [f"//{current_package}:{name}"],
+        )
+
+        md = {
+            "deps": [f"//{current_package}:{name}"],
+            "javac": f"//{current_package}" + javac,
+            "java": f"//{current_package}" + java,
+        }
+
+        return build_rule(
+            name = name,
+            srcs = [download],
+            outs = [name],
+            tools = [CONFIG.JARCAT_TOOL],
+            cmd = " && ".join([
+                '"$TOOL" x $SRCS -o extract_dir',
+                'mkdir $OUT && mkdir $OUT/bin',
+                'mv $(find extract_dir -name javac) $OUT/bin',
+                'mv $(find extract_dir -name java) $OUT/bin',
+                'mv $(find extract_dir -name lib) $OUT',
+            ]),
+            building_description = 'Extracting...',
+            metadata = md,
+            binary = True,
             visibility = visibility,
         )

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -470,7 +470,7 @@ type Configuration struct {
 		JavacFlags         string    `help:"Additional flags to pass to javac when compiling libraries." example:"-Xmx1200M" var:"JAVAC_FLAGS"`
 		JavacTestFlags     string    `help:"Additional flags to pass to javac when compiling tests." example:"-Xmx1200M" var:"JAVAC_TEST_FLAGS"`
 		DefaultMavenRepo   []cli.URL `help:"Default location to load artifacts from in maven_jar rules. Can be overridden on a per-rule basis." var:"DEFAULT_MAVEN_REPO"`
-		Toolchain string `help:"A label identifying a java_toolchain." var:"JAVA_TOOLCHAIN"`
+		Toolchain          string    `help:"A label identifying a java_toolchain." var:"JAVA_TOOLCHAIN"`
 	} `help:"Please has built-in support for compiling Java.\nIt builds uber-jars for binary and test rules which contain all dependencies and can be easily deployed, and with the help of some of Please's additional tools they are deterministic as well.\n\nWe've only tested support for Java 7 and 8, although it's likely newer versions will work with little or no change."`
 	Cpp struct {
 		CCTool             string     `help:"The tool invoked to compile C code. Defaults to gcc but you might want to set it to clang, for example." var:"CC_TOOL"`

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -470,6 +470,7 @@ type Configuration struct {
 		JavacFlags         string    `help:"Additional flags to pass to javac when compiling libraries." example:"-Xmx1200M" var:"JAVAC_FLAGS"`
 		JavacTestFlags     string    `help:"Additional flags to pass to javac when compiling tests." example:"-Xmx1200M" var:"JAVAC_TEST_FLAGS"`
 		DefaultMavenRepo   []cli.URL `help:"Default location to load artifacts from in maven_jar rules. Can be overridden on a per-rule basis." var:"DEFAULT_MAVEN_REPO"`
+		Toolchain string `help:"A label identifying a java_toolchain." var:"JAVA_TOOLCHAIN"`
 	} `help:"Please has built-in support for compiling Java.\nIt builds uber-jars for binary and test rules which contain all dependencies and can be easily deployed, and with the help of some of Please's additional tools they are deterministic as well.\n\nWe've only tested support for Java 7 and 8, although it's likely newer versions will work with little or no change."`
 	Cpp struct {
 		CCTool             string     `help:"The tool invoked to compile C code. Defaults to gcc but you might want to set it to clang, for example." var:"CC_TOOL"`

--- a/test/java_toolchain/src/main/java/net/thoughtmachine/BUILD
+++ b/test/java_toolchain/src/main/java/net/thoughtmachine/BUILD
@@ -1,7 +1,7 @@
 if CONFIG.OS == "linux" or CONFIG.OS == "darwin":
     java_toolchain(
         name = "java14",
-        sdk_url = {
+        jdk_url = {
             "linux": "https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz",
             "darwin": "https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_osx-x64_bin.tar.gz",
         },
@@ -9,7 +9,7 @@ if CONFIG.OS == "linux" or CONFIG.OS == "darwin":
 
     java_toolchain(
         name = "java16",
-        sdk_url = {
+        jdk_url = {
             "linux": "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_linux-x64_bin.tar.gz",
             "darwin": "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_osx-x64_bin.tar.gz",
         },

--- a/test/java_toolchain/src/main/java/net/thoughtmachine/BUILD
+++ b/test/java_toolchain/src/main/java/net/thoughtmachine/BUILD
@@ -1,0 +1,27 @@
+java_toolchain(
+    name = "java14",
+    sdk_url = "https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz",
+)
+
+java_toolchain(
+    name = "java16",
+    sdk_url = "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_linux-x64_bin.tar.gz",
+)
+
+java_test(
+    name = "java14_test",
+    srcs = ["VersionTest.java"],
+    deps = ["//third_party/java:junit"],
+    jvm_args = "-Dexpected_version=14",
+    toolchain = ":java14",
+)
+
+
+java_test(
+    name = "java16_test",
+    srcs = ["VersionTest.java"],
+    deps = ["//third_party/java:junit"],
+    jvm_args = "-Dexpected_version=16-ea",
+    toolchain = ":java16",
+)
+

--- a/test/java_toolchain/src/main/java/net/thoughtmachine/BUILD
+++ b/test/java_toolchain/src/main/java/net/thoughtmachine/BUILD
@@ -2,6 +2,7 @@ java_toolchain(
     name = "java14",
     sdk_url = {
         "linux": "https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz",
+        "freebsd": "https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz",
         "darwin": "https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_osx-x64_bin.tar.gz",
     },
 )
@@ -10,6 +11,7 @@ java_toolchain(
     name = "java16",
     sdk_url = {
         'linux': "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_linux-x64_bin.tar.gz",
+        'freebsd': "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_linux-x64_bin.tar.gz",
         'darwin': "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_osx-x64_bin.tar.gz",
     },
 )

--- a/test/java_toolchain/src/main/java/net/thoughtmachine/BUILD
+++ b/test/java_toolchain/src/main/java/net/thoughtmachine/BUILD
@@ -1,11 +1,17 @@
 java_toolchain(
     name = "java14",
-    sdk_url = "https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz",
+    sdk_url = {
+        "linux": "https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz",
+        "darwin": "https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_osx-x64_bin.tar.gz",
+    },
 )
 
 java_toolchain(
     name = "java16",
-    sdk_url = "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_linux-x64_bin.tar.gz",
+    sdk_url = {
+        'linux': "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_linux-x64_bin.tar.gz",
+        'darwin': "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_osx-x64_bin.tar.gz",
+    },
 )
 
 java_test(

--- a/test/java_toolchain/src/main/java/net/thoughtmachine/BUILD
+++ b/test/java_toolchain/src/main/java/net/thoughtmachine/BUILD
@@ -1,35 +1,33 @@
-java_toolchain(
-    name = "java14",
-    sdk_url = {
-        "linux": "https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz",
-        "freebsd": "https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz",
-        "darwin": "https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_osx-x64_bin.tar.gz",
-    },
-)
+if CONFIG.OS == 'linux' or CONFIG.OS == 'darwin':
+    java_toolchain(
+        name = "java14",
+        sdk_url = {
+            "linux": "https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz",
+            "darwin": "https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_osx-x64_bin.tar.gz",
+        },
+    )
 
-java_toolchain(
-    name = "java16",
-    sdk_url = {
-        'linux': "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_linux-x64_bin.tar.gz",
-        'freebsd': "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_linux-x64_bin.tar.gz",
-        'darwin': "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_osx-x64_bin.tar.gz",
-    },
-)
+    java_toolchain(
+        name = "java16",
+        sdk_url = {
+            'linux': "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_linux-x64_bin.tar.gz",
+            'darwin': "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_osx-x64_bin.tar.gz",
+        },
+    )
 
-java_test(
-    name = "java14_test",
-    srcs = ["VersionTest.java"],
-    deps = ["//third_party/java:junit"],
-    jvm_args = "-Dexpected_version=14",
-    toolchain = ":java14",
-)
+    java_test(
+        name = "java14_test",
+        srcs = ["VersionTest.java"],
+        deps = ["//third_party/java:junit"],
+        jvm_args = "-Dexpected_version=14" if CONFIG.OS == 'linux' else '-Dexpected_version=14.0.1',
+        toolchain = ":java14",
+    )
 
-
-java_test(
-    name = "java16_test",
-    srcs = ["VersionTest.java"],
-    deps = ["//third_party/java:junit"],
-    jvm_args = "-Dexpected_version=16-ea",
-    toolchain = ":java16",
-)
+    java_test(
+        name = "java16_test",
+        srcs = ["VersionTest.java"],
+        deps = ["//third_party/java:junit"],
+        jvm_args = "-Dexpected_version=16-ea",
+        toolchain = ":java16",
+    )
 

--- a/test/java_toolchain/src/main/java/net/thoughtmachine/BUILD
+++ b/test/java_toolchain/src/main/java/net/thoughtmachine/BUILD
@@ -1,4 +1,4 @@
-if CONFIG.OS == 'linux' or CONFIG.OS == 'darwin':
+if CONFIG.OS == "linux" or CONFIG.OS == "darwin":
     java_toolchain(
         name = "java14",
         sdk_url = {
@@ -10,24 +10,23 @@ if CONFIG.OS == 'linux' or CONFIG.OS == 'darwin':
     java_toolchain(
         name = "java16",
         sdk_url = {
-            'linux': "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_linux-x64_bin.tar.gz",
-            'darwin': "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_osx-x64_bin.tar.gz",
+            "linux": "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_linux-x64_bin.tar.gz",
+            "darwin": "https://download.java.net/java/early_access/jdk16/2/GPL/openjdk-16-ea+2_osx-x64_bin.tar.gz",
         },
     )
 
     java_test(
         name = "java14_test",
         srcs = ["VersionTest.java"],
-        deps = ["//third_party/java:junit"],
-        jvm_args = "-Dexpected_version=14" if CONFIG.OS == 'linux' else '-Dexpected_version=14.0.1',
+        jvm_args = "-Dexpected_version=14" if CONFIG.OS == "linux" else "-Dexpected_version=14.0.1",
         toolchain = ":java14",
+        deps = ["//third_party/java:junit"],
     )
 
     java_test(
         name = "java16_test",
         srcs = ["VersionTest.java"],
-        deps = ["//third_party/java:junit"],
         jvm_args = "-Dexpected_version=16-ea",
         toolchain = ":java16",
+        deps = ["//third_party/java:junit"],
     )
-

--- a/test/java_toolchain/src/main/java/net/thoughtmachine/VersionTest.java
+++ b/test/java_toolchain/src/main/java/net/thoughtmachine/VersionTest.java
@@ -1,0 +1,14 @@
+package net.thoughtmachine;
+
+import org.junit.Test;
+
+public class VersionTest {
+  @Test
+  public void TestVersion(){
+    String expectedVersion = System.getProperty("expected_version");
+    String version = System.getProperty("java.version");
+    if (!version.equals(expectedVersion)) {
+      throw new RuntimeException("Version " + version + " was not expected version " + expectedVersion);
+    }
+  }
+}


### PR DESCRIPTION
Implemented building jars and running tests using the java tool-chain.

Still to do:
1) Invoke the javac worker with the toolchains JRE
2) Host the JDKs ourselves so we can control the download link format
3) Write a convenience "please_hosted_jdk" rule that just takes a version and figures out the URL for each platform based on that. 
4) Migrate please to use java toolchan
5) Make sure all the other java rules work with the toolchain (java_runtime_image)
6) documentation