### PR TITLE
Add a max age for locally cached results

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -203,6 +203,9 @@ type BuildMetadata struct {
 	Stdout, Stderr []byte
 	// Serialised build action metadata.
 	RemoteAction []byte
+	// Time this action was written. Used for remote execution to determine if
+	// the action is stale and needs re-checking or not.
+	Timestamp time.Time
 	// Additional outputs from output directories serialised as a csv
 	OutputDirOuts []string
 	// True if this represents a test run.

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -422,6 +422,7 @@ type Configuration struct {
 		VerifyOutputs bool         `help:"Whether to verify all outputs are present after a cached remote execution action. Depending on your server implementation, you may require this to ensure files are really present."`
 		HomeDir       string       `help:"The home directory on the build machine."`
 		Platform      []string     `help:"Platform properties to request from remote workers, in the format key=value."`
+		CacheDuration cli.Duration `help:"Length of time before we re-check locally cached build actions. Default is unlimited."`
 	} `help:"Settings related to remote execution & caching using the Google remote execution APIs. This section is still experimental and subject to change."`
 	Size  map[string]*Size `help:"Named sizes of targets; these are the definitions of what can be passed to the 'size' argument."`
 	Cover struct {


### PR DESCRIPTION
This should make it reasonably possible for the remote to expire things eventually without worrying about clients holding onto them indefinitely.