### PR TITLE
Only upload results if all runs have completed

### DIFF
--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -75,6 +75,7 @@ var KnownFields = map[string]bool{
 	"state":               true,
 	"Results":             true, // Recall that unsuccessful test results aren't cached...
 	"resultsMux":          true,
+	"completedRuns":       true,
 	"BuildingDescription": true,
 	"ShowProgress":        true,
 	"Progress":            true,

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -141,6 +141,8 @@ type BuildTarget struct {
 	Progress float32 `print:"false"`
 	// The results of this test target, if it is one.
 	Results TestSuite `print:"false"`
+	// The number of completed runs
+	completedRuns int `print:"false"`
 	// A mutex to control access to Results
 	resultsMux sync.Mutex `print:"false"`
 	// Description displayed while the command is building.
@@ -352,6 +354,15 @@ func (target *BuildTarget) TestDir(runNumber int) string {
 // TestDirs contains the parent directory of all the test run directories above
 func (target *BuildTarget) TestDirs() string {
 	return path.Join(TmpDir, target.Label.Subrepo, target.Label.PackageName, target.Label.Name+testDirSuffix)
+}
+
+// CompleteRun completes a run and returns true if this was the last run
+func (target *BuildTarget) CompleteRun(state *BuildState) bool {
+	target.resultsMux.Lock()
+	defer target.resultsMux.Unlock()
+
+	target.completedRuns++
+	return target.completedRuns == state.NumTestRuns
 }
 
 // TestResultsFile returns the output results file for tests for this target.

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -30,14 +30,19 @@ const xattrName = "user.plz_test"
 
 // Test runs the tests for a single target.
 func Test(tid int, state *core.BuildState, label core.BuildLabel, remote bool, run int) {
-	state.LogBuildResult(tid, label, core.TargetTesting, "Testing...")
 	target := state.Graph.TargetOrDie(label)
-	test(tid, state.ForTarget(target), label, target, remote, run)
-	if state.Config.Test.Upload != "" && target.CompleteRun(state) {
-		if err := uploadResults(target, state.Config.Test.Upload.String()); err != nil {
-			log.Warning("%s", err)
+
+	// Defer this so that no matter what happens in this test run, we always call target.CompleteRun
+	defer func() {
+		if state.Config.Test.Upload != "" && target.CompleteRun(state) {
+			if err := uploadResults(target, state.Config.Test.Upload.String()); err != nil {
+				log.Warning("%s", err)
+			}
 		}
-	}
+	}()
+
+	state.LogBuildResult(tid, label, core.TargetTesting, "Testing...")
+	test(tid, state.ForTarget(target), label, target, remote, run)
 }
 
 func test(tid int, state *core.BuildState, label core.BuildLabel, target *core.BuildTarget, runRemotely bool, run int) {

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -33,7 +33,7 @@ func Test(tid int, state *core.BuildState, label core.BuildLabel, remote bool, r
 	state.LogBuildResult(tid, label, core.TargetTesting, "Testing...")
 	target := state.Graph.TargetOrDie(label)
 	test(tid, state.ForTarget(target), label, target, remote, run)
-	if state.Config.Test.Upload != "" {
+	if state.Config.Test.Upload != "" && target.CompleteRun(state) {
 		if err := uploadResults(target, state.Config.Test.Upload.String()); err != nil {
 			log.Warning("%s", err)
 		}

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -34,7 +34,8 @@ func Test(tid int, state *core.BuildState, label core.BuildLabel, remote bool, r
 
 	// Defer this so that no matter what happens in this test run, we always call target.CompleteRun
 	defer func() {
-		if state.Config.Test.Upload != "" && target.CompleteRun(state) {
+		runsAllCompleted := target.CompleteRun(state)
+		if runsAllCompleted && state.Config.Test.Upload != "" {
 			if err := uploadResults(target, state.Config.Test.Upload.String()); err != nil {
 				log.Warning("%s", err)
 			}


### PR DESCRIPTION
We were getting the occasional concurrent map access in serialising the xml because each parallel run was attempting to upload the same results. This PR makes it so only the last run uploads the XML. 