### PR TITLE
Fix parameters on go_benchmark rule

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -448,11 +448,10 @@ def go_test(name:str, srcs:list, data:list|dict=None, deps:list=[], worker:str='
     )
 
 
-def go_benchmark(name:str, srcs:list, data:list|dict=None, deps:list=[], worker:str='', visibility:list=None,
-            flags:str='', sandbox:bool=None, cgo:bool=False, filter_srcs:bool=True,
-            external:bool=False, timeout:int=0, flaky:bool|int=0, test_outputs:list=None,
-            labels:list&features&tags=None, size:str=None, static:bool=CONFIG.GO_DEFAULT_STATIC,
-            definitions:str|list|dict=None):
+def go_benchmark(name:str, srcs:list, data:list|dict=None, deps:list=[], visibility:list=None,
+                 sandbox:bool=None, cgo:bool=False, filter_srcs:bool=True, external:bool=False, timeout:int=0,
+                 labels:list&features&tags=None, static:bool=CONFIG.GO_DEFAULT_STATIC, definitions:str|list|dict=None,
+                 test_only=True):
     """Defines a Go test suite that will be run as a benchmark.
 
     Args:
@@ -460,17 +459,13 @@ def go_benchmark(name:str, srcs:list, data:list|dict=None, deps:list=[], worker:
       srcs (list): Go source files to compile.
       data (list): Runtime data files for the test.
       deps (list): Dependencies
-      worker (str): Reference to worker script, A persistent worker process that is used to set up the test.
       visibility (list): Visibility specification
-      flags (str): Flags to apply to the test invocation.
       sandbox (bool): Sandbox the test on Linux to restrict access to namespaces such as network.
       cgo (bool): True if this test depends on a cgo_library.
       filter_srcs (bool): If True, filters source files through Go's standard build constraints.
       external (bool): True if this test is external to the library it's testing, i.e. it uses the
                        feature of Go that allows it to be in the same directory with a _test suffix.
       timeout (int): Timeout in seconds to allow the test to run for.
-      flaky (int | bool): True to mark the test as flaky, or an integer to specify how many reruns.
-      test_outputs (list): Extra test output files to generate from this test.
       labels (list): Labels for this rule.
       size (str): Test size (enormous, large, medium or small).
       static (bool): If True, passes flags to the linker to try to force fully static linking.
@@ -483,6 +478,7 @@ def go_benchmark(name:str, srcs:list, data:list|dict=None, deps:list=[], worker:
                      when calling the Go linker.  If set to a list, pass each value as a
                      definition to the linker.  If set to a dict, each key/value pair is
                      used to contruct the list of definitions passed to the linker.
+       test_only (bool): If True, is only visible to test rules.
     """
     # Unfortunately we have to recompile this to build the test together with its library.
     lib_rule = go_library(
@@ -531,15 +527,13 @@ def go_benchmark(name:str, srcs:list, data:list|dict=None, deps:list=[], worker:
         visibility=visibility,
         test_sandbox=sandbox,
         test_timeout=timeout,
-        size = size,
-        flaky=flaky,
-        test_outputs=test_outputs,
         requires=['go', 'test'],
         labels=labels,
         binary=True,
         building_description="Compiling...",
         needs_transitive_deps=True,
         output_is_complete=True,
+        test_only=test_only,
     )
 
 def go_test_main(name:str, srcs:list, test_only:bool=False,


### PR DESCRIPTION
Some of them didn't make much sense and were left over from the go_test rule. We also probably want to allow go_benchmark to be test_only. 