### PR TITLE
Set required rex version to 2.1

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -93,9 +93,8 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 	// We can't predict what variables like this should be so we sneakily bung something on
 	// the front of the command. It'd be nicer if there were a better way though...
 	var commandPrefix = "export TMP_DIR=\"`pwd`\" && "
-	// TODO(peterebden): Remove this nonsense once API v2.1 is released.
-	files, dirs := outputs(target)
-	if len(target.Outputs()) == 1 { // $OUT is relative when running remotely; make it absolute
+	outs := outputs(target)
+	if len(outs) == 1 { // $OUT is relative when running remotely; make it absolute
 		commandPrefix += `export OUT="$TMP_DIR/$OUT" && `
 	}
 	if target.IsRemoteFile {
@@ -106,9 +105,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 			Arguments: []string{
 				"fetch", strings.Join(target.AllURLs(c.state.Config), " "), "verify", strings.Join(target.Hashes, " "),
 			},
-			OutputFiles:       files,
-			OutputDirectories: dirs,
-			OutputPaths:       append(files, dirs...),
+			OutputPaths: outs,
 		}, nil
 	}
 	cmd := target.GetCommand(c.state)
@@ -127,9 +124,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 			c.bashPath, "--noprofile", "--norc", "-u", "-o", "pipefail", "-c", commandPrefix + cmd,
 		},
 		EnvironmentVariables: c.buildEnv(target, c.stampedBuildEnvironment(target, inputRoot, stamp), target.Sandbox),
-		OutputFiles:          files,
-		OutputDirectories:    dirs,
-		OutputPaths:          append(files, dirs...),
+		OutputPaths:          outs,
 	}, err
 }
 

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -40,7 +40,7 @@ import (
 var log = logging.MustGetLogger("remote")
 
 // The API version we support.
-var apiVersion = semver.SemVer{Major: 2}
+var apiVersion = semver.SemVer{Major: 2, Minor: 1}
 
 // A Client is the interface to the remote API.
 //

--- a/src/remote/remote_test.go
+++ b/src/remote/remote_test.go
@@ -69,29 +69,6 @@ func TestExecuteBuild(t *testing.T) {
 	assert.Equal(t, []byte("hello\n"), metadata.Stdout)
 }
 
-type postBuildFunction func(*core.BuildTarget, string) error
-
-func (f postBuildFunction) Call(target *core.BuildTarget, output string) error {
-	return f(target, output)
-}
-func (f postBuildFunction) String() string { return "" }
-
-func TestExecutePostBuildFunction(t *testing.T) {
-	t.Skip("Post-build function currently triggered at a higher level")
-	c := newClient()
-	target := core.NewBuildTarget(core.BuildLabel{PackageName: "package", Name: "target5"})
-	target.BuildTimeout = time.Minute
-	target.Command = "echo 'wibble wibble wibble' | tee file7"
-	target.PostBuildFunction = postBuildFunction(func(target *core.BuildTarget, output string) error {
-		target.AddOutput("somefile")
-		assert.Equal(t, "wibble wibble wibble", output)
-		return nil
-	})
-	_, err := c.Build(0, target)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"somefile"}, target.Outputs())
-}
-
 func TestExecuteFetch(t *testing.T) {
 	c := newClient()
 	target := core.NewBuildTarget(core.BuildLabel{PackageName: "package", Name: "remote1"})

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -367,26 +367,13 @@ func timeout(target *core.BuildTarget, test bool) time.Duration {
 	return target.BuildTimeout
 }
 
-// outputs returns the outputs of a target, split arbitrarily and inaccurately
-// into files and directories.
-// After some discussion we are hoping that servers are permissive about this if
-// we get it wrong; we prefer to make an effort though as a minor nicety.
-func outputs(target *core.BuildTarget) (files, dirs []string) {
-	outs := target.Outputs()
-	files = make([]string, 0, len(outs))
-	for _, out := range outs {
-		out = target.GetTmpOutput(out)
-		if !strings.ContainsRune(path.Base(out), '.') && !strings.HasSuffix(out, "file") && !target.IsBinary {
-			dirs = append(dirs, out)
-		} else {
-			files = append(files, out)
-		}
-	}
-
+// outputs returns all the outputs for a target.
+func outputs(target *core.BuildTarget) []string {
+	outs := target.GetTmpOutputAll(target.Outputs())
 	for _, out := range target.OutputDirectories {
-		dirs = append(dirs, out.Dir())
+		outs = append(outs, out.Dir())
 	}
-	return files, dirs
+	return outs
 }
 
 // A dirBuilder is for helping build up a tree of Directory protos.


### PR DESCRIPTION
This is gonna be tagged any day now...
We basically require a server with the non-specific output paths field. Our heuristic for guessing inevitably gets it wrong sooner or later and I don't want to keep the crappy code around for it.