### PR TITLE
Re-add the trimpath flags

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -696,7 +696,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
     # Now compile it in a separate step.
     cmd = [
         'export GOPATH="$(find \"$TMP_DIR\" \( -name src -o -name pkg \) -exec dirname {} \; | sort | uniq | tr \'\\n\' \':\' | sed \'s/:$//\')" GO111MODULE="off"',
-        '"$TOOLS_GO" install ' + ' '.join(all_installs or install),
+        '"$TOOLS_GO" install -gcflags "-trimpath \\\"$TMP_DIR\\\"" -asmflags "-trimpath \\\"$TMP_DIR\\\"" ' + ' '.join(all_installs or install),
     ]
     if package_name():
         cmd += [


### PR DESCRIPTION
These got removed in #986 because I was gonna use just `go install -trimpath`, but ended up having to revert that. Hence we should have these back.