### PR TITLE
Implemented --rerun flag for test and cover

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -190,6 +190,8 @@ type BuildState struct {
 	Watch bool
 	// Number of times to run each test target. 1 == once each, plus flakes if necessary.
 	NumTestRuns int
+	// Whether we should rerun the test even if the hash hasn't changed
+	Rerun bool
 	// Whether to run multiple test runs sequentially or across multiple workers (can be useful if tests bind to ports
 	// or similar)
 	TestSequentially bool

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -130,6 +130,9 @@ func test(tid int, state *core.BuildState, label core.BuildLabel, target *core.B
 	}
 
 	needToRun := func() bool {
+		if state.Rerun {
+			return true
+		}
 		if s := target.State(); (s == core.Unchanged || s == core.Reused) && core.PathExists(cachedOutputFile) {
 			// Output file exists already and appears to be valid. We might still need to rerun though
 			// if the coverage files aren't available.


### PR DESCRIPTION
This can be useful if the code hasn't changed but something about the build env has 