### PR TITLE
Add rerun flag to test command

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -198,7 +198,7 @@ type BuildState struct {
 	// True if we're forcing a rebuild of the original targets.
 	ForceRebuild bool
 	// True if we're forcing to rerun tests of the targets.
-	ForceTestRerun bool
+	ForceRerun bool
 	// True to always show test output, even on success.
 	ShowTestOutput bool
 	// True to print all output of all tasks to stderr.

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -197,6 +197,8 @@ type BuildState struct {
 	CleanWorkdirs bool
 	// True if we're forcing a rebuild of the original targets.
 	ForceRebuild bool
+	// True if we're forcing to rerun tests of the targets.
+	ForceTestRerun bool
 	// True to always show test output, even on success.
 	ShowTestOutput bool
 	// True to print all output of all tasks to stderr.

--- a/src/please.go
+++ b/src/please.go
@@ -732,7 +732,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	state.Watch = len(opts.Watch.Args.Targets) > 0
 	state.CleanWorkdirs = !opts.FeatureFlags.KeepWorkdirs
 	state.ForceRebuild = opts.Build.Rebuild
-	state.ForceTestRerun = opts.Test.Rerun || opts.Cover.Rerun
+	state.ForceRerun = opts.Test.Rerun || opts.Cover.Rerun
 	state.ShowTestOutput = opts.Test.ShowOutput || opts.Cover.ShowOutput
 	state.DebugTests = debugTests
 	state.ShowAllOutput = opts.OutputFlags.ShowAllOutput

--- a/src/please.go
+++ b/src/please.go
@@ -111,7 +111,7 @@ var opts struct {
 	Test struct {
 		FailingTestsOk  bool         `long:"failing_tests_ok" hidden:"true" description:"Exit with status 0 even if tests fail (nonzero only if catastrophe happens)"`
 		NumRuns         int          `long:"num_runs" short:"n" default:"1" description:"Number of times to run each test target."`
-		Rerun           bool         `long:"rerun" description:"To force rerunning tests for a target"`
+		Rerun           bool         `long:"rerun" description:"Rerun the test even if the hash hasn't changed."`
 		Sequentially    bool         `long:"sequentially" description:"Whether to run multiple runs of the same test sequentially"`
 		TestResultsFile cli.Filepath `long:"test_results_file" default:"plz-out/log/test_results.xml" description:"File to write combined test results to."`
 		SurefireDir     cli.Filepath `long:"surefire_dir" default:"plz-out/surefire-reports" description:"Directory to copy XML test results to."`
@@ -134,7 +134,7 @@ var opts struct {
 		NoCoverageReport    bool          `long:"nocoverage_report" description:"Suppress the per-file coverage report displayed in the shell"`
 		LineCoverageReport  bool          `short:"l" long:"line_coverage_report" description:" Show a line-by-line coverage report for all affected files."`
 		NumRuns             int           `short:"n" long:"num_runs" default:"1" description:"Number of times to run each test target."`
-		Rerun               bool          `long:"rerun" description:"To force rerunning tests for a target"`
+		Rerun               bool          `long:"rerun" description:"Rerun the test even if the hash hasn't changed."`
 		Sequentially        bool          `long:"sequentially" description:"Whether to run multiple runs of the same test sequentially"`
 		IncludeAllFiles     bool          `short:"a" long:"include_all_files" description:"Include all dependent files in coverage (default is just those from relevant packages)"`
 		IncludeFile         cli.Filepaths `long:"include_file" description:"Filenames to filter coverage display to"`

--- a/src/please.go
+++ b/src/please.go
@@ -134,6 +134,7 @@ var opts struct {
 		NoCoverageReport    bool          `long:"nocoverage_report" description:"Suppress the per-file coverage report displayed in the shell"`
 		LineCoverageReport  bool          `short:"l" long:"line_coverage_report" description:" Show a line-by-line coverage report for all affected files."`
 		NumRuns             int           `short:"n" long:"num_runs" default:"1" description:"Number of times to run each test target."`
+		Rerun               bool          `long:"rerun" description:"To force rerunning tests for a target"`
 		Sequentially        bool          `long:"sequentially" description:"Whether to run multiple runs of the same test sequentially"`
 		IncludeAllFiles     bool          `short:"a" long:"include_all_files" description:"Include all dependent files in coverage (default is just those from relevant packages)"`
 		IncludeFile         cli.Filepaths `long:"include_file" description:"Filenames to filter coverage display to"`
@@ -731,7 +732,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	state.Watch = len(opts.Watch.Args.Targets) > 0
 	state.CleanWorkdirs = !opts.FeatureFlags.KeepWorkdirs
 	state.ForceRebuild = opts.Build.Rebuild
-	state.ForceTestRerun = opts.Test.Rerun
+	state.ForceTestRerun = opts.Test.Rerun || opts.Cover.Rerun
 	state.ShowTestOutput = opts.Test.ShowOutput || opts.Cover.ShowOutput
 	state.DebugTests = debugTests
 	state.ShowAllOutput = opts.OutputFlags.ShowAllOutput

--- a/src/please.go
+++ b/src/please.go
@@ -111,6 +111,7 @@ var opts struct {
 	Test struct {
 		FailingTestsOk  bool         `long:"failing_tests_ok" hidden:"true" description:"Exit with status 0 even if tests fail (nonzero only if catastrophe happens)"`
 		NumRuns         int          `long:"num_runs" short:"n" default:"1" description:"Number of times to run each test target."`
+		Rerun           bool         `long:"rerun" description:"To force rerunning tests for a target"`
 		Sequentially    bool         `long:"sequentially" description:"Whether to run multiple runs of the same test sequentially"`
 		TestResultsFile cli.Filepath `long:"test_results_file" default:"plz-out/log/test_results.xml" description:"File to write combined test results to."`
 		SurefireDir     cli.Filepath `long:"surefire_dir" default:"plz-out/surefire-reports" description:"Directory to copy XML test results to."`
@@ -730,6 +731,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	state.Watch = len(opts.Watch.Args.Targets) > 0
 	state.CleanWorkdirs = !opts.FeatureFlags.KeepWorkdirs
 	state.ForceRebuild = opts.Build.Rebuild
+	state.ForceTestRerun = opts.Test.Rerun
 	state.ShowTestOutput = opts.Test.ShowOutput || opts.Cover.ShowOutput
 	state.DebugTests = debugTests
 	state.ShowAllOutput = opts.OutputFlags.ShowAllOutput

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -130,7 +130,7 @@ func test(tid int, state *core.BuildState, label core.BuildLabel, target *core.B
 	}
 
 	needToRun := func() bool {
-		if state.ForceTestRerun {
+		if state.ForceRerun {
 			return true
 		}
 

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -130,6 +130,10 @@ func test(tid int, state *core.BuildState, label core.BuildLabel, target *core.B
 	}
 
 	needToRun := func() bool {
+		if state.ForceTestRerun {
+			return true
+		}
+
 		if s := target.State(); (s == core.Unchanged || s == core.Reused) && core.PathExists(cachedOutputFile) {
 			// Output file exists already and appears to be valid. We might still need to rerun though
 			// if the coverage files aren't available.

--- a/test/build_defs/test.build_defs
+++ b/test/build_defs/test.build_defs
@@ -8,7 +8,7 @@ def please_repo_e2e_test(
         expected_output: dict,
 ):
     test_cmd = " && ".join(
-        ["cd $DATA_REPO", "export PLZ=$TMP_DIR/$DATA_PLEASE", f"$PLZ {plz_command}"] +
+        ["cd $DATA_REPO", "export PLZ=$TMP_DIR/$DATA_PLEASE", f"{plz_command}"] +
         [f"$TMP_DIR/$DATA_CONTENT_CHECKER '{o}' '{c}'" for o, c in expected_output.items()])
 
     return build_rule(

--- a/test/build_defs/test.build_defs
+++ b/test/build_defs/test.build_defs
@@ -8,7 +8,7 @@ def please_repo_e2e_test(
         expected_output: dict,
 ):
     test_cmd = " && ".join(
-        ["cd $DATA_REPO", f"$TMP_DIR/$DATA_PLEASE {plz_command}"] +
+        ["cd $DATA_REPO", "export PLZ=$TMP_DIR/$DATA_PLEASE", f"$PLZ {plz_command}"] +
         [f"$TMP_DIR/$DATA_CONTENT_CHECKER '{o}' '{c}'" for o, c in expected_output.items()])
 
     return build_rule(

--- a/test/cli/BUILD
+++ b/test/cli/BUILD
@@ -5,6 +5,6 @@ please_repo_e2e_test(
     expected_output = {
         "wibble_test.txt": "wibble wibble wibble\nwibble wibble wibble",
     },
-    plz_command = "test --show_all_output //package:wibble 2>&1 | grep wibble > wibble_test.txt && $PLZ test --rerun --show_all_output //package:wibble 2>&1 | grep wibble >> wibble_test.txt",
+    plz_command = "$PLZ test --show_all_output //package:wibble 2>&1 | grep wibble > wibble_test.txt && $PLZ test --rerun --show_all_output //package:wibble 2>&1 | grep wibble >> wibble_test.txt",
     repo = "test_repo",
 )

--- a/test/cli/BUILD
+++ b/test/cli/BUILD
@@ -1,0 +1,10 @@
+subinclude("//test/build_defs")
+
+please_repo_e2e_test(
+    name = "test_rerun_test",
+    expected_output = {
+        "wibble_test.txt": "wibble wibble wibble\nwibble wibble wibble",
+    },
+    plz_command = "test --show_all_output //package:wibble 2>&1 | grep wibble > wibble_test.txt && $PLZ test --rerun --show_all_output //package:wibble 2>&1 | grep wibble >> wibble_test.txt",
+    repo = "test_repo",
+)

--- a/test/cli/BUILD
+++ b/test/cli/BUILD
@@ -5,6 +5,6 @@ please_repo_e2e_test(
     expected_output = {
         "wibble_test.txt": "wibble wibble wibble\nwibble wibble wibble",
     },
-    plz_command = "$PLZ test --show_all_output //package:wibble 2>&1 | grep wibble > wibble_test.txt && $PLZ test --rerun --show_all_output //package:wibble 2>&1 | grep wibble >> wibble_test.txt",
+    plz_command = "$PLZ test --show_all_output //package:wibble 2>&1 | grep 'wibble wibble wibble' > wibble_test.txt && $PLZ test --rerun --show_all_output //package:wibble 2>&1 | grep 'wibble wibble wibble' >> wibble_test.txt",
     repo = "test_repo",
 )

--- a/test/cli/test_repo/.plzconfig
+++ b/test/cli/test_repo/.plzconfig
@@ -1,0 +1,2 @@
+[Parse]
+BuildFileName = BUILD_FILE

--- a/test/cli/test_repo/package/BUILD_FILE
+++ b/test/cli/test_repo/package/BUILD_FILE
@@ -1,0 +1,5 @@
+gentest(
+    name = "wibble", 
+    #outs = ["wibble.txt"],
+    test_cmd = "echo wibble wibble wibble && echo '' > $RESULTS_FILE",
+)

--- a/test/cli/test_repo/package/BUILD_FILE
+++ b/test/cli/test_repo/package/BUILD_FILE
@@ -1,5 +1,5 @@
 gentest(
     name = "wibble", 
-    #outs = ["wibble.txt"],
-    test_cmd = "echo wibble wibble wibble && echo '' > $RESULTS_FILE",
+    no_test_output = True,
+    test_cmd = "echo wibble wibble wibble",
 )

--- a/test/rule_metadata_test/BUILD
+++ b/test/rule_metadata_test/BUILD
@@ -5,6 +5,6 @@ please_repo_e2e_test(
     expected_output = {
         "plz-out/gen/consumer_package/wibble.txt": "wibble wibble wibble",
     },
-    plz_command = "build //consumer_package:wibble",
+    plz_command = "$PLZ build //consumer_package:wibble",
     repo = "test_repo",
 )


### PR DESCRIPTION
This PR adds a `--rerun` flag to the test command to rerun tests for the selected targets, bypassing the cache for tests. It does not rebuild the dependencies though.

A common use case for this feature is rerunning integration tests against an external component.

## Questions / To do

- [x] How can we test this flag?
- [x] How about the `cover` command?