### PR TITLE
Implement hash_filegroup in the build language

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,9 @@ Version 15.0.0
       with `lib` where appropriate.
     * SHA256 is now the default hash function. SHA1 hashes specified in
       BUILD files will continue to work.
+    * `hash_filegroup` is now implemented in the BUILD language instead of
+      as a builtin. Generally it shouldn't matter but the output format is
+      slightly different (it is hex-encoded instead of base64).
 
 
 Version 14.6.0

--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -286,16 +286,16 @@ def hash_filegroup(name:str, srcs:list=None, deps:list=None, exported_deps:list=
     return build_rule(
         name=name,
         srcs=srcs,
-        cmd='',
+        out_dirs = ['_out'],
+        cmd = 'for S in SRCS; do mv $S "${S%.*}-$(sha256sum $S)${S##*.}"; done',
         deps=deps,
         exported_deps=exported_deps,
         visibility=visibility,
-        building_description='Copying...',
+        building_description='Hashing...',
         output_is_complete=True,
         test_only=test_only,
         labels=labels,
         requires=requires,
-        _hash_filegroup=True,
     )
 
 

--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -286,8 +286,8 @@ def hash_filegroup(name:str, srcs:list=None, deps:list=None, exported_deps:list=
     return build_rule(
         name=name,
         srcs=srcs,
-        out_dirs = ['_out'],
-        cmd = 'for S in SRCS; do mv $S "${S%.*}-$(sha256sum $S)${S##*.}"; done',
+        output_dirs = ['_out'],
+        cmd = 'mkdir _out; for S in $SRCS; do B="$(basename $S)"; mv "$S" "_out/${B%.*}-$(shasum -a 256 $S | cut -d " " -f 1 ).${B##*.}"; done',
         deps=deps,
         exported_deps=exported_deps,
         visibility=visibility,

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -175,9 +175,6 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 			return err
 		}
 	} else {
-		if target.IsHashFilegroup {
-			updateHashFilegroupPaths(state, target)
-		}
 		// Ensure we have downloaded any previous dependencies if that's relevant.
 		if err := downloadInputsIfNeeded(tid, state, target); err != nil {
 			return err

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -244,11 +244,10 @@ func ruleHash(state *core.BuildState, target *core.BuildTarget, runtime bool) []
 	// Should really not be conditional here, but we don't want adding the new flag to
 	// change the hash of every single other target everywhere.
 	// Might consider removing this the next time we peturb the hashing strategy.
-	hashOptionalBool(h, target.Stamp)
-	hashOptionalBool(h, target.IsFilegroup)
-	hashOptionalBool(h, target.IsHashFilegroup)
-	hashOptionalBool(h, target.IsRemoteFile)
-	hashOptionalBool(h, target.Local)
+	hashBool(h, target.Stamp)
+	hashBool(h, target.IsFilegroup)
+	hashBool(h, target.IsRemoteFile)
+	hashBool(h, target.Local)
 	for _, require := range target.Requires {
 		h.Write([]byte(require))
 	}

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -241,9 +241,6 @@ func ruleHash(state *core.BuildState, target *core.BuildTarget, runtime bool) []
 
 	hashBool(h, target.NeedsTransitiveDependencies)
 	hashBool(h, target.OutputIsComplete)
-	// Should really not be conditional here, but we don't want adding the new flag to
-	// change the hash of every single other target everywhere.
-	// Might consider removing this the next time we peturb the hashing strategy.
 	hashBool(h, target.Stamp)
 	hashBool(h, target.IsFilegroup)
 	hashBool(h, target.IsRemoteFile)

--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -23,7 +23,6 @@ var KnownFields = map[string]bool{
 	"IsBinary":                    true,
 	"IsTest":                      true,
 	"IsFilegroup":                 true,
-	"IsHashFilegroup":             true,
 	"IsRemoteFile":                true,
 	"Command":                     true,
 	"Commands":                    true,

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -128,8 +128,6 @@ type BuildTarget struct {
 	NeededForSubinclude bool
 	// Marks the target as a filegroup.
 	IsFilegroup bool `print:"false"`
-	// Marks the target as a hash_filegroup.
-	IsHashFilegroup bool `print:"false"`
 	// Marks the target as a remote_file.
 	IsRemoteFile bool `print:"false"`
 	// Marks that the target was added in a post-build function.
@@ -557,7 +555,7 @@ func (target *BuildTarget) DeclaredOutputNames() []string {
 // Outputs returns a slice of all the outputs of this rule.
 func (target *BuildTarget) Outputs() []string {
 	var ret []string
-	if target.IsFilegroup && !target.IsHashFilegroup {
+	if target.IsFilegroup {
 		ret = make([]string, 0, len(target.Sources))
 		// Filegroups just re-output their inputs.
 		for _, src := range target.Sources {

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -111,7 +111,6 @@ func registerSubincludePackage(s *scope) {
 	f.defaults = buildRule.defaults
 	f.constants = buildRule.constants
 	f.types = buildRule.types
-	f = setNativeCode(s, "hash_filegroup", hashFilegroup)
 	f.args = buildRule.args
 	f.argIndices = buildRule.argIndices
 	f.defaults = buildRule.defaults
@@ -170,12 +169,6 @@ func buildRule(s *scope, args []pyObject) pyObject {
 // filegroup implements the filegroup() builtin.
 func filegroup(s *scope, args []pyObject) pyObject {
 	args[1] = filegroupCommand
-	return buildRule(s, args)
-}
-
-// hashFilegroup implements the hash_filegroup() builtin.
-func hashFilegroup(s *scope, args []pyObject) pyObject {
-	args[1] = hashFilegroupCommand
 	return buildRule(s, args)
 }
 

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -12,9 +12,6 @@ import (
 // filegroupCommand is the command we put on filegroup rules.
 const filegroupCommand = pyString("filegroup")
 
-// hashFilegroupCommand is similarly the command for hash_filegroup rules.
-const hashFilegroupCommand = pyString("hash_filegroup")
-
 const defaultFlakiness = 3
 
 const (
@@ -117,8 +114,7 @@ func createTarget(s *scope, args []pyObject) *core.BuildTarget {
 
 	target.BuildTimeout = sizeAndTimeout(s, size, args[buildTimeoutBuildRuleArgIdx], s.state.Config.Build.Timeout)
 	target.Stamp = isTruthy(stampBuildRuleArgIdx)
-	target.IsHashFilegroup = args[cmdBuildRuleArgIdx] == hashFilegroupCommand
-	target.IsFilegroup = args[cmdBuildRuleArgIdx] == filegroupCommand || target.IsHashFilegroup
+	target.IsFilegroup = args[cmdBuildRuleArgIdx] == filegroupCommand
 	if desc := args[buildingDescriptionBuildRuleArgIdx]; desc != nil && desc != None {
 		target.BuildingDescription = string(desc.(pyString))
 	}

--- a/src/query/print.go
+++ b/src/query/print.go
@@ -104,9 +104,7 @@ func (p *printer) printf(msg string, args ...interface{}) {
 
 // PrintTarget prints an entire build target.
 func (p *printer) PrintTarget() {
-	if p.target.IsHashFilegroup {
-		p.printf("hash_filegroup(\n")
-	} else if p.target.IsFilegroup {
+	if p.target.IsFilegroup {
 		p.printf("filegroup(\n")
 	} else if p.target.IsRemoteFile {
 		p.printf("remote_file(\n")

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -773,9 +773,6 @@ func (c *Client) buildFilegroup(target *core.BuildTarget, command *pb.Command, a
 					TreeDigest: chomk.Digest().ToProto(),
 				})
 			} else if f != nil {
-				if target.IsHashFilegroup {
-					out = updateHashFilename(out, f.Digest)
-				}
 				ar.OutputFiles = append(ar.OutputFiles, &pb.OutputFile{
 					Path:         out,
 					Digest:       f.Digest,

--- a/src/remote/remote_test.go
+++ b/src/remote/remote_test.go
@@ -190,21 +190,6 @@ func TestNoAbsolutePaths2(t *testing.T) {
 	}
 }
 
-func TestUpdateHashFilename(t *testing.T) {
-	digest := &pb.Digest{
-		Hash:      "fdb56422f239f8a53940e510720da53c08783d117135abab6e2df343be70eb77",
-		SizeBytes: 506,
-	}
-	assert.Equal(t,
-		"script/bundle-_bVkIvI5-KU5QOUQcg2lPAh4PRFxNaurbi3zQ75w63c.js",
-		updateHashFilename("script/bundle.js", digest),
-	)
-	assert.Equal(t,
-		"bundle-_bVkIvI5-KU5QOUQcg2lPAh4PRFxNaurbi3zQ75w63c",
-		updateHashFilename("bundle", digest),
-	)
-}
-
 func TestRemoteFilesHashConsistently(t *testing.T) {
 	c := newClientInstance("test")
 	target := core.NewBuildTarget(core.BuildLabel{PackageName: "package", Name: "download"})

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -552,14 +552,6 @@ func reencodeSRI(target *core.BuildTarget, h string) string {
 	return h
 }
 
-// updateHashFilename updates an output filename for a hash_filegroup.
-func updateHashFilename(name string, digest *pb.Digest) string {
-	ext := path.Ext(name)
-	before := name[:len(name)-len(ext)]
-	b, _ := hex.DecodeString(digest.Hash)
-	return before + "-" + base64.RawURLEncoding.EncodeToString(b) + ext
-}
-
 // dialOpts returns a set of dial options to apply based on the config.
 func (c *Client) dialOpts() ([]grpc.DialOption, error) {
 	// Set an arbitrarily large (400MB) max message size so it isn't a limitation.

--- a/test/filegroup/BUILD
+++ b/test/filegroup/BUILD
@@ -12,3 +12,14 @@ plz_e2e_test(
     name = "filegroup_concurrent_build_test",
     cmd = "plz clean //test/filegroup:gen && plz build //test/filegroup/many:all",
 )
+
+hash_filegroup(
+    name = "hashed",
+    srcs = ["hash_filegroup_test.txt"],
+)
+
+sh_test(
+    name = "hash_filegroup_test",
+    src = "hash_filegroup_test.sh",
+    data = [":hashed"],
+)

--- a/test/filegroup/hash_filegroup_test.sh
+++ b/test/filegroup/hash_filegroup_test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+EXPECTED="test/filegroup/hash_filegroup_test-c340e9699046999e0dead1f677a889fc94d90488d3a524183afd30b4e17f80aa.txt"
+if [ "$DATA" != "$EXPECTED" ]; then
+    echo "Unexpected hash filegroup name; was $DATA, should be $EXPECTED"
+    exit 1
+fi

--- a/test/filegroup/hash_filegroup_test.txt
+++ b/test/filegroup/hash_filegroup_test.txt
@@ -1,0 +1,1 @@
+Beware of the Leopard!


### PR DESCRIPTION
Gets rid of a lot of internal specialisation nonsense and makes it work for remote execution.