### PR TITLE
Fix some hashing shenanigans

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1002,6 +1002,19 @@ func (target *BuildTarget) ProvideFor(other *BuildTarget) []BuildLabel {
 	return []BuildLabel{target.Label}
 }
 
+// UnprefixedHashes returns the hashes for the target without any prefixes;
+// they are allowed to have optional prefixes before a colon which aren't taken
+// into account for the resulting hash.
+func (target *BuildTarget) UnprefixedHashes() []string {
+	hashes := target.Hashes[:]
+	for i, h := range hashes {
+		if index := strings.LastIndexByte(h, ':'); index != -1 {
+			hashes[i] = strings.TrimSpace(h[index+1:])
+		}
+	}
+	return hashes
+}
+
 // AddSource adds a source to the build target, deduplicating against existing entries.
 func (target *BuildTarget) AddSource(source BuildInput) {
 	target.Sources = target.addSource(target.Sources, source)


### PR DESCRIPTION
Seemed to sometimes miss matches it should get. Have added a "fast path" that matches the existing calculated hash before going off trying to calculate any different ones.

Think this all needs another go-around at some point, it seems not very simple (although there is some annoying complexity in the logic, but I still think we can do this more clearly).