### PR TITLE
Hide repo aliases if a command is given

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -900,7 +900,7 @@ func initBuild(args []string) string {
 		// Attempt to read config files to produce help for aliases.
 		cli.InitLogging(cli.MinVerbosity)
 		parser.WriteHelp(os.Stderr)
-		if core.FindRepoRoot() {
+		if cli.ActiveCommand(parser.Command) == "please" && core.FindRepoRoot() {
 			if config, err := core.ReadDefaultConfigFiles(nil); err == nil {
 				config.PrintAliases(os.Stderr)
 			}


### PR DESCRIPTION
This is kind of a subtle one, but `plz --help` should print the "Available commands for this repository" bit, but `plz run --help` shouldn't since those aliases don't apply to that command - i.e. the ones it prints immediately above are subcommands for run, not global commands.