### PR TITLE
Fix command URLs printed by plz hash.

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -693,7 +693,7 @@ func (c *Client) PrintHashes(target *core.BuildTarget, isTest bool) {
 	commandDigest := c.digestMessage(cmd)
 	fmt.Printf("Command: %7d bytes: %s\n", commandDigest.SizeBytes, commandDigest.Hash)
 	if c.state.Config.Remote.DisplayURL != "" {
-		fmt.Printf("    URL: %s\n", c.actionURL(commandDigest, false))
+		fmt.Printf("    URL: %s\n", strings.Replace(c.actionURL(commandDigest, false), "/action/", "/command/", 1))
 	}
 	actionDigest := c.digestMessage(&pb.Action{
 		CommandDigest:   commandDigest,


### PR DESCRIPTION
These should have /command/ in them rather than /action/; as is the browser consistently fails with a "can't skip wire type" error.