### PR TITLE
support wildcards when using --include_file option with plz cover

### DIFF
--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -686,9 +686,18 @@ func shouldInclude(file string, files []string) bool {
 		return true
 	}
 	for _, f := range files {
-		if file == f {
+		if file == f || wildcardMatch(file, f) {
 			return true
 		}
+	}
+	return false
+}
+
+// wildcardMatch returns true if fileToMatch ends with wildcard and the file matches the subpath
+func wildcardMatch(file string, fileToMatch string) bool {
+	if strings.HasSuffix(fileToMatch, "*") {
+		subPath := fileToMatch[:len(fileToMatch)-1]
+		return strings.HasPrefix(file, subPath)
 	}
 	return false
 }

--- a/src/output/shell_output_test.go
+++ b/src/output/shell_output_test.go
@@ -48,6 +48,29 @@ func makeTarget(label string, deps ...string) *core.BuildTarget {
 	return target
 }
 
+func TestWildcardMatch(t *testing.T) {
+	t.Run("with non-wildcard input", func(t *testing.T) {
+		file := "opt/tm/file.txt"
+		pathToMatch := "opt/tm/"
+
+		assert.False(t, wildcardMatch(file, pathToMatch))
+	})
+
+	t.Run("with non-matching filepath", func(t *testing.T) {
+		file := "opt/tm/file.txt"
+		pathToMatch := "some/otherpath/*"
+
+		assert.False(t, wildcardMatch(file, pathToMatch))
+	})
+
+	t.Run("with matching filepath", func(t *testing.T) {
+		file := "opt/tm/file.txt"
+		pathToMatch := "opt/tm/*"
+
+		assert.True(t, wildcardMatch(file, pathToMatch))
+	})
+}
+
 // Set dependency pointers on all contents of the graph.
 // Has to be done after to test cycles etc.
 func updateDependencies(graph *core.BuildGraph) {

--- a/src/please.go
+++ b/src/please.go
@@ -137,7 +137,7 @@ var opts struct {
 		Rerun               bool          `long:"rerun" description:"Rerun the test even if the hash hasn't changed."`
 		Sequentially        bool          `long:"sequentially" description:"Whether to run multiple runs of the same test sequentially"`
 		IncludeAllFiles     bool          `short:"a" long:"include_all_files" description:"Include all dependent files in coverage (default is just those from relevant packages)"`
-		IncludeFile         cli.Filepaths `long:"include_file" description:"Filenames to filter coverage display to"`
+		IncludeFile         cli.Filepaths `long:"include_file" description:"Filenames to filter coverage display to. Suffix with '*' to match subpaths."`
 		TestResultsFile     cli.Filepath  `long:"test_results_file" default:"plz-out/log/test_results.xml" description:"File to write combined test results to."`
 		SurefireDir         cli.Filepath  `long:"surefire_dir" default:"plz-out/surefire-reports" description:"Directory to copy XML test results to."`
 		CoverageResultsFile cli.Filepath  `long:"coverage_results_file" default:"plz-out/log/coverage.json" description:"File to write combined coverage results to."`


### PR DESCRIPTION
Example use:

```
plz cover //my/test:target --include_file=my/path/*
```

Unit tests added + tested wildcard using `plz cover` manually with several targets containing nested coverage results.