### PR TITLE
Increase the retry backoff time a bit

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
 	sdkdigest "github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/retry"
 	fpb "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/bazelbuild/remote-apis/build/bazel/semver"
@@ -141,6 +142,9 @@ func (c *Client) initExec() error {
 		return err
 	}
 	c.client = client
+	// Extend timeouts a bit, RetryTransient only gives about 1.5 seconds total which isn't
+	// necessarily very much if the other end needs to sort its life out.
+	c.client.Retrier.Backoff = retry.ExponentialBackoff(500*time.Millisecond, 5*time.Second, retry.Attempts(8))
 	// Query the server for its capabilities. This tells us whether it is capable of
 	// execution, caching or both.
 	resp, err := c.client.GetCapabilities(context.Background())


### PR DESCRIPTION
Seen a few cases where the default policy for RetryTransient isn't enough; this ups the total period from about 1.5 seconds to ~7.5, which is still not painfully long but gives more of a chance for misbehaving servers to see the error of their ways.