### PR TITLE
support pattern match when using --include_file option with plz cover

### DIFF
--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -686,7 +686,7 @@ func shouldInclude(file string, files []string) bool {
 		return true
 	}
 	for _, f := range files {
-		if file == f {
+		if isMatch, _ := path.Match(f, file); isMatch {
 			return true
 		}
 	}

--- a/src/output/shell_output_test.go
+++ b/src/output/shell_output_test.go
@@ -39,6 +39,52 @@ func TestColouriseError(t *testing.T) {
 	assert.EqualValues(t, expected, colouriseError(err))
 }
 
+func TestShouldInclude(t *testing.T) {
+	testCases := []struct {
+		testName        string
+		includeFiles    []string
+		file            string
+		expectedOutcome bool
+	}{
+		{
+			testName:        "with empty file list",
+			includeFiles:    []string{},
+			file:            "opt/tm/file.go",
+			expectedOutcome: true,
+		},
+		{
+			testName:        "with matching file",
+			includeFiles:    []string{"opt/tm/file.go"},
+			file:            "opt/tm/file.go",
+			expectedOutcome: true,
+		},
+		{
+			testName:        "with wildcard match",
+			includeFiles:    []string{"opt/tm/*"},
+			file:            "opt/tm/file.go",
+			expectedOutcome: true,
+		},
+		{
+			testName:        "with no matching files",
+			includeFiles:    []string{"opt/tm/foo.go", "opt/tm/wibble.go"},
+			file:            "opt/tm/file.go",
+			expectedOutcome: false,
+		},
+		{
+			testName:        "with nonsense input",
+			includeFiles:    []string{"opt/tm/%^.&"},
+			file:            "opt/tm/file.go",
+			expectedOutcome: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			assert.Equal(t, testCase.expectedOutcome, shouldInclude(testCase.file, testCase.includeFiles))
+		})
+	}
+}
+
 // Factory function for build targets
 func makeTarget(label string, deps ...string) *core.BuildTarget {
 	target := core.NewBuildTarget(core.ParseBuildLabel(label, ""))

--- a/src/please.go
+++ b/src/please.go
@@ -137,7 +137,7 @@ var opts struct {
 		Rerun               bool          `long:"rerun" description:"Rerun the test even if the hash hasn't changed."`
 		Sequentially        bool          `long:"sequentially" description:"Whether to run multiple runs of the same test sequentially"`
 		IncludeAllFiles     bool          `short:"a" long:"include_all_files" description:"Include all dependent files in coverage (default is just those from relevant packages)"`
-		IncludeFile         cli.Filepaths `long:"include_file" description:"Filenames to filter coverage display to. Suffix with '*' to match subpaths."`
+		IncludeFile         cli.Filepaths `long:"include_file" description:"Filenames to filter coverage display to. Supports shell pattern matching e.g. file/path/*."`
 		TestResultsFile     cli.Filepath  `long:"test_results_file" default:"plz-out/log/test_results.xml" description:"File to write combined test results to."`
 		SurefireDir         cli.Filepath  `long:"surefire_dir" default:"plz-out/surefire-reports" description:"Directory to copy XML test results to."`
 		CoverageResultsFile cli.Filepath  `long:"coverage_results_file" default:"plz-out/log/coverage.json" description:"File to write combined coverage results to."`

--- a/src/please.go
+++ b/src/please.go
@@ -137,7 +137,7 @@ var opts struct {
 		Rerun               bool          `long:"rerun" description:"Rerun the test even if the hash hasn't changed."`
 		Sequentially        bool          `long:"sequentially" description:"Whether to run multiple runs of the same test sequentially"`
 		IncludeAllFiles     bool          `short:"a" long:"include_all_files" description:"Include all dependent files in coverage (default is just those from relevant packages)"`
-		IncludeFile         cli.Filepaths `long:"include_file" description:"Filenames to filter coverage display to"`
+		IncludeFile         cli.Filepaths `long:"include_file" description:"Filenames to filter coverage display to. Suffix with '*' to match subpaths."`
 		TestResultsFile     cli.Filepath  `long:"test_results_file" default:"plz-out/log/test_results.xml" description:"File to write combined test results to."`
 		SurefireDir         cli.Filepath  `long:"surefire_dir" default:"plz-out/surefire-reports" description:"Directory to copy XML test results to."`
 		CoverageResultsFile cli.Filepath  `long:"coverage_results_file" default:"plz-out/log/coverage.json" description:"File to write combined coverage results to."`


### PR DESCRIPTION
Example use: `plz cover //my/test:target --include_file=my/path/*`

Might need more complex pattern to show results for nested directories, not sure if this should be default for the example above?

Unit tests added. Needs manual testing