### PR TITLE
Re-add some notifications

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -265,6 +265,7 @@ func DefaultConfiguration() *Configuration {
 	config.Remote.Secure = true
 	config.Remote.Gzip = true
 	config.Remote.VerifyOutputs = true
+	config.Remote.CacheDuration = cli.Duration(10000 * 24 * time.Hour) // Effectively forever.
 	config.Go.GoTool = "go"
 	config.Go.CgoCCTool = "gcc"
 	config.Go.TestTool = "please_go_test"

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -180,8 +180,10 @@ func processResult(state *core.BuildState, result *core.BuildResult, buildingTar
 			// Reset colour so the entire compiler error output doesn't appear red.
 			log.Errorf("%s failed:\x1b[0m\n%s", result.Label, shortError(result.Err))
 			state.Stop()
-		} else if !plainOutput { // plain output will have already logged this
-			log.Errorf("%s failed: %s", result.Label, shortError(result.Err))
+		} else if msg := shortError(result.Err); msg != "" {
+			log.Errorf("%s failed: %s", result.Label, msg)
+		} else {
+			log.Errorf("%s failed", result.Label)
 		}
 		*failedTargets = append(*failedTargets, label)
 		if result.Status != core.TargetTestFailed {


### PR DESCRIPTION
Adds the "still running after n minutes" prompt for rex.
Adds logging messages when tests fail in non-interactive output (not sure why/when these went away?)
Default cache duration for rex to "long"