### PR TITLE
Fix output hashing for remote_file rules

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -240,8 +240,8 @@ func (c *Client) Build(tid int, target *core.BuildTarget) (*core.BuildMetadata, 
 	if err != nil {
 		return metadata, err
 	}
-	hash, _ := hex.DecodeString(c.digestMessage(ar).Hash)
 	if c.state.TargetHasher != nil {
+		hash, _ := hex.DecodeString(c.outputHash(ar))
 		c.state.TargetHasher.SetHash(target, hash)
 	}
 	if err := c.setOutputs(target, ar); err != nil {

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -574,6 +574,17 @@ func (c *Client) dialOpts() ([]grpc.DialOption, error) {
 	return append(opts, grpc.WithPerRPCCredentials(preSharedToken(string(token)))), nil
 }
 
+// outputHash returns an output hash for a target. If it has a single output it's the hash
+// of that output, otherwise it's the hash of the whole thing.
+// The special-casing is important to make remote_file hash properly (also so you can
+// calculate it manually by sha256sum'ing the file).
+func (c *Client) outputHash(ar *pb.ActionResult) string {
+	if len(ar.OutputFiles) == 1 && len(ar.OutputDirectories) == 0 && len(ar.OutputFileSymlinks) == 0 && len(ar.OutputDirectorySymlinks) == 0 {
+		return ar.OutputFiles[0].Digest.Hash
+	}
+	return c.digestMessage(ar).Hash
+}
+
 // preSharedToken returns a gRPC credential provider for a pre-shared token.
 func preSharedToken(token string) tokenCredProvider {
 	return tokenCredProvider{


### PR DESCRIPTION
They use subresource integrity on the downloaded file, so it has to be the actual hash of the file. Currently it's the hash of the action result which obviously isn't the same.

Will leave it that way in general since there is no single obvious way of calculating the hash of a bunch of directories, but for single files this should make things considerably more working.