### PR TITLE
Store the action digests for use in plz hash and --shell 

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -114,10 +114,10 @@ type pendingDownload struct {
 // It begins the process of contacting the remote server but does not wait for it.
 func New(state *core.BuildState) *Client {
 	c := &Client{
-		state:        state,
-		origState:    state,
-		instance:     state.Config.Remote.Instance,
-		outputs:      map[core.BuildLabel]*pb.Directory{},
+		state:     state,
+		origState: state,
+		instance:  state.Config.Remote.Instance,
+		outputs:   map[core.BuildLabel]*pb.Directory{},
 	}
 	c.stats = newStatsHandler(c)
 	go c.CheckInitialised() // Kick off init now, but we don't have to wait for it.


### PR DESCRIPTION
Building a target can change the target itself which in turn can change the action digest. Before, --shell and plz hash attempted to re-produce the same action digest however at this point the rule had been built. This meant that the action digest was wrong. This just stores them on the client and uses the stored action digest to fetch the action result. 