### PR TITLE
Fix some instances of "is not None"

### DIFF
--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -38,5 +38,5 @@ comprehension = "for" Ident { "," Ident } "in" expression
 slice = "[" [ expression ] [ ":" expression ] "]";
 lambda = "lambda" [ lambda_arg { "," lambda_arg } ] ":" expression;
 lambda_arg = Ident [ "=" expression ];
-operator = ("+" | "-" | "%" | "<" | ">" | "and" | "or" | "is" |
+operator = ("+" | "-" | "%" | "<" | ">" | "and" | "or" | "is" | "is" "not" |
             "in" | "not" "in" | "==" | "!=" | ">=" | "<=" | "|");

--- a/src/parse/asp/grammar.go
+++ b/src/parse/asp/grammar.go
@@ -293,6 +293,8 @@ const (
 	Union = '∪'
 	// Is implements type identity.
 	Is = '≡'
+	// IsNot is the inverse of Is.
+	IsNot = '≢'
 	// Index is used in the parser, but not when parsing code.
 	Index = '['
 )
@@ -317,6 +319,7 @@ var operators = map[string]Operator{
 	"and":    And,
 	"or":     Or,
 	"is":     Is,
+	"is not": IsNot,
 	"in":     In,
 	"not in": NotIn,
 	"==":     Equal,

--- a/src/parse/asp/grammar_parse.go
+++ b/src/parse/asp/grammar_parse.go
@@ -410,6 +410,14 @@ func (p *parser) parseUnconditionalExpressionInPlace(e *Expression) {
 		tok = p.l.Next()
 		o := &e.Op[p.newElement(&e.Op)]
 		o.Op = op
+		if op == Is {
+			if tok := p.l.Peek(); tok.Value == "not" {
+				// Mild hack for "is not" which needs to become a single operator.
+				o.Op = IsNot
+				p.endPos = tok.EndPos()
+				p.l.Next()
+			}
+		}
 		o.Expr = p.parseUnconditionalExpression()
 		if len(o.Expr.Op) > 0 {
 			if op := o.Expr.Op[0].Op; op == And || op == Or || op == Is {
@@ -419,7 +427,6 @@ func (p *parser) parseUnconditionalExpressionInPlace(e *Expression) {
 				o.Expr.Op = nil
 			}
 		}
-		p.l.Peek()
 	}
 }
 

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -306,3 +306,9 @@ func TestInterpreterDictUnion(t *testing.T) {
 		"goofy":  pyInt(3),
 	}, s.Lookup("z"))
 }
+
+func TestIsNotNone(t *testing.T) {
+	s, err := parseFile("src/parse/asp/test_data/interpreter/isnot.build")
+	assert.NoError(t, err)
+	assert.Equal(t, True, s.Lookup("x"))
+}

--- a/src/parse/asp/test_data/interpreter/isnot.build
+++ b/src/parse/asp/test_data/interpreter/isnot.build
@@ -1,0 +1,1 @@
+x = [] is not None


### PR DESCRIPTION
Did the wrong thing when the operand is falsy. Fix requires "is not" to be treated as an explicit operator like "not in".