### PR TITLE
Reorder checks for fetching previously built actions

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -357,11 +357,12 @@ func (c *Client) Download(target *core.BuildTarget) error {
 	}
 	return c.download(target, func() error {
 		buildAction := c.unstampedBuildActionDigests.Get(target.Label)
+		if c.outputsExist(target, buildAction) {
+			return nil
+		}
 		_, ar := c.retrieveResults(target, nil, buildAction, false)
 		if ar == nil {
 			return fmt.Errorf("Failed to retrieve action result for %s", target)
-		} else if c.outputsExist(target, buildAction) {
-			return nil
 		}
 		return c.reallyDownload(target, buildAction, ar)
 	})


### PR DESCRIPTION
If the outputs already exist with this digest we don't need to call retrieveResults to get the action.