### PR TITLE
Check ExecutionMetadata field is not nil

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -684,7 +684,7 @@ func (c *Client) reallyExecute(tid int, target *core.BuildTarget, command *pb.Co
 }
 
 func logResponseTimings(target *core.BuildTarget, ar *pb.ActionResult) {
-	if ar != nil {
+	if ar != nil && ar.ExecutionMetadata != nil {
 		startTime := toTime(ar.ExecutionMetadata.ExecutionStartTimestamp)
 		endTime := toTime(ar.ExecutionMetadata.ExecutionCompletedTimestamp)
 		inputFetchStartTime := toTime(ar.ExecutionMetadata.InputFetchStartTimestamp)


### PR DESCRIPTION
Seen some cases where this seems to panic. Ideally it should never be nil but best to defend ourselves against it.