### PR TITLE
Fix so we download test.results after a failed action

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -666,7 +666,7 @@ func (c *Client) reallyExecute(tid int, target *core.BuildTarget, command *pb.Co
 					err = fmt.Errorf("%s\n%s", err, url)
 				}
 			}
-			return nil, nil, err
+			return metadata, response.Result, err
 		} else if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
I think this was the intended behavior but we never returned the action result from this code path