### PR TITLE
Fix issue with logging completed results in remote exection

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -466,7 +466,7 @@ func (state *BuildState) Hasher(name string) *fs.PathHasher {
 // LogBuildResult logs the result of a target either building or parsing.
 func (state *BuildState) LogBuildResult(tid int, label BuildLabel, status BuildResultStatus, description string) {
 	if status == PackageParsed {
-		func(){
+		func() {
 			// We may have parse tasks waiting for this package to exist, check for them.
 			state.progress.pendingPackageMutex.Lock()
 			defer state.progress.pendingPackageMutex.Unlock()
@@ -486,7 +486,7 @@ func (state *BuildState) LogBuildResult(tid int, label BuildLabel, status BuildR
 		Description: description,
 	})
 	if status == TargetBuilt || status == TargetCached {
-		func(){
+		func() {
 			// We may have parse tasks waiting for this guy to build, check for them.
 			state.progress.pendingTargetMutex.Lock()
 			defer state.progress.pendingTargetMutex.Unlock()

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -708,7 +708,7 @@ func (c *Client) updateProgress(tid int, target *core.BuildTarget, metadata *pb.
 		case pb.ExecutionStage_EXECUTING:
 			c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Building...")
 		case pb.ExecutionStage_COMPLETED:
-			c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Completed...")
+			c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Completed")
 		}
 	} else {
 		switch metadata.Stage {
@@ -719,7 +719,7 @@ func (c *Client) updateProgress(tid int, target *core.BuildTarget, metadata *pb.
 		case pb.ExecutionStage_EXECUTING:
 			c.state.LogBuildResult(tid, target.Label, core.TargetTesting, "Testing...")
 		case pb.ExecutionStage_COMPLETED:
-			c.state.LogBuildResult(tid, target.Label, core.TargetTesting, "Completed...")
+			c.state.LogBuildResult(tid, target.Label, core.TargetTesting, "Completed")
 		}
 	}
 }

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -708,7 +708,8 @@ func (c *Client) updateProgress(tid int, target *core.BuildTarget, metadata *pb.
 		case pb.ExecutionStage_EXECUTING:
 			c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Building...")
 		case pb.ExecutionStage_COMPLETED:
-			c.state.LogBuildResult(tid, target.Label, core.TargetBuilt, "Built")
+			// The build result will be logged in build/build_step.go
+			return
 		}
 	} else {
 		switch metadata.Stage {
@@ -719,7 +720,8 @@ func (c *Client) updateProgress(tid int, target *core.BuildTarget, metadata *pb.
 		case pb.ExecutionStage_EXECUTING:
 			c.state.LogBuildResult(tid, target.Label, core.TargetTesting, "Testing...")
 		case pb.ExecutionStage_COMPLETED:
-			c.state.LogBuildResult(tid, target.Label, core.TargetTested, "Tested")
+			// The test result will be logged in test/test_step.go
+			return
 		}
 	}
 }

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -708,8 +708,7 @@ func (c *Client) updateProgress(tid int, target *core.BuildTarget, metadata *pb.
 		case pb.ExecutionStage_EXECUTING:
 			c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Building...")
 		case pb.ExecutionStage_COMPLETED:
-			// The build result will be logged in build/build_step.go
-			return
+			c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Completed...")
 		}
 	} else {
 		switch metadata.Stage {
@@ -720,8 +719,7 @@ func (c *Client) updateProgress(tid int, target *core.BuildTarget, metadata *pb.
 		case pb.ExecutionStage_EXECUTING:
 			c.state.LogBuildResult(tid, target.Label, core.TargetTesting, "Testing...")
 		case pb.ExecutionStage_COMPLETED:
-			// The test result will be logged in test/test_step.go
-			return
+			c.state.LogBuildResult(tid, target.Label, core.TargetTesting, "Completed...")
 		}
 	}
 }

--- a/tools/java/BUILD
+++ b/tools/java/BUILD
@@ -18,7 +18,7 @@ if CONFIG.OS == "linux" or CONFIG.OS == "darwin":
     java_toolchain(
         name = "toolchain",
         hashes = [
-            "81bf8bee66555b8177fb4c4dd770ee9c1d243bced4bade4661f10fb1b1cf24be",
+            "bcd6c66f3c8a8b78c2caf7e0006be5598c365a2245120b6e8af9096d7c495c34",
             "a357054504bd55cceec52a9468834da5d12448e2b7779b6a1f24367d20454a33",
         ],
         jdk_url = {

--- a/tools/java/BUILD
+++ b/tools/java/BUILD
@@ -19,7 +19,7 @@ if CONFIG.OS == "linux" or CONFIG.OS == "darwin":
         name = "toolchain",
         hashes = [
             "bcd6c66f3c8a8b78c2caf7e0006be5598c365a2245120b6e8af9096d7c495c34",
-            "a357054504bd55cceec52a9468834da5d12448e2b7779b6a1f24367d20454a33",
+            "2486b53995134cf1d4f1a2d5d9590257336fb7ddf19b89ba9a8df9a2d6c05e56",
         ],
         jdk_url = {
             "linux": "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz",

--- a/tools/java/BUILD
+++ b/tools/java/BUILD
@@ -22,7 +22,7 @@ if CONFIG.OS == "linux" or CONFIG.OS == "darwin":
             "2486b53995134cf1d4f1a2d5d9590257336fb7ddf19b89ba9a8df9a2d6c05e56",
         ],
         jdk_url = {
-            "linux": "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz",
-            "darwin": "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.tar.gz",
+            "linux": "https://corretto.aws/downloads/resources/11.0.8.10.1/amazon-corretto-11.0.8.10.1-linux-x64.tar.gz",
+            "darwin": "https://corretto.aws/downloads/resources/11.0.8.10.1/amazon-corretto-11.0.8.10.1-macosx-x64.tar.gz",
         },
     )


### PR DESCRIPTION
We were logging a completed build in the `monitorProgress` method in remote.go as well as in build_step.go and test_step.go. This is a problem when these targets are in the pendingTargets map as the channel gets closed twice. This is the case for sub-includes and target metadata rules. 