### PR TITLE
Ignore local configuration file during init

### DIFF
--- a/src/scm/git.go
+++ b/src/scm/git.go
@@ -116,7 +116,7 @@ func (g *git) IgnoreFile(name string) error {
 	if len(b) > 0 { // Don't append an initial newline if at the start of the file.
 		b = append(b, '\n')
 	}
-	b = append(b, []byte("# Please output directory\nplz-out\n")...)
+	b = append(b, []byte("# Please output directory and local configuration\nplz-out\n.plzconfig.local\n")...)
 	return ioutil.WriteFile(gitignore, b, 0644)
 }
 


### PR DESCRIPTION
As says in the title: let's ignore local config as well. Although the [documentation](https://please.build/config.html) mentions it, I think it's better to help the user.