### PR TITLE
Calculate combined test duration for shell output summary

### DIFF
--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -270,6 +270,7 @@ func printTestResults(state *core.BuildState, failedTargets []core.BuildLabel, f
 	for _, target := range state.Graph.AllTargets() {
 		if target.IsTest {
 			aggregate.TestCases = append(aggregate.TestCases, target.Results.TestCases...)
+			aggregate.Duration += target.Results.Duration
 			if len(target.Results.TestCases) > 0 {
 				if target.Results.Errors() > 0 {
 					printf("${CYAN}%s${RESET} %s\n", target.Label, testResultMessage(target.Results))


### PR DESCRIPTION
manually tested locally

Example output: `1 test target and 14 tests run in 1.428s; 14 passed. Total time 4.34s.`
Previously displayed: `1 test target and 14 tests run in 0s; 14 passed. Total time 4.34s.`