### PR TITLE
Un-sandbox pip_library rule.

### DIFF
--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -411,6 +411,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
         tools = {
             'pip': [CONFIG.PIP_TOOL],
         },
+        sandbox = False,
     )
 
     cmd = '$TOOLS_JARCAT z -d -i .'
@@ -431,7 +432,6 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
             'jarcat': [CONFIG.JARCAT_TOOL],
         },
         post_build = None if licences else _add_licences,
-        sandbox = False,
         labels = ['py:zip-unsafe', 'py', 'pip:' + package_name] if not zip_safe else None,
         visibility = visibility,
     )


### PR DESCRIPTION
Fixes #1088

This change makes a small tweak to un-sandbox the command in `pip_library` that requires network connections to remote resources.

Not sure if we want to add a new test in `tests/python_rules` to point at a pypi dependency (e.g. see tensorflow_test - but with a pypi dependency). Could potentially flake a CI build every now and then but otherwise I'm not sure how we can catch regressions here otherwise.