### PR TITLE
Fix some cache warnings

### DIFF
--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -410,6 +410,9 @@ type mockCache struct{}
 func (*mockCache) Store(target *core.BuildTarget, key []byte, files []string) {
 }
 
+func (*mockCache) StoreFile(target *core.BuildTarget, key []byte, contents io.Reader, filename string) {
+}
+
 func (*mockCache) Retrieve(target *core.BuildTarget, key []byte, outputs []string) bool {
 	if target.Label.Name == "target8" {
 		ioutil.WriteFile("plz-out/gen/package1/file8", []byte("retrieved from cache"), 0664)
@@ -427,6 +430,10 @@ func (*mockCache) Retrieve(target *core.BuildTarget, key []byte, outputs []strin
 		return true
 	}
 	return false
+}
+
+func (*mockCache) RetrieveFile(target *core.BuildTarget, key []byte, filename string) io.ReadCloser {
+	return nil
 }
 
 func (*mockCache) Clean(target *core.BuildTarget) {}

--- a/src/cache/async_cache_test.go
+++ b/src/cache/async_cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"fmt"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -91,11 +92,18 @@ func (c *mockCache) Store(target *core.BuildTarget, key []byte, files []string) 
 	c.Unlock()
 }
 
+func (c *mockCache) StoreFile(target *core.BuildTarget, key []byte, contents io.Reader, filename string) {
+}
+
 func (c *mockCache) Retrieve(target *core.BuildTarget, key []byte, files []string) bool {
 	c.Lock()
 	c.completed[target] = true
 	c.Unlock()
 	return false
+}
+
+func (c *mockCache) RetrieveFile(target *core.BuildTarget, key []byte, filename string) io.ReadCloser {
+	return nil
 }
 
 func (c *mockCache) Clean(target *core.BuildTarget) {

--- a/src/cache/http_cache.go
+++ b/src/cache/http_cache.go
@@ -158,7 +158,7 @@ func (cache *httpCache) request(target *core.BuildTarget, key []byte) (io.ReadCl
 
 func (cache *httpCache) retrieve(target *core.BuildTarget, key []byte) (bool, error) {
 	body, err := cache.request(target, key)
-	if err != nil {
+	if err != nil || body == nil {
 		return false, err
 	}
 	defer body.Close()

--- a/src/core/cache.go
+++ b/src/core/cache.go
@@ -1,5 +1,9 @@
 package core
 
+import (
+	"io"
+)
+
 // Cache is our general interface to caches for built targets.
 // The implementations are in //src/cache, but the interface is in this package because
 // it's passed around on the BuildState object.
@@ -13,7 +17,11 @@ type Cache interface {
 	// that have post-build functions).
 	// If unsuccessful, it will return nil.
 	Retrieve(target *BuildTarget, key []byte, files []string) bool
-	// Retrieves the results of a test run.
+	// Stores the contents of a single file from the given reader.
+	StoreFile(target *BuildTarget, key []byte, contents io.Reader, filename string)
+	// Retrieves the contents of a single file for a build target.
+	// The returned reader is nil if it couldn't be retrieved.
+	RetrieveFile(target *BuildTarget, key []byte, filename string) io.ReadCloser
 	// Cleans any artifacts associated with this target from the cache, for any possible key.
 	// Some implementations may not honour this, depending on configuration etc.
 	Clean(target *BuildTarget)

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -683,6 +683,12 @@ func (config *Configuration) ApplyOverrides(overrides map[string]string) error {
 				return fmt.Errorf("Invalid value for a duration field: %s", v)
 			}
 			field.Set(reflect.ValueOf(d))
+		case reflect.Uint64:
+			var s cli.ByteSize
+			if err := s.UnmarshalText([]byte(v)); err != nil {
+				return fmt.Errorf("Invalid value for a size field: %s", v)
+			}
+			field.Set(reflect.ValueOf(s))
 		case reflect.Slice:
 			// Comma-separated values are accepted.
 			if field.Type().Elem().Kind() == reflect.Struct {

--- a/src/remote/BUILD
+++ b/src/remote/BUILD
@@ -6,7 +6,6 @@ go_library(
     ),
     visibility = ["PUBLIC"],
     deps = [
-        "//src/build",
         "//src/core",
         "//src/fs",
         "//third_party/go:bytestream",


### PR DESCRIPTION
Various "no such file" type errors when trying to cache metadata during remote builds. These are mostly benign but might lead to some things not being cached correctly.

Problem is that we're writing the build metadata file multiple times for stamped targets. The cleanest solution (although not the least code) is to implement the TODO about being able to write a file without going through the disk first.