### PR TITLE
Write a dummy go.mod file into plz-out

### DIFF
--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -256,6 +256,15 @@ func TestRecursiveInitPyCreation(t *testing.T) {
 	assert.True(t, fs.FileExists("plz-out/gen/package1/__init__.py"))
 }
 
+func TestGoModCreation(t *testing.T) {
+	state, _ := newState("//package_go/subpackage:wevs")
+	target := newPyFilegroup(state, "//package1/package2:target1", "file1.py")
+	target.AddLabel("go")
+	_, err := buildFilegroup(state, target)
+	assert.NoError(t, err)
+	assert.True(t, fs.PathExists("plz-out/go.mod"))
+}
+
 func TestCreatePlzOutGo(t *testing.T) {
 	state, target := newState("//package1:target")
 	target.AddLabel("link:plz-out/go/${PKG}/src")


### PR DESCRIPTION
This excludes it from other tooling; easiest example is `go list ./...` which is slow without this and very fast (at least in this repo) once it is written.

I'm not super enthusiastic about language-specific special cases but I'm told this will do quite a bit to make things work and has very little impact on the rest of the system.