### PR TITLE
Support custom out for sh_binary build rule

### DIFF
--- a/rules/sh_rules.build_defs
+++ b/rules/sh_rules.build_defs
@@ -36,7 +36,7 @@ def sh_library(name:str, src:str, deps:list=None, visibility:list=None, labels:l
     )
 
 
-def sh_binary(name:str, main:str|list&srcs, deps:list=None, data:list=None, visibility:list=None,
+def sh_binary(name:str, main:str|list&srcs, out:str="", deps:list=None, data:list=None, visibility:list=None,
               labels:list&features&tags=None):
     """Generates a shell script binary.
 
@@ -50,6 +50,7 @@ def sh_binary(name:str, main:str|list&srcs, deps:list=None, data:list=None, visi
     Args:
       name (str): Name of the rule
       main (str): The script to execute after all files have been uncompressed
+      out (str): Name of the output file to create. Defaults to name + .sh.
       data (list): Runtime data for this rule.
       deps (list): Dependencies of this rule
       visibility (list): Visibility declaration of the rule.
@@ -78,7 +79,7 @@ def sh_binary(name:str, main:str|list&srcs, deps:list=None, data:list=None, visi
     return build_rule(
         name = name,
         srcs = [main],
-        outs = ['%s.sh' % name],
+        outs = [out or name + '.sh'],
         data = data,
         tools = [CONFIG.JARCAT_TOOL],
         cmd = cmds,


### PR DESCRIPTION
I find myself doing this over and over in my `BUILD` files:
```
sh_binary(
    name = "binary",
    main = "main.sh",
)

genrule(
    name = "kubectl_plugin",
    srcs = [":binary"],
    outs = ["kubectl-plugin"],
    cmd = ["cp ${SRC} ${OUT}"],
    binary = True,
)
```

It'd be nice if `sh_binary()` would support a custom `out` argument, the same way `sh_cmd()` already does. (I mostly just copied what was done for that to get here.)