### PR TITLE
Make plz clean --nobackground more robust

### DIFF
--- a/src/build/BUILD
+++ b/src/build/BUILD
@@ -6,7 +6,6 @@ go_library(
     ),
     visibility = ["PUBLIC"],
     deps = [
-        "//src/cache",
         "//src/core",
         "//src/fs",
         "//src/worker",

--- a/src/cache/BUILD
+++ b/src/cache/BUILD
@@ -8,6 +8,7 @@ go_library(
     ),
     visibility = ["PUBLIC"],
     deps = [
+        "//src/clean",
         "//src/cli",
         "//src/core",
         "//src/fs",

--- a/src/cache/dir_cache.go
+++ b/src/cache/dir_cache.go
@@ -19,6 +19,7 @@ import (
 	"github.com/djherbis/atime"
 	"github.com/dustin/go-humanize"
 
+	"github.com/thought-machine/please/src/clean"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 )
@@ -299,13 +300,8 @@ func (cache *dirCache) Clean(target *core.BuildTarget) {
 }
 
 func (cache *dirCache) CleanAll() {
-	if err := core.AsyncDeleteDir(cache.Dir); err != nil {
+	if err := clean.AsyncDeleteDir(cache.Dir); err != nil {
 		log.Error("Failed to clean cache: %s", err)
-	}
-	// We used to store the cache in .plz-cache by default; we now use UserCacheDir but
-	// if the old one's there, we'll clean it out too.
-	if dir2 := path.Join(core.RepoRoot, ".plz-cache"); dir2 != cache.Dir && fs.PathExists(dir2) {
-		core.AsyncDeleteDir(dir2)
 	}
 }
 

--- a/src/clean/BUILD
+++ b/src/clean/BUILD
@@ -1,6 +1,6 @@
 go_library(
     name = "clean",
-    srcs = glob(["*.go"]),
+    srcs = ["clean.go"],
     visibility = ["PUBLIC"],
     deps = [
         "//src/build",
@@ -8,5 +8,15 @@ go_library(
         "//src/fs",
         "//src/test",
         "//third_party/go:logging",
+    ],
+)
+
+go_test(
+    name = "clean_test",
+    srcs = ["clean_test.go"],
+    deps = [
+        ":clean",
+        "//src/fs",
+        "//third_party/go:testify",
     ],
 )

--- a/src/clean/clean.go
+++ b/src/clean/clean.go
@@ -3,13 +3,19 @@
 package clean
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
+	"os/exec"
+	"path"
+	"syscall"
 
 	"gopkg.in/op/go-logging.v1"
 
 	"github.com/thought-machine/please/src/build"
 	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/test"
 )
 
@@ -21,7 +27,7 @@ func Clean(config *core.Configuration, cache core.Cache, background bool) {
 		cache.CleanAll()
 	}
 	if background {
-		if err := core.AsyncDeleteDir(core.OutDir); err != nil {
+		if err := AsyncDeleteDir(core.OutDir); err != nil {
 			log.Warning("Couldn't run clean in background; will do it synchronously: %s", err)
 		} else {
 			fmt.Println("Cleaning in background; you may continue to do pleasing things in this repo in the meantime.")
@@ -63,8 +69,51 @@ func cleanTarget(state *core.BuildState, target *core.BuildTarget, cleanCache bo
 func clean(path string) {
 	if core.PathExists(path) {
 		log.Info("Cleaning path %s", path)
-		if err := os.RemoveAll(path); err != nil {
+		if err := deleteDir(path, false); err != nil {
 			log.Fatalf("Failed to clean path %s: %s", path, err)
 		}
 	}
+}
+
+// AsyncDeleteDir deletes a directory asynchronously.
+// First it renames the directory to something temporary and then forks to delete it.
+// The rename is done synchronously but the actual deletion is async (after fork) so
+// you don't have to wait for large directories to be removed.
+// Conversely there is obviously no guarantee about at what point it will actually cease to
+// be on disk any more.
+func AsyncDeleteDir(dir string) error {
+	return deleteDir(dir, true)
+}
+
+func deleteDir(dir string, async bool) error {
+	rm, err := exec.LookPath("rm")
+	if err != nil {
+		return err
+	} else if !fs.PathExists(dir) {
+		return nil // not an error, just don't need to do anything.
+	}
+	newDir, err := moveDir(dir)
+	if err != nil {
+		return err
+	}
+	if async {
+		// Note that we can't fork() directly and continue running Go code, but ForkExec() works okay.
+		// Hence why we're using rm rather than fork() + os.RemoveAll.
+		_, err = syscall.ForkExec(rm, []string{rm, "-rf", newDir}, nil)
+		return err
+	}
+	out, err := exec.Command(rm, "-rf", newDir).CombinedOutput()
+	if err != nil {
+		log.Error("Failed to remove directory: %s", string(out))
+	}
+	return err
+}
+
+// moveDir moves a directory to a new location and returns that new location.
+func moveDir(dir string) (string, error) {
+	b := make([]byte, 16)
+	rand.Read(b)
+	name := path.Join(path.Dir(dir), ".plz_clean_"+hex.EncodeToString(b))
+	log.Notice("Moving %s to %s", dir, name)
+	return name, os.Rename(dir, name)
 }

--- a/src/clean/clean_test.go
+++ b/src/clean/clean_test.go
@@ -1,0 +1,25 @@
+package clean
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/thought-machine/please/src/fs"
+)
+
+func TestAsyncDeleteDir(t *testing.T) {
+	err := os.MkdirAll("test_dir/a/b/c", os.ModeDir|0775)
+	assert.NoError(t, err)
+	err = AsyncDeleteDir("test_dir")
+	assert.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		if !fs.PathExists("test_dir") {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	assert.False(t, fs.PathExists("test_dir"))
+}

--- a/src/core/utils_test.go
+++ b/src/core/utils_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/src/core/utils_test.go
+++ b/src/core/utils_test.go
@@ -135,19 +135,6 @@ func TestLookPathDoesntExist(t *testing.T) {
 	_, err := LookPath("wibblewobbleflibble", []string{"/usr/local/bin", "/usr/bin", "/bin"})
 	assert.Error(t, err)
 }
-func TestAsyncDeleteDir(t *testing.T) {
-	err := os.MkdirAll("test_dir/a/b/c", DirPermissions)
-	assert.NoError(t, err)
-	err = AsyncDeleteDir("test_dir")
-	assert.NoError(t, err)
-	for i := 0; i < 100; i++ {
-		if !PathExists("test_dir") {
-			return
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	assert.False(t, PathExists("test_dir"))
-}
 
 // buildGraph builds a test graph which we use to test IterSources etc.
 func buildGraph() *BuildGraph {


### PR DESCRIPTION
Currently it uses `rm -rf` for normal `plz clean` but `os.RemoveAll` for `--nobackground` which is roughly akin to `rm -r`. This makes it more robust to read-only files etc.

Also move the code out of `//src/core` since that's big enough already.