### PR TITLE
Imrpove remove file to allow outputting directly into root

### DIFF
--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -352,7 +352,15 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
       strip_prefix (str): When extracting, strip this prefix from the extracted files.
     """
     if extract:
-        assert out, "Must pass 'out' when passing 'extract' to remote_file"
+        if out:
+            outs = [out]
+            output_dirs = []
+            extract_location = "$OUT"
+        else:
+            outs = []
+            output_dirs = ["_extract_dir"]
+            extract_location = "_extract_dir"
+
         remote_rule = remote_file(
             name = name,
             _tag = _tag + 'download',
@@ -363,13 +371,14 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
             labels = labels,
         )
         if strip_prefix:
-            cmd = '"$TOOL" x $SRCS -o "$OUT" -s ' + strip_prefix
+            cmd = f'"$TOOL" x $SRCS -o "{extract_location}" -s "{strip_prefix}"'
         else:
-            cmd = '"$TOOL" x $SRCS -o "$OUT"'
+            cmd = f'"$TOOL" x $SRCS -o "{extract_location}"'
         return build_rule(
             name = name,
             srcs = [remote_rule],
-            outs = [out],
+            outs = outs,
+            output_dirs = output_dirs,
             tools = [CONFIG.JARCAT_TOOL],
             cmd = cmd,
             binary = binary,

--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -331,7 +331,7 @@ def system_library(name:str, srcs:list, deps:list=None, hashes:list=None,
 def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:bool=False,
                 visibility:list=None, licences:list=None, test_only:bool&testonly=False,
                 labels:list=[], deps:list=None, exported_deps:list=None,
-                extract:bool=False, strip_prefix:str='', _tag:str=''):
+                extract:bool=False, strip_prefix:str='', _tag:str='',exported_files=[]):
     """Defines a rule to fetch a file over HTTP(S).
 
     Args:
@@ -350,16 +350,19 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
       extract (bool): Extracts the contents of the downloaded file. It must be either zip or
                       tar format.
       strip_prefix (str): When extracting, strip this prefix from the extracted files.
+      exported_files (list): A list of files to export from the archive when extracting.
     """
     if extract:
         if out:
             outs = [out]
             output_dirs = []
-            extract_location = "$OUT"
+            extract_location = "_extract_dir" if exported_files else f"{out}"
+            mv_cmds = ' && '.join([f'mv _extract_dir/{file} {out}' for file in exported_files])
         else:
             outs = []
-            output_dirs = ["_extract_dir"]
-            extract_location = "_extract_dir"
+            output_dirs = ["_out_dir"]
+            extract_location = "_extract_dir" if exported_files else "_out_dir"
+            mv_cmds = ' && '.join([f'mv _extract_dir/{file} _out_dir' for file in exported_files])
 
         remote_rule = remote_file(
             name = name,
@@ -370,10 +373,19 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
             test_only = test_only,
             labels = labels,
         )
-        if strip_prefix:
-            cmd = f'"$TOOL" x $SRCS -o "{extract_location}" -s "{strip_prefix}"'
+
+        if out:
+            cmd = 'mkdir $OUT'
         else:
-            cmd = f'"$TOOL" x $SRCS -o "{extract_location}"'
+            cmd = 'mkdir _out_dir'
+
+        cmd = f'{cmd} && "$TOOL" x $SRCS -o "{extract_location}"'
+        if strip_prefix:
+            cmd = f'{cmd} -s "{strip_prefix}"'
+
+        if mv_cmds:
+            cmd = f'{cmd} && {mv_cmds}'
+
         return build_rule(
             name = name,
             srcs = [remote_rule],


### PR DESCRIPTION
Means that #1098 works a bit better. 

```
remote_file(
    name = "golangci-lint",
    binary = True,
    extract = True,
    hashes = [
        "98b1eb7c74766079e1deebc3388c13db9bfa9fa0769046d786cf8d1553d7d68b",
        "56b36d1b0a976caf2f49c06e4429aa6021ef0aba13a2e823e063b0605e1dd492",
        "6a7c31abca3f51714e5ea1f0aae5dc78d72e7d57d07f02b1a1778219d5648e21",
    ],
    strip_prefix = "golangci-lint-1.29.0-${OS}-${ARCH}",
    url = "https://github.com/golangci/golangci-lint/releases/download/v1.29.0/golangci-lint-1.29.0-%s-%s.tar.gz" % (
        CONFIG.OS,
        CONFIG.ARCH,
    ),
   exported_files = ["golangci-lint"],
)
```
produces
```
$ plox build //strip-prefix:golangci-lint 
Build finished; total time 410ms, incrementality 50.0%. Outputs:
//strip-prefix:golangci-lint:
  plz-out/bin/strip-prefix/golangci-lint
```
