### PR TITLE
Fix go_binary linking of third party dependencies outside of root #1061

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -6,11 +6,10 @@ rules to Go packages.
 
 # This links all the .a files up one level. This is necessary for some Go tools to find them.
 _LINK_PKGS_CMD = ' '.join([
-    'for FN in `find . -name "*.a" | sort`; do',
+    'find . -name "*.a" -print0 | sort -z | xargs -0 -n1 | while read FN; do',
     'DN=${FN%/*}; BN=${FN##*/}; if [ "${DN##*/}" == "${BN%.a}" ]; then',
-    'ln -s "$TMP_DIR"/$FN ${DN%/*}; fi; done'
+    'ln -s "$TMP_DIR/$FN" "${DN%/*}"; fi; done'
 ])
-
 
 def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=None, deps:list=[],
                visibility:list=None, test_only:bool&testonly=False, complete:bool=True,
@@ -868,15 +867,35 @@ def _replace_test_package(name, output, static, definitions, cgo):
                     set_command(lib, k, f'mv -f $PKG_DIR/{new_name}.a $PKG_DIR/{pkg_name}.a && {v}')
 
 
+def _go_pkg_directory_flags(flag:str):
+    """Returns go pkg directories constructed from the configured GOPATH as well
+    as a shell command to find go pkg directories nested inside of $TMP_DIR.
+    Each listed pkg directory is prefixed with the provided flag. The shell
+    command provides null separated output to safely support special characters
+    in filepaths such as space. It is intended for the output to be used via
+    xargs -0. The command makes an empty go pkg directory to ensure xargs will
+    always have at least one argument and be executed.
+    """
+
+    go_pkg_dir = f'pkg/{CONFIG.GOOS}_{CONFIG.GOARCH}'
+
+    _GOPATH = ' '.join(['%s "%s" %s "%s/%s"' % (flag, p, flag, p, go_pkg_dir) for p in CONFIG.GOPATH.split(':')])
+
+    ensure_go_pkg_dir = f'mkdir -p "$TMP_DIR/{go_pkg_dir}"'
+    find_go_pkg_dirs = f'find "$TMP_DIR" -type d | grep "{go_pkg_dir}$"'
+    prefix_with_flag = 'while read line; do printf -- "'+flag+'\0$line\0"; done'
+
+    return _GOPATH, f'{ensure_go_pkg_dir} && {find_go_pkg_dirs} | {prefix_with_flag}'
+
+
 def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True, abi=False):
     """Returns the commands to run for building a Go library."""
     filter_cmd = 'export SRCS="$(\"${TOOLS_FILTER}\" ${SRCS})"; ' if filter_srcs else ''
     # Invokes the Go compiler.
     complete_flag = '-complete ' if complete else ''
     out_cmd = ' -o "$OUTS_O" -symabis $SRCS_ABI -asmhdr "$OUTS_H"' if abi else ' -o "$OUT"'
-    _GOPATH = ' '.join(
-        ['-I "%s" -I "%s/pkg/%s_%s"' % (p, p, CONFIG.GOOS, CONFIG.GOARCH) for p in CONFIG.GOPATH.split(':')])
-    compile_cmd = f'"$TOOLS_GO" tool compile -trimpath "$TMP_DIR" {complete_flag}{_GOPATH} $(for i in $(find "$TMP_DIR" -name pkg -type d); do echo -n " -I \"$i\"/{CONFIG.GOOS}_{CONFIG.GOARCH} "; done) -pack {out_cmd}'
+    _GOPATH, find_compile_imports = _go_pkg_directory_flags("-I")
+    compile_cmd = f'{find_compile_imports} | xargs -t -0 -J@ "$TOOLS_GO" tool compile -trimpath "$TMP_DIR" {complete_flag}{_GOPATH} @ -pack {out_cmd}'
     # Annotates files for coverage.
     cover_cmd = 'for SRC in $SRCS; do BN=$(basename $SRC); go tool cover -mode=set -var=GoCover_${BN//[.-]/_} $SRC > _tmp.go && mv -f _tmp.go $SRC; done'
     prefix = ('export SRCS="$PKG_DIR/*.go"; ' + _LINK_PKGS_CMD) if all_srcs else _LINK_PKGS_CMD
@@ -893,9 +912,8 @@ def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True
 def _go_binary_cmds(static=False, ldflags='', pkg_config='', definitions=None, gcov=False):
     """Returns the commands to run for linking a Go binary."""
 
-    _GOPATH = ' '.join(
-        ['-I "%s" -I "%s/pkg/%s_%s"' % (p, p, CONFIG.GOOS, CONFIG.GOARCH) for p in CONFIG.GOPATH.split(':')])
-    _link_cmd = f'"$TOOLS_GO" tool link -tmpdir "$TMP_DIR" -extld "$TOOLS_LD" %s $(find "$TMP_DIR" -type d -print | grep "pkg/{CONFIG.GOOS}_{CONFIG.GOARCH}$" | sed -e "s/^/-L \\\"/" -e "s/$/\\"/g" | tr "\\n" " ") -o "$OUT" ' % _GOPATH.replace('-I ', '-L ')
+    _GOPATH, find_link_libraries = _go_pkg_directory_flags("-L")
+    _link_cmd = f'{find_link_libraries} | xargs -t -0 -J@ "$TOOLS_GO" tool link -tmpdir "$TMP_DIR" -extld "$TOOLS_LD" {_GOPATH} @ -o "$OUT"'
     prefix = _LINK_PKGS_CMD + _go_import_path_cmd(CONFIG.GO_IMPORT_PATH)
 
     linkerdefs = []

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -867,26 +867,23 @@ def _replace_test_package(name, output, static, definitions, cgo):
                     set_command(lib, k, f'mv -f $PKG_DIR/{new_name}.a $PKG_DIR/{pkg_name}.a && {v}')
 
 
-def _go_pkg_directory_flags(flag:str):
-    """Returns go pkg directories constructed from the configured GOPATH as well
-    as a shell command to find go pkg directories nested inside of $TMP_DIR.
-    Each listed pkg directory is prefixed with the provided flag. The shell
-    command provides null separated output to safely support special characters
-    in filepaths such as space. It is intended for the output to be used via
-    xargs -0. The command makes an empty go pkg directory to ensure xargs will
-    always have at least one argument and be executed.
+def _create_gopkg_flags(var:str, flag:str):
+    """Returns a script which collects potential package archive directories
+    zipped with the provided flag and stored in an array with the provided var
+    name. The array can then be injected as flag arguments into another command.
+    Since the filepaths are stored as array elements we avoid bash word splitting
+    issues on filepaths which contain spaces. The script directories are
+    collected using a combination of the configured go path as well as searching
+    for directories inside of $TMP_DIR which have the configured pkg/GOOS_GOARCH
+    suffix.
     """
 
-    go_pkg_dir = f'pkg/{CONFIG.GOOS}_{CONFIG.GOARCH}'
+    suffix = f'pkg/{CONFIG.GOOS}_{CONFIG.GOARCH}'
+    gopath = f"echo $GOPATH | awk -F: '{{OFS=ORS;for(k=1;k<=NF;k++){{print $k,$k\"/{suffix}\"}}}}'"
+    search = f'find "$TMP_DIR" -type d -path "*/{suffix}"'
+    gopkgs = f'sort -u <({gopath}) <({search})'
 
-    _GOPATH = ' '.join(['%s "%s" %s "%s/%s"' % (flag, p, flag, p, go_pkg_dir) for p in CONFIG.GOPATH.split(':')])
-
-    ensure_go_pkg_dir = f'mkdir -p "$TMP_DIR/{go_pkg_dir}"'
-    find_go_pkg_dirs = f'find "$TMP_DIR" -type d | grep "{go_pkg_dir}$"'
-    prefix_with_flag = 'while read line; do printf -- "'+flag+'\0$line\0"; done'
-
-    return _GOPATH, f'{ensure_go_pkg_dir} && {find_go_pkg_dirs} | {prefix_with_flag}'
-
+    return f"GOPATH=\"{CONFIG.GOPATH}\" && mapfile -t {var} < <({gopkgs} | awk '{{OFS=ORS;print \"{flag}\",$0}}')"
 
 def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True, abi=False):
     """Returns the commands to run for building a Go library."""
@@ -894,8 +891,8 @@ def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True
     # Invokes the Go compiler.
     complete_flag = '-complete ' if complete else ''
     out_cmd = ' -o "$OUTS_O" -symabis $SRCS_ABI -asmhdr "$OUTS_H"' if abi else ' -o "$OUT"'
-    _GOPATH, find_compile_imports = _go_pkg_directory_flags("-I")
-    compile_cmd = f'{find_compile_imports} | xargs -t -0 -J@ "$TOOLS_GO" tool compile -trimpath "$TMP_DIR" {complete_flag}{_GOPATH} @ -pack {out_cmd}'
+    create_gopkg_flags = _create_gopkg_flags("GOPKG_FLAGS", "-I")
+    compile_cmd = f'{create_gopkg_flags} && "$TOOLS_GO" tool compile -trimpath "$TMP_DIR" {complete_flag} "${GOPKG_FLAGS[@]}" -pack {out_cmd}'
     # Annotates files for coverage.
     cover_cmd = 'for SRC in $SRCS; do BN=$(basename $SRC); go tool cover -mode=set -var=GoCover_${BN//[.-]/_} $SRC > _tmp.go && mv -f _tmp.go $SRC; done'
     prefix = ('export SRCS="$PKG_DIR/*.go"; ' + _LINK_PKGS_CMD) if all_srcs else _LINK_PKGS_CMD
@@ -912,8 +909,8 @@ def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True
 def _go_binary_cmds(static=False, ldflags='', pkg_config='', definitions=None, gcov=False):
     """Returns the commands to run for linking a Go binary."""
 
-    _GOPATH, find_link_libraries = _go_pkg_directory_flags("-L")
-    _link_cmd = f'{find_link_libraries} | xargs -t -0 -J@ "$TOOLS_GO" tool link -tmpdir "$TMP_DIR" -extld "$TOOLS_LD" {_GOPATH} @ -o "$OUT"'
+    create_gopkg_flags = _create_gopkg_flags("GOPKG_FLAGS", "-L")
+    _link_cmd = f'{create_gopkg_flags} && "$TOOLS_GO" tool link -tmpdir "$TMP_DIR" -extld "$TOOLS_LD" "${GOPKG_FLAGS[@]}" -o "$OUT"'
     prefix = _LINK_PKGS_CMD + _go_import_path_cmd(CONFIG.GO_IMPORT_PATH)
 
     linkerdefs = []

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -882,8 +882,9 @@ def _create_gopkg_flags(var:str, flag:str):
     gopath = f"echo $GOPATH | awk -F: '{{OFS=ORS;for(k=1;k<=NF;k++){{print $k,$k\"/{suffix}\"}}}}'"
     search = f'find "$TMP_DIR" -type d -path "*/{suffix}"'
     gopkgs = f'sort -u <({gopath}) <({search})'
+    setvar = f'declare -a {var}; while read -r FN; do {var}+=("$FN"); done'
 
-    return f"GOPATH=\"{CONFIG.GOPATH}\" && mapfile -t {var} < <({gopkgs} | awk '{{OFS=ORS;print \"{flag}\",$0}}')"
+    return f"GOPATH=\"{CONFIG.GOPATH}\" && {setvar} < <({gopkgs} | awk '{{OFS=ORS;print \"{flag}\",$0}}')"
 
 def _go_library_cmds(complete=True, all_srcs=False, cover=True, filter_srcs=True, abi=False):
     """Returns the commands to run for building a Go library."""


### PR DESCRIPTION
For reference I am using MacOS.

This issue only exists for the `go_binary` rule and third party dependencies which are added as library paths through command substitution. i.e. third party dependencies defined outside of the root `third_party/go/BUILD.plz`. The `go_library` rule works only because it's not actually quoting the file paths due to a subtle bug.

```bash
$(for i in $(find "$TMP_DIR" -name pkg -type d); do echo -n " -I \"$i\"/{CONFIG.GOOS}_{CONFIG.GOARCH} "; done)
```

The snippet above in the python `go_library` rule becomes the following in the actual shell.

```bash
$(for i in $(find "$TMP_DIR" -name pkg -type d); do echo -n " -I "$i"/darwin_amd64 "; done)
```

The escaped quote is lost and instead we get string concatenation which is probably not what was originally intended. In regards to the `go_binary` rule it **is** actually quoting the file paths. However, because it is being injected via command substitution it does not work properly. There are a couple issues here.

 Issue **1)** The output of command substitution is split on whitespace regardless of quotes within the output. So, for example, a file path which includes spaces `printargs $(echo '"foo bar\baz.txt"')` would become the following arguments.

```
arg 0: "foo
arg 1: bar\baz.txt"
```

Issue **2)** The quotes within the command substitution output are preserved. So, if we have `-L "foo/bar/pkg/darwin_amd64"` it's going to attempt to look in a directory named `"foo`, which begins with a quote, and not the correct directory `foo`.

This fix removes the need for quoting by using null separated arguments instead and providing them to the link/compile command via xargs instead of command substitution. Once I began manually testing with file paths which included spaces I noticed that the `_LINK_PKGS_CMD` also didn't account for spaces so I fixed it in a similar manner.
