### PR TITLE
Remove ~ secrets test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,6 @@ env:
 
 task:
   install_script: pkg install -y bash protobuf go git python3 && python3 -m ensurepip
-  bashrc_script: touch ~/.bashrc
   build_script: PLZ_ARGS="-o cache.httpurl:http://$CIRRUS_HTTP_CACHE_HOST" ./bootstrap.sh --exclude pip --exclude py2 --exclude no_cirrus --exclude cc
   always:
     log_artifacts:

--- a/test/secrets/BUILD
+++ b/test/secrets/BUILD
@@ -8,22 +8,3 @@ gentest(
     secrets = ["/bin/sh"],
     test_cmd = "$TEST",
 )
-
-tildes_replaced_test = r'''
-echo "[ \"$SECRETS_AD_SECRETS\" = \"/bin/sh $SECRETS_HOME/.bashrc\" ] || \
-(echo "Failed: $SECRETS_HOME $SECRETS_AD_SECRETS"; exit 1)" > "$OUT"'''
-
-gentest(
-    name = "test_tildes_replaced",
-    outs = ["test_tildes_replaced.sh"],
-    cmd = tildes_replaced_test,
-    no_test_output = True,
-    secrets = {
-        "home": ["~"],
-        "ad_secrets": [
-            "/bin/sh",
-            "~/.bashrc",
-        ],
-    },
-    test_cmd = "$TEST",
-)


### PR DESCRIPTION
This test doesn't seem very useful and it was breaking bootstrapping for anybody not using bash. 

Resolves #806