### PR TITLE
Update linguist info for BUILD files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
-*.build_defs linguist-language=Python diff=python
-BUILD linguist-language=Python diff=python
-BUILD.plz linguist-language=Python diff=python
+*.build_defs linguist-language=Starlark diff=python
+BUILD.plz linguist-language=Starlark diff=python
 docs/* linguist-documentation
 *_bindata.go linguist-generated
 third_party/go/zip/* linguist-vendored


### PR DESCRIPTION
BUILD files are natively recognised by linguist now as Starlark (which ours aren't precisely, but it's closer than Python).