### PR TITLE
Fix up base loop condition in clean up old outputs

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -696,7 +696,7 @@ func RemoveOutputs(target *core.BuildTarget) error {
 // It returns true if something was removed.
 func checkForStaleOutput(filename string, err error) bool {
 	if perr, ok := err.(*os.PathError); ok && perr.Err.Error() == "not a directory" {
-		for dir := path.Dir(filename); dir != "." && dir != "/" && path.Base(dir) != "plz-out"; dir = path.Dir(dir) {
+		for dir := filename; dir != "." && dir != "/" && path.Base(dir) != "plz-out"; dir = path.Dir(dir) {
 			if fs.FileExists(dir) {
 				log.Warning("Removing %s which appears to be a stale output file", dir)
 				os.Remove(dir)


### PR DESCRIPTION
Addresses #766 

I have noticed that this will clear out files when it should really error in some cases. 

If you have:

```
//foo:bar -> plz-out/gen/foo/bar
//foo/bar/baz -> plz-out/gen/foo/bar/baz/baz.a
```

If baz gets built second it will clear out the file `plz-out/gen/foo/bar` when it shouldn't. I'm not sure we can do much better though. Post build functions and output directories make it near impossible to correctly determine if a file is still owned by another rule. 

We could instead error at this point suggesting the user manually deletes this file. 