### PR TITLE
Allow local remote files

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -1006,7 +1006,13 @@ func fetchOneRemoteFile(state *core.BuildState, target *core.BuildTarget, url st
 	}
 	defer f.Close()
 	if strings.HasPrefix(url, "file://") {
-		fromfile, err := os.Open(strings.TrimPrefix(url, "file://"))
+		filename := strings.TrimPrefix(url, "file://")
+		if !path.IsAbs(filename) {
+			return fmt.Errorf("URL %s must be an absolute path", url)
+		} else if strings.HasPrefix(filename, core.RepoRoot) {
+			return fmt.Errorf("URL %s is within the repo, you cannot use remote_file for this", url)
+		}
+		fromfile, err := os.Open(filename)
 		if err != nil {
 			return fmt.Errorf("Error copying %s: %w", url, err)
 		}

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -364,6 +364,15 @@ func TestCheckRuleHashes(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestFetchLocalRemoteFile(t *testing.T) {
+	state, target := newState("//package4:target2")
+	target.AddSource(core.URLLabel("file://" + os.Getenv("TMP_DIR") + "/src/build/test_data/local_remote_file.txt"))
+	target.AddOutput("local_remote_file.txt")
+	err := fetchRemoteFile(state, target)
+	assert.NoError(t, err)
+	assert.True(t, fs.FileExists(path.Join(target.TmpDir(), "local_remote_file.txt")))
+}
+
 func TestBuildMetadatafileIsCreated(t *testing.T) {
 	stdOut := "wibble wibble wibble"
 

--- a/src/build/test_data/local_remote_file.txt
+++ b/src/build/test_data/local_remote_file.txt
@@ -1,0 +1,1 @@
+How much wood could a woodchuck chuck if a woodchuck could chuck wood?


### PR DESCRIPTION
Allow `remote_file` to load local files prefixed by `file://`. This addresses one aspect of #645 (although it will not necessarily cover everything since not all `go_get` rules go this way). It also happens to be something I will find useful shortly...