### PR TITLE
Build FreeBSD binaries in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,33 @@ jobs:
            key: python-linux-alt-v2-{{ checksum "third_party/python/BUILD" }}
            paths: [ ".plz-cache/third_party/python" ]
 
+   build-freebsd:
+     working_directory: ~/please
+     docker:
+       - image: thoughtmachine/please_freebsd_builder:20200820
+     resource_class: large
+     steps:
+       - checkout
+       - attach_workspace:
+           at: /tmp/workspace
+       - restore_cache:
+           key: go-freebsd-v1-{{ checksum "third_party/go/BUILD" }}
+       - run:
+           name: Extract plz
+           command: tar -xzf /tmp/workspace/linux_amd64/please_*.tar.gz
+       - run:
+           name: Cross-compile
+           command: ./please/please build -p --profile ci --arch freebsd_amd64 //package:all
+       - persist_to_workspace:
+           root: plz-out/pkg
+           paths:
+             - freebsd_amd64/please_*.tar.*
+       - store_artifacts:
+           path: plz-out/log
+       - save_cache:
+           key: go-freebsd-v1-{{ checksum "third_party/go/BUILD" }}
+           paths: [ ".plz-cache/third_party/go" ]
+
    lint:
      working_directory: ~/please
      docker:
@@ -197,7 +224,7 @@ jobs:
        - add_ssh_keys:
            fingerprints:
              - "cc:57:b9:67:31:65:a6:70:8c:e3:e7:90:ca:e6:a6:41"
-       - run: /tmp/workspace/gen_release.pex --signer /tmp/workspace/release_signer /tmp/workspace/linux_amd64/* /tmp/workspace/darwin_amd64/*
+       - run: /tmp/workspace/gen_release.pex --signer /tmp/workspace/release_signer /tmp/workspace/*_amd64/*
 
    docs:
      docker:
@@ -227,6 +254,9 @@ workflows:
           requires:
             - build-linux
             - build-linux-alt
+      - build-freebsd:
+          requires:
+            - build-linux
       - test-rex:
           requires:
             - build-linux
@@ -235,6 +265,7 @@ workflows:
             - build-linux
       - release:
           requires:
+            - build-freebsd
             - build-linux
             - build-linux-alt
             - build-darwin

--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -567,7 +567,7 @@ def python_wheel(name:str, version:str, hashes:list=None, package_name:str=None,
 def _patch_cmd(patch):
     """Returns a command for the given patch or patches, with OS-specific tweaks where needed."""
     patches = [patch] if isinstance(patch, str) else patch
-    if CONFIG.OS == 'freebsd':
+    if CONFIG.HOSTOS == 'freebsd':
         # --no-backup-if-mismatch is not supported, but we need to get rid of the .orig
         # files for hashes to match correctly.
         return patches, [f'patch -p0 < $(location {patch})' for patch in patches] + ['find . -name "*.orig" | xargs rm']

--- a/tools/images/freebsd_builder/Dockerfile
+++ b/tools/images/freebsd_builder/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:focal
+MAINTAINER peter.ebden@gmail.com
+
+# A few miscellaneous dependencies.
+RUN apt-get update && apt-get install -y curl git locales && apt-get clean
+
+# Go
+RUN curl -fsSL https://dl.google.com/go/go1.15.linux-amd64.tar.gz | tar -xzC /usr/local
+RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+ENV GOOS=freebsd
+ENV GOARCH=amd64
+RUN go install std
+
+# Locale
+RUN locale-gen en_GB.UTF-8
+
+WORKDIR /tmp

--- a/tools/images/freebsd_builder/Dockerfile
+++ b/tools/images/freebsd_builder/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:focal
 MAINTAINER peter.ebden@gmail.com
 
 # A few miscellaneous dependencies.
-RUN apt-get update && apt-get install -y curl git locales && apt-get clean
+RUN apt-get update && apt-get install -y curl git locales gcc xz-utils && apt-get clean
 
 # Go
 RUN curl -fsSL https://dl.google.com/go/go1.15.linux-amd64.tar.gz | tar -xzC /usr/local

--- a/tools/images/freebsd_builder/Dockerfile
+++ b/tools/images/freebsd_builder/Dockerfile
@@ -2,16 +2,11 @@ FROM ubuntu:focal
 MAINTAINER peter.ebden@gmail.com
 
 # A few miscellaneous dependencies.
-RUN apt-get update && apt-get install -y curl git locales gcc xz-utils && apt-get clean
+RUN apt-get update && apt-get install -y curl git gcc xz-utils && apt-get clean
 
 # Go
 RUN curl -fsSL https://dl.google.com/go/go1.15.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
-ENV GOOS=freebsd
-ENV GOARCH=amd64
-RUN go install std
-
-# Locale
-RUN locale-gen en_GB.UTF-8
+RUN GOOS=freebsd go install std
 
 WORKDIR /tmp

--- a/tools/images/freebsd_builder/README.md
+++ b/tools/images/freebsd_builder/README.md
@@ -1,0 +1,7 @@
+Please FreeBSD builder image
+----------------------------
+
+This image contains necessary dependencies for building
+a version of Please for FreeBSD. It is obviously not
+actually FreeBSD itself; we use this because CircleCI
+doesn't support native FreeBSD builders.


### PR DESCRIPTION
This obviously isn't an actual FreeBSD setup, but simply cross-compiles the release binaries.
That seems to work fine as long as we run a `go install std` in the Dockerfile. Admittedly I don't have a BSD VM handy to test this on right now.

Found one small bug along the way so that's nice, although fairly specific to this workflow.

Resolves a comment in #645 