### PR TITLE
Implement retries to the HTTP cache with go-retryablehttp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/hashicorp/go-retryablehttp v0.6.7
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/karrick/godirwalk v1.7.8

--- a/go.sum
+++ b/go.sum
@@ -150,12 +150,17 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92Bcuy
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3 h1:zKjpN5BK/P5lMYrLmBHdBULWbJ0XpYR+7NGzqkZzoD4=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-retryablehttp v0.6.7 h1:8/CAEZt/+F7kR7GevNHulKkUjLht3CPmn7egmhieNKo=
+github.com/hashicorp/go-retryablehttp v0.6.7/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=

--- a/src/cache/BUILD
+++ b/src/cache/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//src/core",
         "//src/fs",
         "//third_party/go:atime",
+        "//third_party/go:go-retryablehttp",
         "//third_party/go:humanize",
         "//third_party/go:logging",
     ],

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -12,6 +12,28 @@ import (
 
 var log = logging.MustGetLogger("cache")
 
+// logWrapper wraps the standard logger to provide a Printf function
+// for use with retryablehttp.
+type logWrapper struct {
+	*logging.Logger
+}
+
+func (w *logWrapper) Error(msg string, keysAndValues ...interface{}) {
+	w.Errorf("%v: %v", msg, keysAndValues)
+}
+
+func (w *logWrapper) Info(msg string, keysAndValues ...interface{}) {
+	w.Infof("%v: %v", msg, keysAndValues)
+}
+
+func (w *logWrapper) Debug(msg string, keysAndValues ...interface{}) {
+	w.Debugf("%v: %v", msg, keysAndValues)
+}
+
+func (w *logWrapper) Warn(msg string, keysAndValues ...interface{}) {
+	w.Warningf("%v: %v", msg, keysAndValues)
+}
+
 // NewCache is the factory function for creating a cache setup from the given config.
 func NewCache(state *core.BuildState) core.Cache {
 	c := newSyncCache(state, false)

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -245,6 +245,7 @@ func DefaultConfiguration() *Configuration {
 	config.Cache.HTTPWriteable = true
 	config.Cache.HTTPTimeout = cli.Duration(25 * time.Second)
 	config.Cache.HTTPConcurrentRequestLimit = 20
+	config.Cache.HTTPRetry = 4
 	if dir, err := os.UserCacheDir(); err == nil {
 		config.Cache.Dir = path.Join(dir, "please")
 	}
@@ -381,6 +382,7 @@ type Configuration struct {
 		HTTPWriteable              bool         `help:"If True this plz instance will write content back to the HTTP cache.\nBy default it runs in read-only mode."`
 		HTTPTimeout                cli.Duration `help:"Timeout for operations contacting the HTTP cache, in seconds."`
 		HTTPConcurrentRequestLimit int          `help:"The maximum amount of concurrent requests that can be open. Default 20."`
+		HTTPRetry                  int          `help:"The maximum number of retries before a request will give up, if a request is retryable"`
 	} `help:"Please has several built-in caches that can be configured in its config file.\n\nThe simplest one is the directory cache which by default is written into the .plz-cache directory. This allows for fast retrieval of code that has been built before (for example, when swapping Git branches).\n\nThere is also a remote RPC cache which allows using a centralised server to store artifacts. A typical pattern here is to have your CI system write artifacts into it and give developers read-only access so they can reuse its work.\n\nFinally there's a HTTP cache which is very similar, but a little obsolete now since the RPC cache outperforms it and has some extra features. Otherwise the two have similar semantics and share quite a bit of implementation.\n\nPlease has server implementations for both the RPC and HTTP caches."`
 	Test struct {
 		Timeout         cli.Duration `help:"Default timeout applied to all tests. Can be overridden on a per-rule basis."`

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -637,3 +637,18 @@ go_get(
     revision = "v1.0.0",
     test_only = True,
 )
+
+go_get(
+    name = "go-cleanhttp",
+    get = "github.com/hashicorp/go-cleanhttp",
+    revision = "v0.5.1",
+)
+
+go_get(
+    name = "go-retryablehttp",
+    get = "github.com/hashicorp/go-retryablehttp",
+    revision = "v0.6.7",
+    deps = [
+        ":go-cleanhttp",
+    ],
+)


### PR DESCRIPTION
A number of builds that I was doing rely on a somewhat unreliable
webdav-S3 server bridge, where occasionally timeouts happen or a file
cuts of in transit due to one error or another. Instead of immediately
pretending a file doesn't exist (or never uploading a file), retry
a certain number of times first in a controlled manner.

Closes #1140

Signed-off-by: Robert Xu <me@robxu9.com>