### PR TITLE
Allow subinclude to take multiple arguments

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -58,7 +58,7 @@ def lower(self:str) -> str:
 def fail(msg:str):
     pass
 
-def subinclude(target:str, hash:str=None):
+def subinclude(target:str):
     pass
 def load(target:str, names:str=None):
     pass


### PR DESCRIPTION
Fixes #955 

This does drop the `hash` argument, but I'd argue that is more of a bug that it's still there; it's not documented and has no effect (and since we dropped remote subincludes it has no real purpose any more anyway).