### PR TITLE
Allow staying in the current directory when running a target

### DIFF
--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -22,15 +22,15 @@ import (
 var log = logging.MustGetLogger("run")
 
 // Run implements the running part of 'plz run'.
-func Run(state *core.BuildState, label core.BuildLabel, args []string, remote, env bool) {
-	run(context.Background(), state, label, args, false, false, remote, env, false)
+func Run(state *core.BuildState, label core.BuildLabel, args []string, remote, env bool, dir string) {
+	run(context.Background(), state, label, args, false, false, remote, env, false, dir)
 }
 
 // Parallel runs a series of targets in parallel.
 // Returns a relevant exit code (i.e. if at least one subprocess exited unsuccessfully, it will be
 // that code, otherwise 0 if all were successful).
 // The given context can be used to control the lifetime of the subprocesses.
-func Parallel(ctx context.Context, state *core.BuildState, labels []core.BuildLabel, args []string, numTasks int, quiet, remote, env, detach bool) int {
+func Parallel(ctx context.Context, state *core.BuildState, labels []core.BuildLabel, args []string, numTasks int, quiet, remote, env, detach bool, dir string) int {
 	limiter := make(chan struct{}, numTasks)
 	var g errgroup.Group
 	for _, label := range labels {
@@ -38,7 +38,7 @@ func Parallel(ctx context.Context, state *core.BuildState, labels []core.BuildLa
 		g.Go(func() error {
 			limiter <- struct{}{}
 			defer func() { <-limiter }()
-			return run(ctx, state, label, args, true, quiet, remote, env, detach)
+			return run(ctx, state, label, args, true, quiet, remote, env, detach, dir)
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -53,10 +53,10 @@ func Parallel(ctx context.Context, state *core.BuildState, labels []core.BuildLa
 // Sequential runs a series of targets sequentially.
 // Returns a relevant exit code (i.e. if at least one subprocess exited unsuccessfully, it will be
 // that code, otherwise 0 if all were successful).
-func Sequential(state *core.BuildState, labels []core.BuildLabel, args []string, quiet, remote, env bool) int {
+func Sequential(state *core.BuildState, labels []core.BuildLabel, args []string, quiet, remote, env bool, dir string) int {
 	for _, label := range labels {
 		log.Notice("Running %s", label)
-		if err := run(context.Background(), state, label, args, true, quiet, remote, env, false); err != nil {
+		if err := run(context.Background(), state, label, args, true, quiet, remote, env, false, dir); err != nil {
 			log.Error("%s", err)
 			return err.(*exitError).code
 		}
@@ -68,7 +68,7 @@ func Sequential(state *core.BuildState, labels []core.BuildLabel, args []string,
 // If fork is true then we fork to run the target and return any error from the subprocesses.
 // If it's false this function never returns (because we either win or die; it's like
 // Game of Thrones except rather less glamorous).
-func run(ctx context.Context, state *core.BuildState, label core.BuildLabel, args []string, fork, quiet, remote, setenv, detach bool) error {
+func run(ctx context.Context, state *core.BuildState, label core.BuildLabel, args []string, fork, quiet, remote, setenv, detach bool, dir string) error {
 	target := state.Graph.TargetOrDie(label)
 	if !target.IsBinary {
 		log.Fatalf("Target %s cannot be run; it's not marked as binary", label)
@@ -104,6 +104,12 @@ func run(ctx context.Context, state *core.BuildState, label core.BuildLabel, arg
 	output.SetWindowTitle("plz run: " + strings.Join(args, " "))
 	env := environ(state.Config, setenv)
 	if !fork {
+		if dir != "" {
+			err := syscall.Chdir(dir)
+			if err != nil {
+				log.Fatalf("Error changing directory %s: %s", dir, err)
+			}
+		}
 		// Plain 'plz run'. One way or another we never return from the following line.
 		must(syscall.Exec(splitCmd[0], args, env), args)
 	} else if detach {
@@ -111,13 +117,14 @@ func run(ctx context.Context, state *core.BuildState, label core.BuildLabel, arg
 		cmd := exec.Command(splitCmd[0], args[1:]...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+		cmd.Dir = dir
 		return toExitError(cmd.Start(), args, nil)
 	}
 	// Run as a normal subcommand.
 	// Note that we don't connect stdin. It doesn't make sense for multiple processes.
 	// The process executor doesn't actually support not having a timeout, but the max is ~290 years so nobody
 	// should know the difference.
-	_, output, err := process.New("").ExecWithTimeout(nil, "", env, time.Duration(math.MaxInt64), false, false, !quiet, args)
+	_, output, err := process.New("").ExecWithTimeout(nil, dir, env, time.Duration(math.MaxInt64), false, false, !quiet, args)
 	return toExitError(err, args, output)
 }
 

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -18,17 +18,17 @@ func init() {
 
 func TestSequential(t *testing.T) {
 	state, labels1, labels2 := makeState()
-	code := Sequential(state, labels1, nil, true, false, false)
+	code := Sequential(state, labels1, nil, true, false, false, "")
 	assert.Equal(t, 0, code)
-	code = Sequential(state, labels2, nil, false, false, false)
+	code = Sequential(state, labels2, nil, false, false, false, "")
 	assert.Equal(t, 1, code)
 }
 
 func TestParallel(t *testing.T) {
 	state, labels1, labels2 := makeState()
-	code := Parallel(context.Background(), state, labels1, nil, 5, false, false, false, false)
+	code := Parallel(context.Background(), state, labels1, nil, 5, false, false, false, false, "")
 	assert.Equal(t, 0, code)
-	code = Parallel(context.Background(), state, labels2, nil, 5, true, false, false, false)
+	code = Parallel(context.Background(), state, labels2, nil, 5, true, false, false, false, "")
 	assert.Equal(t, 1, code)
 }
 

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -171,6 +171,6 @@ func build(ctx context.Context, state *core.BuildState, labels []core.BuildLabel
 	callback(ns, labels)
 	if state.NeedRun {
 		// Don't wait for this, its lifetime will be controlled by the context.
-		go run.Parallel(ctx, state, labels, nil, state.Config.Please.NumThreads, false, false, false, false)
+		go run.Parallel(ctx, state, labels, nil, state.Config.Please.NumThreads, false, false, false, false, "")
 	}
 }


### PR DESCRIPTION
This is an attempt to fix #1159

I'm not particularly a fan of the `StayInDir` name, so I'm open to ideas.

Sadly, because of the nature of how please changes the directory, the implementation isn't really nice either, let me know if you want me to change it.

Last, but not least: In addition to "staying in the current directory", we could add a dir parameter as well that lets the user define which directory to change to. WDYT? 