### PR TITLE
Log a bit more detail about 'incomplete response' errors

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -693,6 +693,7 @@ func (c *Client) reallyExecute(tid int, target *core.BuildTarget, command *pb.Co
 		return metadata, response.Result, nil
 	default:
 		if !resp.Done {
+			log.Error("Received an incomplete response for %s: %#v", target, resp)
 			return nil, nil, fmt.Errorf("Received an incomplete response for %s", target)
 		}
 		return nil, nil, fmt.Errorf("Unknown response type (was a %T): %#v", resp.Result, resp) // Shouldn't get here


### PR DESCRIPTION
Have seen this happen fairly occasionally.

The SDK has an explicit check for empty messages so there must be _something_ in there, although it's hard to see what. This _might_ shed some light.