### PR TITLE
Fix staying in directory

### DIFF
--- a/src/core/command_replacements_test.go
+++ b/src/core/command_replacements_test.go
@@ -42,6 +42,14 @@ func TestLocations(t *testing.T) {
 	assert.Equal(t, expected, replaceSequences(state, target1))
 }
 
+func TestOutLocation(t *testing.T) {
+	target2 := makeTarget2("//path/to:target2", "", nil)
+	target1 := makeTarget2("//path/to:target1", "ln -s $(out_location //path/to:target2) ${OUT}", target2)
+
+	expected := "ln -s plz-out/gen/path/to/target2.py ${OUT}"
+	assert.Equal(t, expected, replaceSequences(state, target1))
+}
+
 func TestAbsOutLocation(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -78,7 +78,7 @@ func run(ctx context.Context, state *core.BuildState, label core.BuildLabel, arg
 	}
 	if remote {
 		// Send this off to be done remotely.
-		// This deliberately misses the out_exe bit below, but also doesn't pick up whatever's going on with java -jar;
+		// This deliberately misses the abs_out_exe bit below, but also doesn't pick up whatever's going on with java -jar;
 		// however that will be obsolete post #920 anyway.
 		if state.RemoteClient == nil {
 			log.Fatalf("You must configure remote execution to use plz run --remote")
@@ -87,7 +87,8 @@ func run(ctx context.Context, state *core.BuildState, label core.BuildLabel, arg
 	}
 	// ReplaceSequences always quotes stuff in case it contains spaces or special characters,
 	// that works fine if we interpret it as a shell but not to pass it as an argument here.
-	command, _ := core.ReplaceSequences(state, target, fmt.Sprintf("$(out_exe %s)", target.Label))
+	// We use abs_out_exe instead of out_exe here so we can use the same command in the root dir and in subdirectories.
+	command, _ := core.ReplaceSequences(state, target, fmt.Sprintf("$(abs_out_exe %s)", target.Label))
 	arg0 := strings.Trim(command, "\"")
 	// Handle targets where $(exe ...) returns something nontrivial
 	splitCmd := strings.Split(arg0, " ")


### PR DESCRIPTION
Unfortunately the feature introduced in #1161 is non-functional: changing the directory breaks the run command, as the command is resolved relatively to the repo root. Somehow it slipped by me, sorry about that.

Here is a fix that seems to solve the problem: calculate the absolute path of the executable.

Could use some help with testing. Also, I'm not sure if conceptually this is the right solution.