### PR TITLE
Added subrepo name rule to interpreter

### DIFF
--- a/docs/language.html
+++ b/docs/language.html
@@ -65,6 +65,8 @@
           - returns a copy of the given list with the contents sorted.</li>
 	    <li><code><span class="fn-name">package_name</span><span class="fn-p">(</span><span class="fn-arg"></span><span class="fn-p">)</span></code>
           - returns the package being currently parsed.</li>
+        <li><code><span class="fn-name">subrepo_name</span><span class="fn-p">(</span><span class="fn-arg"></span><span class="fn-p">)</span></code>
+            - returns the subrepo of the package being currently parsed or the empty string if this is not a subrepo.</li>
 	    <li><code><span class="fn-name">join_path</span><span class="fn-p">(</span><span class="fn-arg">x</span>, <span class="fn-arg">...</span><span class="fn-p">)</span></code>
           - joins the given path elements using the OS separator. It will intelligently
       handle repeated or missing separators.</li>

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -127,6 +127,8 @@ def get_base_path() -> str:
     pass
 def package_name() -> str:
     pass
+def subrepo_name() -> str:
+    pass
 
 def canonicalise(label:str) -> str:
     """Converts the given build label to its full form.

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -44,6 +44,7 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "join_path", joinPath).varargs = true
 	setNativeCode(s, "get_base_path", packageName)
 	setNativeCode(s, "package_name", packageName)
+	setNativeCode(s, "subrepo_name", subrepoName)
 	setNativeCode(s, "canonicalise", canonicalise)
 	setNativeCode(s, "get_labels", getLabels)
 	setNativeCode(s, "add_dep", addDep)
@@ -576,6 +577,10 @@ func joinPath(s *scope, args []pyObject) pyObject {
 
 func packageName(s *scope, args []pyObject) pyObject {
 	return pyString(s.pkg.Name)
+}
+
+func subrepoName(s *scope, args []pyObject) pyObject {
+	return pyString("///" + s.pkg.SubrepoName)
 }
 
 func canonicalise(s *scope, args []pyObject) pyObject {

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -580,7 +580,7 @@ func packageName(s *scope, args []pyObject) pyObject {
 }
 
 func subrepoName(s *scope, args []pyObject) pyObject {
-	return pyString("///" + s.pkg.SubrepoName)
+	return pyString(s.pkg.SubrepoName)
 }
 
 func canonicalise(s *scope, args []pyObject) pyObject {

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -14,9 +14,12 @@ import (
 )
 
 func parseFileToStatements(filename string) (*scope, []*Statement, error) {
+	return parseFileToStatementsInPkg(filename, core.NewPackage("test/package"))
+}
+
+func parseFileToStatementsInPkg(filename string, pkg *core.Package) (*scope, []*Statement, error) {
 	state := core.NewDefaultBuildState()
 	state.Config.BuildConfig = map[string]string{"parser-engine": "python27"}
-	pkg := core.NewPackage("test/package")
 	parser := NewParser(state)
 	parser.MustLoadBuiltins("builtins.build_defs", nil, rules.MustAsset("builtins.build_defs.gob"))
 	statements, err := parser.parse(filename)
@@ -319,4 +322,13 @@ func TestRemoveAffixes(t *testing.T) {
 	assert.EqualValues(t, "PEP 616: New removeprefix() and removesuffix() string methods", s.Lookup("x"))
 	assert.EqualValues(t, "New removeprefix() and removesuffix() string methods", s.Lookup("y"))
 	assert.EqualValues(t, "removeprefix() and removesuffix() ", s.Lookup("z"))
+}
+
+func TestSubrepoName(t *testing.T) {
+	pkg := core.NewPackage("test/pkg")
+	pkg.SubrepoName = "pleasings"
+	s, _, err := parseFileToStatementsInPkg("src/parse/asp/test_data/interpreter/subrepo_name.build", pkg)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, "///pleasings", s.Lookup("subrepo"))
 }

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -330,5 +330,5 @@ func TestSubrepoName(t *testing.T) {
 	s, _, err := parseFileToStatementsInPkg("src/parse/asp/test_data/interpreter/subrepo_name.build", pkg)
 	assert.NoError(t, err)
 
-	assert.EqualValues(t, "///pleasings", s.Lookup("subrepo"))
+	assert.EqualValues(t, "pleasings", s.Lookup("subrepo"))
 }

--- a/src/parse/asp/test_data/interpreter/subrepo_name.build
+++ b/src/parse/asp/test_data/interpreter/subrepo_name.build
@@ -1,0 +1,1 @@
+subrepo = subrepo_name()


### PR DESCRIPTION
I wonder if cononicalise could be made to handle sub-repos as well. 

fixes: #1179