### PR TITLE
java_test(): handle case where $TOOLS_JUNIT is a real file

### DIFF
--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -332,7 +332,7 @@ def java_test(name:str, srcs:list, resources:list=None, resources_root:str=None,
         data['data'] += toolchain_info.deps
         java_cmd = '$DATA_JAVA'
 
-    cmd = 'ln -s `which $TOOLS_JUNIT` . && ' + cmd
+    cmd = 'ln -s "$(if [ -f "$TOOLS_JUNIT" ]; then echo "$TOOLS_JUNIT"; else echo "$(which "$TOOLS_JUNIT")"; fi)" . && ' + cmd
     test_cmd = f'{java_cmd} -Dbuild.please.testpackage={test_package} {jvm_args} -jar $(location :{name}) {flags}'
 
     deps = [lib_rule]


### PR DESCRIPTION
`TOOLS_JUNIT` can sometimes contain a path to a real file as well as the name of an executable file in `PATH`. Handle either eventuality by creating a symlink to `$TOOLS_JUNIT` if it is a path to a real file, or creating a symlink to the output of `which $TOOLS_JUNIT` otherwise.

Fixes #1206.