### PR TITLE
fix: filegroup_hash used shasum which was part of perl not coreutils

### DIFF
--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -284,8 +284,8 @@ def hash_filegroup(name:str, srcs:list=None, deps:list=None, exported_deps:list=
       requires (list): Kinds of output from other rules that this one requires.
     """
     cmd = 'mkdir _out && '
-    cmd += 'SHA256CMD="$(command -v sha256sum || echo shasum)" && '
-    cmd += 'SHA256ARGS="$(command -v sha256sum >/dev/null || echo \'-a 256\')" && '
+    cmd += 'SHA256CMD="$(which sha256sum || echo shasum)" && '
+    cmd += 'SHA256ARGS="$(which sha256sum >/dev/null || echo \'-a 256\')" && '
     cmd += 'for S in $SRCS; do '
     cmd += '    B="$(basename $S)" && '
     cmd += '    HASH="$(${SHA256CMD} ${SHA256ARGS} $S | cut -d " " -f 1)" && '

--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -284,9 +284,11 @@ def hash_filegroup(name:str, srcs:list=None, deps:list=None, exported_deps:list=
       requires (list): Kinds of output from other rules that this one requires.
     """
     cmd = 'mkdir _out && '
+    cmd += 'SHA256CMD="$(command -v sha256sum || echo shasum)" && '
+    cmd += 'SHA256ARGS="$(command -v sha256sum >/dev/null || echo \'-a 256\')" && '
     cmd += 'for S in $SRCS; do '
     cmd += '    B="$(basename $S)" && '
-    cmd += '    HASH="$(sha256sum $S | cut -d " " -f 1)" && '
+    cmd += '    HASH="$(${SHA256CMD} ${SHA256ARGS} $S | cut -d " " -f 1)" && '
     cmd += '    mv "$S" "_out/${B%.*}-${HASH}.${B##*.}"; '
     cmd += 'done'
     return build_rule(

--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -283,11 +283,17 @@ def hash_filegroup(name:str, srcs:list=None, deps:list=None, exported_deps:list=
       test_only (bool): If true the exported file can only be used by test targets.
       requires (list): Kinds of output from other rules that this one requires.
     """
+    cmd = 'mkdir _out && '
+    cmd += 'for S in $SRCS; do '
+    cmd += '    B="$(basename $S)" && '
+    cmd += '    HASH="$(sha256sum $S | cut -d " " -f 1)" && '
+    cmd += '    mv "$S" "_out/${B%.*}-${HASH}.${B##*.}"; '
+    cmd += 'done'
     return build_rule(
         name=name,
         srcs=srcs,
         output_dirs = ['_out'],
-        cmd = 'mkdir _out; for S in $SRCS; do B="$(basename $S)"; mv "$S" "_out/${B%.*}-$(shasum -a 256 $S | cut -d " " -f 1 ).${B##*.}"; done',
+        cmd = cmd,
         deps=deps,
         exported_deps=exported_deps,
         visibility=visibility,


### PR DESCRIPTION
shasum is part of perl and it was not on the standard path on my machine (Manjaro/Arch).
In addition since the invocation was wrapped in a subshell and a string expansion the error was not detected by bash.