### PR TITLE
fix: pip_library labels not applied then zip safe

### DIFF
--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -437,7 +437,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
             'jarcat': [CONFIG.JARCAT_TOOL],
         },
         post_build = None if licences else _add_licences,
-        labels = ['py:zip-unsafe', 'py', 'pip:' + package_name] if not zip_safe else None,
+        labels = ['py', 'pip:' + package_name] + (['py:zip-unsafe'] if not zip_safe else []),
         visibility = visibility,
     )
 

--- a/test/python_rules/BUILD
+++ b/test/python_rules/BUILD
@@ -204,14 +204,14 @@ plz_e2e_test(
     name = "correct_labels_on_pip_libary_non_zip_safe",
     cmd = "plz query print -f labels //third_party/python:numpy",
     expected_output = "expected_labels_on_numpy.txt",
-    deps = ["//third_party/python:numpy"],
     labels = ["py3"],
+    deps = ["//third_party/python:numpy"],
 )
 
 plz_e2e_test(
     name = "correct_labels_on_pip_libary_zip_safe",
     cmd = "plz query print -f labels //third_party/python:grpcio",
     expected_output = "expected_labels_on_grpcio.txt",
-    deps = ["//third_party/python:grpcio"],
     labels = ["py3"],
+    deps = ["//third_party/python:grpcio"],
 )

--- a/test/python_rules/BUILD
+++ b/test/python_rules/BUILD
@@ -1,3 +1,5 @@
+subinclude("//build_defs:plz_e2e_test")
+
 # Test for a panic provoked by a python_library using a proto_library as a resource.
 proto_library(
     name = "test_proto",
@@ -196,4 +198,18 @@ python_test(
     srcs = ["data_dict_test.py"],
     data = {"txt": ["data.txt"]},
     labels = ["py3"],
+)
+
+plz_e2e_test(
+    name = "correct_labels_on_pip_libary_non_zip_safe",
+    cmd = "plz query print -f labels //third_party/python:numpy",
+    expected_output = "expected_labels_on_numpy.txt",
+    deps = ["//third_party/python:numpy"],
+)
+
+plz_e2e_test(
+    name = "correct_labels_on_pip_libary_zip_safe",
+    cmd = "plz query print -f labels //third_party/python:grpcio",
+    expected_output = "expected_labels_on_grpcio.txt",
+    deps = ["//third_party/python:grpcio"],
 )

--- a/test/python_rules/BUILD
+++ b/test/python_rules/BUILD
@@ -147,15 +147,15 @@ python_test(
     ],
 )
 
-# python_test(
-#     name = "tensorflow_test",
-#     srcs = ["tensorflow_test.py"],
-#     labels = [
-#         "py3",
-#         "pip",
-#     ],
-#     deps = ["//third_party/python:tensorflow"],
-# )
+python_test(
+    name = "tensorflow_test",
+    srcs = ["tensorflow_test.py"],
+    labels = [
+        "py3",
+        "pip",
+    ],
+    deps = ["//third_party/python:tensorflow"],
+)
 
 python_test(
     name = "pandas_test",

--- a/test/python_rules/BUILD
+++ b/test/python_rules/BUILD
@@ -147,15 +147,15 @@ python_test(
     ],
 )
 
-python_test(
-    name = "tensorflow_test",
-    srcs = ["tensorflow_test.py"],
-    labels = [
-        "py3",
-        "pip",
-    ],
-    deps = ["//third_party/python:tensorflow"],
-)
+# python_test(
+#     name = "tensorflow_test",
+#     srcs = ["tensorflow_test.py"],
+#     labels = [
+#         "py3",
+#         "pip",
+#     ],
+#     deps = ["//third_party/python:tensorflow"],
+# )
 
 python_test(
     name = "pandas_test",
@@ -205,6 +205,7 @@ plz_e2e_test(
     cmd = "plz query print -f labels //third_party/python:numpy",
     expected_output = "expected_labels_on_numpy.txt",
     deps = ["//third_party/python:numpy"],
+    labels = ["py3"],
 )
 
 plz_e2e_test(
@@ -212,4 +213,5 @@ plz_e2e_test(
     cmd = "plz query print -f labels //third_party/python:grpcio",
     expected_output = "expected_labels_on_grpcio.txt",
     deps = ["//third_party/python:grpcio"],
+    labels = ["py3"],
 )

--- a/test/python_rules/expected_labels_on_grpcio.txt
+++ b/test/python_rules/expected_labels_on_grpcio.txt
@@ -1,2 +1,2 @@
 py
-pip:grpcio==1.29.0
+pip:grpcio==1.32.0

--- a/test/python_rules/expected_labels_on_grpcio.txt
+++ b/test/python_rules/expected_labels_on_grpcio.txt
@@ -1,0 +1,2 @@
+py
+pip:grpcio==1.29.0

--- a/test/python_rules/expected_labels_on_numpy.txt
+++ b/test/python_rules/expected_labels_on_numpy.txt
@@ -1,0 +1,3 @@
+py
+pip:numpy==1.18.4
+py:zip-unsafe


### PR DESCRIPTION
If the zip_safe=True then the resulting pip_library would not have any labels applied.