### PR TITLE
Fix plz_e2e_tests not passing PLZ_ARGS

### DIFF
--- a/build_defs/plz_e2e_test.build_defs
+++ b/build_defs/plz_e2e_test.build_defs
@@ -9,10 +9,10 @@ def plz_e2e_test(name:str, cmd:str, pre_cmd:str=None, expected_output:str=None,
     # but we can make it do it and it's a convenient way of testing the tool itself.
 
     def _e2e_test_cmd(cmd):
-        profile_flag = '--profile ci' if CONFIG.get('CI') else ''
+        args = '$PLZ_ARGS'
         if package_name().startswith('test/parse'):
-            profile_flag += ' -o parse.buildfilename:BUILD,BUILD.plz,BUILD.test '
-        cmd = cmd.replace('plz ', f'$(location //src:please) --nolock {profile_flag} -o cache.dirclean:false --log_file plz-out/log/{name}.log ')
+            args += ' -o parse.buildfilename:BUILD,BUILD.plz,BUILD.test '
+        cmd = cmd.replace('plz ', f'$(location //src:please) --nolock {args} -o cache.dirclean:false --log_file plz-out/log/{name}.log ')
         if expected_failure:
             test_cmd = '%s 2>&1 | tee output; if [ $? -eq 0 ]; then exit 1; fi; ' % cmd
         else:
@@ -52,4 +52,5 @@ def plz_e2e_test(name:str, cmd:str, pre_cmd:str=None, expected_output:str=None,
         no_test_output = True,
         sandbox = False,
         local = True,
+        pass_env = ["PLZ_ARGS"],
     )

--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -133,7 +133,7 @@ def gentest(name:str, test_cmd:str|dict, labels:list&features&tags=None, cmd:str
             deps:list=None, tools:list|dict=None, data:list|dict=None, visibility:list=None, timeout:int=0,
             needs_transitive_deps:bool=False, flaky:bool|int=0, secrets:list|dict=None, no_test_output:bool=False,
             test_outputs:list=None, output_is_complete:bool=True, requires:list=None,
-            sandbox:bool=None, size:str=None, local:bool=False):
+            sandbox:bool=None, size:str=None, local:bool=False, pass_env:list=None):
     """A rule which creates a test with an arbitrary command.
 
     The command must return zero on success and nonzero on failure. Test results are written
@@ -174,6 +174,8 @@ def gentest(name:str, test_cmd:str|dict, labels:list&features&tags=None, cmd:str
       size (str): Test size (enormous, large, medium or small).
       local: Forces the rule to be built locally; when remote execution is enabled it will not
              be sent remotely but executed on the local machine.
+      pass_env: List of environment variables to be passed from outside. Any changes to them will
+                be recorded in this target's hash and will hence force it to rebuild.
     """
     return build_rule(
         name = name,
@@ -199,6 +201,7 @@ def gentest(name:str, test_cmd:str|dict, labels:list&features&tags=None, cmd:str
         test_outputs = test_outputs,
         flaky = flaky,
         local = local,
+        pass_env = pass_env,
     )
 
 


### PR DESCRIPTION
This was breaking incrementality and causing the e2e tests to re-build java stuff because they weren't using the right profile. 