### PR TITLE
Cache lookup of missing blobs

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -441,7 +441,7 @@ func (c *Client) uploadLocalTarget(target *core.BuildTarget) error {
 	for _, c := range m {
 		chomks = append(chomks, c)
 	}
-	if err := c.client.UploadIfMissing(context.Background(), chomks...); err != nil {
+	if err := c.uploadIfMissing(context.Background(), chomks...); err != nil {
 		return err
 	}
 	return c.setOutputs(target, ar)

--- a/src/remote/blobs.go
+++ b/src/remote/blobs.go
@@ -27,7 +27,10 @@ func (c *Client) uploadBlobs(f func(ch chan<- *chunker.Chunker) error) error {
 }
 
 func (c *Client) uploadIfMissing(ctx context.Context, chomks ...*chunker.Chunker) error {
-	if err := c.client.UploadIfMissing(ctx, c.filterChunks(chomks)...); err != nil {
+	filtered := c.filterChunks(chomks)
+	if len(filtered) == 0 {
+		return nil
+	} else if err := c.client.UploadIfMissing(ctx, filtered...); err != nil {
 		return err
 	}
 	c.existingBlobMutex.Lock()

--- a/src/remote/blobs.go
+++ b/src/remote/blobs.go
@@ -35,8 +35,8 @@ func (c *Client) uploadIfMissing(ctx context.Context, chomks ...*chunker.Chunker
 	}
 	c.existingBlobMutex.Lock()
 	defer c.existingBlobMutex.Unlock()
-	for _, chunk := range chomks {
-		c.existingBlobs[chunk.Digest().Hash] = struct{}{}
+	for _, chunker := range filtered {
+		c.existingBlobs[chunker.Digest().Hash] = struct{}{}
 	}
 	return nil
 }
@@ -45,9 +45,9 @@ func (c *Client) filterChunks(chomks []*chunker.Chunker) []*chunker.Chunker {
 	ret := make([]*chunker.Chunker, 0, len(chomks))
 	c.existingBlobMutex.Lock()
 	defer c.existingBlobMutex.Unlock()
-	for _, chunk := range chomks {
-		if _, present := c.existingBlobs[chunk.Digest().Hash]; !present {
-			ret = append(ret, chunk)
+	for _, chunker := range chomks {
+		if _, present := c.existingBlobs[chunker.Digest().Hash]; !present {
+			ret = append(ret, chunker)
 		}
 	}
 	return ret


### PR DESCRIPTION
A little experimentation suggests that this reduces blobs looked up to ~1/4 in the plz repo.

Only concern is memory usage since it will grow fairly continually...

There is a suspicious amount of similarity in the requests so it might do even better if we serialised the requests. I don't think that's a good idea given UploadIfMissing is also doing the uploads; potentially we could push this logic into the SDK and have that do it around just the FindMissingBlobs call.