### PR TITLE
Pass through exit on error

### DIFF
--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -129,6 +129,7 @@ def genrule(name:str, cmd:str|list|dict, srcs:list|dict=None, out:str=None, outs
         pass_env = pass_env,
         local = local,
         output_dirs = output_dirs,
+        exit_on_error = exit_on_error,
     )
 
 
@@ -208,6 +209,7 @@ def gentest(name:str, test_cmd:str|dict, labels:list&features&tags=None, cmd:str
         flaky = flaky,
         local = local,
         pass_env = pass_env,
+        exit_on_error = exit_on_error,
     )
 
 

--- a/tools/build_langserver/lsp/definition_test.go
+++ b/tools/build_langserver/lsp/definition_test.go
@@ -63,7 +63,7 @@ func TestDefinitionBuiltin(t *testing.T) {
 	assert.Equal(t, []lsp.Location{
 		{
 			URI:   lsp.DocumentURI("file://" + path.Join(cacheDir, "please/misc_rules.build_defs")),
-			Range: xrng(3, 0, 131, 5),
+			Range: xrng(3, 0, 132, 5),
 		},
 	}, locs)
 }


### PR DESCRIPTION
we should probably start setting this to true in a few places where we know the cmd being run is safe with this change. 