### PR TITLE
Add log_append cli flag for appending log to existing file

### DIFF
--- a/src/cli/logging.go
+++ b/src/cli/logging.go
@@ -52,12 +52,16 @@ func InitLogging(verbosity Verbosity) {
 }
 
 // InitFileLogging initialises an optional logging backend to a file.
-func InitFileLogging(logFile string, logFileLevel Verbosity) {
+func InitFileLogging(logFile string, logFileLevel Verbosity, append bool) {
 	fileLogLevel = logging.Level(logFileLevel)
 	if err := os.MkdirAll(path.Dir(logFile), os.ModeDir|0775); err != nil {
 		log.Fatalf("Error creating log file directory: %s", err)
 	}
-	file, err := os.Create(logFile)
+	flags := os.O_RDWR | os.O_CREATE | os.O_TRUNC
+	if append {
+		flags = os.O_RDWR | os.O_CREATE | os.O_APPEND
+	}
+	file, err := os.OpenFile(logFile, flags, 0666)
 	if err != nil {
 		log.Fatalf("Error opening log file: %s", err)
 	}

--- a/src/please.go
+++ b/src/please.go
@@ -62,6 +62,7 @@ var opts struct {
 		Verbosity         cli.Verbosity `short:"v" long:"verbosity" description:"Verbosity of output (error, warning, notice, info, debug)" default:"warning"`
 		LogFile           cli.Filepath  `long:"log_file" description:"File to echo full logging output to" default:"plz-out/log/build.log"`
 		LogFileLevel      cli.Verbosity `long:"log_file_level" description:"Log level for file output" default:"debug"`
+		LogAppend         bool          `long:"log_append" description:"Append log to existing file instead of overwriting its content"`
 		InteractiveOutput bool          `long:"interactive_output" description:"Show interactive output in a terminal"`
 		PlainOutput       bool          `short:"p" long:"plain_output" description:"Don't show interactive output."`
 		Colour            bool          `long:"colour" description:"Forces coloured output from logging & other shell output."`
@@ -894,7 +895,7 @@ func readConfigAndSetRoot(forceUpdate bool) *core.Configuration {
 		if !path.IsAbs(string(opts.OutputFlags.LogFile)) {
 			opts.OutputFlags.LogFile = cli.Filepath(path.Join(core.RepoRoot, string(opts.OutputFlags.LogFile)))
 		}
-		cli.InitFileLogging(string(opts.OutputFlags.LogFile), opts.OutputFlags.LogFileLevel)
+		cli.InitFileLogging(string(opts.OutputFlags.LogFile), opts.OutputFlags.LogFileLevel, opts.OutputFlags.LogAppend)
 	}
 	if opts.FeatureFlags.NoHashVerification {
 		log.Warning("You've disabled hash verification; this is intended to help temporarily while modifying build targets. You shouldn't use this regularly.")

--- a/tools/build_langserver/langserver_main.go
+++ b/tools/build_langserver/langserver_main.go
@@ -36,7 +36,7 @@ func main() {
 	cli.ParseFlagsOrDie("build_langserver", &opts)
 	cli.InitLogging(opts.Verbosity)
 	if opts.LogFile != "" {
-		cli.InitFileLogging(string(opts.LogFile), opts.Verbosity)
+		cli.InitFileLogging(string(opts.LogFile), opts.Verbosity, false)
 	}
 	if err := serve(lsp.NewHandler()); err != nil {
 		log.Fatalf("fail to start server: %s", err)


### PR DESCRIPTION
This PR adds log appending to an existing `build.log` file.

As explained on [Gitter](https://gitter.im/please-build/Lobby?at=5f774ceed5337c048e09bcb1), in some cases a CI workflow consists of multiple `plz` executions and we want to retain the log for each of them for debugging purposes. It's probably not useful locally at all.

It's disabled for the language server as it doesn't seem useful there (but could be changed in a different PR).