### PR TITLE
Make window resizing a no-op on Windows

### DIFF
--- a/src/cli/logging.go
+++ b/src/cli/logging.go
@@ -7,12 +7,10 @@ import (
 	"container/list"
 	"fmt"
 	"os"
-	"os/signal"
 	"path"
 	"regexp"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/peterebden/go-cli-init"
 	"golang.org/x/crypto/ssh/terminal"
@@ -177,13 +175,7 @@ func (backend *LogBackend) SetPassthrough(passthrough bool, interactiveRows int)
 	backend.interactiveRows = interactiveRows
 	backend.mutex.Unlock()
 	if passthrough {
-		go func() {
-			sig := make(chan os.Signal, 10)
-			signal.Notify(sig, syscall.SIGWINCH)
-			for range sig {
-				backend.recalcWindowSize()
-			}
-		}()
+		go notifyOnWindowResize(backend.recalcWindowSize)
 	}
 	backend.recalcWindowSize()
 }

--- a/src/cli/winch_other.go
+++ b/src/cli/winch_other.go
@@ -1,4 +1,5 @@
 // +build !windows
+
 package cli
 
 import (

--- a/src/cli/winch_other.go
+++ b/src/cli/winch_other.go
@@ -1,0 +1,18 @@
+// +build !windows
+package cli
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// notifyOnWindowResize calls the given function whenever the size of the terminal window changes
+// (when receiving a SIGWINCH on most platforms).
+func notifyOnWindowResize(f func()) {
+	sig := make(chan os.Signal, 10)
+	signal.Notify(sig, syscall.SIGWINCH)
+	for range sig {
+		f()
+	}
+}

--- a/src/cli/winch_windows.go
+++ b/src/cli/winch_windows.go
@@ -1,0 +1,5 @@
+package cli
+
+// notifyOnWindowResize is a no-op on Windows.
+func notifyOnWindowResize(f func()) {
+}


### PR DESCRIPTION
As mentioned in #1268 this doesn't compile right now since SIGWINCH isn't available.

For now I'm just making it a no-op; you could implement a poll but it's probably not worth it for now (printing will still be a bit horrible if your poll doesn't happen in time, which it likely won't). Better to revisit niceties like this once we get to a point of _something_ working on that platform.