### PR TITLE
Improve help output for versionchecksum slightly

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -339,7 +339,7 @@ func DefaultConfiguration() *Configuration {
 type Configuration struct {
 	Please struct {
 		Version          cli.Version `help:"Defines the version of plz that this repo is supposed to use currently. If it's not present or the version matches the currently running version no special action is taken; otherwise if SelfUpdate is set Please will attempt to download an appropriate version, otherwise it will issue a warning and continue.\n\nNote that if this is not set, you can run plz update to update to the latest version available on the server." var:"PLZ_VERSION"`
-		VersionChecksum  []string    `help:"Defines a hex-encoded sha256 checksum that the downloaded version must match. Can be specified multiple times to support different architectures."`
+		VersionChecksum  []string    `help:"Defines a hex-encoded sha256 checksum that the downloaded version must match. Can be specified multiple times to support different architectures." example:"abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"`
 		Location         string      `help:"Defines the directory Please is installed into.\nDefaults to ~/.please but you might want it to be somewhere else if you're installing via another method (e.g. the debs and install script still use /opt/please)."`
 		SelfUpdate       bool        `help:"Sets whether plz will attempt to update itself when the version set in the config file is different."`
 		DownloadLocation cli.URL     `help:"Defines the location to download Please from when self-updating. Defaults to the Please web server, but you can point it to some location of your own if you prefer to keep traffic within your network or use home-grown versions."`

--- a/src/help/config.go
+++ b/src/help/config.go
@@ -15,7 +15,7 @@ var urlRegex = regexp.MustCompile("https?://[^ ]+[^.]")
 // ExampleValue returns an example value for a config field based on its type.
 func ExampleValue(f reflect.Value, name string, t reflect.Type, example, options string) string {
 	if t.Kind() == reflect.Slice {
-		return ExampleValue(f, name, t.Elem(), example, options) + fmt.Sprintf("\n\n%s can be repeated", name)
+		return ExampleValue(reflect.New(t.Elem()).Elem(), name, t.Elem(), example, options) + fmt.Sprintf("${RESET}\n\n${YELLOW}%s${RESET} can be repeated", name)
 	} else if example != "" {
 		return example
 	} else if options != "" {


### PR DESCRIPTION
Print element values instead of slices (i.e. not `[]string Value`). 
Also provide a specific example for versionchecksum (which negates the benefit of the generic fix, but c'est la vie)