### PR TITLE
Turn gzip compression off by default

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -272,7 +272,6 @@ func DefaultConfiguration() *Configuration {
 	config.Remote.NumExecutors = 20 // kind of arbitrary
 	config.Remote.HomeDir = "~"
 	config.Remote.Secure = true
-	config.Remote.Gzip = true
 	config.Remote.VerifyOutputs = true
 	config.Remote.CacheDuration = cli.Duration(10000 * 24 * time.Hour) // Effectively forever.
 	config.Go.GoTool = "go"


### PR DESCRIPTION
Goodness knows why I defaulted this to true. It's a bad default because many servers don't support it.

This isn't a breaking change since all gRPC servers support no compression.