### PR TITLE
Implement go toolchains

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
        - image: thoughtmachine/please_alpine:20200905-2
      resource_class: large
      environment:
-       PLZ_ARGS: "-p --profile ci --profile alpine"
+       PLZ_ARGS: "-p --profile ci --profile alpine --exclude no-musl"
      steps:
        - checkout
        - restore_cache:

--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -339,6 +339,7 @@
       keep to 1 package per dir as in classic Go, it's still probably a good idea to match Please
       rules to Go packages.</p>
 
+    {{ template "lexicon_entry.html" .Named "go_toolchain" }}
     {{ template "lexicon_entry.html" .Named "go_library" }}
     {{ template "lexicon_entry.html" .Named "cgo_library" }}
     {{ template "lexicon_entry.html" .Named "go_binary" }}

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -3,11 +3,36 @@
 Go has a strong built-in concept of packages so it's probably a good idea to match Please
 rules to Go packages.
 """
-def go_toolchain(name:str, url:str = '', version:str = '', hashes:list = [], visibility:list = ["PUBLIC"]):
+def go_toolchain(name:str, url:str|dict = '', version:str = '', hashes:list = [], visibility:list = ["PUBLIC"]):
+    """
+    Downloads the golang SDK and exposes :<name>|go and :<name>|gofmt as entry points. To use this rule add the
+    following to your .plzconfig:
+
+    [go]
+    GoTool = //.../<name>|go
+
+    Args:
+      name (str): Name of the rule.
+      url (str | dict): The URL used to download the golang SDK. Can be a single string or a dictionary mapping
+                        GOOS-GOARCH to URLs i.e. lunux-amd64: 'https://...'. Either provide url or version, but not both.
+      version (str): The version of the golang SDK to download. The SDK will be downloaded from https://golang.org/dl/...
+                     and the rule will use the current platforms GOOS and GOARCH setting. Either provide url or version,
+                     but not both.
+      hashes (list): A list of possible hashes for the downloaded sdk archive. Optional.
+      visibility (list): Visibility specification. Defaults to public.
+    """
+    if url and version:
+        raise ParseError("Either version or url should be provided but not both")
+
+    if version:
+        sdk_url = f'https://golang.org/dl/go{version}.{CONFIG.GOOS}-{CONFIG.GOARCH}.tar.gz'
+    else:
+        sdk_url = url if isinstance(jdk_url, str) else url[f'{CONFIG.GOOS}-{CONFIG.GOARCH}']
+
     download = remote_file(
         name = name,
         _tag = 'download',
-        url = f'https://golang.org/dl/go{version}.linux-amd64.tar.gz' if version else url,
+        url = sdk_url,
         hashes = hashes,
     )
 

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -3,6 +3,27 @@
 Go has a strong built-in concept of packages so it's probably a good idea to match Please
 rules to Go packages.
 """
+def go_toolchain(name:str, url:str = '', version:str = '', hashes:list = [], visibility:list = ["PUBLIC"]):
+    download = remote_file(
+        name = name,
+        _tag = 'download',
+        url = f'https://golang.org/dl/go{version}.linux-amd64.tar.gz' if version else url,
+        hashes = hashes,
+    )
+
+    # TODO(jpoole): optionally build the SDK from source for cross compilation/race detector etc.
+    return build_rule(
+        name = name,
+        srcs = [download],
+        cmd = 'tar -xf $SRCS && mv go $OUT && chmod +x $OUT/bin/*',
+        outs = [name],
+        entry_points = {
+            'go': f'{name}/bin/go',
+            'gofmt': f'{name}/bin/gofmt',
+        },
+        binary = True,
+        visibility = visibility,
+    )
 
 
 def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=None, deps:list=[],

--- a/test/build_defs/test.build_defs
+++ b/test/build_defs/test.build_defs
@@ -5,6 +5,7 @@ def please_repo_e2e_test(
         repo: str,
         deps: list=[],
         expected_output: dict,
+        labels: list = [],
 ):
     test_cmd = " && ".join([
         "mv $DATA_FREE_BSD_CONFIG $DATA_REPO",
@@ -28,5 +29,5 @@ def please_repo_e2e_test(
         data = data,
         test = True,
         no_test_output = True,
-        labels = ["plz_e2e_test", "e2e"],
+        labels = labels + ["plz_e2e_test", "e2e"],
     )

--- a/test/go_rules/toolchain/BUILD
+++ b/test/go_rules/toolchain/BUILD
@@ -7,4 +7,5 @@ please_repo_e2e_test (
         "out.txt": "wibble wibble wibble",
     },
     repo = "test_repo",
+    labels = ["no-musl"],
 )

--- a/test/go_rules/toolchain/BUILD
+++ b/test/go_rules/toolchain/BUILD
@@ -1,0 +1,10 @@
+subinclude("//test/build_defs")
+
+please_repo_e2e_test (
+    name = "toolchain_test",
+    plz_command = "plz test //src/foo:foo_test && plz run //src:main > out.txt",
+    expected_output = {
+        "out.txt": "wibble wibble wibble",
+    },
+    repo = "test_repo",
+)

--- a/test/go_rules/toolchain/test_repo/.plzconfig
+++ b/test/go_rules/toolchain/test_repo/.plzconfig
@@ -1,0 +1,6 @@
+[go]
+GoTool = //tools:toolchain|go
+ImportPath = testrepo
+
+[Parse]
+BuildFileName = BUILD_FILE

--- a/test/go_rules/toolchain/test_repo/go.mod
+++ b/test/go_rules/toolchain/test_repo/go.mod
@@ -1,0 +1,1 @@
+module "testrepo"

--- a/test/go_rules/toolchain/test_repo/src/BUILD_FILE
+++ b/test/go_rules/toolchain/test_repo/src/BUILD_FILE
@@ -1,0 +1,5 @@
+go_binary (
+  name = "main",
+  srcs = ["main.go"],
+  deps = ["//src/foo"],
+)

--- a/test/go_rules/toolchain/test_repo/src/foo/BUILD_FILE
+++ b/test/go_rules/toolchain/test_repo/src/foo/BUILD_FILE
@@ -1,0 +1,11 @@
+go_library (
+  name = "foo",
+  srcs = ["foo.go"],
+  visibility = ["//src:main"],
+)
+
+go_test (
+  name = "foo_test",
+  srcs = ["foo_test.go"],
+  deps = [":foo"],
+)

--- a/test/go_rules/toolchain/test_repo/src/foo/foo.go
+++ b/test/go_rules/toolchain/test_repo/src/foo/foo.go
@@ -1,0 +1,3 @@
+package foo
+
+const Foo = "wibble wibble wibble"

--- a/test/go_rules/toolchain/test_repo/src/foo/foo_test.go
+++ b/test/go_rules/toolchain/test_repo/src/foo/foo_test.go
@@ -1,0 +1,9 @@
+package foo
+
+import "testing"
+
+func TestFoo(t *testing.T){
+	if Foo != "wibble wibble wibble" {
+		panic("failed")
+	}
+}

--- a/test/go_rules/toolchain/test_repo/src/main.go
+++ b/test/go_rules/toolchain/test_repo/src/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+	"testrepo/src/foo"
+)
+
+func main() {
+	fmt.Println(foo.Foo)
+}

--- a/test/go_rules/toolchain/test_repo/tools/BUILD_FILE
+++ b/test/go_rules/toolchain/test_repo/tools/BUILD_FILE
@@ -1,0 +1,4 @@
+go_toolchain(
+    name = "toolchain",
+    version = "1.15.2",
+)


### PR DESCRIPTION
This enables please to download a go toolchain rather than relying on the host machine having go installed. 