### PR TITLE
fix: export to root directory

### DIFF
--- a/src/fs/fs.go
+++ b/src/fs/fs.go
@@ -90,8 +90,10 @@ func WriteFile(fromFile io.Reader, to string, mode os.FileMode) error {
 		return err
 	}
 	dir, file := path.Split(to)
-	if err := os.MkdirAll(dir, DirPermissions); err != nil {
-		return err
+	if dir != "" {
+		if err := os.MkdirAll(dir, DirPermissions); err != nil {
+			return err
+		}
 	}
 	tempFile, err := ioutil.TempFile(dir, file)
 	if err != nil {


### PR DESCRIPTION
Exporting outputs fails when the target directory is the repository root.
