### PR TITLE
Fix more typos

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -5,7 +5,7 @@ rules to Go packages.
 """
 def go_toolchain(name:str, url:str|dict = '', version:str = '', hashes:list = [], visibility:list = ["PUBLIC"]):
     """
-    Downloads the golang SDK and exposes :<name>|go and :<name>|gofmt as entry points. To use this rule add the
+    Downloads Go and exposes :<name>|go and :<name>|gofmt as entry points. To use this rule add the
     following to your .plzconfig:
 
     [go]
@@ -13,12 +13,12 @@ def go_toolchain(name:str, url:str|dict = '', version:str = '', hashes:list = []
 
     Args:
       name (str): Name of the rule.
-      url (str | dict): The URL used to download the golang SDK. Can be a single string or a dictionary mapping
+      url (str | dict): The URL used to download Go. Can be a single string or a dictionary mapping
                         GOOS-GOARCH to URLs i.e. linux-amd64: 'https://...'. Either provide url or version, but not both.
-      version (str): The version of the golang SDK to download. The SDK will be downloaded from https://golang.org/dl/...
+      version (str): The version of Go to download. Go will be downloaded from https://golang.org/dl/...
                      and the rule will use the current platforms GOOS and GOARCH setting. Either provide url or version,
                      but not both.
-      hashes (list): A list of possible hashes for the downloaded sdk archive. Optional.
+      hashes (list): A list of possible hashes for the downloaded archive. Optional.
       visibility (list): Visibility specification. Defaults to public.
     """
     if url and version:
@@ -27,7 +27,7 @@ def go_toolchain(name:str, url:str|dict = '', version:str = '', hashes:list = []
     if version:
         sdk_url = f'https://golang.org/dl/go{version}.{CONFIG.GOOS}-{CONFIG.GOARCH}.tar.gz'
     else:
-        sdk_url = url if isinstance(jdk_url, str) else url[f'{CONFIG.GOOS}-{CONFIG.GOARCH}']
+        sdk_url = url if isinstance(sdk_url, str) else url[f'{CONFIG.GOOS}-{CONFIG.GOARCH}']
 
     download = remote_file(
         name = name,
@@ -36,7 +36,7 @@ def go_toolchain(name:str, url:str|dict = '', version:str = '', hashes:list = []
         hashes = hashes,
     )
 
-    # TODO(jpoole): optionally build the SDK from source for cross compilation/race detector etc.
+    # TODO(jpoole): optionally build the stdlib from source for cross compilation/race detector etc.
     return build_rule(
         name = name,
         srcs = [download],


### PR DESCRIPTION
Actually, it's rarely called "golang SDK", it's rather called Go (and stdlib).

Also, fixed a copy-paste typo