### PR TITLE
Make glob() include hidden files in bazel compat mode

### DIFF
--- a/docs/config.html
+++ b/docs/config.html
@@ -630,7 +630,7 @@
     <p>Currently the only attribute here is <code>compatibility</code>, when that is enabled
       some aspects of the parser behave a little differently; some of the rule names and flags
       change, <code>//visibility:public</code> is interpreted specially and WORKSPACE files are
-      parsed to find external dependencies. The <a href="/lexicon.html#glob"><code>glob</code></a>
+      parsed to find external dependencies. The <a href="lexicon.html#glob"><code>glob</code></a>
       builtin also changes to include hidden files by default.<p>
 
     <p>There is a <code>--bazel_compat</code> flag to <code>plz init</code> which sets this

--- a/docs/config.html
+++ b/docs/config.html
@@ -630,7 +630,8 @@
     <p>Currently the only attribute here is <code>compatibility</code>, when that is enabled
       some aspects of the parser behave a little differently; some of the rule names and flags
       change, <code>//visibility:public</code> is interpreted specially and WORKSPACE files are
-      parsed to find external dependencies.<p>
+      parsed to find external dependencies. The <a href="/lexicon.html#glob"><code>glob</code></a>
+      builtin also changes to include hidden files by default.<p>
 
     <p>There is a <code>--bazel_compat</code> flag to <code>plz init</code> which sets this
       on initialising a new repo.</p>

--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -58,6 +58,9 @@
       directory of the build file. This means that <code>glob(["**/*.go"], exclude = ["*_test.go"])</code>
       will exclude all files ending in &quot;test.go&quot;.</p>
 
+    <p>Hidden files (those starting with a <code>.</code>) are not matched by any patterns
+      unless you pass <code>hidden=True</code>.</p>
+
     <p>It bears noting that you cannot glob generated files, only source files. Also glob will not
       descend into any directories that contain a BUILD file; this maintains an invariant that
       each file is owned by exactly one package (or potentially none, but then Please doesn't know

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -101,7 +101,7 @@ def dict(d):
     raise 'dict is not callable'
 
 
-def glob(include:list, exclude:list&excludes=[], hidden:bool=False) -> list:
+def glob(include:list, exclude:list&excludes=[], hidden:bool=CONFIG.BAZEL_COMPATIBILITY) -> list:
     pass
 
 


### PR DESCRIPTION
Also extend documentation to be a bit more explicit about the `hidden` argument.

I suppose this could technically be breaking so we might want to submit it in v16.

Fixes #1297 