### PR TITLE
fix: match all conditions in config_setting

### DIFF
--- a/rules/config_rules.build_defs
+++ b/rules/config_rules.build_defs
@@ -36,7 +36,7 @@ def config_setting(name:str, values:dict, visibility:list=None):
                      For example: {'cpu': 'amd64'} is successful if the CPU architecture is amd64.
       visibility (list): Visibility of the rule.
     """
-    on = any([_config_on(k, v) for k, v in sorted(values.items())])
+    on = all([_config_on(k, v) for k, v in sorted(values.items())])
     return build_rule(
         name = name,
         outs = [name],


### PR DESCRIPTION
According to the documentation above the config_setting rule,
it should match all conditions in values.

Bazel works the same way:
https://docs.bazel.build/versions/master/configurable-attributes.html
