### PR TITLE
Make the test output timings a bit clearer

### DIFF
--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -275,12 +275,12 @@ func printTestResults(state *core.BuildState, failedTargets []core.BuildLabel, f
 			aggregate.Duration += target.Results.Duration
 			if len(target.Results.TestCases) > 0 {
 				if target.Results.Errors() > 0 {
-					printf("${CYAN}%s${RESET} %s\n", target.Label, testResultMessage(target.Results))
+					printf("${CYAN}%s${RESET} %s\n", target.Label, testResultMessage(target.Results, false))
 				} else if target.Results.Failures() > 0 {
-					printf("${RED}%s${RESET} %s\n", target.Label, testResultMessage(target.Results))
+					printf("${RED}%s${RESET} %s\n", target.Label, testResultMessage(target.Results, false))
 				} else if detailed || len(failedTargets) == 0 {
 					// Succeeded or skipped
-					printf("${GREEN}%s${RESET} %s\n", target.Label, testResultMessage(target.Results))
+					printf("${GREEN}%s${RESET} %s\n", target.Label, testResultMessage(target.Results, false))
 				}
 				if state.ShowTestOutput || detailed {
 					// Determine max width of test name so we align them
@@ -312,8 +312,8 @@ func printTestResults(state *core.BuildState, failedTargets []core.BuildLabel, f
 			}
 		}
 	}
-	printf(fmt.Sprintf("${BOLD_WHITE}%s and %s${BOLD_WHITE}. Total time %s.${RESET}\n",
-		pluralise(targets, "test target", "test targets"), testResultMessage(aggregate), duration))
+	printf(fmt.Sprintf("${BOLD_WHITE}%s and %s${BOLD_WHITE}. Total real time %s.${RESET}\n",
+		pluralise(targets, "test target", "test targets"), testResultMessage(aggregate, true), duration))
 }
 
 func showExecutionOutput(execution core.TestExecution) {
@@ -409,10 +409,15 @@ func logProgress(ctx context.Context, state *core.BuildState, buildingTargets []
 }
 
 // Produces a string describing the results of one test (or a single aggregation).
-func testResultMessage(results core.TestSuite) string {
+func testResultMessage(results core.TestSuite, total bool) string {
 	msg := fmt.Sprintf("%s run", pluralise(results.Tests(), "test", "tests"))
 	if results.Duration >= 0.0 {
-		msg += fmt.Sprintf(" in ${BOLD_WHITE}%s${RESET}", results.Duration.Round(testDurationGranularity))
+		rounded := results.Duration.Round(testDurationGranularity)
+		if total {
+			msg += fmt.Sprintf(" using %s total compute time${RESET}", rounded)
+		} else {
+			msg += fmt.Sprintf(" in ${BOLD_WHITE}%s${RESET}", rounded)
+		}
 	}
 	msg += fmt.Sprintf("; ${BOLD_GREEN}%d passed${RESET}", results.Passes())
 	if results.Errors() > 0 {

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -275,12 +275,12 @@ func printTestResults(state *core.BuildState, failedTargets []core.BuildLabel, f
 			aggregate.Duration += target.Results.Duration
 			if len(target.Results.TestCases) > 0 {
 				if target.Results.Errors() > 0 {
-					printf("${CYAN}%s${RESET} %s\n", target.Label, testResultMessage(target.Results, false))
+					printf("${CYAN}%s${RESET} %s\n", target.Label, testResultMessage(target.Results, true))
 				} else if target.Results.Failures() > 0 {
-					printf("${RED}%s${RESET} %s\n", target.Label, testResultMessage(target.Results, false))
+					printf("${RED}%s${RESET} %s\n", target.Label, testResultMessage(target.Results, true))
 				} else if detailed || len(failedTargets) == 0 {
 					// Succeeded or skipped
-					printf("${GREEN}%s${RESET} %s\n", target.Label, testResultMessage(target.Results, false))
+					printf("${GREEN}%s${RESET} %s\n", target.Label, testResultMessage(target.Results, true))
 				}
 				if state.ShowTestOutput || detailed {
 					// Determine max width of test name so we align them
@@ -312,8 +312,9 @@ func printTestResults(state *core.BuildState, failedTargets []core.BuildLabel, f
 			}
 		}
 	}
-	printf(fmt.Sprintf("${BOLD_WHITE}%s and %s${BOLD_WHITE}. Total real time %s.${RESET}\n",
-		pluralise(targets, "test target", "test targets"), testResultMessage(aggregate, true), duration))
+	printf(fmt.Sprintf("${BOLD_WHITE}%s and %s${BOLD_WHITE}.${RESET}\n",
+		pluralise(targets, "test target", "test targets"), testResultMessage(aggregate, false)))
+	printf("${BOLD_WHITE}Total time: %s real, %s compute.${RESET}\n", duration, aggregate.Duration)
 }
 
 func showExecutionOutput(execution core.TestExecution) {
@@ -409,15 +410,10 @@ func logProgress(ctx context.Context, state *core.BuildState, buildingTargets []
 }
 
 // Produces a string describing the results of one test (or a single aggregation).
-func testResultMessage(results core.TestSuite, total bool) string {
+func testResultMessage(results core.TestSuite, showDuration bool) string {
 	msg := fmt.Sprintf("%s run", pluralise(results.Tests(), "test", "tests"))
-	if results.Duration >= 0.0 {
-		rounded := results.Duration.Round(testDurationGranularity)
-		if total {
-			msg += fmt.Sprintf(" using %s total compute time${RESET}", rounded)
-		} else {
-			msg += fmt.Sprintf(" in ${BOLD_WHITE}%s${RESET}", rounded)
-		}
+	if showDuration && results.Duration >= 0.0 {
+		msg += fmt.Sprintf(" in ${BOLD_WHITE}%s${RESET}", results.Duration.Round(testDurationGranularity))
 	}
 	msg += fmt.Sprintf("; ${BOLD_GREEN}%d passed${RESET}", results.Passes())
 	if results.Errors() > 0 {


### PR DESCRIPTION
Previously it can print things like
```
593 test targets and 5960 tests run in 9h46m2.957s; 5947 passed, 1 failed, 12 skipped. Total time 16m15.1s.
```
which I've heard comment is a bit confusing since it clearly didn't take 9 hours; that figure is more of a "total" than the one labelled "Total time".
This will print something like
```
593 test targets and 5960 tests run using 9h46m2.957s total compute time; 5947 passed, 1 failed, 12 skipped. Total real time 16m15.1s.
```
I think this is clearer as to what it means but a bit clunky still since it's wordier. Thoughts?