### PR TITLE
Round the displayed compute duration

### DIFF
--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -314,7 +314,7 @@ func printTestResults(state *core.BuildState, failedTargets []core.BuildLabel, f
 	}
 	printf(fmt.Sprintf("${BOLD_WHITE}%s and %s${BOLD_WHITE}.${RESET}\n",
 		pluralise(targets, "test target", "test targets"), testResultMessage(aggregate, false)))
-	printf("${BOLD_WHITE}Total time: %s real, %s compute.${RESET}\n", duration, aggregate.Duration)
+	printf("${BOLD_WHITE}Total time: %s real, %s compute.${RESET}\n", duration, aggregate.Duration.Round(durationGranularity))
 }
 
 func showExecutionOutput(execution core.TestExecution) {


### PR DESCRIPTION
Before:
```
Total time: 3.83s real, 1.020462757s compute.
```
After:
```
Total time: 100ms real, 10ms compute.
```