### PR TITLE
Cgo without cgo

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -306,6 +306,17 @@ def cgo_library(name:str, srcs:list, go_srcs:list=[], c_srcs:list=[], hdrs:list=
       test_only (bool): If True, is only visible to test rules.
       import_path (str): If set, this will override the import path of the generated go package.
     """
+    if not srcs:
+        return go_library(
+            name = name,
+            srcs = go_srcs,
+            out = out,
+            deps = deps,
+            import_path = import_path,
+            visibility = visibility,
+            test_only = test_only,
+        )
+
     file_srcs = [src for src in srcs if not src.startswith('/') and not src.startswith(':')]
     post_build = lambda rule, output: [add_out(rule, 'c' if line.endswith('.c') else 'go', line) for line in output]
     subdir2 = (subdir + '/') if subdir and not subdir.endswith('/') else subdir

--- a/test/go_rules/cgo_optional/BUILD
+++ b/test/go_rules/cgo_optional/BUILD
@@ -1,0 +1,14 @@
+cgo_library(
+    name = "cgo_optional",
+    srcs = [],
+    go_srcs = ["go.go"],
+)
+
+go_test(
+    name = "cgo_optional_test",
+    srcs = ["go_test.go"],
+    deps = [
+        ":cgo_optional",
+        "//third_party/go:testify",
+    ],
+)

--- a/test/go_rules/cgo_optional/go.go
+++ b/test/go_rules/cgo_optional/go.go
@@ -1,0 +1,15 @@
+package cgo
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// CheckAnswer checks that the given answer matches the canonical one.
+func CheckAnswer(answer string) error {
+	ans, _ := strconv.ParseInt(answer, 13, 32)
+	if int(ans) != 6*9 {
+		return fmt.Errorf("universe parameters incorrect")
+	}
+	return nil
+}

--- a/test/go_rules/cgo_optional/go_test.go
+++ b/test/go_rules/cgo_optional/go_test.go
@@ -1,0 +1,11 @@
+package cgo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuestion(t *testing.T) {
+	assert.NoError(t, CheckAnswer("42"))
+}


### PR DESCRIPTION
CGO is often not required for all platforms. This PR improves cross-compilation support by allowing to build regular go libraries when no cgo sources are provided (for example by using `select` to return an empty list on platforms not requiring cgo)