### PR TITLE
go_get: use entire package names in tag names

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -850,7 +850,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
         tags = ['get']
         module_major_version = [module_major_version]
     else:
-        tags = [basename(dirname(g)) for g in get]
+        tags = [g.replace('/', '_') for g in get]
         revision = revision or [None for g in get]
         module_major_version = module_major_version or ['' for g in get]
     all_installs = []


### PR DESCRIPTION
When generating tag names from package names in the `go_get` rule, use a sanitised version of the entire package name rather than the last-but-one component in the path. This avoids breakage in cases where multiple packages with the same last-but-one path component are fetched as part of the same `go_get` rule (e.g. `https://github.com/x/y` and `https://github.com/x/z`).

Closes #1326.