### PR TITLE
go_get: support multiple patches

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -803,7 +803,7 @@ def cgo_test(name:str, srcs:list, data:list=None, deps:list=None, visibility:lis
 
 
 def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list=None,
-           visibility:list=None, patch:str=None, binary:bool=False, test_only:bool&testonly=False,
+           visibility:list=None, patch:str|list=None, binary:bool=False, test_only:bool&testonly=False,
            install:list=None, revision:str|list=None, strip:list=None, hashes:list=None,
            extra_outs:list=[], licences:list=None, module_major_version:str|list=''):
     """Defines a dependency on a third-party Go library.
@@ -827,7 +827,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
       deps (list): Dependencies
       exported_deps (list): Dependencies to make available to anything using this rule.
       visibility (list): Visibility specification
-      patch (str): Patch file to apply
+      patch (str | list): Patch file or files to apply
       binary (bool): True if the output of the rule is a binary.
       test_only (bool): If true this rule will only be visible to tests.
       install (list): Allows specifying the exact list of packages to install. If this is not passed,
@@ -855,6 +855,8 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
         tags = [g.replace('/', '_') for g in get]
         revision = revision or [None for g in get]
         module_major_version = module_major_version or ['' for g in get]
+    if isinstance(patch, str):
+        patch = [patch]
     all_installs = []
     outs = extra_outs
     provides = {}
@@ -951,7 +953,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
         return a_rule
 
 
-def _go_get_download(name:str, tag:str, get:str, repo:str='', patch:str=None, hashes:list=None,
+def _go_get_download(name:str, tag:str, get:str, repo:str='', patch:list=[], hashes:list=None,
                      test_only:bool&testonly=False, revision:str=None, strip:list=None,
                      labels:list=[], licences:list=None, module_major_version:str):
     if hashes and not revision:
@@ -992,14 +994,14 @@ def _go_get_download(name:str, tag:str, get:str, repo:str='', patch:str=None, ha
         cmd += ['find . -name .git | xargs rm -rf']
         tools = [CONFIG.GO_TOOL]
     if patch:
-        cmd += [f'patch -d {subdir} -p1 < "$TMP_DIR"/$SRCS_PATCH']
+        cmd += [f'for p in "$TMP_DIR"/$SRCS_PATCH; do patch -d {subdir} -p1 < $p; done']
     if strip:
         cmd += [f'rm -rf {subdir}/{s}' for s in strip]
     return build_rule(
         name = name,
         tag = tag,
         srcs = {
-            'patch': [patch],
+            'patch': patch,
             'get': get_deps,
         },
         outs = [subdir],


### PR DESCRIPTION
Bring `go_get` into line with `pip_library` and `python_wheel` by allowing the `patch` parameter to define multiple patches in a list as well as a single patch in a string.