### PR TITLE
go_get: fix 'strip' parameter type regression

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -804,7 +804,7 @@ def cgo_test(name:str, srcs:list, data:list=None, deps:list=None, visibility:lis
 
 def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list=None,
            visibility:list=None, patch:str|list|dict=None, binary:bool=False, test_only:bool&testonly=False,
-           install:list|dict=None, revision:str|list=None, strip:list=None, hashes:list=None,
+           install:list|dict=None, revision:str|list=None, strip:list|dict=None, hashes:list=None,
            extra_outs:list=[], licences:list=None, module_major_version:str|list=''):
     """Defines a dependency on a third-party Go library.
 


### PR DESCRIPTION
Commit ed17c353 accidentally reverted the change to `go_get`'s type signature that was made in commit 8d06fc86, preventing a dict from being passed in the `strip` parameter. Correct the `strip` parameter's type to once again allow dicts to be passed.