### PR TITLE
infer goroot from install list when get repository is empty

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -933,10 +933,8 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
     if srcs == [] and isinstance(get, list) and get == [] and install != [] and binary == False:
         # we are going to infer the getroot name from the 1st install dependency
         getroot = install[0][:-4] if install[0].endswith('/...') else install[0]
-        if len(install) == 1 and not install[0].endswith('/...'):
-            outs += [getroot + ".a"]
-        else:
-            outs += [getroot]
+        # NOTE: for this case in the install list I'm expecting full package names 
+        outs += [i[:-4] if i.endswith('/...') else i+".a" for i in install]
         provides = {'go': go_rule} # I can't find the sources 
 
     # Now compile it in a separate step.

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -906,6 +906,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
             licences = licences,
             module_major_version = module_major_version,
         )
+            
         get_roots += [getroot]
         srcs += [get_rule]
         provides = {'go': go_rule, 'go_src': get_rule}
@@ -929,10 +930,13 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
             all_installs += [getone]
 
     # in case of installing packages using other package sources 
-    if srcs == [] and get == [] and install != [] and binary == False:
+    if srcs == [] and isinstance(get, list) and get == [] and install != [] and binary == False:
         # we are going to infer the getroot name from the 1st install dependency
         getroot = install[0][:-4] if install[0].endswith('/...') else install[0]
-        outs += [getroot]
+        if len(install) == 1:
+            outs += [getroot + ".a"]
+        else:
+            outs += [getroot]
         provides = {'go': go_rule} # I can't find the sources 
 
     # Now compile it in a separate step.

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -928,6 +928,13 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
         else:
             all_installs += [getone]
 
+    # in case of installing packages using other package sources 
+    if srcs == [] and get == [] and install != [] and binary == False:
+        # we are going to infer the getroot name from the 1st install dependency
+        getroot = install[0][:-4] if install[0].endswith('/...') else install[0]
+        outs += [getroot]
+        provides = {'go': go_rule} # I can't find the sources 
+
     # Now compile it in a separate step.
     cmd = [
         'export GOPATH="$(find \"$TMP_DIR\" \( -name src -o -name pkg \) -exec dirname {} \; | sort | uniq | tr \'\\n\' \':\' | sed \'s/:$//\')" GO111MODULE="off"',

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -930,12 +930,15 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
             all_installs += [getone]
 
     # in case of installing packages using other package sources 
-    if srcs == [] and isinstance(get, list) and get == [] and install != [] and binary == False:
-        # we are going to infer the getroot name from the 1st install dependency
-        getroot = install[0][:-4] if install[0].endswith('/...') else install[0]
-        # NOTE: for this case in the install list I'm expecting full package names 
-        outs += [i[:-4] if i.endswith('/...') else i+".a" for i in install]
-        provides = {'go': go_rule} # I can't find the sources 
+    if not get and not install:
+        raise ParseError("must provide get or install!")
+    else:
+        if srcs == [] and binary == False:
+            # we are going to infer the getroot name from the 1st install dependency
+            getroot = install[0][:-4] if install[0].endswith('/...') else install[0]
+            # NOTE: for this case in the install list I'm expecting full package names 
+            outs += [i[:-4] if i.endswith('/...') else i+".a" for i in install]
+            provides = {'go': go_rule} # I can't find the sources 
 
     # Now compile it in a separate step.
     cmd = [

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -933,7 +933,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
     if srcs == [] and isinstance(get, list) and get == [] and install != [] and binary == False:
         # we are going to infer the getroot name from the 1st install dependency
         getroot = install[0][:-4] if install[0].endswith('/...') else install[0]
-        if len(install) == 1:
+        if len(install) == 1 and not install[0].endswith('/...'):
             outs += [getroot + ".a"]
         else:
             outs += [getroot]


### PR DESCRIPTION
Ref:  https://github.com/thought-machine/please/commit/b76da168a0bb36600dc55818c0349bf2e2c283c8 

This patch will allow this type of go_get pattern where we will download a lib only once but we will split the installation into multiple go_get modules: 
```
go_get(
    name = "genproto",
    get = "google.golang.org/genproto",
    install = [
        "protobuf/...",
    ],
    repo = "github.com/google/go-genproto",
    revision = "8ce4113da6f7a70fe564ce27f8fd9f6149b76120",
    deps = [
        "//third_party/go/google.golang.org:protobuf",
        "//third_party/go/github.com/golang:protobuf",
    ],
)

go_get(
    name = "rpc",
    get = [],
    install = [
        "google.golang.org/genproto/googleapis/rpc/...",
    ],
    deps = [
        ":genproto",
    ],
)
```
This was previously worked only for binaries. 
The drawback is the install rule uses first install statement as getroot so it must be the most comprehensive one
