### PR TITLE
go_get: don't expect "....a" to be outputted when install contains "..."

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -917,6 +917,9 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
             for i in installone:
                 if not i or i == ".":
                     outs += [getroot + ".a"]
+                elif i == "...":
+                    get_roots += [getroot]
+                    outs += [getroot]
                 elif i.endswith("/..."):
                     out = getroot + "/" + i.removesuffix("/...")
                     get_roots += [out]


### PR DESCRIPTION
In `go_get`, treat the element `"..."` in the `install` list as a special case: expect the rule to output a directory structure consistent with the package name, rather than the file `....a` inside that directory structure.

Closes #1355.