### PR TITLE
Demonstrate subrepo include problem

### DIFF
--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -286,8 +286,6 @@ func rescanDeps(state *core.BuildState, changed map[*core.BuildTarget]struct{}) 
 }
 
 // This is the builtin subrepo for pleasings.
-// TODO(peterebden): Should really provide a github_archive builtin that knows how to construct
-//                   the URL and strip_prefix etc.
 const pleasings = `
 http_archive(
     name = "pleasings",

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -82,6 +82,7 @@ func doTasks(tid int, state *core.BuildState, parses core.ParseTaskQueue, builds
 			go func() {
 				parse.Parse(tid, state, p.Label, p.Dependent, p.ForSubinclude)
 				state.TaskDone(false)
+				close(p.Notify)
 			}()
 		case l, ok := <-builds:
 			if !ok {


### PR DESCRIPTION
This avoids hangs in situations like #1378 because we initiate the parse but don't leverage the channel mechanism for detecting when that parse has completed. 

The problem was:
Thread 1: Parse //cmd:all
    1) subinclude("//pleasings2//go")
    2) register pending target "///pleasings//go"
    3) queue pending parse for ///pleaseings//go
    4) wait for close on ///pleasings//go pending target channel 

Thread 2: parse ///pleasings//go
    1) check subrepo
    2) register pending target "//:pleasings2"
    3) parse //:all
    4) subinclude("///pleasings2//go")
    5) See that we've already queued ///pleasings2//go
    6) wait for close on ///pleasings//go pending target channel  

At this points both threads expect the other to finish building ///pleasings2//go

In my solution, thread 1 just asks for a parse and doesn't register a pending parse. This means that thread 2 doesn't block and carries on to fully parse itself. Thread 1 then polls the graph and picks up when this is done. When it comes to wait for ///pleasings//go to be built, it finds it already has. 
    
