### PR TITLE
Pre-set the empty blob into the "existing blobs" map

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -130,7 +130,7 @@ func New(state *core.BuildState) *Client {
 		outputs:   map[core.BuildLabel]*pb.Directory{},
 		mdStore:   newDirMDStore(time.Duration(state.Config.Remote.CacheDuration)),
 		existingBlobs: map[string]struct{}{
-			digest.Empty.Hash: struct{}{},
+			digest.Empty.Hash: {},
 		},
 		fileMetadataCache: filemetadata.NewNoopCache(),
 	}

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/client"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/retry"
 	fpb "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
@@ -123,12 +124,14 @@ type pendingDownload struct {
 // It begins the process of contacting the remote server but does not wait for it.
 func New(state *core.BuildState) *Client {
 	c := &Client{
-		state:             state,
-		origState:         state,
-		instance:          state.Config.Remote.Instance,
-		outputs:           map[core.BuildLabel]*pb.Directory{},
-		mdStore:           newDirMDStore(time.Duration(state.Config.Remote.CacheDuration)),
-		existingBlobs:     map[string]struct{}{},
+		state:     state,
+		origState: state,
+		instance:  state.Config.Remote.Instance,
+		outputs:   map[core.BuildLabel]*pb.Directory{},
+		mdStore:   newDirMDStore(time.Duration(state.Config.Remote.CacheDuration)),
+		existingBlobs: map[string]struct{}{
+			digest.Empty.Hash: struct{}{},
+		},
 		fileMetadataCache: filemetadata.NewNoopCache(),
 	}
 	c.stats = newStatsHandler(c)


### PR DESCRIPTION
Only makes a small difference but it's basically free; we can easily make 10-20 requests for the empty blob before we get a response telling us it exists, so might as well skip those.