### PR TITLE
Fix outputs check to use .Outputs() rather than the private field

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -744,7 +744,7 @@ func (target *BuildTarget) CheckTargetOwnsBuildOutputs(state *BuildState) error 
 		return nil
 	}
 
-	for _, output := range target.outputs {
+	for _, output := range target.Outputs() {
 		targetPackage := target.Label.PackageName
 		out := filepath.Join(targetPackage, output)
 


### PR DESCRIPTION
Fixes: #1399