### PR TITLE
feat: better colour display with light colours schemes like Solarized Light

### DIFF
--- a/docs/config.html
+++ b/docs/config.html
@@ -124,6 +124,10 @@
       <li><b>SystemStats</b> (bool)<br/>
 	Whether or not to show basic system resource usage in the interactive display.
         Defaults to <code>False</code>.</li>
+
+      <li><b>ColourScheme</b> (string)<br/>
+	Shell colour scheme mode, dark or light. Adapts interactive display colours to the colour scheme mode.
+        Defaults to <code>dark</code>.</li>
     </ul>
 
     <h3 id="build">[Build]</h3>

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -269,6 +269,7 @@ func DefaultConfiguration() *Configuration {
 	config.Test.Timeout = cli.Duration(10 * time.Minute)
 	config.Display.SystemStats = true
 	config.Display.MaxWorkers = 40
+	config.Display.ColourScheme = "dark"
 	config.Remote.NumExecutors = 20 // kind of arbitrary
 	config.Remote.HomeDir = "~"
 	config.Remote.Secure = true
@@ -359,9 +360,10 @@ type Configuration struct {
 		GitFunctions     bool `help:"Activates built-in functions git_branch, git_commit, git_show and git_state. If disabled they will not be usable at parse time."`
 	} `help:"The [parse] section in the config contains settings specific to parsing files."`
 	Display struct {
-		UpdateTitle bool `help:"Updates the title bar of the shell window Please is running in as the build progresses. This isn't on by default because not everyone's shell is configured to reset it again after and we don't want to alter it forever."`
-		SystemStats bool `help:"Whether or not to show basic system resource usage in the interactive display. Has no effect without that configured."`
-		MaxWorkers  int  `help:"Maximum number of worker rows to display at any one time."`
+		UpdateTitle  bool   `help:"Updates the title bar of the shell window Please is running in as the build progresses. This isn't on by default because not everyone's shell is configured to reset it again after and we don't want to alter it forever."`
+		SystemStats  bool   `help:"Whether or not to show basic system resource usage in the interactive display. Has no effect without that configured."`
+		MaxWorkers   int    `help:"Maximum number of worker rows to display at any one time."`
+		ColourScheme string `help:"Shell colour scheme mode, dark or light. Defaults to dark"`
 	} `help:"Please has an animated display mode which shows the currently building targets.\nBy default it will autodetect whether it is using an interactive TTY session and choose whether to use it or not, although you can force it on or off via flags.\n\nThe display is heavily inspired by Buck's SuperConsole."`
 	Colours map[string]string `help:"Colour code overrides in interactive output. These correspond to requirements on each target."`
 	Build   struct {

--- a/src/output/print.go
+++ b/src/output/print.go
@@ -13,6 +13,11 @@ func initPrintf(config *core.Configuration) {
 	if !cli.ShowColouredOutput {
 		replacements = map[string]string{}
 	} else {
+		if config.Display.ColourScheme == "light" {
+			for k, v := range lightOverrides {
+				replacements[k] = v
+			}
+		}
 		for k, v := range config.Colours {
 			replacements[k] = v
 		}
@@ -53,4 +58,12 @@ var replacements = map[string]string{
 	"RESET":        "\x1b[0m",
 	"ERASE_AFTER":  "\x1b[K",
 	"CLEAR_END":    "\x1b[0J",
+}
+
+// replacements overrides for light colour scheme.
+var lightOverrides = map[string]string{
+	"BOLD_GREY":  "\x1b[37;1m",
+	"BOLD_WHITE": "\x1b[30;1m",
+	"GREY":       "\x1b[37m",
+	"WHITE":      "\x1b[30m",
 }


### PR DESCRIPTION
With light colours schemes like "Solarized Light", things displayed in white are not easily readable.

Add a `Display.ColoursScheme` config parameter.
When set to `light`, white and grey colours are inverted in interactive display.