### PR TITLE
Fix out of order importconfigs

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -245,9 +245,9 @@ def _generate_pkg_import_cfg_cmd(out, pkg_location, handle_basename_eq_dirname=F
     else:
         format_packagefile_directive = 'xargs -I{} echo "packagefile {}=' + pkg_location + '/{}.a"'
 
-    return f'{find_archives} | {remove_pkg_location} | {remove_ext} | {format_packagefile_directive} > {out}'
+    return f'{find_archives} | {remove_pkg_location} | {remove_ext} | {format_packagefile_directive} | sort -u > {out}'
 def _aggregate_import_cfg_cmd():
-    return 'find . -name "*.importconfig" | xargs -I{} cat {} >> importconfig'
+    return 'find . -name "*.importconfig" | sort -u | xargs -I{} cat {} >> importconfig'
 
 def _trim_import_path(pkg):
     parts = pkg.split("/")

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -247,7 +247,7 @@ def _generate_pkg_import_cfg_cmd(out, pkg_location, handle_basename_eq_dirname=F
 
     return f'{find_archives} | {remove_pkg_location} | {remove_ext} | {format_packagefile_directive} | sort -u > {out}'
 def _aggregate_import_cfg_cmd():
-    return 'find . -name "*.importconfig" | sort -u | xargs -I{} cat {} >> importconfig'
+    return 'find . -name "*.importconfig" | xargs -I{} cat {} | sort -u >> importconfig'
 
 def _trim_import_path(pkg):
     parts = pkg.split("/")


### PR DESCRIPTION
This patch make sure the importfiles are generated in the same order all the time and the hash of the `#import_config` targets would not be the same between two builds.
Example:

```
$ plz hash //third_party/go/github.com/grpc-ecosystem:_go-grpc-middleware#import_config && cat $(plz query output //third_party/go/github.com/grpc-ecosystem:_go-grpc-middleware#import_config)
Hashes calculated, total time 240ms:
  //third_party/go/github.com/grpc-ecosystem:_go-grpc-middleware#import_config: eb71427831b452dbe19f182de7bc6588be865533d8f633d21aca8648decfa926
packagefile github.com/grpc-ecosystem/go-grpc-middleware/tags=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/tags.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware/util/metautils=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/util/metautils.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware/util/backoffutils=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/util/backoffutils.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware/logging=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/logging.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware/recovery=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/recovery.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware/retry=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/retry.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware.a
$ plz clean -f                                               
$ plz hash //third_party/go/github.com/grpc-ecosystem:_go-grpc-middleware#import_config && cat $(plz query output //third_party/go/github.com/grpc-ecosystem:_go-grpc-middleware#import_config)
Hashes calculated, total time 34.82s:
  //third_party/go/github.com/grpc-ecosystem:_go-grpc-middleware#import_config: 1fb8d2edfc298ecae4c3b78932dc531c9d92cf11a1660be52f8db124bdb3b1b8
packagefile github.com/grpc-ecosystem/go-grpc-middleware/retry=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/retry.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware/logging=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/logging.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware/tags=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/tags.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware/recovery=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/recovery.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware/util/backoffutils=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/util/backoffutils.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware/util/metautils=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware/util/metautils.a
packagefile github.com/grpc-ecosystem/go-grpc-middleware=third_party/go/github.com/grpc-ecosystem/pkg/linux_amd64/github.com/grpc-ecosystem/go-grpc-middleware.a

```