### PR TITLE
Remove -b flag as it's been deprecated and removed

### DIFF
--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -398,7 +398,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
         # which is itself Debian-specific, so we need to find if we're running on Debian. AAAAARGGGHHHH...
         pip_cmd = f'[ -f /etc/debian_version ] && SYS_FLAG="--system" || SYS_FLAG=""; {pip_cmd} $SYS_FLAG'
 
-    pip_cmd += f' -b build {repo_flag} {index_flag} {pip_flags} {package_name}'
+    pip_cmd += f' {repo_flag} {index_flag} {pip_flags} {package_name}'
 
     if strip:
         pip_cmd += ' && find . %s | xargs rm -rf' % ' -or '.join(['-name "%s"' % s for s in strip])


### PR DESCRIPTION
Pip should use $TMPDIR for this which should be fine as Please no longer tried to guess the outputs in a post build function. It now uses output directories to determine them. 

Fixes: #1419