### PR TITLE
Update python_intro.md, correcting reference to go_get()

### DIFF
--- a/docs/codelabs/python_intro.md
+++ b/docs/codelabs/python_intro.md
@@ -256,7 +256,7 @@ pip_library(
 
 This will download NumPy for us to use in our project. We use the `package()` built-in function to set the default
 visibility for this package. This can be very useful for third-party rules to avoid having to specify
-`visibility = ["PUBLIC"]` on every `go_get()` invocation.
+`visibility = ["PUBLIC"]` on every `pip_library()` invocation.
 
 NB: The visibility "PUBLIC" is a special case. Typically, items in the visibility list are labels. "PUBLIC" is equivalent
 to `//...`.


### PR DESCRIPTION
Correcting a reference to go_get(), to refer to pip_library(), because this is the python intro afterall