### PR TITLE
Make output dirs rename outputs rather than copying them

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -563,7 +563,7 @@ func addOutputDirectoryToBuildOutput(target *core.BuildTarget, dir core.OutputDi
 			target.AddOutput(f.Name())
 			outs = append(outs, f.Name())
 
-			if err := fs.RecursiveCopy(from, to, target.OutMode()); err != nil {
+			if err := os.Rename(from, to); err != nil {
 				return nil, err
 			}
 		}
@@ -586,13 +586,14 @@ func copyOutDir(target *core.BuildTarget, from string, to string) ([]string, err
 		err := fs.Walk(from, func(name string, isDir bool) error {
 			dest := path.Join(to, name[len(from):])
 			if isDir {
-				return fs.EnsureDir(dest)
+				return os.MkdirAll(dest, fs.DirPermissions)
 			}
 
 			outName := relativeToTmpdir(dest)
 			outs = append(outs, outName)
 			target.AddOutput(outName)
-			return fs.CopyFile(name, dest, target.OutMode())
+
+			return os.Rename(name, dest)
 		})
 		return outs, err
 	}

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -153,7 +153,7 @@ func TestOutputDirDoubleStar(t *testing.T) {
 	newTarget := func(withDoubleStar bool) (*core.BuildState, *core.BuildTarget) {
 		// Test modifying a command in the post-build function.
 		state, target := newState("//package1:target8")
-		target.Command = "mkdir OUT_DIR && mkdir OUT_DIR/foo && touch OUT_DIR/foo/file7"
+		target.Command = "mkdir -p OUT_DIR/foo && touch OUT_DIR/foo/file7"
 
 		if withDoubleStar {
 			target.OutputDirectories = append(target.OutputDirectories, "OUT_DIR/**")


### PR DESCRIPTION
Fixes #1407 