### PR TITLE
Improve docs lexicon templating

### DIFF
--- a/docs/template_lexicon.go
+++ b/docs/template_lexicon.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"text/template"
+	"regexp"
 )
 
 type rules struct {

--- a/docs/template_lexicon.go
+++ b/docs/template_lexicon.go
@@ -27,10 +27,11 @@ func (r *rules) Named(name string) *rule {
 func (r *rules) AddLinks(name, docstring string) string {
 	if strings.Contains(name, "_") { // Don't do it for something generic like "tarball"
 		for k := range r.Functions {
+			var re = regexp.MustCompile("\b("+k+")\b")
 			if name == k {
-				docstring = strings.Replace(docstring, " "+k, " <code>"+k+"</code>", -1)
+				docstring = re.ReplaceAllString(docstring, "<code>$1</code>")
 			} else {
-				docstring = strings.Replace(docstring, " "+k, ` <a href="#`+k+`">`+k+"</a>", -1)
+				docstring = re.ReplaceAllString(docstring, `<a href="#$1">$1</a>`)
 			}
 		}
 	}


### PR DESCRIPTION
This fixes the partial word highlighting, such as in https://please.build/lexicon.html#python_test or https://please.build/lexicon.html#http_archive

I've not ran it though, so I'm not too certain it's perfect. `k` should probably be escaped in that regexp construction, but none of the targets have regex special characters so it should be okay?

Also, the comment on line 29 seems to imply that it'll stop things like "tarball" being linked from other targets? But instead it just stops any links being in the "tarball" target description. Also meaning the "gentest" description doesn't link to "genrule"