### PR TITLE
fix: allow configurable pip to be a target again

### DIFF
--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -374,7 +374,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
     if install_subdirectory:
      target += '/' + outs[0]
 
-    pip_tool = CONFIG.PIP_TOOL or '$TOOLS_PYTHON -m pip'
+    pip_tool = "$TOOLS_PIP" or '$TOOLS_PYTHON -m pip'
 
     pip_cmd = (
         f'mkdir {pip_target_dir} && '

--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -374,7 +374,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
     if install_subdirectory:
      target += '/' + outs[0]
 
-    pip_tool = "$TOOLS_PIP" or '$TOOLS_PYTHON -m pip'
+    pip_tool = "$TOOLS_PIP" if CONFIG.PIP_TOOL else '$TOOLS_PYTHON -m pip'
 
     pip_cmd = (
         f'mkdir {pip_target_dir} && '


### PR DESCRIPTION
The configurable Pip tool, got broken if it was set to a target. This fixes it back.