### PR TITLE
Added proper WaitForPackage semantics and used them for subincludes

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -226,7 +226,9 @@ type stateProgress struct {
 	pendingTargets     map[BuildLabel]chan struct{}
 	pendingTargetMutex sync.Mutex
 	// Used to track general package parsing requests.
-	pendingPackages     map[packageKey]chan struct{}
+	pendingPackages map[packageKey]chan struct{}
+	// similar to pendingPackages but consumers haven't committed to parsing the package
+	packageWaits        map[packageKey]chan struct{}
 	pendingPackageMutex sync.Mutex
 	// The set of known states
 	allStates []*BuildState
@@ -484,6 +486,9 @@ func (state *BuildState) LogBuildResult(tid int, label BuildLabel, status BuildR
 			if ch, present := state.progress.pendingPackages[packageKey{Name: label.PackageName, Subrepo: label.Subrepo}]; present {
 				close(ch) // This signals to anyone waiting that it's done.
 			}
+			if ch, present := state.progress.packageWaits[packageKey{Name: label.PackageName, Subrepo: label.Subrepo}]; present {
+				close(ch) // This signals to anyone waiting that it's done.
+			}
 		}()
 		return // We don't notify anything else on these.
 	}
@@ -649,10 +654,10 @@ func (state *BuildState) ExpandVisibleOriginalTargets() BuildLabels {
 	return ret
 }
 
-// WaitForPackage either returns the given package which is already parsed and available,
-// or returns nil if nothing's parsed it already, in which case everything else calling this
-// will wait for the caller to parse it themselves.
-func (state *BuildState) WaitForPackage(label BuildLabel) *Package {
+// SyncParsePackage either returns the given package which is already parsed and available,
+// or returns nil indicating it is ready to be parsed. Everything subsequently calling this
+// will block until the original caller parse it.
+func (state *BuildState) SyncParsePackage(label BuildLabel) *Package {
 	if p := state.Graph.PackageByLabel(label); p != nil {
 		return p
 	}
@@ -667,6 +672,37 @@ func (state *BuildState) WaitForPackage(label BuildLabel) *Package {
 	state.progress.pendingPackages[key] = make(chan struct{})
 	state.progress.pendingPackageMutex.Unlock()
 	return state.Graph.PackageByLabel(label) // Important to check again; it's possible to race against this whole lot.
+}
+
+// WaitForPackage is similar to WaitForBuiltTarget however
+func (state *BuildState) WaitForPackage(l, dependent BuildLabel) *Package {
+	if p := state.Graph.PackageByLabel(l); p != nil {
+		return p
+	}
+	key := packageKey{Name: l.PackageName, Subrepo: l.Subrepo}
+
+	state.progress.pendingPackageMutex.Lock()
+
+	// If something has promised to parse it, wait for them to do so
+	if ch, present := state.progress.pendingPackages[key]; present {
+		state.progress.pendingPackageMutex.Unlock()
+		<-ch
+		return state.Graph.PackageByLabel(l)
+	}
+
+	// If something has already queued the package to be parsed, wait for them
+	if ch, present := state.progress.packageWaits[key]; present {
+		state.progress.pendingPackageMutex.Unlock()
+		<-ch
+		return state.Graph.PackageByLabel(l)
+	}
+
+	// Otherwise queue the target for parse and recurse
+	state.AddPendingParse(l, dependent, true)
+	state.progress.packageWaits[key] = make(chan struct{})
+	state.progress.pendingPackageMutex.Unlock()
+
+	return state.WaitForPackage(l, dependent)
 }
 
 // WaitForBuiltTarget blocks until the given label is available as a build target and has been successfully built.
@@ -940,6 +976,7 @@ func NewBuildState(config *Configuration) *BuildState {
 			numPending:      1,
 			pendingTargets:  map[BuildLabel]chan struct{}{},
 			pendingPackages: map[packageKey]chan struct{}{},
+			packageWaits:    map[packageKey]chan struct{}{},
 			success:         true,
 		},
 	}

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -3,6 +3,7 @@ package asp
 import (
 	"fmt"
 	"reflect"
+	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -100,6 +101,7 @@ func (i *interpreter) interpretStatements(s *scope, statements []*Statement) (re
 			} else {
 				err = fmt.Errorf("%s", r)
 			}
+			log.Debug(string(debug.Stack()))
 		}
 	}()
 	return s.interpretStatements(statements), nil // Would have panicked if there was an error

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -101,7 +101,7 @@ func (i *interpreter) interpretStatements(s *scope, statements []*Statement) (re
 			} else {
 				err = fmt.Errorf("%s", r)
 			}
-			log.Debug(string(debug.Stack()))
+			log.Debug("%v", debug.Stack())
 		}
 	}()
 	return s.interpretStatements(statements), nil // Would have panicked if there was an error

--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -108,7 +108,7 @@ func (p *aspParser) RunPostBuildFunction(threadID int, state *core.BuildState, t
 // runBuildFunction runs either the pre- or post-build function.
 func (p *aspParser) runBuildFunction(tid int, state *core.BuildState, target *core.BuildTarget, callbackType string, f func() error) error {
 	state.LogBuildResult(tid, target.Label, core.PackageParsing, fmt.Sprintf("Running %s-build function for %s", callbackType, target.Label))
-	pkg := state.WaitForPackage(target.Label)
+	pkg := state.SyncParsePackage(target.Label)
 	changed, err := pkg.EnterBuildCallback(f)
 	if err != nil {
 		state.LogBuildError(tid, target.Label, core.ParseFailed, err, "Failed %s-build function for %s", callbackType, target.Label)

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -37,7 +37,7 @@ func Parse(tid int, state *core.BuildState, label, dependent core.BuildLabel, fo
 
 func parse(tid int, state *core.BuildState, label, dependent core.BuildLabel, forSubinclude bool) error {
 	// See if something else has parsed this package first.
-	pkg := state.WaitForPackage(label)
+	pkg := state.SyncParsePackage(label)
 	if pkg != nil {
 		// Does exist, all we need to do is toggle on this target
 		return activateTarget(tid, state, pkg, label, dependent, forSubinclude)
@@ -104,7 +104,7 @@ func checkSubrepo(tid int, state *core.BuildState, label, dependent core.BuildLa
 		return nil, fmt.Errorf("Subrepo %s is not defined (referenced by %s)", label.Subrepo, dependent)
 	}
 	// For local subincludes, the subrepo has to already be defined at this point in the BUILD file
-	return nil, fmt.Errorf("Subrepo %v is not defined yet. It must appear before it is used by subinclude()", sl)
+	return nil, fmt.Errorf("%s -> %s", dependent, label)
 }
 
 // parseSubrepoPackage parses a package to make sure subrepos are available.

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -117,7 +117,7 @@ func findOriginalTasks(state *core.BuildState, preTargets, targets []core.BuildL
 		for _, target := range preTargets {
 			if target.IsAllTargets() {
 				log.Debug("Waiting for pre-target %s...", target)
-				state.WaitForPackage(target)
+				state.SyncParsePackage(target)
 				log.Debug("Pre-target %s parsed, continuing...", target)
 			}
 		}

--- a/test/local_subinclude_test/BUILD
+++ b/test/local_subinclude_test/BUILD
@@ -3,7 +3,7 @@ subinclude("//test/build_defs")
 please_repo_e2e_test(
     name = "test",
     expected_output = {
-        "out.txt": "//:pleasings\n//dir:pleasings2",
+        "out.txt": "//:gotest\n//:pleasings\n//dir:gotest\n//dir:pleasings2",
     },
     plz_command = "plz query alltargets > out.txt",
     repo = "test_repo",

--- a/test/local_subinclude_test/test_repo/BUILD_FILE
+++ b/test/local_subinclude_test/test_repo/BUILD_FILE
@@ -1,2 +1,6 @@
-# TODO(jpoole): figure out why pleasings aren't available at this point...
-# subinclude("///pleasings//k8s")
+subinclude("///dir/pleasings2//go")
+
+gotestsum_test(
+    name = "gotest",
+    race = True,
+)

--- a/test/local_subinclude_test/test_repo/dir/BUILD_FILE
+++ b/test/local_subinclude_test/test_repo/dir/BUILD_FILE
@@ -5,3 +5,8 @@ github_repo(
 )
 
 subinclude("///dir/pleasings2//go")
+
+gotestsum_test(
+    name = "gotest",
+    race = True,
+)


### PR DESCRIPTION
This avoid the lockup. Before the parsing of the subinclude package would also trigger a call to `WaitForTarget` which would hang because the original subinclude had already called that function:

old: 
1) //:all subincludes ///foo/bar//bazz
2) //:all queues ///foo/bar//bazz for parse and waits for it to be built (adding the channel to the pendingTargets map) 
3) parse of ///foo/bar//bazz checks for subrepos and parses the //foo package
4) //foo subincludes  ///foo/bar//bazz
5) //foo believes that something has already queued ///foo/bar//bazz to be built so blocks waiting on the channel from #2

At this point, we lock up essentially because as far as each thread is concerned, the other has committed to building ///foo/bar//bazz.

The new approach tries to avoid this by triggering a parse of the subrepos package before queuing the actual subinclude target:
 
1) //:all subincludes ///foo/bar//bazz
2) //:all queues //foo for parse and waits for the parse (adding the channel to a new non committal packageWaits map) 
3) We must then encounter the subrepo first in the package and add //foo:bar to the build graph
4) //foo subincludes ///foo/bar//bazz
5) We see that the subrepo is in the same package so skip queuing the parse again
6) //foo queues ///foo/bar//bazz to be pares (then built) 
7) Parsing ///foo/bar//bazz checks the subrepo and sees it's already been added so activates the target and waits for it to build
8) At this point the normal build/parse workflow plays out eventually releasing the locks once a successful build/parse build result gets logged.
9) The suninclude from step 1 continues execution, returning immediately when waiting for ///foo/bar//bazz as it was already built
