### PR TITLE
Update lexicon.html

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -3,8 +3,8 @@
     <p>This is the reference for the complete set of builtin rules & functions.</p>
 
     <ul>
-      <li><a href="#python-builtins">Python style builtins</a></li>
-      <li><a href="#please-builtins">Please builtins</a></li>
+      <li><a href="#python_builtins">Python style builtins</a></li>
+      <li><a href="#please_builtins">Please builtins</a></li>
       <li><a href="#cc">C and C++ rules</a></li>
       <li><a href="#go">Go rules</a></li>
       <li><a href="#java">Java rules</a></li>
@@ -15,7 +15,7 @@
       <li><a href="#subrepo">Subrepo rules</a></li>
     </ul>
 
-    <h2><a name="python-builtins">Python builtins</a></h2>
+    <h2><a name="python_builtins">Python builtins</a></h2>
 
     <p>The build language largely resembles Python. As such, following python inpired functions are available as builtins:</p>
     <ul>
@@ -113,7 +113,7 @@
             - <span class="red">deprecated</span>, use a comprehension if needed. Returns a shallow copy of this dictionary.</li>
     </ul>
 
-    <h2 id="please-builtins">Please builtins</h2>
+    <h2 id="please_builtins">Please builtins</h2>
     <p>In addition to the python builtins, Please also has a rich set of its own functions.</p>
 
     <h3>log</h3>


### PR DESCRIPTION
It doesn't seem to highlight the right tab when selected. (Always highlight python-builtins when the user clicks on either python-builtins or please-builtins.) Not sure if this will fix it but I don't have a good way to test this.