### PR TITLE
Run arch fix

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -434,6 +434,11 @@ var buildFunctions = map[string]func() int{
 				dir = originalWorkingDirectory
 			}
 
+			// This is a bit strange as normally if you run a binary for another platform, this will fail. In some cases
+			// this can be quite useful though e.g. to compile a binary for a target arch, then run an .sh script to
+			// push that to docker.
+			opts.Run.Args.Target.Subrepo = opts.BuildFlags.Arch.String()
+
 			run.Run(state, opts.Run.Args.Target, opts.Run.Args.Args.AsStrings(), opts.Run.Remote, opts.Run.Env, dir)
 		}
 		return 1 // We should never return from run.Run so if we make it here something's wrong.
@@ -834,7 +839,6 @@ func runPlease(state *core.BuildState, targets []core.BuildLabel) {
 		output.MonitorState(ctx, state, !pretty, detailedTests, streamTests, string(opts.OutputFlags.TraceFile))
 		wg.Done()
 	}()
-
 	plz.Run(targets, opts.BuildFlags.PreTargets, state, config, opts.BuildFlags.Arch)
 	cancel()
 	wg.Wait()

--- a/src/please.go
+++ b/src/please.go
@@ -434,12 +434,7 @@ var buildFunctions = map[string]func() int{
 				dir = originalWorkingDirectory
 			}
 
-			// This is a bit strange as normally if you run a binary for another platform, this will fail. In some cases
-			// this can be quite useful though e.g. to compile a binary for a target arch, then run an .sh script to
-			// push that to docker.
-			opts.Run.Args.Target.Subrepo = opts.BuildFlags.Arch.String()
-
-			run.Run(state, opts.Run.Args.Target, opts.Run.Args.Args.AsStrings(), opts.Run.Remote, opts.Run.Env, dir)
+			run.Run(state, opts.Run.Args.Target, opts.Run.Args.Args.AsStrings(), opts.Run.Remote, opts.Run.Env, dir, opts.BuildFlags.Arch)
 		}
 		return 1 // We should never return from run.Run so if we make it here something's wrong.
 	},
@@ -450,7 +445,7 @@ var buildFunctions = map[string]func() int{
 				dir = originalWorkingDirectory
 			}
 
-			os.Exit(run.Parallel(context.Background(), state, state.ExpandOriginalLabels(), opts.Run.Parallel.Args.AsStrings(), opts.Run.Parallel.NumTasks, opts.Run.Parallel.Quiet, opts.Run.Remote, opts.Run.Env, opts.Run.Parallel.Detach, dir))
+			os.Exit(run.Parallel(context.Background(), state, state.ExpandOriginalLabels(), opts.Run.Parallel.Args.AsStrings(), opts.Run.Parallel.NumTasks, opts.Run.Parallel.Quiet, opts.Run.Remote, opts.Run.Env, opts.Run.Parallel.Detach, dir, opts.BuildFlags.Arch))
 		}
 		return 1
 	},
@@ -461,7 +456,7 @@ var buildFunctions = map[string]func() int{
 				dir = originalWorkingDirectory
 			}
 
-			os.Exit(run.Sequential(state, state.ExpandOriginalLabels(), opts.Run.Sequential.Args.AsStrings(), opts.Run.Sequential.Quiet, opts.Run.Remote, opts.Run.Env, dir))
+			os.Exit(run.Sequential(state, state.ExpandOriginalLabels(), opts.Run.Sequential.Args.AsStrings(), opts.Run.Sequential.Quiet, opts.Run.Remote, opts.Run.Env, dir, opts.BuildFlags.Arch))
 		}
 		return 1
 	},

--- a/src/run/BUILD
+++ b/src/run/BUILD
@@ -6,6 +6,7 @@ go_library(
         "//src/core",
         "//src/output",
         "//src/process",
+        "//src/cli",
         "//third_party/go:errgroup",
         "//third_party/go:logging",
     ],

--- a/src/run/BUILD
+++ b/src/run/BUILD
@@ -3,10 +3,10 @@ go_library(
     srcs = ["run_step.go"],
     visibility = ["PUBLIC"],
     deps = [
+        "//src/cli",
         "//src/core",
         "//src/output",
         "//src/process",
-        "//src/cli",
         "//third_party/go:errgroup",
         "//third_party/go:logging",
     ],

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -55,7 +55,7 @@ func Parallel(ctx context.Context, state *core.BuildState, labels []core.BuildLa
 // Sequential runs a series of targets sequentially.
 // Returns a relevant exit code (i.e. if at least one subprocess exited unsuccessfully, it will be
 // that code, otherwise 0 if all were successful).
-func Sequential(state *core.BuildState, labels []core.BuildLabel, args []string, quiet, remote, env bool, dir string,  arch cli.Arch) int {
+func Sequential(state *core.BuildState, labels []core.BuildLabel, args []string, quiet, remote, env bool, dir string, arch cli.Arch) int {
 	for _, label := range labels {
 		log.Notice("Running %s", label)
 		if err := run(context.Background(), state, label, args, true, quiet, remote, env, false, dir, arch); err != nil {

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/op/go-logging.v1"
 
+	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/output"
 	"github.com/thought-machine/please/src/process"
@@ -23,15 +24,15 @@ import (
 var log = logging.MustGetLogger("run")
 
 // Run implements the running part of 'plz run'.
-func Run(state *core.BuildState, label core.BuildLabel, args []string, remote, env bool, dir string) {
-	run(context.Background(), state, label, args, false, false, remote, env, false, dir)
+func Run(state *core.BuildState, label core.BuildLabel, args []string, remote, env bool, dir string, arch cli.Arch) {
+	run(context.Background(), state, label, args, false, false, remote, env, false, dir, arch)
 }
 
 // Parallel runs a series of targets in parallel.
 // Returns a relevant exit code (i.e. if at least one subprocess exited unsuccessfully, it will be
 // that code, otherwise 0 if all were successful).
 // The given context can be used to control the lifetime of the subprocesses.
-func Parallel(ctx context.Context, state *core.BuildState, labels []core.BuildLabel, args []string, numTasks int, quiet, remote, env, detach bool, dir string) int {
+func Parallel(ctx context.Context, state *core.BuildState, labels []core.BuildLabel, args []string, numTasks int, quiet, remote, env, detach bool, dir string, arch cli.Arch) int {
 	limiter := make(chan struct{}, numTasks)
 	var g errgroup.Group
 	for _, label := range labels {
@@ -39,7 +40,7 @@ func Parallel(ctx context.Context, state *core.BuildState, labels []core.BuildLa
 		g.Go(func() error {
 			limiter <- struct{}{}
 			defer func() { <-limiter }()
-			return run(ctx, state, label, args, true, quiet, remote, env, detach, dir)
+			return run(ctx, state, label, args, true, quiet, remote, env, detach, dir, arch)
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -54,10 +55,10 @@ func Parallel(ctx context.Context, state *core.BuildState, labels []core.BuildLa
 // Sequential runs a series of targets sequentially.
 // Returns a relevant exit code (i.e. if at least one subprocess exited unsuccessfully, it will be
 // that code, otherwise 0 if all were successful).
-func Sequential(state *core.BuildState, labels []core.BuildLabel, args []string, quiet, remote, env bool, dir string) int {
+func Sequential(state *core.BuildState, labels []core.BuildLabel, args []string, quiet, remote, env bool, dir string,  arch cli.Arch) int {
 	for _, label := range labels {
 		log.Notice("Running %s", label)
-		if err := run(context.Background(), state, label, args, true, quiet, remote, env, false, dir); err != nil {
+		if err := run(context.Background(), state, label, args, true, quiet, remote, env, false, dir, arch); err != nil {
 			log.Error("%s", err)
 			return err.(*exitError).code
 		}
@@ -69,7 +70,14 @@ func Sequential(state *core.BuildState, labels []core.BuildLabel, args []string,
 // If fork is true then we fork to run the target and return any error from the subprocesses.
 // If it's false this function never returns (because we either win or die; it's like
 // Game of Thrones except rather less glamorous).
-func run(ctx context.Context, state *core.BuildState, label core.BuildLabel, args []string, fork, quiet, remote, setenv, detach bool, dir string) error {
+func run(ctx context.Context, state *core.BuildState, label core.BuildLabel, args []string, fork, quiet, remote, setenv, detach bool, dir string, arch cli.Arch) error {
+	// This is a bit strange as normally if you run a binary for another platform, this will fail. In some cases
+	// this can be quite useful though e.g. to compile a binary for a target arch, then run an .sh script to
+	// push that to docker.
+	if arch.OS != "" && label.Subrepo == "" {
+		label.Subrepo = arch.String()
+	}
+
 	target := state.Graph.TargetOrDie(label)
 	if !target.IsBinary {
 		log.Fatalf("Target %s cannot be run; it's not marked as binary", label)

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"github.com/thought-machine/please/src/cli"
 	"os"
 	"testing"
 
@@ -18,17 +19,17 @@ func init() {
 
 func TestSequential(t *testing.T) {
 	state, labels1, labels2 := makeState(core.DefaultConfiguration())
-	code := Sequential(state, labels1, nil, true, false, false, "")
+	code := Sequential(state, labels1, nil, true, false, false, "", cli.Arch{})
 	assert.Equal(t, 0, code)
-	code = Sequential(state, labels2, nil, false, false, false, "")
+	code = Sequential(state, labels2, nil, false, false, false, "", cli.Arch{})
 	assert.Equal(t, 1, code)
 }
 
 func TestParallel(t *testing.T) {
 	state, labels1, labels2 := makeState(core.DefaultConfiguration())
-	code := Parallel(context.Background(), state, labels1, nil, 5, false, false, false, false, "")
+	code := Parallel(context.Background(), state, labels1, nil, 5, false, false, false, false, "", cli.Arch{})
 	assert.Equal(t, 0, code)
-	code = Parallel(context.Background(), state, labels2, nil, 5, true, false, false, false, "")
+	code = Parallel(context.Background(), state, labels2, nil, 5, true, false, false, false, "", cli.Arch{})
 	assert.Equal(t, 1, code)
 }
 

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -171,6 +171,6 @@ func build(ctx context.Context, state *core.BuildState, labels []core.BuildLabel
 	callback(ns, labels)
 	if state.NeedRun {
 		// Don't wait for this, its lifetime will be controlled by the context.
-		go run.Parallel(ctx, state, labels, nil, state.Config.Please.NumThreads, false, false, false, false, "")
+		go run.Parallel(ctx, state, labels, nil, state.Config.Please.NumThreads, false, false, false, false, "", cli.Arch{})
 	}
 }


### PR DESCRIPTION
Fixes: #1460

We need to check the flag that the user provides instead of state.OriginalArch as state.OriginalArch is set to the host OS even if nothing is provided. We don't want to set the subrepo on the labels in this case. 