### PR TITLE
Fix pip_library in newer versions of Debian/python-pip

### DIFF
--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -392,11 +392,6 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None, 
         # but that prevents downloading binary wheels. This is more fiddly but seems to work.
         # Unfortunately it does *not* work similarly on the Debian problem :(
         pip_cmd = 'echo "[install]\nprefix=" > setup.cfg; ' + pip_cmd
-    if CONFIG.OS == 'linux' and not CONFIG.DISABLE_VENDOR_FLAGS:
-        # Fix for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=830892
-        # tl;dr: Debian has broken --target with a custom patch, the only way to fix is to pass --system
-        # which is itself Debian-specific, so we need to find if we're running on Debian. AAAAARGGGHHHH...
-        pip_cmd = f'[ -f /etc/debian_version ] && SYS_FLAG="--system" || SYS_FLAG=""; {pip_cmd} $SYS_FLAG'
 
     pip_cmd += f' {repo_flag} {index_flag} {pip_flags} {package_name}'
 


### PR DESCRIPTION
In 2017, this [change](https://github.com/thought-machine/please/commit/1fee49aa7b1f0123b092acc99b683730271610e5) was added to resolve this bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=830892. Following the bug thread down it has been resolved upstream since December 2018.

---

Without this removed, on Ubuntu 20.04 and running `./bootstrap.sh` in this repository, I get:
```    
...
//third_party/python:_grpcio#srcs
Error building target //third_party/python:_grpcio#srcs: exit status 2

Usage:   
  /home/vjftw/.asdf/installs/python/3.6.12/bin/python3 -m pip install [options] <requirement specifier> [package-index-options] ...
  /home/vjftw/.asdf/installs/python/3.6.12/bin/python3 -m pip install [options] -r <requirements file> [package-index-options] ...
  /home/vjftw/.asdf/installs/python/3.6.12/bin/python3 -m pip install [options] [-e] <vcs project url> ...
  /home/vjftw/.asdf/installs/python/3.6.12/bin/python3 -m pip install [options] [-e] <local project path> ...
  /home/vjftw/.asdf/installs/python/3.6.12/bin/python3 -m pip install [options] <archive url/path> ...

no such option: --system
```

the `--system` option no longer exists in the `python-pip` Debian package as it was only added as a workaround for this bug.