### PR TITLE
Fix conflated fields related to cross compiling

### DIFF
--- a/docs/codelabs/k8s.md
+++ b/docs/codelabs/k8s.md
@@ -47,7 +47,7 @@ For the sake of this codelabs, we'll make a simple hello world HTTP service in P
 $ plz init --no_prompt
 ```
 
-### Create the Go service
+### Creating a Python service
 Create a file `hello_service/main.py`:
 
 ```python

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -17,21 +17,30 @@ type BuildEnv []string
 
 // GeneralBuildEnvironment creates the shell env vars used for a command, not based
 // on any specific target etc.
-func GeneralBuildEnvironment(config *Configuration) BuildEnv {
-	// TODO(peterebden): why is this not just config.GetBuildEnv()?
+func GeneralBuildEnvironment(state *BuildState) BuildEnv {
 	env := BuildEnv{
 		// Need this for certain tools, for example sass
-		"LANG=" + config.Build.Lang,
+		"LANG=" + state.Config.Build.Lang,
+		// Need to know these for certain rules.
+		"ARCH=" + state.Arch.Arch,
+		"OS=" + state.Arch.OS,
+		// These are slightly modified forms that are more convenient for some things.
+		"XARCH=" + state.Arch.XArch(),
+		"XOS=" + state.Arch.XOS(),
+		// It's easier to just make these available for Go-based rules.
+		"GOARCH=" + state.Arch.GoArch(),
+		"GOOS=" + state.Arch.OS,
 	}
-	if config.Cpp.PkgConfigPath != "" {
-		env = append(env, "PKG_CONFIG_PATH="+config.Cpp.PkgConfigPath)
+	if state.Config.Cpp.PkgConfigPath != "" {
+		env = append(env, "PKG_CONFIG_PATH="+state.Config.Cpp.PkgConfigPath)
 	}
-	return append(env, config.GetBuildEnv()...)
+
+	return append(env, state.Config.GetBuildEnv()...)
 }
 
 // TargetEnvironment returns the basic parts of the build environment.
 func TargetEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
-	env := append(GeneralBuildEnvironment(state.Config),
+	env := append(GeneralBuildEnvironment(state),
 		"PKG="+target.Label.PackageName,
 		"PKG_DIR="+target.Label.PackageDir(),
 		"NAME="+target.Label.Name,

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -440,8 +440,8 @@ func (target *BuildTarget) allSourcePaths(graph *BuildGraph, full buildPathsFunc
 // AllURLs returns all the URLs for this target.
 // This should only be called if the target is a remote file.
 // The URLs will have any embedded environment variables expanded according to the given config.
-func (target *BuildTarget) AllURLs(config *Configuration) []string {
-	env := GeneralBuildEnvironment(config)
+func (target *BuildTarget) AllURLs(state *BuildState) []string {
+	env := GeneralBuildEnvironment(state)
 	ret := make([]string, len(target.Sources))
 	for i, s := range target.Sources {
 		ret[i] = os.Expand(string(s.(URLLabel)), env.ReplaceEnvironment)

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -503,7 +503,7 @@ func TestAllLocalSources(t *testing.T) {
 }
 
 func TestAllURLs(t *testing.T) {
-	config := DefaultConfiguration()
+	state := NewDefaultBuildState()
 	target := makeTarget1("//src/core:remote1", "")
 	target.IsRemoteFile = true
 	target.AddSource(URLLabel("https://github.com/thought-machine/please"))
@@ -511,7 +511,7 @@ func TestAllURLs(t *testing.T) {
 	assert.Equal(t, []string{
 		"https://github.com/thought-machine/please",
 		"https://github.com/thought-machine/pleasings",
-	}, target.AllURLs(config))
+	}, target.AllURLs(state))
 }
 
 func TestCheckSecrets(t *testing.T) {

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -622,17 +622,7 @@ func (config *Configuration) Path() []string {
 }
 
 func (config *Configuration) getBuildEnv(includePath bool, includeUnsafe bool) []string {
-	env := []string{
-		// Need to know these for certain rules.
-		"ARCH=" + config.Build.Arch.Arch,
-		"OS=" + config.Build.Arch.OS,
-		// These are slightly modified forms that are more convenient for some things.
-		"XARCH=" + config.Build.Arch.XArch(),
-		"XOS=" + config.Build.Arch.XOS(),
-		// It's easier to just make these available for Go-based rules.
-		"GOARCH=" + config.Build.Arch.GoArch(),
-		"GOOS=" + config.Build.Arch.OS,
-	}
+	var env []string
 
 	// from the BuildEnv config keyword
 	for k, v := range config.BuildEnv {

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -622,7 +622,7 @@ func (config *Configuration) Path() []string {
 }
 
 func (config *Configuration) getBuildEnv(includePath bool, includeUnsafe bool) []string {
-	var env []string
+	env := []string{}
 
 	// from the BuildEnv config keyword
 	for k, v := range config.BuildEnv {

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -395,7 +395,7 @@ type Configuration struct {
 	} `help:"Please has an animated display mode which shows the currently building targets.\nBy default it will autodetect whether it is using an interactive TTY session and choose whether to use it or not, although you can force it on or off via flags.\n\nThe display is heavily inspired by Buck's SuperConsole."`
 	Colours map[string]string `help:"Colour code overrides in interactive output. These correspond to requirements on each target."`
 	Build   struct {
-		Arch              cli.Arch     `help:"Architecture to compile for. Defaults to the host architecture."`
+		Arch              cli.Arch     `help:"The target architecture to compile for. Defaults to the host architecture."`
 		Timeout           cli.Duration `help:"Default timeout for build actions. Default is ten minutes."`
 		Path              []string     `help:"The PATH variable that will be passed to the build processes.\nDefaults to /usr/local/bin:/usr/bin:/bin but of course can be modified if you need to get binaries from other locations." example:"/usr/local/bin:/usr/bin:/bin"`
 		Config            string       `help:"The build config to use when one is not chosen on the command line. Defaults to opt." example:"opt | dbg"`

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"os"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -261,13 +260,6 @@ func TestBuildPathWithPathEnv(t *testing.T) {
 	config, err := ReadConfigFiles([]string{"src/core/test_data/passenv.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, config.Build.Path, strings.Split(os.Getenv("PATH"), ":"))
-}
-
-func xos() string {
-	if runtime.GOOS == "darwin" {
-		return "osx"
-	}
-	return runtime.GOOS
 }
 
 func TestUpdateArgsWithAliases(t *testing.T) {

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -200,17 +200,11 @@ func TestBuildEnvSection(t *testing.T) {
 	config, err := ReadConfigFiles([]string{"src/core/test_data/buildenv.plzconfig"}, nil)
 	assert.NoError(t, err)
 	expected := []string{
-		"ARCH=" + runtime.GOARCH,
 		"BAR_BAR=first",
 		"FOO_BAR=second",
-		"GOARCH=" + runtime.GOARCH,
-		"GOOS=" + runtime.GOOS,
-		"OS=" + runtime.GOOS,
 		"PATH=" + os.Getenv("TMP_DIR") + ":/usr/local/bin:/usr/bin:/bin",
-		"XARCH=x86_64",
-		"XOS=" + xos(),
 	}
-	assert.Equal(t, expected, config.GetBuildEnv())
+	assert.ElementsMatch(t, expected, config.GetBuildEnv())
 }
 
 func TestPassEnv(t *testing.T) {
@@ -221,17 +215,11 @@ func TestPassEnv(t *testing.T) {
 	config, err := ReadConfigFiles([]string{"src/core/test_data/passenv.plzconfig"}, nil)
 	assert.NoError(t, err)
 	expected := []string{
-		"ARCH=" + runtime.GOARCH,
 		"BAR=second",
 		"FOO=first",
-		"GOARCH=" + runtime.GOARCH,
-		"GOOS=" + runtime.GOOS,
-		"OS=" + runtime.GOOS,
 		"PATH=" + os.Getenv("TMP_DIR") + ":" + os.Getenv("PATH"),
-		"XARCH=x86_64",
-		"XOS=" + xos(),
 	}
-	assert.Equal(t, expected, config.GetBuildEnv())
+	assert.ElementsMatch(t, expected, config.GetBuildEnv())
 }
 
 func TestPassUnsafeEnv(t *testing.T) {
@@ -242,17 +230,11 @@ func TestPassUnsafeEnv(t *testing.T) {
 	config, err := ReadConfigFiles([]string{"src/core/test_data/passunsafeenv.plzconfig"}, nil)
 	assert.NoError(t, err)
 	expected := []string{
-		"ARCH=" + runtime.GOARCH,
 		"BAR=second",
 		"FOO=first",
-		"GOARCH=" + runtime.GOARCH,
-		"GOOS=" + runtime.GOOS,
-		"OS=" + runtime.GOOS,
 		"PATH=" + os.Getenv("TMP_DIR") + ":" + os.Getenv("PATH"),
-		"XARCH=x86_64",
-		"XOS=" + xos(),
 	}
-	assert.Equal(t, expected, config.GetBuildEnv())
+	assert.ElementsMatch(t, expected, config.GetBuildEnv())
 }
 
 func TestPassUnsafeEnvExcludedFromHash(t *testing.T) {

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -156,8 +156,12 @@ type BuildState struct {
 	Include, Exclude []string
 	// Actual targets to exclude from discovery
 	ExcludeTargets []BuildLabel
-	// The original architecture that the user requested to build for.
-	OriginalArch cli.Arch
+	// The original architecture that the user requested to build for. Either the host arch, --arch, or the arch in the
+	// .plzconfig
+	TargetArch cli.Arch
+	// The architecture this state is for. This might change as we re-parse packages for different architectures e.g.
+	// for tools that run on the host vs. outputs that are compiled for the target arch above.
+	Arch cli.Arch
 	// True if we require rule hashes to be correctly verified (usually the case).
 	VerifyHashes bool
 	// Aggregated coverage for this run
@@ -888,7 +892,7 @@ func (state *BuildState) ForArch(arch cli.Arch) *BuildState {
 	// This is slightly wrong in that other things (e.g. user-specified command line overrides) should
 	// in fact take priority over this, but that's a lot more fiddly to get right.
 	s := state.ForConfig(".plzconfig_" + arch.String())
-	s.Config.Build.Arch = arch
+	s.Arch = arch
 	return s
 }
 
@@ -897,7 +901,7 @@ func (state *BuildState) findArch(arch cli.Arch) *BuildState {
 	state.progress.mutex.Lock()
 	defer state.progress.mutex.Unlock()
 	for _, s := range state.progress.allStates {
-		if s.Config.Build.Arch == arch {
+		if s.Arch == arch {
 			return s
 		}
 	}
@@ -968,7 +972,8 @@ func NewBuildState(config *Configuration) *BuildState {
 		NeedBuild:       true,
 		XattrsSupported: config.Build.Xattrs,
 		Coverage:        TestCoverage{Files: map[string][]LineCoverage{}},
-		OriginalArch:    cli.HostArch(),
+		TargetArch:      config.Build.Arch,
+		Arch: cli.HostArch(),
 		Stats:           &SystemStats{},
 		progress: &stateProgress{
 			numActive:       1, // One for the initial target adding on the main thread.

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -973,7 +973,7 @@ func NewBuildState(config *Configuration) *BuildState {
 		XattrsSupported: config.Build.Xattrs,
 		Coverage:        TestCoverage{Files: map[string][]LineCoverage{}},
 		TargetArch:      config.Build.Arch,
-		Arch: cli.HostArch(),
+		Arch:            cli.HostArch(),
 		Stats:           &SystemStats{},
 		progress: &stateProgress{
 			numActive:       1, // One for the initial target adding on the main thread.

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -489,7 +489,7 @@ func printHashes(state *core.BuildState, duration time.Duration) {
 
 func printTempDirs(state *core.BuildState, duration time.Duration) {
 	fmt.Printf("Temp directories prepared, total time %s:\n", duration)
-	state = state.ForArch(state.OriginalArch)
+	state = state.ForArch(state.TargetArch)
 	for _, label := range state.ExpandVisibleOriginalTargets() {
 		target := state.Graph.TargetOrDie(label)
 		cmd := target.GetCommand(state)

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -891,7 +891,7 @@ func newConfig(state *core.BuildState) *pyConfig {
 		c["FEATURES"] = pyList{}
 	}
 
-	arch := config.Build.Arch
+	arch := state.Arch
 
 	c["OS"] = pyString(arch.OS)
 	c["ARCH"] = pyString(arch.Arch)
@@ -899,13 +899,8 @@ func newConfig(state *core.BuildState) *pyConfig {
 	c["HOSTARCH"] = pyString(arch.HostArch())
 	c["GOOS"] = pyString(arch.OS)
 	c["GOARCH"] = pyString(arch.GoArch())
-
-	targetArch := arch
-	if state.OriginalArch.OS != "" {
-		targetArch = state.OriginalArch
-	}
-	c["TARGET_OS"] = pyString(targetArch.OS)
-	c["TARGET_ARCH"] = pyString(targetArch.Arch)
+	c["TARGET_OS"] = pyString(state.TargetArch.OS)
+	c["TARGET_ARCH"] = pyString(state.TargetArch.Arch)
 
 	return &pyConfig{base: c}
 }

--- a/src/please.go
+++ b/src/please.go
@@ -439,7 +439,7 @@ var buildFunctions = map[string]func() int{
 				opts.Run.Args.Target.Annotation = opts.Run.EntryPoint
 			}
 
-			run.Run(state, opts.Run.Args.Target, opts.Run.Args.Args.AsStrings(), opts.Run.Remote, opts.Run.Env, dir, opts.BuildFlags.Arch)
+			run.Run(state, opts.Run.Args.Target, opts.Run.Args.Args.AsStrings(), opts.Run.Remote, opts.Run.Env, dir)
 		}
 		return 1 // We should never return from run.Run so if we make it here something's wrong.
 	},
@@ -450,7 +450,7 @@ var buildFunctions = map[string]func() int{
 				dir = originalWorkingDirectory
 			}
 
-			os.Exit(run.Parallel(context.Background(), state, opts.Run.Parallel.PositionalArgs.Targets, opts.Run.Parallel.Args.AsStrings(), opts.Run.Parallel.NumTasks, opts.Run.Parallel.Quiet, opts.Run.Remote, opts.Run.Env, opts.Run.Parallel.Detach, dir, opts.BuildFlags.Arch))
+			os.Exit(run.Parallel(context.Background(), state, opts.Run.Parallel.PositionalArgs.Targets, opts.Run.Parallel.Args.AsStrings(), opts.Run.Parallel.NumTasks, opts.Run.Parallel.Quiet, opts.Run.Remote, opts.Run.Env, opts.Run.Parallel.Detach, dir))
 		}
 		return 1
 	},
@@ -461,7 +461,7 @@ var buildFunctions = map[string]func() int{
 				dir = originalWorkingDirectory
 			}
 
-			os.Exit(run.Sequential(state, opts.Run.Sequential.PositionalArgs.Targets, opts.Run.Sequential.Args.AsStrings(), opts.Run.Sequential.Quiet, opts.Run.Remote, opts.Run.Env, dir, opts.BuildFlags.Arch))
+			os.Exit(run.Sequential(state, opts.Run.Sequential.PositionalArgs.Targets, opts.Run.Sequential.Args.AsStrings(), opts.Run.Sequential.Quiet, opts.Run.Remote, opts.Run.Env, dir))
 		}
 		return 1
 	},
@@ -805,7 +805,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	state.DownloadOutputs = (!opts.Build.NoDownload && !opts.Run.Remote && len(targets) > 0 && (!targets[0].IsAllSubpackages() || len(opts.BuildFlags.Include) > 0)) || opts.Build.Download
 	state.SetIncludeAndExclude(opts.BuildFlags.Include, opts.BuildFlags.Exclude)
 	if opts.BuildFlags.Arch.OS != "" {
-		state.OriginalArch = opts.BuildFlags.Arch
+		state.TargetArch = opts.BuildFlags.Arch
 	}
 
 	if state.DebugTests && len(targets) != 1 {
@@ -839,7 +839,7 @@ func runPlease(state *core.BuildState, targets []core.BuildLabel) {
 		output.MonitorState(ctx, state, !pretty, detailedTests, streamTests, string(opts.OutputFlags.TraceFile))
 		wg.Done()
 	}()
-	plz.Run(targets, opts.BuildFlags.PreTargets, state, config, opts.BuildFlags.Arch)
+	plz.Run(targets, opts.BuildFlags.PreTargets, state, config, state.TargetArch)
 	cancel()
 	wg.Wait()
 }

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -68,7 +68,7 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, config *
 // RunHost is a convenience function that uses the host architecture, the given state's
 // configuration and no pre targets. It is otherwise identical to Run.
 func RunHost(targets []core.BuildLabel, state *core.BuildState) {
-	Run(targets, nil, state, state.Config, cli.Arch{})
+	Run(targets, nil, state, state.Config, cli.HostArch())
 }
 
 func doTasks(tid int, state *core.BuildState, parses core.ParseTaskQueue, builds core.BuildTaskQueue, tests core.TestTaskQueue, remote bool) {
@@ -139,7 +139,7 @@ func findOriginalTaskSet(state *core.BuildState, targets []core.BuildLabel, addT
 }
 
 func findOriginalTask(state *core.BuildState, target core.BuildLabel, addToList bool, arch cli.Arch) {
-	if arch.Arch != "" {
+	if arch != cli.HostArch() {
 		target.Subrepo = arch.String()
 	}
 	if target.IsAllSubpackages() {

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -94,7 +94,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 		// not include the environment variables since we don't communicate those to the remote server).
 		return &pb.Command{
 			Arguments: []string{
-				"fetch", strings.Join(target.AllURLs(c.state.Config), " "), "verify", strings.Join(target.Hashes, " "),
+				"fetch", strings.Join(target.AllURLs(c.state), " "), "verify", strings.Join(target.Hashes, " "),
 			},
 			OutputFiles:       files,
 			OutputDirectories: dirs,
@@ -119,7 +119,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 // stampedBuildEnvironment returns a build environment, optionally with a stamp if stamp is true.
 func (c *Client) stampedBuildEnvironment(target *core.BuildTarget, inputRoot *pb.Directory, stamp bool) []string {
 	if target.IsFilegroup {
-		return core.GeneralBuildEnvironment(c.state.Config) // filegroups don't need a full build environment
+		return core.GeneralBuildEnvironment(c.state) // filegroups don't need a full build environment
 	} else if !stamp {
 		return core.BuildEnvironment(c.state, target, ".")
 	}
@@ -175,7 +175,7 @@ func (c *Client) buildRunCommand(target *core.BuildTarget) (*pb.Command, error) 
 	return &pb.Command{
 		Platform:             c.platform,
 		Arguments:            outs,
-		EnvironmentVariables: c.buildEnv(target, core.GeneralBuildEnvironment(c.state.Config), false),
+		EnvironmentVariables: c.buildEnv(target, core.GeneralBuildEnvironment(c.state), false),
 	}, nil
 }
 

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -769,7 +769,7 @@ func (c *Client) DataRate() (int, int, int, int) {
 // fetchRemoteFile sends a request to fetch a file using the remote asset API.
 func (c *Client) fetchRemoteFile(tid int, target *core.BuildTarget, actionDigest *pb.Digest) (*core.BuildMetadata, *pb.ActionResult, error) {
 	c.state.LogBuildResult(tid, target.Label, core.TargetBuilding, "Downloading...")
-	urls := target.AllURLs(c.state.Config)
+	urls := target.AllURLs(c.state)
 	req := &fpb.FetchBlobRequest{
 		InstanceName: c.instance,
 		Timeout:      ptypes.DurationProto(target.BuildTimeout),

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"context"
-	"github.com/thought-machine/please/src/cli"
 	"os"
 	"testing"
 

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -19,17 +19,17 @@ func init() {
 
 func TestSequential(t *testing.T) {
 	state, labels1, labels2 := makeState(core.DefaultConfiguration())
-	code := Sequential(state, labels1, nil, true, false, false, "", cli.Arch{})
+	code := Sequential(state, labels1, nil, true, false, false, "")
 	assert.Equal(t, 0, code)
-	code = Sequential(state, labels2, nil, false, false, false, "", cli.Arch{})
+	code = Sequential(state, labels2, nil, false, false, false, "")
 	assert.Equal(t, 1, code)
 }
 
 func TestParallel(t *testing.T) {
 	state, labels1, labels2 := makeState(core.DefaultConfiguration())
-	code := Parallel(context.Background(), state, labels1, nil, 5, false, false, false, false, "", cli.Arch{})
+	code := Parallel(context.Background(), state, labels1, nil, 5, false, false, false, false, "")
 	assert.Equal(t, 0, code)
-	code = Parallel(context.Background(), state, labels2, nil, 5, true, false, false, false, "", cli.Arch{})
+	code = Parallel(context.Background(), state, labels2, nil, 5, true, false, false, false, "")
 	assert.Equal(t, 1, code)
 }
 

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -177,6 +177,6 @@ func build(ctx context.Context, state *core.BuildState, labels []core.BuildLabel
 				BuildLabel: l,
 			}
 		}
-		go run.Parallel(ctx, state, als, nil, state.Config.Please.NumThreads, false, false, false, false, "", cli.Arch{})
+		go run.Parallel(ctx, state, als, nil, state.Config.Please.NumThreads, false, false, false, false, "")
 	}
 }

--- a/src/worker/worker.go
+++ b/src/worker/worker.go
@@ -94,7 +94,7 @@ func getOrStartWorker(state *core.BuildState, worker string) (*workerServer, err
 		worker = path
 	}
 	cmd := state.ProcessExecutor.ExecCommand(worker)
-	cmd.Env = core.GeneralBuildEnvironment(state.Config)
+	cmd.Env = core.GeneralBuildEnvironment(state)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
It seems like users are (understandably) expecting to use `build.arch` to define the architecture we're compiling for. We were using it track the current arch of the build state as well. This mostly works but means that if users set it in the main .plzconfig, we don't have a state for the host arch, and we think we've loaded the env specific config. 

This PR does a few things:
1) adds a `state.Arch` field that tracks the arch that the current build state is for.
2) Renamed OriginalArch to TargetArch. This is now set to `build.arch` unless `--arch` is set. This will not be set to the arch in `///linux_amd64//some:target` but that makes sense as we might take multiple targets with different architectures. 
3) No longer pass around the empty arch beyond user input. These architecture fields should either be set to the host architecture OR the target architecture (i.e. state.Arch). 
4) Refactored the `plz run` stuff to use state.TargetArch 
5) Building the env now depends on the build state, rather than just the config, because that's where the arch lives now. 

Fixes: #1494 