### PR TITLE
Disable changing window.location.hash on scroll as it causes a reload…

### DIFF
--- a/docs/action.js
+++ b/docs/action.js
@@ -96,10 +96,7 @@
               winner = hash;
             }
           }
-
-          // Update URL hash and hightlight link
           if (winner) {
-            window.location.hash = winner;
             menuLinksWithAvailableTargets[winner].style.color = "white";
           }
         },


### PR DESCRIPTION
e.g. on firefox

Fixes: #1512