### PR TITLE
add failing test case for golang.org/x/sys

### DIFF
--- a/test/go_modules/test_repo/src/BUILD_FILE
+++ b/test/go_modules/test_repo/src/BUILD_FILE
@@ -6,5 +6,6 @@ go_test (
     "//third_party/go:zstd",
     "//third_party/go:go-sqlite3",
     "//third_party/go:snappy",
+    "//third_party/go:term",
   ]
 )

--- a/test/go_modules/test_repo/src/import_test.go
+++ b/test/go_modules/test_repo/src/import_test.go
@@ -1,11 +1,13 @@
 package src
 
 import (
+	"os"
 	"testing"
 
 	"github.com/DataDog/zstd"
 	"github.com/golang/snappy"
 	"github.com/mattn/go-sqlite3"
+	"github.com/moby/term"
 	"github.com/peterebden/go-cli-init/v2"
 )
 
@@ -23,4 +25,9 @@ func TestSQLLite3(t *testing.T) {
 
 func TestSnappy(t *testing.T) {
 	_ = snappy.MaxEncodedLen(1234)
+}
+
+func TestTerm(t *testing.T) {
+	fd := os.Stdin.Fd()
+	_ = term.IsTerminal(fd)
 }

--- a/test/go_modules/test_repo/third_party/go/BUILD_FILE
+++ b/test/go_modules/test_repo/third_party/go/BUILD_FILE
@@ -66,3 +66,18 @@ go_module(
     module = "github.com/golang/snappy",
     version = "v0.0.2",
 )
+
+go_module(
+    name = "sys",
+    module = "golang.org/x/sys",
+    version = "v0.0.0-20200930185726-fdedc70b468f",
+    install = ["unix", "internal/unsafeheader"],
+)
+
+go_module(
+    name = "term",
+    module = "github.com/moby/term",
+    version = "v0.0.0-20200312100748-672ec06f55cd",
+    install = ["."],
+    deps = [":sys"],
+)


### PR DESCRIPTION
```
Error building target //third_party/go:_term#a_rule: exit status 2
# github.com/moby/term
third_party/go/src/github.com/moby/term/tc.go:13:28: undefined: unix.SYS_IOCTL
third_party/go/src/github.com/moby/term/tc.go:18:28: undefined: unix.SYS_IOCTL
third_party/go/src/github.com/moby/term/termios_bsd.go:24:31: undefined: unix.SYS_IOCTL
third_party/go/src/github.com/moby/term/termios_bsd.go:37:31: undefined: unix.SYS_IOCTL
Build stopped after 1m34.82s. 1 target failed:
    //third_party/go:_term#a_rule
Error building target //third_party/go:_term#a_rule: exit status 2
# github.com/moby/term
third_party/go/src/github.com/moby/term/tc.go:13:28: undefined: unix.SYS_IOCTL
third_party/go/src/github.com/moby/term/tc.go:18:28: undefined: unix.SYS_IOCTL
third_party/go/src/github.com/moby/term/termios_bsd.go:24:31: undefined: unix.SYS_IOCTL
third_party/go/src/github.com/moby/term/termios_bsd.go:37:31: undefined: unix.SYS_IOCTL
```

Update: this could be a macOS thing.