### PR TITLE
Remove RPC-level compression options

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -474,8 +474,6 @@ type Configuration struct {
 		TokenFile     string       `help:"A file containing a token that is attached to outgoing RPCs to authenticate them. This is somewhat bespoke; we are still investigating further options for authentication."`
 		Timeout       cli.Duration `help:"Timeout for connections made to the remote server."`
 		Secure        bool         `help:"Whether to use TLS for communication or not."`
-		Gzip          bool         `help:"Deprecated, has no effect."`
-		Zstd          bool         `help:"Deprecated, has no effect."`
 		VerifyOutputs bool         `help:"Whether to verify all outputs are present after a cached remote execution action. Depending on your server implementation, you may require this to ensure files are really present."`
 		HomeDir       string       `help:"The home directory on the build machine."`
 		Shell         string       `help:"Path to the shell to use to execute actions in. Default looks up bash based on the build.path setting."`

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -474,8 +474,8 @@ type Configuration struct {
 		TokenFile     string       `help:"A file containing a token that is attached to outgoing RPCs to authenticate them. This is somewhat bespoke; we are still investigating further options for authentication."`
 		Timeout       cli.Duration `help:"Timeout for connections made to the remote server."`
 		Secure        bool         `help:"Whether to use TLS for communication or not."`
-		Gzip          bool         `help:"Whether to use gzip compression for communication."`
-		Zstd          bool         `help:"Whether to use zstd compression for communication."`
+		Gzip          bool         `help:"Deprecated, has no effect."`
+		Zstd          bool         `help:"Deprecated, has no effect."`
 		VerifyOutputs bool         `help:"Whether to verify all outputs are present after a cached remote execution action. Depending on your server implementation, you may require this to ensure files are really present."`
 		HomeDir       string       `help:"The home directory on the build machine."`
 		Shell         string       `help:"Path to the shell to use to execute actions in. Default looks up bash based on the build.path setting."`

--- a/src/remote/BUILD
+++ b/src/remote/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//third_party/go:errgroup",
         "//third_party/go:genproto_api",
         "//third_party/go:genproto_rpc",
-        "//third_party/go:go-grpc-compression",
         "//third_party/go:grpc",
         "//third_party/go:grpc-middleware",
         "//third_party/go:logging",

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -23,11 +23,9 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/mostynb/go-grpc-compression/zstd"
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/status"
 
 	"github.com/thought-machine/please/src/core"
@@ -523,16 +521,10 @@ func reencodeSRI(target *core.BuildTarget, h string) string {
 
 // dialOpts returns a set of dial options to apply based on the config.
 func (c *Client) dialOpts() ([]grpc.DialOption, error) {
-	// Set an arbitrarily large (400MB) max message size so it isn't a limitation.
-	callOpts := []grpc.CallOption{grpc.MaxCallRecvMsgSize(419430400)}
-	if c.state.Config.Remote.Zstd {
-		callOpts = append(callOpts, grpc.UseCompressor(zstd.Name))
-	} else if c.state.Config.Remote.Gzip {
-		callOpts = append(callOpts, grpc.UseCompressor(gzip.Name))
-	}
 	opts := []grpc.DialOption{
 		grpc.WithStatsHandler(c.stats),
-		grpc.WithDefaultCallOptions(callOpts...),
+		// Set an arbitrarily large (400MB) max message size so it isn't a limitation.
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(419430400)),
 	}
 	if c.state.Config.Remote.TokenFile == "" {
 		return opts, nil

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -735,30 +735,6 @@ go_module(
 )
 
 go_module(
-    name = "go-grpc-compression",
-    install = ["zstd"],
-    module = "github.com/mostynb/go-grpc-compression",
-    version = "v1.1.6",
-    deps = [
-        ":grpc",
-        ":zstd",
-    ],
-)
-
-go_module(
-    name = "zstd",
-    install = [
-        "fse",
-        "huff0",
-        "snappy",
-        "zstd",
-        "zstd/...",
-    ],
-    module = "github.com/klauspost/compress",
-    version = "v1.11.0",
-)
-
-go_module(
     name = "goldmark",
     install = [
         "...",


### PR DESCRIPTION
I don't think any servers in the wild actually support these. We used to but don't any more.
Upstream is moving to blob-level compression which is more efficient.

This isn't really breaking since setting missing config values isn't fatal; it would warn but that's all (it might arguably perform worse, but as noted above I doubt anyone is using this).