### PR TITLE
Enable build-rule authors to access a stable directory for global files

### DIFF
--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -31,6 +32,7 @@ func GeneralBuildEnvironment(state *BuildState) BuildEnv {
 		// It's easier to just make these available for Go-based rules.
 		"GOARCH=" + state.Arch.GoArch(),
 		"GOOS=" + state.Arch.OS,
+		"GLOBAL_DIR=" + filepath.Join(RepoRoot, GlobalDir),
 	}
 	if state.Config.Cpp.PkgConfigPath != "" {
 		env = append(env, "PKG_CONFIG_PATH="+state.Config.Cpp.PkgConfigPath)

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"fmt"
-	"github.com/thought-machine/please/src/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -11,10 +10,16 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/thought-machine/please/src/fs"
 )
 
 // OutDir is the root output directory for everything.
 const OutDir string = "plz-out"
+
+// GlobalDir is the root of the global directory which exists without any
+// build targets.
+const GlobalDir string = "plz-out/global"
 
 // TmpDir is the root of the temporary directory for building targets & running tests.
 const TmpDir string = "plz-out/tmp"


### PR DESCRIPTION
Introduce a global directory plz-out/global. Build rule authors can use
this directory for files not related to any specific build target. At build-
time the directory can be accessed through environment variable
GLOBAL_DIR.

One use case of global directory is the dart pub cache
(https://dart.dev/tools/pub/cmd/pub-cache):

Dart tools heavily rely on the pub cache, but the cache itself is
location sensitive thus will not work if it is put in TMP_DIR. When dart
tools run, absolute file paths to the pub cache are written to certain
config files, so that a config file generated in plz-out/tmp will not
work in plz-out/gen.

Another issue is that "pub global activate <exe>" compiles a special
snapshot file as an executable (it is binary file but not real
executable files, only the dart interpreter can run it), which is also
location sensitive.

These issues can be solved nicely with GLOBAL_DIR, for example, by
introducing a folder plz-out/global/dart/pub_cache, without breaking
Please's hermeticity.