### PR TITLE
Fix remote cross compile

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -73,9 +73,20 @@ func (c *Client) buildAction(target *core.BuildTarget, isTest, stamp bool) (*pb.
 	return command, actionDigest, nil
 }
 
+// stateForTarget returns an appropriate state for the current target.
+// TODO(peterebden): This is very much a limitation of the current setup; there is a complex interaction between how we set
+//                   HOME and how we get the correct state object for cross-compiling.
+//                   When we release v16 and make this the default we should be able to significantly simplify this.
+func (c *Client) stateForTarget(target *core.BuildTarget) *core.BuildState {
+	if !c.state.Config.FeatureFlags.PleaseDownloadTools {
+		return c.state
+	}
+	return c.state.ForTarget(target)
+}
+
 // buildCommand builds the command for a single target.
 func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory, isTest, isRun, stamp bool) (*pb.Command, error) {
-	state := c.state.ForTarget(target)
+	state := c.stateForTarget(target)
 	if isTest {
 		return c.buildTestCommand(state, target)
 	} else if isRun {


### PR DESCRIPTION
There is a really nasty and complex interaction here.

- Remote execution needs to get the right state object for cross-compiling. Right now it doesn't do that properly.
- However it _also_ has a modified state object to set the remote home dir. Getting the cross-compiled one loses that information and so things break.
- The ultimate solution is to use PleaseDownloadTools & the correct state object which fixes everything.
- However to have a sensible transition to get there we need to check that flag for now.

This seems as good as I can do for now. Definitely looking forward to v16 to simplify some of this code.