### PR TITLE
Make install add pleasew to path instead of plz itself

### DIFF
--- a/tools/misc/get_plz.sh
+++ b/tools/misc/get_plz.sh
@@ -29,7 +29,9 @@ for x in `ls "$DIR"`; do
     ln -sf "${DIR}/${x}" "$LOCATION"
 done
 ln -sf "${LOCATION}/please" "${LOCATION}/plz"
-mkdir "${LOCATION}/bin" && curl http://get.please.build/pleasew -s --output "${LOCATION}/bin/plz"
+mkdir "${LOCATION}/bin"
+curl https://get.please.build/pleasew -s --output "${LOCATION}/bin/plz"
+chmod +x "${LOCATION}/bin/plz"
 
 echo
 

--- a/tools/misc/get_plz.sh
+++ b/tools/misc/get_plz.sh
@@ -39,10 +39,10 @@ if ! hash plz 2>/dev/null; then
         ln -s ~/.please/plz ~/.local/bin/plz
     elif [ -f ~/.profile ]; then
         echo 'export PATH="${PATH}:${HOME}/.please/bin"' >> ~/.profile
-        echo "Added Please to path. You may need to run 'source ~/.profile' to pick up the new PATH."
+        echo "Added Please to path. Run 'source ~/.profile' to pick up the new PATH in this terminal session."
     else
-        echo "Unsure how to add to PATH, not modifying anything. If desired add '~/.please/bin' to your PATH"
-        echo "or, install please system-wide with 'sudo cp ~/.please/bin/* /usr/bin' or similar"
+        echo "Unsure how to add to PATH, not modifying anything. If desired, add '~/.please/bin' to your PATH"
+        echo "or install please system-wide with 'sudo cp ~/.please/bin/* /usr/bin' or similar"
     fi
 fi
 

--- a/tools/misc/get_plz.sh
+++ b/tools/misc/get_plz.sh
@@ -22,26 +22,31 @@ LOCATION="${HOME}/.please"
 DIR="${LOCATION}/${VERSION}"
 mkdir -p "$DIR"
 
-echo "Downloading Please ${VERSION} to ${DIR}..."
+echo "Downloading Please ${VERSION}..."
 curl -fsSL "${PLEASE_URL}" | tar -xzpf- --strip-components=1 -C "$DIR"
 # Link it all back up a dir
 for x in `ls "$DIR"`; do
     ln -sf "${DIR}/${x}" "$LOCATION"
 done
 ln -sf "${LOCATION}/please" "${LOCATION}/plz"
+mkdir "${LOCATION}/bin" && curl http://get.please.build/pleasew -s --output "${LOCATION}/bin/plz"
+
+echo
 
 if ! hash plz 2>/dev/null; then
-    echo "Adding plz to PATH..."
     if [ -d ~/.local/bin ]; then
+        echo "Adding plz to ~/.local/bin..."
         ln -s ~/.please/plz ~/.local/bin/plz
     elif [ -f ~/.profile ]; then
-        echo 'export PATH="${PATH}:${HOME}/.please"' >> ~/.profile
-        echo "You may need to run 'source ~/.profile' to pick up the new PATH."
+        echo 'export PATH="${PATH}:${HOME}/.please/bin"' >> ~/.profile
+        echo "Added Please to path. You may need to run 'source ~/.profile' to pick up the new PATH."
     else
-        echo "Unsure how to add to PATH, not modifying anything. If desired add '${HOME}/.please' manually to your PATH."
+        echo "Unsure how to add to PATH, not modifying anything. If desired add '~/.please/bin' to your PATH"
+        echo "or, install please system-wide with 'sudo cp ~/.please/bin/* /usr/bin' or similar"
     fi
 fi
 
-echo "Please installed."
+echo
+echo "Please has been installed under ${LOCATION}"
 echo "Run plz --help for more information about how to invoke it,"
 echo "or plz help for information on specific help topics."

--- a/tools/misc/get_plz.sh
+++ b/tools/misc/get_plz.sh
@@ -33,9 +33,8 @@ mkdir "${LOCATION}/bin"
 curl https://get.please.build/pleasew -s --output "${LOCATION}/bin/plz"
 chmod +x "${LOCATION}/bin/plz"
 
-echo
-
 if ! hash plz 2>/dev/null; then
+    echo
     if [ -d ~/.local/bin ]; then
         echo "Adding plz to ~/.local/bin..."
         ln -s ~/.please/plz ~/.local/bin/plz
@@ -43,8 +42,11 @@ if ! hash plz 2>/dev/null; then
         echo 'export PATH="${PATH}:${HOME}/.please/bin"' >> ~/.profile
         echo "Added Please to path. Run 'source ~/.profile' to pick up the new PATH in this terminal session."
     else
-        echo "Unsure how to add to PATH, not modifying anything. If desired, add '~/.please/bin' to your PATH"
-        echo "or install please system-wide with 'sudo cp ~/.please/bin/* /usr/bin' or similar"
+        echo "We were unable to automatically add Please to the PATH."
+        echo "If desired, add this line to your ~/.profile or equivalent:"
+        echo "    'PATH=\${PATH}:~/.please/bin'"
+        echo "or install please system-wide with"
+        echo "    'sudo cp ~/.please/bin/* /usr/lcoal/bin'"
     fi
 fi
 
@@ -52,3 +54,7 @@ echo
 echo "Please has been installed under ${LOCATION}"
 echo "Run plz --help for more information about how to invoke it,"
 echo "or plz help for information on specific help topics."
+echo
+echo "It is also highly recommended to set up command line completions."
+echo "To do so, add this line to your ~/.bashrc or ~/.zshrc:"
+echo "    source <(plz --completion_script)"


### PR DESCRIPTION
This leaves the old location for please as is so that it's less impactful and introduces a new `~/.please/bin` where we instal the wrapper script. 