### PR TITLE
Add support for single strings in the TOOLS argument

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -3,7 +3,7 @@
 
 # Do not change the order of arguments to this function without updating the iota in targets.go to match it.
 def build_rule(name:str, cmd:str|dict='', test_cmd:str|dict='', srcs:list|dict=None, data:list|dict=None, outs:list|dict=None,
-               deps:list=None, exported_deps:list=None, secrets:list|dict=None, tools:list|dict=None, test_tools:list|dict=None,
+               deps:list=None, exported_deps:list=None, secrets:list|dict=None, tools:str|list|dict=None, test_tools:str|list|dict=None,
                labels:list=None, visibility:list=CONFIG.DEFAULT_VISIBILITY, hashes:list=None, binary:bool=False, test:bool=False,
                test_only:bool=CONFIG.DEFAULT_TESTONLY, building_description:str=None, needs_transitive_deps:bool=False,
                output_is_complete:bool=False, _=None, sandbox:bool=CONFIG.BUILD_SANDBOX,

--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -142,7 +142,7 @@ def genrule(name:str, cmd:str|list|dict, srcs:list|dict=None, out:str=None, outs
 
 
 def gentest(name:str, test_cmd:str|dict, labels:list&features&tags=None, cmd:str|dict=None, srcs:list|dict=None,
-            outs:list=None, deps:list=None, exported_deps:list=None, tools:str|list|dict=None, test_tools:list|dict=None,
+            outs:list=None, deps:list=None, exported_deps:list=None, tools:str|list|dict=None, test_tools:str|list|dict=None,
             data:list|dict=None, visibility:list=None, timeout:int=0, needs_transitive_deps:bool=False,
             flaky:bool|int=0, secrets:list|dict=None, no_test_output:bool=False, test_outputs:list=None,
             output_is_complete:bool=True, requires:list=None, sandbox:bool=None, size:str=None, local:bool=False,
@@ -169,7 +169,7 @@ def gentest(name:str, test_cmd:str|dict, labels:list&features&tags=None, cmd:str
       exported_deps (list): Dependencies that will become visible to any rules that depend on this rule.
       tools (str | list | dict): Tools used to build this rule; similar to srcs but are not copied to the temporary
                     build directory.
-      test_tools (list | dict): Like tools but available to test_cmd instead.
+      test_tools (str | list | dict): Like tools but available to test_cmd instead.
       secrets (list | dict): Secrets available to this rule while building.
       data (list | dict): Runtime data files for the test.
       visibility (list): Visibility declaration of this rule.

--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -6,7 +6,7 @@ def genrule(name:str, cmd:str|list|dict, srcs:list|dict=None, out:str=None, outs
             building_description:str='Building...', data:list=None, hashes:list=None, timeout:int=0, binary:bool=False,
             sandbox:bool=None, needs_transitive_deps:bool=False, output_is_complete:bool=True,
             test_only:bool&testonly=False, secrets:list|dict=None, requires:list=None, provides:dict=None,
-            pre_build:function=None, post_build:function=None, tools:list|dict=None, pass_env:list=None,
+            pre_build:function=None, post_build:function=None, tools:str|list|dict=None, pass_env:list=None,
             local:bool=False, output_dirs:list=[], exit_on_error:bool=CONFIG.EXIT_ON_ERROR, entry_points:dict={},
             env:dict={}):
     """A general build rule which allows the user to specify a command.
@@ -33,7 +33,7 @@ def genrule(name:str, cmd:str|list|dict, srcs:list|dict=None, out:str=None, outs
       data (list): Runtime data for this rule.
       deps (list): Dependencies of this rule.
       exported_deps (list): Dependencies that will become visible to any rules that depend on this rule.
-      tools (list | dict): Tools used to build this rule; similar to srcs but are not copied to the
+      tools (str | list | dict): Tools used to build this rule; similar to srcs but are not copied to the
                            temporary build directory. Should be accessed via $(exe //path/to:tool)
                            or similar.
                            Entries that are not build labels are assumed to be system-level commands
@@ -142,7 +142,7 @@ def genrule(name:str, cmd:str|list|dict, srcs:list|dict=None, out:str=None, outs
 
 
 def gentest(name:str, test_cmd:str|dict, labels:list&features&tags=None, cmd:str|dict=None, srcs:list|dict=None,
-            outs:list=None, deps:list=None, exported_deps:list=None, tools:list|dict=None, test_tools:list|dict=None,
+            outs:list=None, deps:list=None, exported_deps:list=None, tools:str|list|dict=None, test_tools:list|dict=None,
             data:list|dict=None, visibility:list=None, timeout:int=0, needs_transitive_deps:bool=False,
             flaky:bool|int=0, secrets:list|dict=None, no_test_output:bool=False, test_outputs:list=None,
             output_is_complete:bool=True, requires:list=None, sandbox:bool=None, size:str=None, local:bool=False,
@@ -167,7 +167,7 @@ def gentest(name:str, test_cmd:str|dict, labels:list&features&tags=None, cmd:str
       outs (list): Output files of this rule.
       deps (list): Dependencies of this rule.
       exported_deps (list): Dependencies that will become visible to any rules that depend on this rule.
-      tools (list| dict): Tools used to build this rule; similar to srcs but are not copied to the temporary
+      tools (str | list | dict): Tools used to build this rule; similar to srcs but are not copied to the temporary
                     build directory.
       test_tools (list | dict): Like tools but available to test_cmd instead.
       secrets (list | dict): Secrets available to this rule while building.

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -282,13 +282,21 @@ func addMaybeNamed(s *scope, name string, obj pyObject, anon func(core.BuildInpu
 		s.Assert(named != nil, "%s cannot be given as a dict", name)
 		for k, v := range d {
 			if v != None {
-				l, ok := asList(v)
-				s.Assert(ok, "Values of %s must be lists of strings", name)
-				for _, li := range l {
-					if bi := parseBuildInput(s, li, name, systemAllowed, tool); bi != nil {
+				if l, ok := asList(v); ok {
+					for _, li := range l {
+						if bi := parseBuildInput(s, li, name, systemAllowed, tool); bi != nil {
+							named(k, bi)
+						}
+					}
+					continue
+				}
+				if str, ok := asString(v); ok {
+					if bi := parseBuildInput(s, str, name, systemAllowed, tool); bi != nil {
 						named(k, bi)
 					}
+					continue
 				}
+				s.Assert(ok, "Values of %s must be a string or lists of strings", name)
 			}
 		}
 	} else if obj != None {

--- a/test/misc_rules/BUILD
+++ b/test/misc_rules/BUILD
@@ -44,9 +44,25 @@ genrule(
     cmd = "echo \"test\" > test1.txt && ln -s test1.txt test2.txt",
 )
 
-# Test to set string to tools 
+# Test to set string to tools argument
 genrule(
-    name = "test_string_tools",
-    tools = "test",
-    cmd = "echo String tools",
+    name = "tools_string",
+    tools = "bash",
+    cmd = "$TOOL -c \"echo 'String tools' > tools_string.txt\"",
+    outs = [
+        "tools_string.txt",
+    ],
+)
+
+# Test to set string to test_tools argument
+gentest(
+    name = "test_tools_string",
+    tools = "bash",
+    no_test_output = True,
+    test_tools = "bash",
+    cmd = "$TOOL -c \"echo 'test string tools' > test_tools_strings.txt\"",
+    outs = [
+        "test_tools_strings.txt",
+    ],
+    test_cmd = "[ \"`cat $TEST`\" == \"test string tools\" ]"
 )

--- a/test/misc_rules/BUILD
+++ b/test/misc_rules/BUILD
@@ -43,3 +43,10 @@ genrule(
     ],
     cmd = "echo \"test\" > test1.txt && ln -s test1.txt test2.txt",
 )
+
+# Test to set string to tools 
+genrule(
+    name = "test_string_tools",
+    tools = "test",
+    cmd = "echo String tools",
+)

--- a/test/misc_rules/BUILD
+++ b/test/misc_rules/BUILD
@@ -57,10 +57,12 @@ genrule(
 # Test to set string to test_tools argument
 gentest(
     name = "test_tools_string",
-    tools = "bash",
+    tools = {
+        "SHELL": "bash",
+    },
     no_test_output = True,
     test_tools = "bash",
-    cmd = "$TOOL -c \"echo 'test string tools' > test_tools_strings.txt\"",
+    cmd = "$SHELL -c \"echo 'test string tools' > test_tools_strings.txt\"",
     outs = [
         "test_tools_strings.txt",
     ],


### PR DESCRIPTION
This change adds support for strings addresses the #1364