### PR TITLE
Attach metadata to outgoing remote execution requests

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -481,6 +481,7 @@ type Configuration struct {
 		Shell         string       `help:"Path to the shell to use to execute actions in. Default looks up bash based on the build.path setting."`
 		Platform      []string     `help:"Platform properties to request from remote workers, in the format key=value."`
 		CacheDuration cli.Duration `help:"Length of time before we re-check locally cached build actions. Default is unlimited."`
+		BuildID       string       `help:"ID of the build action that's being run, to attach to remote requests."`
 	} `help:"Settings related to remote execution & caching using the Google remote execution APIs. This section is still experimental and subject to change."`
 	Size  map[string]*Size `help:"Named sizes of targets; these are the definitions of what can be passed to the 'size' argument."`
 	Cover struct {

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -640,7 +640,7 @@ func (c *Client) reallyExecute(tid int, target *core.BuildTarget, command *pb.Co
 		}
 	}()
 
-	resp, err := c.client.ExecuteAndWaitProgress(context.Background(), &pb.ExecuteRequest{
+	resp, err := c.client.ExecuteAndWaitProgress(c.contextWithMetadata(target), &pb.ExecuteRequest{
 		InstanceName:    c.instance,
 		ActionDigest:    digest,
 		SkipCacheLookup: true, // We've already done it above.

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -567,11 +567,11 @@ func (cred tokenCredProvider) RequireTransportSecurity() bool {
 
 // contextWithMetadata returns a context with metadata corresponding to the given build target.
 func (c *Client) contextWithMetadata(target *core.BuildTarget) context.Context {
-	const key = "build.bazel.remote.execution.v2.requestmetadata-bin"  // as defined by the proto
+	const key = "build.bazel.remote.execution.v2.requestmetadata-bin" // as defined by the proto
 	b, _ := proto.Marshal(&pb.RequestMetadata{
 		ActionId:                target.Label.String(),
 		CorrelatedInvocationsId: c.state.Config.Remote.BuildID,
-		ToolDetails:             &pb.ToolDetails{
+		ToolDetails: &pb.ToolDetails{
 			ToolName:    "please",
 			ToolVersion: core.PleaseVersion.String(),
 		},

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	treesdk "github.com/bazelbuild/remote-apis-sdks/go/pkg/tree"
 	"io/ioutil"
 	"os"
 	"path"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
+	treesdk "github.com/bazelbuild/remote-apis-sdks/go/pkg/tree"
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/bazelbuild/remote-apis/build/bazel/semver"
 	"github.com/golang/protobuf/proto"
@@ -26,6 +26,7 @@ import (
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/thought-machine/please/src/core"
@@ -562,4 +563,18 @@ func (cred tokenCredProvider) GetRequestMetadata(ctx context.Context, uri ...str
 
 func (cred tokenCredProvider) RequireTransportSecurity() bool {
 	return false // Allow these to be provided over an insecure channel; this facilitates e.g. service meshes like Istio.
+}
+
+// contextWithMetadata returns a context with metadata corresponding to the given build target.
+func (c *Client) contextWithMetadata(target *core.BuildTarget) context.Context {
+	const key = "build.bazel.remote.execution.v2.requestmetadata-bin"  // as defined by the proto
+	b, _ := proto.Marshal(&pb.RequestMetadata{
+		ActionId:                target.Label.String(),
+		CorrelatedInvocationsId: c.state.Config.Remote.BuildID,
+		ToolDetails:             &pb.ToolDetails{
+			ToolName:    "please",
+			ToolVersion: core.PleaseVersion.String(),
+		},
+	})
+	return metadata.NewOutgoingContext(context.Background(), metadata.Pairs(key, string(b)))
 }


### PR DESCRIPTION
Discovered this in the proto recently and I think we could definitely make use of it. Right now I'm only attaching it to execution requests - it could be sent with others too but I don't think we would do much with it so haven't bothered for now.

This also introduces a build id as the "correlated invocations id"; for now it is scoped to remote only. Dunno if we want to make this a more general concept (I feel it should be treated with some care).

There's also a "tool invocation id" field, which I think is roughly aimed at actions that contribute towards a single final target, but we don't really have any concept of that.