### PR TITLE
Update remote-apis-sdks to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4 // indirect
 	github.com/bazelbuild/buildtools v0.0.0-20190228125936-4bcdbd1064fc
-	github.com/bazelbuild/remote-apis v0.0.0-20200904140912-1aeb39973178
-	github.com/bazelbuild/remote-apis-sdks v0.0.0-20200921162846-81a3a82fc300
+	github.com/bazelbuild/remote-apis v0.0.0-20201113154229-1e9ccef3705c
+	github.com/bazelbuild/remote-apis-sdks v0.0.0-20210219194604-fdb5dae38ca8
 	github.com/bmatcuk/doublestar v1.3.0 // indirect
 	github.com/coreos/go-semver v0.2.0
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,7 @@ github.com/bazelbuild/remote-apis v0.0.0-20200127100703-2846a67ac8fe h1:psm84nne
 github.com/bazelbuild/remote-apis v0.0.0-20200127100703-2846a67ac8fe/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/bazelbuild/remote-apis v0.0.0-20200904140912-1aeb39973178 h1:qDZ7lr7knlTckZgbKwWD1PHTY6WYe5V+DqILuzpMHPY=
 github.com/bazelbuild/remote-apis v0.0.0-20200904140912-1aeb39973178/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
+github.com/bazelbuild/remote-apis v0.0.0-20201113154229-1e9ccef3705c/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20191119014045-9f0428c343a9 h1:KU66ZTme1RxNuBPyseaHmSHZKQMM52yrCDhGhMCqOUU=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20191119014045-9f0428c343a9/go.mod h1:qgVeF5etXayzvt6OKXzeSg9Y0QDXfeH9H4EWKo/MNLM=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20191125202410-a21ff57ff57c h1:8zx14LG5/YyL54A3R/oIOG5TsilYs7EnVLlVMWXjHOU=
@@ -80,6 +81,8 @@ github.com/bazelbuild/remote-apis-sdks v0.0.0-20200331142530-d833149cbc0b h1:o4t
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20200331142530-d833149cbc0b/go.mod h1:sAMybttCdA6S0dbSG/xluhJY6D3qlEkAkgfcyOyRee4=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20200921162846-81a3a82fc300 h1:Ec9c/BJpNS7uT1cciiMFEl0ekyAFsvro/kNFbBElAEg=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20200921162846-81a3a82fc300/go.mod h1:qYwgoeLmixW0VkG6F665WCYE4oneGGqvDzUNmzukY1c=
+github.com/bazelbuild/remote-apis-sdks v0.0.0-20210219194604-fdb5dae38ca8 h1:TttGBWNzVdB6DEivgr0daBV6c3MLSEOA32aEdNkeoP4=
+github.com/bazelbuild/remote-apis-sdks v0.0.0-20210219194604-fdb5dae38ca8/go.mod h1:7ydB5NoX3Valx/bZbXH6wL9QJ6oKLJxrLyav+wYhisU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bmatcuk/doublestar v1.3.0 h1:1jLE2y0VpSrOn/QR9G4f2RmrCtkM3AuATcWradjHUvM=
@@ -269,6 +272,7 @@ github.com/kevinburke/go-bindata v3.13.0+incompatible/go.mod h1:/pEEZ72flUW2p0yi
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.10.11 h1:K9z59aO18Aywg2b/WSgBaUX99mHy2BES18Cr5lBKZHk=
 github.com/klauspost/compress v1.10.11/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.6/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=
 github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -295,6 +299,7 @@ github.com/miekg/dns v1.0.14 h1:9jZdLNd/P4+SfEJ0TNyxYpsK8N4GtfylBLqtbYN1sbA=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mostynb/go-grpc-compression v1.1.2 h1:emrImHjSPW/H4aarNxuiPG1uN1WgIlVdR3M0LH5HH5E=
 github.com/mostynb/go-grpc-compression v1.1.2/go.mod h1:pdfSJ8XayqYFTIn9b5dKM2gKCHYRgnvG9UJ2/pLOl7E=
+github.com/mostynb/zstdpool-syncpool v0.0.3/go.mod h1:lC4L6zTmUc7cUKGiMn6aOuHmxzkL4mzpTg4wxpLBbuk=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/nicksnyder/go-i18n v1.10.1 h1:isfg77E/aCD7+0lD/D00ebR2MV5vgeQ276WYyDaCRQc=
 github.com/nicksnyder/go-i18n v1.10.1/go.mod h1:e4Di5xjP9oTVrC6y3C7C0HoSYXjSbhh/dU0eUV32nB4=

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,7 @@ github.com/bazelbuild/remote-apis v0.0.0-20200127100703-2846a67ac8fe h1:psm84nne
 github.com/bazelbuild/remote-apis v0.0.0-20200127100703-2846a67ac8fe/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/bazelbuild/remote-apis v0.0.0-20200904140912-1aeb39973178 h1:qDZ7lr7knlTckZgbKwWD1PHTY6WYe5V+DqILuzpMHPY=
 github.com/bazelbuild/remote-apis v0.0.0-20200904140912-1aeb39973178/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
+github.com/bazelbuild/remote-apis v0.0.0-20201113154229-1e9ccef3705c h1:rk6YYsIbLDZ/frDYZPANInvCUqAEjPitjRSyWTcsjiA=
 github.com/bazelbuild/remote-apis v0.0.0-20201113154229-1e9ccef3705c/go.mod h1:9Y+1FnaNUGVV6wKE0Jdh+mguqDUsyd9uUqokalrC7DQ=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20191119014045-9f0428c343a9 h1:KU66ZTme1RxNuBPyseaHmSHZKQMM52yrCDhGhMCqOUU=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20191119014045-9f0428c343a9/go.mod h1:qgVeF5etXayzvt6OKXzeSg9Y0QDXfeH9H4EWKo/MNLM=
@@ -272,6 +273,7 @@ github.com/kevinburke/go-bindata v3.13.0+incompatible/go.mod h1:/pEEZ72flUW2p0yi
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.10.11 h1:K9z59aO18Aywg2b/WSgBaUX99mHy2BES18Cr5lBKZHk=
 github.com/klauspost/compress v1.10.11/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.6 h1:EgWPCW6O3n1D5n99Zq3xXBt9uCwRGvpwGOusOLNBRSQ=
 github.com/klauspost/compress v1.11.6/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=
 github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
@@ -299,6 +301,7 @@ github.com/miekg/dns v1.0.14 h1:9jZdLNd/P4+SfEJ0TNyxYpsK8N4GtfylBLqtbYN1sbA=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mostynb/go-grpc-compression v1.1.2 h1:emrImHjSPW/H4aarNxuiPG1uN1WgIlVdR3M0LH5HH5E=
 github.com/mostynb/go-grpc-compression v1.1.2/go.mod h1:pdfSJ8XayqYFTIn9b5dKM2gKCHYRgnvG9UJ2/pLOl7E=
+github.com/mostynb/zstdpool-syncpool v0.0.3 h1:G1+LWTHSedQUaiW7V7wiGdufKk3Xyyot/6vjBDeugFs=
 github.com/mostynb/zstdpool-syncpool v0.0.3/go.mod h1:lC4L6zTmUc7cUKGiMn6aOuHmxzkL4mzpTg4wxpLBbuk=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/nicksnyder/go-i18n v1.10.1 h1:isfg77E/aCD7+0lD/D00ebR2MV5vgeQ276WYyDaCRQc=

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -14,7 +14,6 @@ import (
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata"
-	"github.com/bazelbuild/remote-apis-sdks/go/pkg/tree"
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/golang/protobuf/ptypes"
 
@@ -488,7 +487,7 @@ func (c *Client) verifyActionResult(target *core.BuildTarget, command *pb.Comman
 
 // uploadLocalTarget uploads the outputs of a target that was built locally.
 func (c *Client) uploadLocalTarget(target *core.BuildTarget) error {
-	m, ar, err := tree.ComputeOutputsToUpload(target.OutDir(), target.Outputs(), int(c.client.ChunkMaxSize), filemetadata.NewNoopCache())
+	m, ar, err := c.client.ComputeOutputsToUpload(target.OutDir(), target.Outputs(), int(c.client.ChunkMaxSize), filemetadata.NewNoopCache())
 	if err != nil {
 		return err
 	}

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -273,14 +273,14 @@ func (c *Client) uploadInputDir(ch chan<- *uploadinfo.Entry, target *core.BuildT
 	}
 	if !isTest && target.Stamp {
 		stamp := core.StampFile(target)
-		chomk, digest := c.blobEntry(stamp)
+		entry := uploadinfo.EntryFromBlob(stamp)
 		if ch != nil {
-			ch <- chomk
+			ch <- entry
 		}
 		d := b.Dir(".")
 		d.Files = append(d.Files, &pb.FileNode{
 			Name:   target.StampFileName(),
-			Digest: digest,
+			Digest: entry.Digest.ToProto(),
 		})
 	}
 	return b, nil
@@ -543,10 +543,5 @@ func (c *Client) buildEnv(target *core.BuildTarget, env []string, sandbox bool) 
 
 func (c *Client) protoEntry(msg proto.Message) (*uploadinfo.Entry, *pb.Digest) {
 	entry, _ := uploadinfo.EntryFromProto(msg)
-	return entry, entry.Digest.ToProto()
-}
-
-func (c *Client) blobEntry(b []byte) (*uploadinfo.Entry, *pb.Digest) {
-	entry := uploadinfo.EntryFromBlob(b)
 	return entry, entry.Digest.ToProto()
 }

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -14,7 +14,9 @@ import (
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/uploadinfo"
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 
 	"github.com/thought-machine/please/src/core"
@@ -32,21 +34,21 @@ func (c *Client) uploadAction(target *core.BuildTarget, isTest, isRun bool) (*pb
 		if err != nil {
 			return err
 		}
-		inputRootChunker, _ := chunker.NewFromProto(inputRoot, int(c.client.ChunkMaxSize))
+		inputRootChunker, inputRootDigest := c.chunkProto(inputRoot)
 		ch <- inputRootChunker
 		command, err = c.buildCommand(target, inputRoot, isTest, isRun, target.Stamp)
 		if err != nil {
 			return err
 		}
-		commandChunker, _ := chunker.NewFromProto(command, int(c.client.ChunkMaxSize))
+		commandChunker, commandDigest := c.chunkProto(command)
 		ch <- commandChunker
-		actionChunker, _ := chunker.NewFromProto(&pb.Action{
-			CommandDigest:   commandChunker.Digest().ToProto(),
-			InputRootDigest: inputRootChunker.Digest().ToProto(),
+		actionChunker, actionDigest := c.chunkProto(&pb.Action{
+			CommandDigest:   commandDigest,
+			InputRootDigest: inputRootDigest,
 			Timeout:         ptypes.DurationProto(timeout(target, isTest)),
-		}, int(c.client.ChunkMaxSize))
+		})
 		ch <- actionChunker
-		digest = actionChunker.Digest().ToProto()
+		digest = actionDigest
 		return nil
 	})
 	return command, digest, err
@@ -272,14 +274,14 @@ func (c *Client) uploadInputDir(ch chan<- *chunker.Chunker, target *core.BuildTa
 	}
 	if !isTest && target.Stamp {
 		stamp := core.StampFile(target)
-		chomk := chunker.NewFromBlob(stamp, int(c.client.ChunkMaxSize))
+		chomk, digest := c.chunkBlob(stamp)
 		if ch != nil {
 			ch <- chomk
 		}
 		d := b.Dir(".")
 		d.Files = append(d.Files, &pb.FileNode{
 			Name:   target.StampFileName(),
-			Digest: chomk.Digest().ToProto(),
+			Digest: digest,
 		})
 	}
 	return b, nil
@@ -288,7 +290,7 @@ func (c *Client) uploadInputDir(ch chan<- *chunker.Chunker, target *core.BuildTa
 // addChildDirs adds a set of child directories to a builder.
 func (c *Client) addChildDirs(b *dirBuilder, name string, dg *pb.Digest) error {
 	dir := &pb.Directory{}
-	if err := c.client.ReadProto(context.Background(), digest.NewFromProtoUnvalidated(dg), dir); err != nil {
+	if _, err := c.client.ReadProto(context.Background(), digest.NewFromProtoUnvalidated(dg), dir); err != nil {
 		return err
 	}
 	d := b.Dir(name)
@@ -347,7 +349,9 @@ func (c *Client) uploadInput(b *dirBuilder, ch chan<- *chunker.Chunker, input co
 				IsExecutable: info.Mode()&0100 != 0,
 			})
 			if ch != nil {
-				ch <- chunker.NewFromFile(name, digest.NewFromProtoUnvalidated(dg), int(c.client.ChunkMaxSize))
+				entry := uploadinfo.EntryFromFile(digest.NewFromProtoUnvalidated(dg), name)
+				chomk, _ := chunker.New(entry, false, int(c.client.ChunkMaxSize))
+				ch <- chomk
 			}
 			return nil
 		}); err != nil {
@@ -384,14 +388,14 @@ func (c *Client) buildMetadata(ar *pb.ActionResult, needStdout, needStderr bool)
 		Stderr: ar.StderrRaw,
 	}
 	if needStdout && len(metadata.Stdout) == 0 && ar.StdoutDigest != nil {
-		b, err := c.client.ReadBlob(context.Background(), digest.NewFromProtoUnvalidated(ar.StdoutDigest))
+		b, _, err := c.client.ReadBlob(context.Background(), digest.NewFromProtoUnvalidated(ar.StdoutDigest))
 		if err != nil {
 			return metadata, err
 		}
 		metadata.Stdout = b
 	}
 	if needStderr && len(metadata.Stderr) == 0 && ar.StderrDigest != nil {
-		b, err := c.client.ReadBlob(context.Background(), digest.NewFromProtoUnvalidated(ar.StderrDigest))
+		b, _, err := c.client.ReadBlob(context.Background(), digest.NewFromProtoUnvalidated(ar.StderrDigest))
 		if err != nil {
 			return metadata, err
 		}
@@ -487,12 +491,13 @@ func (c *Client) verifyActionResult(target *core.BuildTarget, command *pb.Comman
 
 // uploadLocalTarget uploads the outputs of a target that was built locally.
 func (c *Client) uploadLocalTarget(target *core.BuildTarget) error {
-	m, ar, err := c.client.ComputeOutputsToUpload(target.OutDir(), target.Outputs(), int(c.client.ChunkMaxSize), filemetadata.NewNoopCache())
+	m, ar, err := c.client.ComputeOutputsToUpload(target.OutDir(), target.Outputs(), filemetadata.NewNoopCache())
 	if err != nil {
 		return err
 	}
 	chomks := make([]*chunker.Chunker, 0, len(m))
-	for _, c := range m {
+	for _, entry := range m {
+		c, _ := chunker.New(entry, false, int(c.client.ChunkMaxSize))
 		chomks = append(chomks, c)
 	}
 	if err := c.uploadIfMissing(context.Background(), chomks...); err != nil {
@@ -538,4 +543,16 @@ func (c *Client) buildEnv(target *core.BuildTarget, env []string, sandbox bool) 
 		}
 	}
 	return vars
+}
+
+func (c *Client) chunkProto(msg proto.Message) (*chunker.Chunker, *pb.Digest) {
+	entry, _ := uploadinfo.EntryFromProto(msg)
+	chunk, _ := chunker.New(entry, false, int(c.client.ChunkMaxSize))
+	return chunk, entry.Digest.ToProto()
+}
+
+func (c *Client) chunkBlob(b []byte) (*chunker.Chunker, *pb.Digest) {
+	entry := uploadinfo.EntryFromBlob(b)
+	chunk, _ := chunker.New(entry, false, int(c.client.ChunkMaxSize))
+	return chunk, entry.Digest.ToProto()
 }

--- a/src/remote/blobs.go
+++ b/src/remote/blobs.go
@@ -30,7 +30,7 @@ func (c *Client) uploadIfMissing(ctx context.Context, chomks ...*chunker.Chunker
 	filtered := c.filterChunks(chomks)
 	if len(filtered) == 0 {
 		return nil
-	} else if _, err := c.client.UploadIfMissing(ctx, filtered...); err != nil {
+	} else if _, _, err := c.client.UploadIfMissing(ctx, filtered...); err != nil {
 		return err
 	}
 	c.existingBlobMutex.Lock()

--- a/src/remote/blobs.go
+++ b/src/remote/blobs.go
@@ -3,7 +3,7 @@ package remote
 import (
 	"context"
 
-	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/uploadinfo"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -11,23 +11,23 @@ import (
 // It handles all the logic around the various upload methods etc.
 // The given function is a callback that receives a channel to send these blobs on; it
 // should close it when finished.
-func (c *Client) uploadBlobs(f func(ch chan<- *chunker.Chunker) error) error {
+func (c *Client) uploadBlobs(f func(ch chan<- *uploadinfo.Entry) error) error {
 	const buffer = 10 // Buffer it a bit but don't get too far ahead.
-	ch := make(chan *chunker.Chunker, buffer)
+	ch := make(chan *uploadinfo.Entry, buffer)
 	var g errgroup.Group
 	g.Go(func() error { return f(ch) })
-	chomks := []*chunker.Chunker{}
+	chomks := []*uploadinfo.Entry{}
 	for chomk := range ch {
 		chomks = append(chomks, chomk)
 	}
 	if err := g.Wait(); err != nil {
 		return err
 	}
-	return c.uploadIfMissing(context.Background(), chomks...)
+	return c.uploadIfMissing(context.Background(), chomks)
 }
 
-func (c *Client) uploadIfMissing(ctx context.Context, chomks ...*chunker.Chunker) error {
-	filtered := c.filterChunks(chomks)
+func (c *Client) uploadIfMissing(ctx context.Context, chomks []*uploadinfo.Entry) error {
+	filtered := c.filterEntries(chomks)
 	if len(filtered) == 0 {
 		return nil
 	} else if _, _, err := c.client.UploadIfMissing(ctx, filtered...); err != nil {
@@ -35,19 +35,19 @@ func (c *Client) uploadIfMissing(ctx context.Context, chomks ...*chunker.Chunker
 	}
 	c.existingBlobMutex.Lock()
 	defer c.existingBlobMutex.Unlock()
-	for _, chunker := range filtered {
-		c.existingBlobs[chunker.Digest().Hash] = struct{}{}
+	for _, entry := range filtered {
+		c.existingBlobs[entry.Digest.Hash] = struct{}{}
 	}
 	return nil
 }
 
-func (c *Client) filterChunks(chomks []*chunker.Chunker) []*chunker.Chunker {
-	ret := make([]*chunker.Chunker, 0, len(chomks))
+func (c *Client) filterEntries(entries []*uploadinfo.Entry) []*uploadinfo.Entry {
+	ret := make([]*uploadinfo.Entry, 0, len(entries))
 	c.existingBlobMutex.Lock()
 	defer c.existingBlobMutex.Unlock()
-	for _, chunker := range chomks {
-		if _, present := c.existingBlobs[chunker.Digest().Hash]; !present {
-			ret = append(ret, chunker)
+	for _, entry := range entries {
+		if _, present := c.existingBlobs[entry.Digest.Hash]; !present {
+			ret = append(ret, entry)
 		}
 	}
 	return ret

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -177,7 +177,7 @@ func (c *Client) initExec() error {
 		NoSecurity:         !c.state.Config.Remote.Secure,
 		TransportCredsOnly: c.state.Config.Remote.Secure,
 		DialOpts:           dialOpts,
-	}, client.UseBatchOps(true), client.RetryTransient(), client.RPCTimeouts(client.DefaultRPCTimeouts))
+	}, client.UseBatchOps(true), &client.TreeSymlinkOpts{Preserved: true}, client.RetryTransient(), client.RPCTimeouts(client.DefaultRPCTimeouts))
 	if err != nil {
 		return err
 	}

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
-	treesdk "github.com/bazelbuild/remote-apis-sdks/go/pkg/tree"
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/bazelbuild/remote-apis/build/bazel/semver"
 	"github.com/golang/protobuf/proto"
@@ -77,7 +76,7 @@ func (c *Client) setOutputs(target *core.BuildTarget, ar *pb.ActionResult) error
 		}
 
 		if outDir := maybeGetOutDir(d.Path, target.OutputDirectories); outDir != "" {
-			files, dirs, err := getOutputsForOutDir(target, outDir, tree)
+			files, dirs, err := c.getOutputsForOutDir(target, outDir, tree)
 			if err != nil {
 				return err
 			}
@@ -102,12 +101,12 @@ func (c *Client) setOutputs(target *core.BuildTarget, ar *pb.ActionResult) error
 	return nil
 }
 
-func getOutputsForOutDir(target *core.BuildTarget, outDir core.OutputDirectory, tree *pb.Tree) ([]*pb.FileNode, []*pb.DirectoryNode, error) {
+func (c *Client) getOutputsForOutDir(target *core.BuildTarget, outDir core.OutputDirectory, tree *pb.Tree) ([]*pb.FileNode, []*pb.DirectoryNode, error) {
 	files := make([]*pb.FileNode, 0, len(tree.Root.Files))
 	dirs := make([]*pb.DirectoryNode, 0, len(tree.Root.Directories))
 
 	if outDir.ShouldAddFiles() {
-		outs, err := treesdk.FlattenTree(tree, "")
+		outs, err := c.client.FlattenTree(tree, "")
 		if err != nil {
 			return nil, nil, err
 		}

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bazelbuild/remote-apis-sdks/go/pkg/chunker"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
+	"github.com/bazelbuild/remote-apis-sdks/go/pkg/uploadinfo"
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/bazelbuild/remote-apis/build/bazel/semver"
 	"github.com/golang/protobuf/proto"
@@ -71,7 +71,7 @@ func (c *Client) setOutputs(target *core.BuildTarget, ar *pb.ActionResult) error
 	}
 	for _, d := range ar.OutputDirectories {
 		tree := &pb.Tree{}
-		if err := c.client.ReadProto(context.Background(), digest.NewFromProtoUnvalidated(d.TreeDigest), tree); err != nil {
+		if _, err := c.client.ReadProto(context.Background(), digest.NewFromProtoUnvalidated(d.TreeDigest), tree); err != nil {
 			return wrap(err, "Downloading tree digest for %s [%s]", d.Path, d.TreeDigest.Hash)
 		}
 
@@ -409,7 +409,7 @@ func (b *dirBuilder) dir(dir, child string) *pb.Directory {
 // Build "builds" the directory. It calculate the digests of all the items in the directory tree, and returns the root
 // directory. If ch is non-nil, it will upload the directory protos to ch. Build doesn't upload any of the actual files
 // in the directory tree, just the protos.
-func (b *dirBuilder) Build(ch chan<- *chunker.Chunker) *pb.Directory {
+func (b *dirBuilder) Build(ch chan<- *uploadinfo.Entry) *pb.Directory {
 	// Upload the directory structure
 	b.walk(".", ch)
 	return b.root
@@ -451,7 +451,7 @@ func (b *dirBuilder) tree(tree *pb.Tree, root string, dir *pb.Directory) {
 
 // Walk walks the directory tree calculating the digest. If ch is non-nil, it will also upload the direcory protos.
 // Walk does not upload the actual files in the tree, just the tree structure.
-func (b *dirBuilder) walk(name string, ch chan<- *chunker.Chunker) *pb.Digest {
+func (b *dirBuilder) walk(name string, ch chan<- *uploadinfo.Entry) *pb.Digest {
 	dir := b.dirs[name]
 	for _, d := range dir.Directories {
 		if d.Digest == nil { // It's not nil if we're reusing outputs from an earlier call.
@@ -463,11 +463,11 @@ func (b *dirBuilder) walk(name string, ch chan<- *chunker.Chunker) *pb.Digest {
 	sort.Slice(dir.Files, func(i, j int) bool { return dir.Files[i].Name < dir.Files[j].Name })
 	sort.Slice(dir.Directories, func(i, j int) bool { return dir.Directories[i].Name < dir.Directories[j].Name })
 	sort.Slice(dir.Symlinks, func(i, j int) bool { return dir.Symlinks[i].Name < dir.Symlinks[j].Name })
-	chomk, _ := chunker.NewFromProto(dir, chunker.DefaultChunkSize)
+	entry, _ := uploadinfo.EntryFromProto(dir)
 	if ch != nil {
-		ch <- chomk
+		ch <- entry
 	}
-	return chomk.Digest().ToProto()
+	return entry.Digest.ToProto()
 }
 
 // convertPlatform converts the platform entries from the config into a Platform proto.

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -396,9 +396,12 @@ go_module(
 
 go_module(
     name = "errgroup",
-    install = ["errgroup"],
+    install = [
+        "errgroup",
+        "semaphore",
+    ],
     module = "golang.org/x/sync",
-    version = "457c5828408160d6a47e17645169cf8fa20218c4",
+    version = "036812b2e83c0ddf193dd5a34e034151da389d09",
     deps = [":net"],
 )
 
@@ -568,7 +571,7 @@ go_module(
     name = "remote-apis",
     install = ["build/..."],
     module = "github.com/bazelbuild/remote-apis",
-    version = "2846a67ac8feb5001e9f704b66f5acc1e90f1ade",
+    version = "9e72daff42c941baaf43a4c370e2607a984c58a7",
     deps = [
         ":genproto_api",
         ":grpc",
@@ -576,17 +579,11 @@ go_module(
     ],
 )
 
-go_mod_download(
-    name = "remote-apis-sdks-download",
-    module = "github.com/peterebden/remote-apis-sdks",
-    version = "271eb5b72e7dca1dda1d4dee87d99a17194cf146",
-)
-
 go_module(
     name = "remote-apis-sdks",
-    download = ":remote-apis-sdks-download",
     install = ["go/..."],
     module = "github.com/bazelbuild/remote-apis-sdks",
+    version = "fdb5dae38ca890ae7311dc0d320e2d327df10485",
     deps = [
         ":cmp",
         ":errgroup",
@@ -598,6 +595,8 @@ go_module(
         ":pborman_uuid",
         ":protobuf",
         ":remote-apis",
+        ":zstd",
+        ":zstdpool",
     ],
 )
 
@@ -794,4 +793,26 @@ go_module(
     name = "cpuid",
     module = "github.com/klauspost/cpuid",
     version = "v1.3.1",
+)
+
+go_module(
+    name = "zstd",
+    install = [
+        "fse",
+        "huff0",
+        "zstd",
+        "zstd/...",
+        "snappy",
+    ],
+    module = "github.com/klauspost/compress",
+    version = "v1.11.7",
+)
+
+go_module(
+    name = "zstdpool",
+    module = "github.com/mostynb/zstdpool-syncpool",
+    version = "v0.0.3",
+    deps = [
+        ":zstd",
+    ],
 )


### PR DESCRIPTION
This rolls in a bunch of breaking changes from upstream.

All the stuff on my fork that we want has been upstreamed too so we can get off that \o/