### PR TITLE
interpreter: print stack trace as string

### DIFF
--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -101,7 +101,7 @@ func (i *interpreter) interpretStatements(s *scope, statements []*Statement) (re
 			} else {
 				err = fmt.Errorf("%s", r)
 			}
-			log.Debug("%v", debug.Stack())
+			log.Debug("%s", debug.Stack())
 		}
 	}()
 	return s.interpretStatements(statements), nil // Would have panicked if there was an error


### PR DESCRIPTION
`debug.Stack()` returns a byte slice, so print it to `DEBUG` using the `%s` verb (i.e. as a string) rather than `%v` (i.e. as a literal slice of bytes) to ensure it is formatted correctly.

Closes #1613.