### PR TITLE
Make individual sandbox dirs configurable

### DIFF
--- a/docs/config.html
+++ b/docs/config.html
@@ -431,7 +431,8 @@
         <p>
           Activates sandboxing for individual build actions, which isolates them
           from network access, IPC and some aspects of the filesystem. Currently
-          only works on Linux. Defaults to <code class="code">False</code>.
+          only works on Linux. Defaults to <code class="code">False</code>.<br />
+          <span class="red">Deprecated from v16: use <a href="#sandbox">sandbox.build</a> instead.
         </p>
       </div>
     </li>
@@ -482,6 +483,65 @@
     passing secrets into custom rules; any variables containing SECRET or
     PASSWORD won't be logged.
   </p>
+</section>
+
+<section class="mt4">
+  <h2 id="sandbox" class="title-2">[Sandbox]</h2>
+  <ul class="bulleted-list">
+    <li>
+      <div>
+        <h3 class="mt1 f6 lh-title">
+          Tool
+        </h3>
+
+        <p>
+          The binary to use for sandboxing build/test actions. Typically this
+          is <code>please_sandbox</code>.<br />
+          It receives the program to execute and all its arguments in its <code>argv</code>,
+          it is expected to do whatever it needs to then <code>exec</code> the real action.
+        </p>
+      </div>
+    </li>
+    <li>
+      <div>
+        <h3 class="mt1 f6 lh-title">
+          Build <span class="normal">(bool)</span>
+        </h3>
+
+        <p>
+          Activates sandboxing for individual build actions, which isolates them
+          from network access, IPC and the repo-local filesystem. Currently
+          only works on Linux. Defaults to <code class="code">False</code>.
+        </p>
+      </div>
+    </li>
+    <li>
+      <div>
+        <h3 class="mt1 f6 lh-title">
+          Test <span class="normal">(bool)</span>
+        </h3>
+
+        <p>
+          Activates sandboxing for individual test actions, which isolates them
+          from network access, IPC and the repo-local filesystem. Currently
+          only works on Linux. Defaults to <code class="code">False</code>.
+        </p>
+      </div>
+    </li>
+    <li>
+      <div>
+        <h3 class="mt1 f6 lh-title">
+          Dir <span class="normal">(repeated string)</span>
+        </h3>
+
+        <p>
+          Directories that the sandbox tool should mask (it's unspecified how, although mounting an
+          empty filesystem over the top is the current implementation).<br />
+          These are passed to the tool itself in the <code>SANDBOX_DIRS</code> env var as a comma-separated list.
+        </p>
+      </div>
+    </li>
+  </ul>
 </section>
 
 <section class="mt4">
@@ -687,6 +747,7 @@
           Activates sandboxing for individual tests, which isolates them from
           network access, IPC and some aspects of the filesystem. Currently only
           works on Linux. Defaults to <code class="code">False</code>.
+          <span class="red">Deprecated from v16: use <a href="#sandbox">sandbox.test</a> instead.
         </p>
       </div>
     </li>

--- a/docs/config.html
+++ b/docs/config.html
@@ -429,7 +429,7 @@
         </h3>
 
         <p>
-          Activates sandboxing for individual build actions, which isolates them
+          Activates sandboxing for build actions, which isolates them
           from network access, IPC and some aspects of the filesystem. Currently
           only works on Linux. Defaults to <code class="code">False</code>.<br />
           <span class="red">Deprecated from v16: use <a href="#sandbox">sandbox.build</a> instead.
@@ -496,7 +496,7 @@
 
         <p>
           The binary to use for sandboxing build/test actions. Typically this
-          is <code>please_sandbox</code>.<br />
+          is <code>please_sandbox</code>, which currently only does anything on Linux.<br />
           It receives the program to execute and all its arguments in its <code>argv</code>,
           it is expected to do whatever it needs to then <code>exec</code> the real action.
         </p>
@@ -509,7 +509,7 @@
         </h3>
 
         <p>
-          Activates sandboxing for individual build actions, which isolates them
+          Activates sandboxing for build actions, which isolates them
           from network access, IPC and the repo-local filesystem. Currently
           only works on Linux. Defaults to <code class="code">False</code>.
         </p>
@@ -522,7 +522,7 @@
         </h3>
 
         <p>
-          Activates sandboxing for individual test actions, which isolates them
+          Activates sandboxing for test actions, which isolates them
           from network access, IPC and the repo-local filesystem. Currently
           only works on Linux. Defaults to <code class="code">False</code>.
         </p>
@@ -744,7 +744,7 @@
         </h3>
 
         <p>
-          Activates sandboxing for individual tests, which isolates them from
+          Activates sandboxing for tests, which isolates them from
           network access, IPC and some aspects of the filesystem. Currently only
           works on Linux. Defaults to <code class="code">False</code>.
           <span class="red">Deprecated from v16: use <a href="#sandbox">sandbox.test</a> instead.

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -124,7 +124,7 @@ func BuildEnvironment(state *BuildState, target *BuildTarget, tmpDir string) Bui
 		env = append(env, secrets)
 	}
 	if target.Sandbox && len(state.Config.Sandbox.Dir) > 0 {
-		env = append(env, "SANDBOX_DIRS=" + strings.Join(state.Config.Sandbox.Dir, ","))
+		env = append(env, "SANDBOX_DIRS="+strings.Join(state.Config.Sandbox.Dir, ","))
 	}
 	if state.Config.Bazel.Compatibility {
 		// Obviously this is only a subset of the variables Bazel would expose, but there's
@@ -209,7 +209,7 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) Bui
 		env = append(env, "DEBUG=true")
 	}
 	if target.TestSandbox && len(state.Config.Sandbox.Dir) > 0 {
-		env = append(env, "SANDBOX_DIRS=" + strings.Join(state.Config.Sandbox.Dir, ","))
+		env = append(env, "SANDBOX_DIRS="+strings.Join(state.Config.Sandbox.Dir, ","))
 	}
 	return withUserProvidedEnv(target, env)
 }

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -123,6 +123,9 @@ func BuildEnvironment(state *BuildState, target *BuildTarget, tmpDir string) Bui
 		secrets = strings.ReplaceAll(secrets, ":", " ")
 		env = append(env, secrets)
 	}
+	if target.Sandbox && len(state.Config.Sandbox.Dir) > 0 {
+		env = append(env, "SANDBOX_DIRS=" + strings.Join(state.Config.Sandbox.Dir, ","))
+	}
 	if state.Config.Bazel.Compatibility {
 		// Obviously this is only a subset of the variables Bazel would expose, but there's
 		// no point populating ones that we literally have no clue what they should be.
@@ -204,6 +207,9 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) Bui
 	}
 	if state.DebugTests {
 		env = append(env, "DEBUG=true")
+	}
+	if target.TestSandbox && len(state.Config.Sandbox.Dir) > 0 {
+		env = append(env, "SANDBOX_DIRS=" + strings.Join(state.Config.Sandbox.Dir, ","))
 	}
 	return withUserProvidedEnv(target, env)
 }

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -222,6 +222,20 @@ func ReadConfigFiles(filenames []string, profiles []string) (*Configuration, err
 		os.Setenv("HTTP_PROXY", config.Build.HTTPProxy.String())
 	}
 
+	// Deal with the various sandbox settings that are moving.
+	if config.Build.Sandbox {
+		log.Warning("build.sandbox in config is deprecated, use sandbox.build instead");
+		config.Sandbox.Build = true
+	}
+	if config.Test.Sandbox {
+		log.Warning("test.sandbox in config is deprecated, use sandbox.test instead");
+		config.Sandbox.Test = true
+	}
+	if config.Build.PleaseSandboxTool != "" {
+		log.Warning("build.pleasesandboxtool in config is deprecated, use sandbox.tool instead");
+		config.Sandbox.Tool = config.Build.PleaseSandboxTool
+	}
+
 	// We can only verify options by reflection (we need struct tags) so run them quickly through this.
 	return config, config.ApplyOverrides(map[string]string{
 		"build.hashfunction": config.Build.HashFunction,
@@ -347,7 +361,7 @@ func DefaultConfiguration() *Configuration {
 	config.Bazel.Compatibility = usingBazelWorkspace
 
 	// Please tools
-	config.Build.PleaseSandboxTool = "//_please:tools|please_sandbox"
+	config.Sandbox.Tool = "//_please:tools|please_sandbox"
 	config.Go.FilterTool = "//_please:tools|please_go_filter"
 	config.Go.PleaseGoTool = "//_please:tools|please_go"
 	config.Go.EmbedTool = "//_please:tools|please_go_embed"
@@ -398,9 +412,9 @@ type Configuration struct {
 		Config               string       `help:"The build config to use when one is not chosen on the command line. Defaults to opt." example:"opt | dbg"`
 		FallbackConfig       string       `help:"The build config to use when one is chosen and a required target does not have one by the same name. Also defaults to opt." example:"opt | dbg"`
 		Lang                 string       `help:"Sets the language passed to build rules when building. This can be important for some tools (although hopefully not many) - we've mostly observed it with Sass."`
-		Sandbox              bool         `help:"True to sandbox individual build actions, which isolates them from network access and some aspects of the filesystem. Currently only works on Linux." var:"BUILD_SANDBOX"`
+		Sandbox              bool         `help:"Deprecated, use sandbox.build instead."`
 		Xattrs               bool         `help:"True (the default) to attempt to use xattrs to record file metadata. If false Please will fall back to using additional files where needed, which is more compatible but has slightly worse performance."`
-		PleaseSandboxTool    string       `help:"The location of the please_sandbox tool to use."`
+		PleaseSandboxTool    string       `help:"Deprecated, use sandbox.tool instead."`
 		Nonce                string       `help:"This is an arbitrary string that is added to the hash of every build target. It provides a way to force a rebuild of everything when it's changed.\nWe will bump the default of this whenever we think it's required - although it's been a pretty long time now and we hope that'll continue."`
 		PassEnv              []string     `help:"A list of environment variables to pass from the current environment to build rules. For example\n\nPassEnv = HTTP_PROXY\n\nwould copy your HTTP_PROXY environment variable to the build env for any rules."`
 		PassUnsafeEnv        []string     `help:"Similar to PassEnv, a list of environment variables to pass from the current environment to build rules. Unlike PassEnv, the environment variable values are not used when calculating build target hashes."`
@@ -426,10 +440,16 @@ type Configuration struct {
 	} `help:"Please has several built-in caches that can be configured in its config file.\n\nThe simplest one is the directory cache which by default is written into the .plz-cache directory. This allows for fast retrieval of code that has been built before (for example, when swapping Git branches).\n\nThere is also a remote RPC cache which allows using a centralised server to store artifacts. A typical pattern here is to have your CI system write artifacts into it and give developers read-only access so they can reuse its work.\n\nFinally there's a HTTP cache which is very similar, but a little obsolete now since the RPC cache outperforms it and has some extra features. Otherwise the two have similar semantics and share quite a bit of implementation.\n\nPlease has server implementations for both the RPC and HTTP caches."`
 	Test struct {
 		Timeout         cli.Duration `help:"Default timeout applied to all tests. Can be overridden on a per-rule basis."`
-		Sandbox         bool         `help:"True to sandbox individual tests, which isolates them from network access, IPC and some aspects of the filesystem. Currently only works on Linux." var:"TEST_SANDBOX"`
+		Sandbox              bool         `help:"Deprecated, use sandbox.test instead."`
 		DisableCoverage []string     `help:"Disables coverage for tests that have any of these labels spcified."`
 		Upload          cli.URL      `help:"URL to upload test results to (in XML format)"`
 	} `help:"A config section describing settings related to testing in general."`
+	Sandbox struct {
+		Tool string `help:"The location of the tool to use for sandboxing (typically please_sandbox)."`
+		Dir  []string `help:"Directories to hide within the sandbox"`
+		Build bool `help:"True to sandbox individual build actions, which isolates them from network access and some aspects of the filesystem. Currently only works on Linux." var:"BUILD_SANDBOX"`
+		Test bool `help:"True to sandbox individual tests, which isolates them from network access, IPC and some aspects of the filesystem. Currently only works on Linux." var:"TEST_SANDBOX"`
+	} `help:"A config section describing settings relating to sandboxing of build actions."`
 	Remote struct {
 		URL           string       `help:"URL for the remote server."`
 		CASURL        string       `help:"URL for the CAS service, if it is different to the main one."`

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -224,15 +224,15 @@ func ReadConfigFiles(filenames []string, profiles []string) (*Configuration, err
 
 	// Deal with the various sandbox settings that are moving.
 	if config.Build.Sandbox {
-		log.Warning("build.sandbox in config is deprecated, use sandbox.build instead");
+		log.Warning("build.sandbox in config is deprecated, use sandbox.build instead")
 		config.Sandbox.Build = true
 	}
 	if config.Test.Sandbox {
-		log.Warning("test.sandbox in config is deprecated, use sandbox.test instead");
+		log.Warning("test.sandbox in config is deprecated, use sandbox.test instead")
 		config.Sandbox.Test = true
 	}
 	if config.Build.PleaseSandboxTool != "" {
-		log.Warning("build.pleasesandboxtool in config is deprecated, use sandbox.tool instead");
+		log.Warning("build.pleasesandboxtool in config is deprecated, use sandbox.tool instead")
 		config.Sandbox.Tool = config.Build.PleaseSandboxTool
 	}
 
@@ -440,15 +440,15 @@ type Configuration struct {
 	} `help:"Please has several built-in caches that can be configured in its config file.\n\nThe simplest one is the directory cache which by default is written into the .plz-cache directory. This allows for fast retrieval of code that has been built before (for example, when swapping Git branches).\n\nThere is also a remote RPC cache which allows using a centralised server to store artifacts. A typical pattern here is to have your CI system write artifacts into it and give developers read-only access so they can reuse its work.\n\nFinally there's a HTTP cache which is very similar, but a little obsolete now since the RPC cache outperforms it and has some extra features. Otherwise the two have similar semantics and share quite a bit of implementation.\n\nPlease has server implementations for both the RPC and HTTP caches."`
 	Test struct {
 		Timeout         cli.Duration `help:"Default timeout applied to all tests. Can be overridden on a per-rule basis."`
-		Sandbox              bool         `help:"Deprecated, use sandbox.test instead."`
+		Sandbox         bool         `help:"Deprecated, use sandbox.test instead."`
 		DisableCoverage []string     `help:"Disables coverage for tests that have any of these labels spcified."`
 		Upload          cli.URL      `help:"URL to upload test results to (in XML format)"`
 	} `help:"A config section describing settings related to testing in general."`
 	Sandbox struct {
-		Tool string `help:"The location of the tool to use for sandboxing (typically please_sandbox)."`
-		Dir  []string `help:"Directories to hide within the sandbox"`
-		Build bool `help:"True to sandbox individual build actions, which isolates them from network access and some aspects of the filesystem. Currently only works on Linux." var:"BUILD_SANDBOX"`
-		Test bool `help:"True to sandbox individual tests, which isolates them from network access, IPC and some aspects of the filesystem. Currently only works on Linux." var:"TEST_SANDBOX"`
+		Tool  string   `help:"The location of the tool to use for sandboxing (typically please_sandbox)."`
+		Dir   []string `help:"Directories to hide within the sandbox"`
+		Build bool     `help:"True to sandbox individual build actions, which isolates them from network access and some aspects of the filesystem. Currently only works on Linux." var:"BUILD_SANDBOX"`
+		Test  bool     `help:"True to sandbox individual tests, which isolates them from network access, IPC and some aspects of the filesystem. Currently only works on Linux." var:"TEST_SANDBOX"`
 	} `help:"A config section describing settings relating to sandboxing of build actions."`
 	Remote struct {
 		URL           string       `help:"URL for the remote server."`

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -995,7 +995,7 @@ func newBlake3() hash.Hash {
 // callers can't initialise all the required private fields.
 func NewBuildState(config *Configuration) *BuildState {
 	// Deliberately ignore the error here so we don't require the sandbox tool until it's needed.
-	sandboxTool, _ := LookBuildPath(config.Build.PleaseSandboxTool, config)
+	sandboxTool, _ := LookBuildPath(config.Sandbox.Tool, config)
 	state := &BuildState{
 		Graph:        NewGraph(),
 		pendingTasks: queue.NewPriorityQueue(10000, true), // big hint, why not

--- a/test/build_defs/.plzconfig.e2e
+++ b/test/build_defs/.plzconfig.e2e
@@ -1,6 +1,6 @@
 ; Don't download tools. Tests should use the tools from this repo.
-[build]
-PleaseSandboxTool = please_sandbox
+[sandbox]
+Tool = please_sandbox
 
 [go]
 PleaseGoTool = please_go

--- a/tools/sandbox/sandbox.c
+++ b/tools/sandbox/sandbox.c
@@ -7,6 +7,7 @@
 
 #ifdef __linux__
 
+#include <errno.h>
 #include <sched.h>
 #include <signal.h>
 #include <string.h>
@@ -129,6 +130,26 @@ int mount_tmp() {
     if (mount("none", "/", NULL, MS_REMOUNT | MS_RDONLY | MS_BIND, NULL) != 0) {
         perror("remount ro");
         return 1;
+    }
+    // If SANDBOX_DIRS is set, we expect a comma-separated list of directories to mount a tmpfs over in order to hide them.
+    // If one or more directories don't exist, that is OK, but any other error is fatal.
+    char* dirs = getenv("SANDBOX_DIRS");
+    if (dirs != NULL) {
+      char *token = strtok(dirs, ",");
+      while(token) {
+        if (mount("tmpfs", token, "tmpfs", flags, NULL) != 0) {
+          if (errno == ENOTDIR) {
+            // This isn't fatal, it's OK for them not to exist (in that case we just have nothing to sandbox).
+            fprintf(stderr, "Not mounting over %s since it isn't a directory\n", token);
+          } else {
+            perror("mount tmpfs");
+            return 1;
+          }
+        }
+        token = strtok(NULL, ",");
+      }
+      // Remove the env var; downstream things don't need to know what these were.
+      unsetenv("SANDBOX_DIRS");
     }
     return chdir(d);
 }


### PR DESCRIPTION
Also restructures the sandbox config settings into their own section, which I think is a bit more logical (e.g. it's clear that the tool is global rather than `test` pulling in the one from `build`).
The old ones are deprecated, with the old settings carrying over for now; I assume the migration shouldn't be too hard tho.