### PR TITLE
Make please_go handle relative paths to tools

### DIFF
--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -1,12 +1,14 @@
 package main
 
 import (
-	"github.com/thought-machine/please/tools/please_go/test"
 	"log"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/peterebden/go-cli-init/v4/flags"
 
+	"github.com/thought-machine/please/tools/please_go/test"
 	"github.com/thought-machine/please/tools/please_go/install"
 )
 
@@ -38,7 +40,7 @@ var opts = struct {
 	} `command:"testmain" alias:"t" description:"Generates a go main package to run the tests in a package."`
 }{
 	Usage: `
-please-go is used by the go build rules to compile and test go modules and packages. 
+please-go is used by the go build rules to compile and test go modules and packages.
 
 Unlike 'go build', this tool doesn't rely on the go path or modules to find packages. Instead it takes in
 a go import config just like 'go tool compile/link -importcfg'.
@@ -52,8 +54,8 @@ var subCommands = map[string]func() int{
 			opts.PleaseGoInstall.ModuleName,
 			opts.PleaseGoInstall.ImportConfig,
 			opts.PleaseGoInstall.LDFlags,
-			opts.PleaseGoInstall.GoTool,
-			opts.PleaseGoInstall.CCTool,
+			mustResolvePath(opts.PleaseGoInstall.GoTool),
+			mustResolvePath(opts.PleaseGoInstall.CCTool),
 			opts.PleaseGoInstall.Out,
 		)
 		if err := pleaseGoInstall.Install(opts.PleaseGoInstall.Args.Packages); err != nil {
@@ -78,4 +80,19 @@ var subCommands = map[string]func() int{
 func main() {
 	command := flags.ParseFlagsOrDie("please-go", &opts)
 	os.Exit(subCommands[command]())
+}
+
+// mustResolvePath converts a relative path to absolute if it has any separators in it.
+func mustResolvePath(in string) string {
+	if in == "" {
+		return in
+	}
+	if !filepath.IsAbs(in) && strings.ContainsRune(in, filepath.Separator) {
+		abs, err := filepath.Abs(in)
+		if err != nil {
+			log.Fatalf("Failed to make %s absolute: %s", in, err)
+		}
+		return abs
+	}
+	return in
 }

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/peterebden/go-cli-init/v4/flags"
 
-	"github.com/thought-machine/please/tools/please_go/test"
 	"github.com/thought-machine/please/tools/please_go/install"
+	"github.com/thought-machine/please/tools/please_go/test"
 )
 
 var opts = struct {


### PR DESCRIPTION
Think this is causing some issues for remote execution; if the path to GoTool is e.g. `third_party/go/bin/go` then we need to make that absolute in order to exec it.

This doesn't come up for us internally; I think our servers still do a little magic to make this work, but will be needed for us to interoperate with Buildbarn / Buildgrid etc.