### PR TITLE
Stop sending output files & dirs

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -606,6 +606,19 @@ func (target *BuildTarget) FullOutputs() []string {
 	return outs
 }
 
+// AllOutputs returns a slice of all the outputs of this rule, including any output directories.
+// Outs are passed through GetTmpOutput as appropriate.
+func (target *BuildTarget) AllOutputs() []string {
+	outs := target.Outputs()
+	for i, out := range outs {
+		outs[i] = target.GetTmpOutput(out)
+	}
+	for _, out := range target.OutputDirectories {
+		outs = append(outs, out.Dir())
+	}
+	return outs
+}
+
 // NamedOutputs returns a slice of all the outputs of this rule with a given name.
 // If the name is not declared by this rule it panics.
 func (target *BuildTarget) NamedOutputs(name string) []string {

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -197,6 +197,14 @@ func TestFullOutputs(t *testing.T) {
 	assert.Equal(t, []string{"plz-out/gen/src/core/file1.go", "plz-out/gen/src/core/file2.go"}, target.FullOutputs())
 }
 
+func TestAllOutputs(t *testing.T) {
+	target := makeTarget1("//please:please", "PUBLIC")
+	target.AddOutput("please")
+	target.AddOutput("plz")
+	target.AddOutputDirectory("dir")
+	assert.Equal(t, []string{"please.out", "plz", "dir"}, target.AllOutputs())
+}
+
 func TestProvideFor(t *testing.T) {
 	// target1 is provided directly since they have a simple dependency
 	target1 := makeTarget1("//src/core:target1", "PUBLIC")

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -102,7 +102,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 			Arguments: []string{
 				"fetch", strings.Join(target.AllURLs(state), " "), "verify", strings.Join(target.Hashes, " "),
 			},
-			OutputPaths:       outs,
+			OutputPaths: outs,
 		}, nil
 	}
 	cmd := target.GetCommand(state)

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -90,9 +90,8 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 		commandPrefix += fmt.Sprintf("export %s=\"%s\" && ", k, v)
 	}
 
-	// TODO(peterebden): Remove this nonsense once API v2.1 is released.
-	files, dirs := outputs(target)
-	if len(target.Outputs()) == 1 { // $OUT is relative when running remotely; make it absolute
+	outs := target.AllOutputs()
+	if len(outs) == 1 { // $OUT is relative when running remotely; make it absolute
 		commandPrefix += `export OUT="$TMP_DIR/$OUT" && `
 	}
 	if target.IsRemoteFile {
@@ -103,9 +102,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 			Arguments: []string{
 				"fetch", strings.Join(target.AllURLs(state), " "), "verify", strings.Join(target.Hashes, " "),
 			},
-			OutputFiles:       files,
-			OutputDirectories: dirs,
-			OutputPaths:       append(files, dirs...),
+			OutputPaths:       outs,
 		}, nil
 	}
 	cmd := target.GetCommand(state)
@@ -117,9 +114,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 		Platform:             c.platform,
 		Arguments:            process.BashCommand(c.shellPath, commandPrefix+cmd, state.Config.Build.ExitOnError),
 		EnvironmentVariables: c.buildEnv(target, c.stampedBuildEnvironment(state, target, inputRoot, stamp), target.Sandbox),
-		OutputFiles:          files,
-		OutputDirectories:    dirs,
-		OutputPaths:          append(files, dirs...),
+		OutputPaths:          outs,
 	}, err
 }
 

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -334,28 +334,6 @@ func timeout(target *core.BuildTarget, test bool) time.Duration {
 	return target.BuildTimeout
 }
 
-// outputs returns the outputs of a target, split arbitrarily and inaccurately
-// into files and directories.
-// After some discussion we are hoping that servers are permissive about this if
-// we get it wrong; we prefer to make an effort though as a minor nicety.
-func outputs(target *core.BuildTarget) (files, dirs []string) {
-	outs := target.Outputs()
-	files = make([]string, 0, len(outs))
-	for _, out := range outs {
-		out = target.GetTmpOutput(out)
-		if !strings.ContainsRune(path.Base(out), '.') && !strings.HasSuffix(out, "file") && !target.IsBinary {
-			dirs = append(dirs, out)
-		} else {
-			files = append(files, out)
-		}
-	}
-
-	for _, out := range target.OutputDirectories {
-		dirs = append(dirs, out.Dir())
-	}
-	return files, dirs
-}
-
 // A dirBuilder is for helping build up a tree of Directory protos.
 //
 // This is pretty awkward; we need to recursively build a whole set of directories


### PR DESCRIPTION
Been wanting to get rid of this for ages.

At this point it is just making things worse as well as being ugly; I think most major REAPI servers support `output_paths` (at least Buildgrid and Buildbarn do), but while Buildgrid is coping OK, Buildbarn doesn't quite follow it right (they iterate all three fields whereas the API says you should ignore Files and Dirs if Paths is set). I might send them a PR for that too.