### PR TITLE
Fix binary go_get() targets when directly cross-compiling them

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -69,6 +69,7 @@ def go_toolchain(name:str, url:str|dict = '', version:str = '', hashes:list = []
         } if CONFIG.CGO_ENABLED == "1" else {},
         binary = True,
         visibility = visibility,
+        building_description = "Installing...",
     )
 
 
@@ -952,7 +953,11 @@ def _go_install(name:str, get_roots:list, install:list, binary:bool, srcs:list, 
         ]
 
     if binary:
-        outs = ['bin/' + name]
+        if CONFIG.OS == CONFIG.HOSTOS and CONFIG.OS == CONFIG.HOSTARCH:
+            outs = [f'bin/{name}']
+        else:
+            outs = [f'bin/{CONFIG.GOOS}_{CONFIG.GOARCH}/{name}']
+
     else:
         outs = [f'pkg/{CONFIG.GOOS}_{CONFIG.GOARCH}/{out}' for out in outs]
         # Outputs are created one directory down from where we want them.

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -953,7 +953,7 @@ def _go_install(name:str, get_roots:list, install:list, binary:bool, srcs:list, 
         ]
 
     if binary:
-        if CONFIG.OS == CONFIG.HOSTOS and CONFIG.OS == CONFIG.HOSTARCH:
+        if CONFIG.OS == CONFIG.HOSTOS and CONFIG.ARCH == CONFIG.HOSTARCH:
             outs = [f'bin/{name}']
         else:
             outs = [f'bin/{CONFIG.GOOS}_{CONFIG.GOARCH}/{name}']


### PR DESCRIPTION
This didn't really come up because generally these are used by tools and so aren't actually cross compiled. 