### PR TITLE
Rewrite argv to new location in sandbox

### DIFF
--- a/tools/sandbox/BUILD
+++ b/tools/sandbox/BUILD
@@ -19,3 +19,11 @@ c_binary(
     visibility = ["PUBLIC"],
     deps = [":sandbox"],
 )
+
+cc_test(
+    name = "sandbox_test",
+    srcs = ["sandbox_test.cc"],
+    deps = [
+        ":sandbox",
+    ],
+)

--- a/tools/sandbox/sandbox.c
+++ b/tools/sandbox/sandbox.c
@@ -82,23 +82,6 @@ int map_ids(int out_id, const char* path) {
     return 0;
 }
 
-// exec_name returns the name of the new binary to exec() as.
-// old_name is the current name; if it's within old_dir it will be re-prefixed to new_dir.
-char* exec_name(const char* old_name, const char* old_dir, const char* new_dir) {
-  const int new_dir_len = strlen(new_dir);
-  const int old_dir_len = strlen(old_dir);
-  const int old_name_len = strlen(old_name);
-  if (strncmp(old_dir, old_name, old_dir_len) != 0) {  // is old_name prefixed with old_dir
-    return (char*)old_name;  // Dodgy cast but we know we don't alter it again later.
-  }
-  const int new_len = new_dir_len + old_name_len - old_dir_len + 1;
-  char* new_name = malloc(new_len + 1);
-  strcpy(new_name, new_dir);
-  strcpy(new_name + new_dir_len, old_name + old_dir_len);
-  new_name[new_len] = 0;
-  return new_name;
-}
-
 // mount_tmp mounts a tmpfs on /tmp for the tests to muck about in and
 // bind mounts the test directory to /tmp/plz_sandbox.
 // If the given string pointer (the argv[0] of the new process) is within the old temp dir
@@ -280,3 +263,20 @@ int contain(char* argv[], bool net, bool mount) {
 }
 
 #endif  // __linux__
+
+// exec_name returns the name of the new binary to exec() as.
+// old_name is the current name; if it's within old_dir it will be re-prefixed to new_dir.
+char* exec_name(const char* old_name, const char* old_dir, const char* new_dir) {
+  const int new_dir_len = strlen(new_dir);
+  const int old_dir_len = strlen(old_dir);
+  const int old_name_len = strlen(old_name);
+  if (strncmp(old_dir, old_name, old_dir_len) != 0) {  // is old_name prefixed with old_dir
+    return (char*)old_name;  // Dodgy cast but we know we don't alter it again later.
+  }
+  const int new_len = new_dir_len + old_name_len - old_dir_len + 1;
+  char* new_name = malloc(new_len + 1);
+  strcpy(new_name, new_dir);
+  strcpy(new_name + new_dir_len, old_name + old_dir_len);
+  new_name[new_len] = 0;
+  return new_name;
+}

--- a/tools/sandbox/sandbox.c
+++ b/tools/sandbox/sandbox.c
@@ -84,12 +84,12 @@ int map_ids(int out_id, const char* path) {
 
 // exec_name returns the name of the new binary to exec() as.
 // old_name is the current name; if it's within old_dir it will be re-prefixed to new_dir.
-char* exec_name(char* old_name, const char* old_dir, const char* new_dir) {
+char* exec_name(const char* old_name, const char* old_dir, const char* new_dir) {
   const int new_dir_len = strlen(new_dir);
   const int old_dir_len = strlen(old_dir);
   const int old_name_len = strlen(old_name);
   if (strncmp(old_dir, old_name, old_dir_len) != 0) {  // is old_name prefixed with old_dir
-    return old_name;
+    return (char*)old_name;  // Dodgy cast but we know we don't alter it again later.
   }
   const int new_len = new_dir_len + old_name_len - old_dir_len + 1;
   char* new_name = malloc(new_len + 1);

--- a/tools/sandbox/sandbox.c
+++ b/tools/sandbox/sandbox.c
@@ -3,6 +3,7 @@
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #ifdef __linux__
@@ -10,7 +11,6 @@
 #include <errno.h>
 #include <sched.h>
 #include <signal.h>
-#include <string.h>
 #include <net/if.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>

--- a/tools/sandbox/sandbox.h
+++ b/tools/sandbox/sandbox.h
@@ -5,3 +5,7 @@
 // whether it should move to new network and mount namespaces.
 // It returns an exit code (so 0 on success, nonzero on failure).
 int contain(char* argv[], bool net, bool mount);
+
+// exec_name returns the name of the new binary to exec() as.
+// old_name is the current name; if it's within old_dir it will be re-prefixed to new_dir.
+char* exec_name(const char* old_name, const char* old_dir, const char* new_dir);

--- a/tools/sandbox/sandbox_test.cc
+++ b/tools/sandbox/sandbox_test.cc
@@ -1,0 +1,26 @@
+#include <UnitTest++/UnitTest++.h>
+
+extern "C" {
+#include "tools/sandbox/sandbox.h"
+}
+
+namespace plz {
+
+TEST(ExecNameNotWithinDir) {
+  CHECK_EQUAL("/usr/bin/bash", exec_name("/usr/bin/bash", "/work/plz-out/tmp/target.build", "/tmp/plz_sandbox"));
+}
+
+TEST(ExecNameWithinDir) {
+  CHECK_EQUAL("/tmp/plz_sandbox/test.bin", exec_name("/work/plz-out/tmp/target.build/test.bin", "/work/plz-out/tmp/target.build", "/tmp/plz_sandbox"));
+}
+
+TEST(ExecNameShorterThanSandboxDir) {
+  CHECK_EQUAL("/tmp/plz_sandbox/test.bin", exec_name("/lib/test.bin", "/lib", "/tmp/plz_sandbox"));
+}
+
+TEST(SameDir) {
+  // We wouldn't normally do this but it should still work fine.
+  CHECK_EQUAL("/tmp/plz_sandbox/test.bin", exec_name("/tmp/plz_sandbox/test.bin", "/tmp/plz_sandbox", "/tmp/plz_sandbox"));
+}
+
+}


### PR DESCRIPTION
Previously it was still pointing through to the old workdir, so if things used `argv[0]` to look up their own location, they'd get a readonly copy.