### PR TITLE
Deprecate raise

### DIFF
--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -3,9 +3,8 @@ file_input = { statement };
 
 # Any single statement. Must occur on its own line.
 statement = ( "pass" | "continue" | func_def | for | if | return |
-          raise | assert | ident_statement | literal ) EOL;
+             assert | ident_statement | literal ) EOL;
 return = "return" [ expression { "," expression } ];
-raise = "raise" expression;
 assert = "assert" expression [ "," expression ];
 for = "for" Ident { "," Ident } "in" expression ":" EOL { statement };
 if = "if" expression ":" EOL { statement }

--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -1080,6 +1080,18 @@
       </li>
     </ul>
   </section>
+
+  <section class="mt4">
+    <h3 class="title-3" id="fail">
+      fail
+    </h3>
+
+    <code class="code-signature">fail(message)</code>
+
+    <p>Causes an immediate failure in parsing of the current build file.</p>
+
+    <p>Use this where you might <code>raise</code> in Python.</p>
+  </section>
 </section>
 
 <section class="mt4">

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -210,11 +210,15 @@ def dirname(p:str) -> str:
     return before
 
 
-# Exception types.
-# There is no actual Exception, but str() is similar enough here.
-ParseError = str
-ConfigError = str
-ValueError = str
+def _deprecated_exception(msg):
+    log.warning('Builtin exception types are deprecated, please use fail() instead. ' +
+                'See https://github.com/thought-machine/please/issues/1598 for more information.')
+    return str(msg)
+
+# These are deprecated and will be removed in v17.
+ParseError = _deprecated_exception
+ConfigError = _deprecated_exception
+ValueError = _deprecated_exception
 
 
 # Post-build callback functions.

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -96,9 +96,9 @@ def int(s:str) -> int:
 def str(s) -> str:
     pass
 def list(l):
-    raise 'list is not callable'
+    fail('list is not callable')
 def dict(d):
-    raise 'dict is not callable'
+    fail('dict is not callable')
 
 
 def glob(include:list, exclude:list&excludes=[], hidden:bool=CONFIG.BAZEL_COMPATIBILITY) -> list:
@@ -153,13 +153,13 @@ def copy(self:dict) -> dict:
 
 
 def git_branch(short:bool=True) -> str:
-    raise 'Disabled in config'
+    fail('Disabled in config')
 def git_commit() -> str:
-    raise 'Disabled in config'
+    fail('Disabled in config')
 def git_show(fmt:str) -> str:
-    raise 'Disabled in config'
+    fail('Disabled in config')
 def git_state(clean_label:str="clean", dirty_label:str="dirty") -> str:
-    raise 'Disabled in config'
+    fail('Disabled in config')
 
 def debug(args):
     pass
@@ -258,4 +258,3 @@ def json(value) -> str:
 def breakpoint():
     """Breaks into an interactive debugging session."""
     pass
-

--- a/rules/config_rules.build_defs
+++ b/rules/config_rules.build_defs
@@ -63,7 +63,7 @@ def _config_on(name, value):
     elif name == 'os':
         return CONFIG.OS == value.lower()
     else:
-        raise ParseError('Unknown config_setting key %s' % name)
+        fail('Unknown config_setting key %s' % name)
 
 
 # We name CPUs as Go does, but support some additional aliases to match Bazel.

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -26,7 +26,7 @@ def go_toolchain(name:str, url:str|dict = '', version:str = '', hashes:list = []
                             want to manually cross-compile parts of the repo but not others.
     """
     if url and version:
-        raise ParseError("Either version or url should be provided but not both")
+        fail("Either version or url should be provided but not both")
 
     if version:
         sdk_url = f'https://golang.org/dl/go{version}.{CONFIG.HOSTOS}-{CONFIG.HOSTARCH}.tar.gz'
@@ -1080,10 +1080,10 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
                   aspects of compilation.
     """
     if version and download:
-        raise ParseError("You have provided both version and download. Must provided one or the other.")
+        fail("You have provided both version and download. Must provided one or the other.")
 
     if not download and not version:
-        raise ParseError("Either version or download should be provided")
+        fail("Either version or download should be provided")
 
     install = [f"{module}/{i}" if i != "." else module for i in install]
 
@@ -1297,7 +1297,7 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
 
     # in case of installing packages using other package sources
     if not get and not install:
-        raise ParseError("must provide get or install!")
+        fail("must provide get or install!")
     else:
         if not srcs and not binary:
             # we are going to infer the getroot name from the 1st install dependency
@@ -1549,7 +1549,7 @@ def _go_import_path_cmd(import_path):
     if not import_path:
         return ''
     elif import_path.startswith('/'):
-        raise ConfigError('GO_IMPORT_PATH cannot start with a /')
+        fail('GO_IMPORT_PATH cannot start with a /')
     elif '/' in import_path:
         return ' && mkdir -p %s && ln -s "$TMP_DIR" %s' % (dirname(import_path), import_path)
     else:
@@ -1581,7 +1581,7 @@ def _replace_test_package(name, output, static, definitions, cgo):
     built for this test which has the actual test functions in it.
     """
     if not name.endswith('#main') or not name.startswith('_'):
-        raise ValueError('unexpected rule name: ' + name)
+        fail('unexpected rule name: ' + name)
     lib = name[:-5] + '#main_lib'
     new_name = name[1:-5]
     for line in output:

--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -35,7 +35,7 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], 
             resources_cmd = '$(for SRC in $SRCS_RESOURCES; do mkdir -p $(dirname "_tmp/$SRC");cp "$SRC" "_tmp/$SRC"; done)'
 
     if srcs and src_dir:
-        raise ParseError('You cannot pass both srcs and src_dir to java_library')
+        fail('You cannot pass both srcs and src_dir to java_library')
     if srcs or src_dir:
         if javac_flags:
             # See http://bazel.io/blog/2015/06/25/ErrorProne.html for more info about this flag;
@@ -196,11 +196,11 @@ def java_runtime_image(name:str, main_module:str, main_class:str, modules:list, 
       jlink_args (str): Arguments to pass to the JVM in the run script.
     """
     if not CONFIG.JAVA_HOME:
-        raise Exception('Java home needs to be set to link java runtime images against jmods.')
+        fail('Java home needs to be set to link java runtime images against jmods.')
     if not CONFIG.JLINK_TOOL:
-        raise Exception('A jlink tool is required to build java runtime images.')
+        fail('A jlink tool is required to build java runtime images.')
     if not modules:
-        raise Exception('You cannot assemble a java runtime image without specifying any modules.')
+        fail('You cannot assemble a java runtime image without specifying any modules.')
     out = out or name
     depflags = r'`find "$TMP_DIR" -name "*.jar" | tr \\\\n :`'
     modules = ','.join(modules)
@@ -240,7 +240,7 @@ def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, dep
       toolchain (str): A label identifying a java_toolchain rule which will be used to build this java binary.
     """
     if main_class and manifest:
-        raise ParseError("Can't pass both main_class and manifest to java_binary")
+        fail("Can't pass both main_class and manifest to java_binary")
     if srcs:
         lib_rule = java_library(
             name = f'_{name}#lib',
@@ -386,7 +386,7 @@ def maven_jar(name:str, id:str, repository:str|list=None, hash:str=None, hashes:
                      e.g. logback-core-1.1.3-tests.jar and logback-core-1.1.3-test-sources.jar
     """
     if hash and hashes:
-        raise ParseError('You can pass only one of hash or hashes to maven_jar')
+        fail('You can pass only one of hash or hashes to maven_jar')
 
     hashes = hashes if hashes else [hash] if hash else None
 
@@ -495,7 +495,7 @@ def _parse_maven_artifact(id, sources=True, licences=None):
     elif len(parts) == 3:
         group, artifact, version = parts
     else:
-        raise ParseError(f'Unknown artifact format: {id} (should be group:artifact:version)')
+        fail(f'Unknown artifact format: {id} (should be group:artifact:version)')
     return group, artifact, version, sources, licences
 
 
@@ -515,13 +515,13 @@ def _jarcat_cmd(main_class=None, preamble=None, manifest=None):
 def _java_toolchain(name : str, jdk_url : str|dict='', jdk:str='', visibility:list = ["PUBLIC"], hashes = []) -> str:
     """Downloads the JDK so language rules can use the toolchain"""
     if jdk_url and jdk:
-        raise ParseError("Either jdk or jdk_url should be provided but not both")
+        fail("Either jdk or jdk_url should be provided but not both")
 
     if not jdk:
         jdk_url = jdk_url if isinstance(jdk_url, str) else jdk_url.get(CONFIG.OS)
 
         if not jdk_url:
-            raise ParseError(f"No jdk_url defined for platform {CONFIG.OS}")
+            fail(f"No jdk_url defined for platform {CONFIG.OS}")
 
         jdk = remote_file(
             name=f"_{name}#download",

--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -107,7 +107,7 @@ def genrule(name:str, cmd:str|list|dict, srcs:list|dict=None, out:str=None, outs
       env (dict): Any additional environment variables to set for this build rule.
     """
     if out and outs:
-        raise TypeError('Can\'t specify both "out" and "outs".')
+        fail('Can\'t specify both "out" and "outs".')
     return build_rule(
         name = name,
         srcs = srcs,
@@ -576,11 +576,11 @@ def decompose(label:str):
         package, _, name = label.partition(':')
         return package.lstrip('/'), name
     else:
-        raise ValueError(f"{label} doesn't look like a build label")
+        fail(f"{label} doesn't look like a build label")
 
 
 def check_config(key:str, section:str='buildconfig', rule:str='', example:str='...'):
-    """Checks the configuration for the given item and raises an exception if it's not set.
+    """Checks the configuration for the given item and dies if it's not set.
 
     Args:
       key (str): Config key that must be set, e.g. ANDROID_HOME
@@ -595,7 +595,7 @@ def check_config(key:str, section:str='buildconfig', rule:str='', example:str='.
         rule_msg = f' to use {rule} rules' if rule else ''
         msg = f'You must set {section}.{key} in your .plzconfig{rule_msg}'
         msg = f'{msg}, e.g.\n[{section}]\n{key} = {example}\n'
-        raise ConfigError(msg)
+        fail(msg)
     return val
 
 

--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -80,7 +80,7 @@ def python_library(name:str, srcs:list=[], resources:list=[], deps:list=[], visi
         )
         deps += [zip_rule]
     elif strip:
-        raise ParseError("Can't pass strip=True to a python_library with no srcs")
+        fail("Can't pass strip=True to a python_library with no srcs")
 
     return filegroup(
         name=name,
@@ -488,8 +488,7 @@ def python_wheel(name:str, version:str, hashes:list=None, package_name:str=None,
     initial = package_name[0]
     url_base = repo or CONFIG.PYTHON_WHEEL_REPO
     if not url_base:
-        raise ParseError('python.wheel_repo is not set in the config, must pass repo explicitly '
-                         'to python_wheel')
+        fail('python.wheel_repo is not set in the config, must pass repo explicitly to python_wheel')
     urls = []
     if name_scheme:
         urls += [name_scheme.format(url_base=url_base,

--- a/src/parse/asp/grammar.go
+++ b/src/parse/asp/grammar.go
@@ -32,7 +32,7 @@ type Statement struct {
 	For     *ForStatement
 	If      *IfStatement
 	Return  *ReturnStatement
-	Raise   *Expression
+	Raise   *Expression  // Deprecated
 	Assert  *struct {
 		Expr    *Expression
 		Message *Expression

--- a/src/parse/asp/grammar.go
+++ b/src/parse/asp/grammar.go
@@ -32,7 +32,7 @@ type Statement struct {
 	For     *ForStatement
 	If      *IfStatement
 	Return  *ReturnStatement
-	Raise   *Expression  // Deprecated
+	Raise   *Expression // Deprecated
 	Assert  *struct {
 		Expr    *Expression
 		Message *Expression

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -349,6 +349,7 @@ func (s *scope) interpretStatements(statements []*Statement) pyObject {
 				}
 			}
 		} else if stmt.Raise != nil {
+			log.Warning("The raise keyword is deprecated, please use fail() instead. See https://github.com/thought-machine/please/issues/1598 for more information.")
 			s.Error(s.interpretExpression(stmt.Raise).String())
 		} else if stmt.Literal != nil {
 			s.interpretExpression(stmt.Literal)


### PR DESCRIPTION
Adds explicit warnings on creating exception types or the `raise` statement.

Starts on #1598 although I don't think we should finish it off until v17.