### PR TITLE
Save file walking results in glob()

### DIFF
--- a/src/fs/glob.go
+++ b/src/fs/glob.go
@@ -65,6 +65,29 @@ func IsGlob(pattern string) bool {
 // Glob implements matching using Go's built-in filepath.Glob, but extends it to support
 // Ant-style patterns using **.
 func Glob(buildFileNames []string, rootPath string, includes, excludes []string, includeHidden bool) []string {
+	return NewGlobber(buildFileNames).Glob(rootPath, includes, excludes, includeHidden)
+}
+
+// A Globber is used to implement Glob. You can persist one for use to save repeated filesystem calls, but
+// it isn't safe for use in concurrent goroutines.
+type Globber struct{
+	buildFileNames []string
+	walkedDirs     map[string]walkedDir
+}
+
+type walkedDir struct{
+	fileNames, subPackages []string
+}
+
+// NewGlobber creates a new Globber. You should call this rather than creating one directly (or use Glob() if you don't care).
+func NewGlobber(buildFileNames []string) *Globber {
+	return &Globber{
+		buildFileNames: buildFileNames,
+		walkedDirs: map[string]walkedDir{},
+	}
+}
+
+func (globber *Globber) Glob(rootPath string, includes, excludes []string, includeHidden bool) []string {
 	if rootPath == "" {
 		rootPath = "."
 	}
@@ -73,7 +96,7 @@ func Glob(buildFileNames []string, rootPath string, includes, excludes []string,
 	for _, include := range includes {
 		mustBeValidGlobString(include)
 
-		matches, err := glob(rootPath, include, excludes, buildFileNames, includeHidden)
+		matches, err := globber.glob(rootPath, include, excludes, includeHidden)
 		if err != nil {
 			panic(fmt.Errorf("error globbing files with %v: %v", include, err))
 		}
@@ -85,38 +108,27 @@ func Glob(buildFileNames []string, rootPath string, includes, excludes []string,
 	return filenames
 }
 
-func glob(rootPath string, glob string, excludes []string, buildFileNames []string, includeHidden bool) ([]string, error) {
+func (globber *Globber) glob(rootPath string, glob string, excludes []string, includeHidden bool) ([]string, error) {
 	p, err := patternToMatcher(rootPath, glob)
 	if err != nil {
 		return nil, err
 	}
-
-	var globMatches []string
-	var subPackages []string
-	err = Walk(rootPath, func(name string, isDir bool) error {
-		if isBuildFile(buildFileNames, name) {
-			packageName := filepath.Dir(name)
-			if packageName != rootPath {
-				subPackages = append(subPackages, packageName)
-				return filepath.SkipDir
-			}
-		}
-		match, err := p.Match(name)
-		if err != nil {
-			return err
-		}
-		if match {
-			globMatches = append(globMatches, name)
-		}
-		return nil
-	})
+	walkedDir, err := globber.walkDir(rootPath)
 	if err != nil {
 		return nil, err
+	}
+	var globMatches []string
+	for _, name := range walkedDir.fileNames {
+		if match, err := p.Match(name); err != nil {
+			return nil, err
+		} else if match {
+			globMatches = append(globMatches, name)
+		}
 	}
 
 	matches := make([]string, 0, len(globMatches))
 	for _, m := range globMatches {
-		if isInDirectories(m, subPackages) {
+		if isInDirectories(m, walkedDir.subPackages) {
 			continue
 		}
 		if !includeHidden && isHidden(m) {
@@ -134,6 +146,28 @@ func glob(rootPath string, glob string, excludes []string, buildFileNames []stri
 		matches = append(matches, m)
 	}
 	return matches, nil
+}
+
+func (globber *Globber) walkDir(rootPath string) (walkedDir, error) {
+	if dir, present := globber.walkedDirs[rootPath]; present {
+		return dir, nil
+	}
+	dir := walkedDir{}
+	if err := Walk(rootPath, func(name string, isDir bool) error {
+		if isBuildFile(globber.buildFileNames, name) {
+			packageName := filepath.Dir(name)
+			if packageName != rootPath {
+				dir.subPackages = append(dir.subPackages, packageName)
+				return filepath.SkipDir
+			}
+		}
+		dir.fileNames = append(dir.fileNames, name)
+		return nil
+	}); err != nil {
+		return dir, err
+	}
+	globber.walkedDirs[rootPath] = dir
+	return dir, nil
 }
 
 func mustBeValidGlobString(glob string) {

--- a/src/fs/glob.go
+++ b/src/fs/glob.go
@@ -70,12 +70,12 @@ func Glob(buildFileNames []string, rootPath string, includes, excludes []string,
 
 // A Globber is used to implement Glob. You can persist one for use to save repeated filesystem calls, but
 // it isn't safe for use in concurrent goroutines.
-type Globber struct{
+type Globber struct {
 	buildFileNames []string
 	walkedDirs     map[string]walkedDir
 }
 
-type walkedDir struct{
+type walkedDir struct {
 	fileNames, subPackages []string
 }
 
@@ -83,7 +83,7 @@ type walkedDir struct{
 func NewGlobber(buildFileNames []string) *Globber {
 	return &Globber{
 		buildFileNames: buildFileNames,
-		walkedDirs: map[string]walkedDir{},
+		walkedDirs:     map[string]walkedDir{},
 	}
 }
 

--- a/src/fs/glob_test.go
+++ b/src/fs/glob_test.go
@@ -12,8 +12,12 @@ import (
 
 var buildFileNames = []string{"TEST_BUILD", "BUILD"}
 
+func glob(rootPath string, glob string, excludes []string, includeHidden bool) ([]string, error) {
+	return NewGlobber(buildFileNames).glob(rootPath, glob, excludes, includeHidden)
+}
+
 func TestCanGlobFileAtRootWithDoubleStar(t *testing.T) {
-	files, err := glob("src/fs/test_data/test_subfolder1", "**/*.txt", nil, buildFileNames, false)
+	files, err := glob("src/fs/test_data/test_subfolder1", "**/*.txt", nil, false)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{
 		"src/fs/test_data/test_subfolder1/a.txt",
@@ -22,7 +26,7 @@ func TestCanGlobFileAtRootWithDoubleStar(t *testing.T) {
 }
 
 func TestCanGlobDirectories(t *testing.T) {
-	files, err := glob("src/fs", "test_data/*", nil, buildFileNames, false)
+	files, err := glob("src/fs", "test_data/*", nil,  false)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{
 		"src/fs/test_data/test_subfolder++",
@@ -42,7 +46,7 @@ func TestIsGlob(t *testing.T) {
 }
 
 func TestGlobRanges(t *testing.T) {
-	files, err := glob("src/fs/test_data", "test_subfolder3/[a-z]est.py", nil, buildFileNames, false)
+	files, err := glob("src/fs/test_data", "test_subfolder3/[a-z]est.py", nil, false)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{
 		"src/fs/test_data/test_subfolder3/test.py",
@@ -51,7 +55,7 @@ func TestGlobRanges(t *testing.T) {
 }
 
 func TestGlobQuestion(t *testing.T) {
-	files, err := glob("src/fs/test_data", "test_subfolder3/?est.py", nil, buildFileNames, false)
+	files, err := glob("src/fs/test_data", "test_subfolder3/?est.py", nil, false)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{
 		"src/fs/test_data/test_subfolder3/test.py",
@@ -61,7 +65,7 @@ func TestGlobQuestion(t *testing.T) {
 }
 
 func TestGlobPlusPlusInDirName(t *testing.T) {
-	files, err := glob("src/fs/test_data/test_subfolder++", "**/*.txt", nil, buildFileNames, false)
+	files, err := glob("src/fs/test_data/test_subfolder++", "**/*.txt", nil, false)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"src/fs/test_data/test_subfolder++/test.txt"}, files)
 }

--- a/src/fs/glob_test.go
+++ b/src/fs/glob_test.go
@@ -26,7 +26,7 @@ func TestCanGlobFileAtRootWithDoubleStar(t *testing.T) {
 }
 
 func TestCanGlobDirectories(t *testing.T) {
-	files, err := glob("src/fs", "test_data/*", nil,  false)
+	files, err := glob("src/fs", "test_data/*", nil, false)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{
 		"src/fs/test_data/test_subfolder++",

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -480,7 +480,10 @@ func glob(s *scope, args []pyObject) pyObject {
 	exclude := asStringList(s, args[1], "exclude")
 	hidden := args[2].IsTruthy()
 	exclude = append(exclude, s.state.Config.Parse.BuildFileName...)
-	return fromStringList(fs.Glob(s.state.Config.Parse.BuildFileName, s.pkg.SourceRoot(), include, exclude, hidden))
+	if s.globber == nil {
+		s.globber = fs.NewGlobber(s.state.Config.Parse.BuildFileName)
+	}
+	return fromStringList(s.globber.Glob(s.pkg.SourceRoot(), include, exclude, hidden))
 }
 
 func asStringList(s *scope, arg pyObject, name string) []string {

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/fs"
 )
 
 // An interpreter holds the package-independent state about our parsing process.
@@ -195,6 +196,7 @@ type scope struct {
 	parent      *scope
 	locals      pyDict
 	config      *pyConfig
+	globber     *fs.Globber
 	// True if this scope is for a pre- or post-build callback.
 	Callback bool
 


### PR DESCRIPTION
It can be very slow to do repeated `glob()` calls into a large directory; I am testing with some work on LLVM and it takes approx 15 seconds to get plz to sort itself out and get moving.

Basically all the time is spent walking it over and over again. Main issue is that we walk the entire root dir every time, which can be (and in this case is) large, even if the glob expressions are fairly targeted.

This essentially memoises those walks; I think there is more we could do about (possibly?) more efficient matching, or getting really smart about walking bits of the tree as needed, but this is pretty good (and simple) for now.

Reduces time from ~15s -> ~2.7s in my use case.