### PR TITLE
Optimise for fixed path prefixes in glob()

### DIFF
--- a/src/fs/glob.go
+++ b/src/fs/glob.go
@@ -94,7 +94,13 @@ func (ft *fileTree) Add(name string) {
 // AllPrefixed returns all files in this tree with the given prefix.
 func (ft *fileTree) AllPrefixed(prefix []string) []string {
 	if len(prefix) == 0 {
-		return ft.files
+		ret := ft.files[:]
+		for name, child := range ft.children {
+			for _, file := range child.AllPrefixed(nil) {
+				ret = append(ret, path.Join(name, file))
+			}
+		}
+		return ret
 	}
 	child, present := ft.children[prefix[0]]
 	if !present {

--- a/src/fs/glob.go
+++ b/src/fs/glob.go
@@ -101,6 +101,7 @@ func (ft *fileTree) AllPrefixed(prefix []string) []string {
 				ret = append(ret, path.Join(name, file))
 			}
 		}
+		sort.Strings(ret)
 		return ret
 	}
 	child, present := ft.children[prefix[0]]
@@ -241,7 +242,7 @@ func (globber *Globber) walkDir(rootPath string) (walkedDir, error) {
 }
 
 // globPrefix extracts the fixed prefix part from a glob expression.
-// i.e. "src/fs/**/*.go" -> ["src", "fs"], ["**", "/*.go"]
+// i.e. "src/fs/**/*.go" -> ["src", "fs"]
 func (globber *Globber) globPrefix(expression string) []string {
 	parts := splitPath(expression)
 	for i, part := range parts {
@@ -249,7 +250,9 @@ func (globber *Globber) globPrefix(expression string) []string {
 			return parts[:i]
 		}
 	}
-	// If we get here, the entire expression was fixed; leave the last item off which saves some craziness later.
+	// If we get here, the entire expression was fixed; leave the last item off which other
+	// parts of the code find easier to handle later - we would otherwise have to special case
+	// the glob matches since we don't want to do `filepath.Glob("")`.
 	return parts[:len(parts)-1]
 }
 

--- a/src/fs/glob.go
+++ b/src/fs/glob.go
@@ -156,11 +156,6 @@ func (globber *Globber) Glob(rootPath string, includes, excludes []string, inclu
 	var filenames []string
 	for _, include := range includes {
 		mustBeValidGlobString(include)
-		// TODO(peterebden): Add this to mustBeValidGlobString as a fatal error in v17
-		if strings.HasPrefix(include, "/") {
-			log.Warning("Glob expression %s should not begin with a /", include)
-			include = strings.TrimPrefix(include, "/")
-		}
 
 		matches, err := globber.glob(rootPath, include, excludes, includeHidden)
 		if err != nil {
@@ -259,6 +254,9 @@ func (globber *Globber) globPrefix(expression string) []string {
 func mustBeValidGlobString(glob string) {
 	if glob == "" {
 		panic("cannot use an empty string as a glob")
+	}
+	if strings.HasPrefix(glob, "/") {
+		panic("globs cannot be absolute")
 	}
 }
 

--- a/src/fs/glob.go
+++ b/src/fs/glob.go
@@ -156,6 +156,8 @@ func (globber *Globber) Glob(rootPath string, includes, excludes []string, inclu
 	var filenames []string
 	for _, include := range includes {
 		mustBeValidGlobString(include)
+		// glob(["./x"]) is equivalent to just glob(["x"])
+		include = strings.TrimPrefix(include, "./")
 
 		matches, err := globber.glob(rootPath, include, excludes, includeHidden)
 		if err != nil {

--- a/src/fs/glob.go
+++ b/src/fs/glob.go
@@ -156,6 +156,11 @@ func (globber *Globber) Glob(rootPath string, includes, excludes []string, inclu
 	var filenames []string
 	for _, include := range includes {
 		mustBeValidGlobString(include)
+		// TODO(peterebden): Add this to mustBeValidGlobString as a fatal error in v17
+		if strings.HasPrefix(include, "/") {
+			log.Warning("Glob expression %s should not begin with a /", include)
+			include = strings.TrimPrefix(include, "/")
+		}
 
 		matches, err := globber.glob(rootPath, include, excludes, includeHidden)
 		if err != nil {

--- a/src/fs/glob.go
+++ b/src/fs/glob.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -111,6 +112,7 @@ func (ft *fileTree) AllPrefixed(prefix []string) []string {
 	for i, name := range files {
 		ret[i] = path.Join(prefix[0], name)
 	}
+	sort.Strings(ret)
 	return ret
 }
 

--- a/src/fs/glob.go
+++ b/src/fs/glob.go
@@ -93,7 +93,7 @@ func (ft *fileTree) Add(name string) {
 
 // AllPrefixed returns all files in this tree with the given prefix.
 func (ft *fileTree) AllPrefixed(prefix []string) []string {
-	if len(prefix) == 0 {
+	if len(prefix) == 0 || (len(prefix) == 1 && prefix[0] == ".") {
 		ret := ft.files[:]
 		for name, child := range ft.children {
 			for _, file := range child.AllPrefixed(nil) {


### PR DESCRIPTION
Basically lets us walk into fixed prefix parts efficiently rather than always walking over every possible path and trying to match them.

Reduces my test case from 5s -> 0.5s

Mildly worried about the increase in complexity here. All tests pass but I am a little worried that it'd be possible to get some edge case wrong.