### PR TITLE
Intepret statements that contain only literal expressions.

### DIFF
--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -351,7 +351,7 @@ func (s *scope) interpretStatements(statements []*Statement) pyObject {
 		} else if stmt.Raise != nil {
 			s.Error(s.interpretExpression(stmt.Raise).String())
 		} else if stmt.Literal != nil {
-			// Do nothing, literal statements are likely docstrings and don't require any action.
+			s.interpretExpression(stmt.Literal)
 		} else if stmt.Continue {
 			// This is definitely awkward since we need to control a for loop that's happening in a function outside this scope.
 			return continueIteration


### PR DESCRIPTION
It's not a nice pattern IMO but happens in Bazelisms where you can't have top-level loops so constructs like
```
[cc_library(
    ....
) for x in y]
```
are maybe more common (in plz I would encourage a straight for loop which I think is a lot clearer).

Bit surprised we've not run into this before...