### PR TITLE
Update alt image to Go 1.16.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
    build-linux-alt:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu_alt:20210313
+       - image: thoughtmachine/please_ubuntu_alt:20210316
      resource_class: large
      environment:
        PLZ_ARGS: "-p -c cover --profile ci-alt"

--- a/tools/images/ubuntu_alt/Dockerfile
+++ b/tools/images/ubuntu_alt/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get update && \
     curl unzip git locales pkg-config zlib1g-dev clang && \
     apt-get clean
 
-# Go - we want to test 1.15 here to check we're compatible but the latest package available is 1.10.
-RUN curl -fsSL https://dl.google.com/go/go1.15.10.linux-amd64.tar.gz | tar -xzC /usr/local
+# Go - we require 1.16 here to check we're compatible but the latest package available is 1.10.
+RUN curl -fsSL https://dl.google.com/go/go1.16.2.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Locale


### PR DESCRIPTION
We're going to need this for #1601 (and you mentioned it in #1649 too)