### PR TITLE
Add -I. to protoc

### DIFF
--- a/rules/proto_rules.build_defs
+++ b/rules/proto_rules.build_defs
@@ -390,7 +390,7 @@ def _protoc_rule(name, srcs, deps, language, plugin, protoc_flags, root_dir, pre
 
     cmd = f'$TOOLS_PROTOC ' + ' '.join(flags)
     if root_dir:
-        cmd = f'cd {root_dir}; {cmd} ${{SRCS//{root_dir}\\//}} && cd "$TMP_DIR"'
+        cmd = f'cd {root_dir}; {cmd} -I. ${{SRCS//{root_dir}\\//}} && cd "$TMP_DIR"'
     else:
         cmd += ' ${SRCS}'
 

--- a/rules/proto_rules.build_defs
+++ b/rules/proto_rules.build_defs
@@ -388,9 +388,9 @@ def _protoc_rule(name, srcs, deps, language, plugin, protoc_flags, root_dir, pre
     out_dir = "out_dir"
     language_out_dir = plugin['language']
 
-    cmd = f'$TOOLS_PROTOC ' + ' '.join(flags)
+    cmd = f'$TOOLS_PROTOC -I. ' + ' '.join(flags)
     if root_dir:
-        cmd = f'cd {root_dir}; {cmd} -I$TMP_DIR/{root_dir} ${{SRCS//{root_dir}\\//}} && cd "$TMP_DIR"'
+        cmd = f'cd {root_dir}; {cmd} ${{SRCS//{root_dir}\\//}} && cd "$TMP_DIR"'
     else:
         cmd += ' ${SRCS}'
 

--- a/rules/proto_rules.build_defs
+++ b/rules/proto_rules.build_defs
@@ -390,7 +390,7 @@ def _protoc_rule(name, srcs, deps, language, plugin, protoc_flags, root_dir, pre
 
     cmd = f'$TOOLS_PROTOC ' + ' '.join(flags)
     if root_dir:
-        cmd = f'cd {root_dir}; {cmd} -I. ${{SRCS//{root_dir}\\//}} && cd "$TMP_DIR"'
+        cmd = f'cd {root_dir}; {cmd} -I$TMP_DIR/{root_dir} ${{SRCS//{root_dir}\\//}} && cd "$TMP_DIR"'
     else:
         cmd += ' ${SRCS}'
 

--- a/test/proto_rules/root_dir/BUILD
+++ b/test/proto_rules/root_dir/BUILD
@@ -1,0 +1,14 @@
+subinclude("//test/build_defs")
+
+proto_library(
+    name = "root_dir",
+    srcs = ["test.proto", "other_test.proto"],
+    languages = ["go"],
+    root_dir = "test\/proto_rules",
+)
+
+
+plz_e2e_test(
+    name = "query_somepath_reverse_test",
+    cmd = "plz build //test/proto_rules/root_dir/...",
+)

--- a/test/proto_rules/root_dir/other_test.proto
+++ b/test/proto_rules/root_dir/other_test.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package root_dir;
+
+import "root_dir/test.proto";
+
+message OtherTestMessage {
+    root_dir.TestMessage msg = 1;
+}

--- a/test/proto_rules/root_dir/test.proto
+++ b/test/proto_rules/root_dir/test.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package root_dir;
+
+message TestMessage {
+    string id = 1;
+}

--- a/third_party/proto/BUILD
+++ b/third_party/proto/BUILD
@@ -1,5 +1,5 @@
 protoc_binary(
     name = "protoc",
-    version = "3.12.2",
+    version = "3.15.2",
     visibility = ["PUBLIC"],
 )


### PR DESCRIPTION
Normally, the current wd is added to the include path. If other proto paths are provided (because you're using protoc_binary()) then this isn't the case and you get errors like the one in the linked issue.

I think when we provide `-I` we always want to augment the import path not replace it. This should make that so.  

Fixes: #1646