### PR TITLE
Don't force remote to skip cache lookup

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -650,7 +650,6 @@ func (c *Client) reallyExecute(tid int, target *core.BuildTarget, command *pb.Co
 	resp, err := c.client.ExecuteAndWaitProgress(c.contextWithMetadata(target), &pb.ExecuteRequest{
 		InstanceName:    c.instance,
 		ActionDigest:    digest,
-		SkipCacheLookup: true, // We've already done it above.
 	}, updateProgress)
 	if err != nil {
 		// Handle timing issues if we try to resume an execution as it fails. If we get a


### PR DESCRIPTION
Arguably it is nice as a performance hint, but may be useful for testing buildgrid to allow it to do it itself.