### PR TITLE
Fix proto paths when using root_dir

### DIFF
--- a/rules/proto_rules.build_defs
+++ b/rules/proto_rules.build_defs
@@ -341,8 +341,6 @@ def grpc_languages():
             protoc_flags=[
                 '--go-grpc_out="$OUT_DIR"',
                 '--go_out="$OUT_DIR"',
-                '--go_opt=paths=source_relative',
-                '--go-grpc_opt=paths=source_relative',
                 '--plugin=protoc-gen-go="`which $TOOLS_GO`"',
                 '--plugin=protoc-gen-go-grpc="`which $TOOLS_GRPC_GO`"',
             ] if CONFIG.GRPC_GO_PLUGIN else [

--- a/rules/proto_rules.build_defs
+++ b/rules/proto_rules.build_defs
@@ -339,10 +339,12 @@ def grpc_languages():
                 test_only = test_only,
             ),
             protoc_flags=[
-                '--grpc-go_out="$OUT_DIR"',
+                '--go-grpc_out="$OUT_DIR"',
                 '--go_out="$OUT_DIR"',
+                '--go_opt=paths=source_relative',
+                '--go-grpc_opt=paths=source_relative',
                 '--plugin=protoc-gen-go="`which $TOOLS_GO`"',
-                '--plugin=protoc-gen-grpc-go="`which $TOOLS_GRPC_GO`"',
+                '--plugin=protoc-gen-go-grpc="`which $TOOLS_GRPC_GO`"',
             ] if CONFIG.GRPC_GO_PLUGIN else [
                 '--go_out="$OUT_DIR"',
                 '--plugin=protoc-gen-go="`which $TOOLS_GO`"',
@@ -354,7 +356,8 @@ def grpc_languages():
                 CONFIG.PROTOC_GO_PLUGIN,
             ],
             deps = [CONFIG.PROTO_GO_DEP, CONFIG.GRPC_GO_DEP],
-            pre_build = _go_path_mapping(True),
+            # if we're using the old unified protoc plugin, tell it to generate grpc
+            pre_build = _go_path_mapping(not CONFIG.GRPC_GO_PLUGIN),
             provides=['srcs'],
         ),
         # We don't really support grpc-js right now, so this is the same as proto-js.

--- a/rules/proto_rules.build_defs
+++ b/rules/proto_rules.build_defs
@@ -135,7 +135,7 @@ def _go_path_mapping(grpc):
     def _map_go_paths(rule_name):
         mapping = ',M'.join(get_labels(rule_name, 'proto:go-map:'))
         cmd = get_command(rule_name)
-        new_cmd = cmd.replace('--go_out=paths=source_relative:', f'--go_out=paths=source_relative,{grpc_plugin}M{mapping}:')
+        new_cmd = cmd.replace('--go_out=', f'--go_out={grpc_plugin}M{mapping}:')
         set_command(rule_name, new_cmd)
     return _map_go_paths
 
@@ -260,7 +260,7 @@ def proto_languages():
                 deps = deps,
                 test_only = test_only,
             ),
-            protoc_flags = ['--go_out=paths=source_relative:"$OUT_DIR"', '--plugin=protoc-gen-go="`which $TOOLS_GO`"'],
+            protoc_flags = ['--go_out="$OUT_DIR"', '--plugin=protoc-gen-go="`which $TOOLS_GO`"'],
             tools = [CONFIG.PROTOC_GO_PLUGIN],
             deps = [CONFIG.PROTO_GO_DEP],
             pre_build = _go_path_mapping(False),
@@ -344,7 +344,7 @@ def grpc_languages():
                 '--plugin=protoc-gen-go="`which $TOOLS_GO`"',
                 '--plugin=protoc-gen-grpc-go="`which $TOOLS_GRPC_GO`"',
             ] if CONFIG.GRPC_GO_PLUGIN else [
-                '--go_out=paths=source_relative:"$OUT_DIR"',
+                '--go_out="$OUT_DIR"',
                 '--plugin=protoc-gen-go="`which $TOOLS_GO`"',
             ],
             tools = {
@@ -390,13 +390,16 @@ def _protoc_rule(name, srcs, deps, language, plugin, protoc_flags, root_dir, pre
 
     cmd = f'$TOOLS_PROTOC -I. ' + ' '.join(flags)
     if root_dir:
-        cmd = f'cd {root_dir}; {cmd} ${{SRCS//{root_dir}\\//}} && cd "$TMP_DIR"'
+        escaped_root_dir = root_dir.replace("/", "\/")
+        cmd = f'cd {root_dir}; {cmd} ${{SRCS//{escaped_root_dir}\\//}} && cd "$TMP_DIR"'
     else:
         cmd += ' ${SRCS}'
 
     cmd = f'(export OUT_DIR=$TMP_DIR/{language_out_dir} && {cmd})'
 
-    cmd += f' && (mv -f {language_out_dir}/${{PKG_DIR}}/* {out_dir}; true) && (mv -f {language_out_dir}/* {out_dir}; true)'
+    pkg_dir = package_name().removeprefix(root_dir).removeprefix("/")
+
+    cmd += f' && (mv -f {language_out_dir}/{pkg_dir}/* {out_dir}; true) && (mv -f {language_out_dir}/* {out_dir}; true)'
 
     cmd = f'mkdir out_dir && mkdir {language_out_dir} && {cmd}'
 

--- a/test/proto_rules/go_grpc_ff/proto/BUILD
+++ b/test/proto_rules/go_grpc_ff/proto/BUILD
@@ -1,5 +1,18 @@
 package(
     GRPC_GO_PLUGIN = "//third_party/go:protoc-gen-go-grpc",
+    PROTOC_GO_PLUGIN = ":protoc-gen-go",
+)
+
+# This is different from //third_party/go:protoc-gen-go which is the old unified grpc and proto plugin
+go_module(
+    name = "protoc-gen-go",
+    install = ["cmd/protoc-gen-go"],
+    binary = True,
+    module = "google.golang.org/protobuf",
+    version = "v1.25.0",
+    deps = [
+        "//third_party/go:cmp",
+    ],
 )
 
 grpc_library(

--- a/test/proto_rules/root_dir/BUILD
+++ b/test/proto_rules/root_dir/BUILD
@@ -7,10 +7,11 @@ proto_library(
         "test.proto",
     ],
     languages = ["go"],
-    root_dir = "test\\/proto_rules",
+    root_dir = "test/proto_rules",
 )
 
 plz_e2e_test(
-    name = "query_somepath_reverse_test",
-    cmd = "plz build //test/proto_rules/root_dir/...",
+    name = "root_dir_test",
+    cmd = "plz build //test/proto_rules/root_dir:_root_dir#protoc_go",
+    expect_output_contains = "plz-out/gen/test/proto_rules/root_dir/test.pb.go",
 )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -177,7 +177,7 @@ go_module(
 go_mod_download(
     name = "genproto_download",
     module = "google.golang.org/genproto",
-    version = "2b5a72b8730b0b16380010cfe5286c42108d88e7",
+    version = "v0.0.0-20210315173758-2651cd453018",
 )
 
 # genproto stuff for grpc to resolve cyclic deps


### PR DESCRIPTION
I don't think source relative is meant to be provided like that. It doesn't seem to make a difference. The docs suggest providing it as such:
```
--go_opt=paths=source_relative
```

The rest of the PR is hopefully fairly non-controversial.

I've done a `plz build --include proto` in core3 and they all build with this change. 