### PR TITLE
Allow compression when uploading test results

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -443,6 +443,7 @@ type Configuration struct {
 		Sandbox         bool         `help:"Deprecated, use sandbox.test instead."`
 		DisableCoverage []string     `help:"Disables coverage for tests that have any of these labels spcified."`
 		Upload          cli.URL      `help:"URL to upload test results to (in XML format)"`
+		Gzip            bool         `help:"True to upload the test results gzipped."`
 	} `help:"A config section describing settings related to testing in general."`
 	Sandbox struct {
 		Tool  string   `help:"The location of the tool to use for sandboxing (typically please_sandbox)."`

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -443,7 +443,7 @@ type Configuration struct {
 		Sandbox         bool         `help:"Deprecated, use sandbox.test instead."`
 		DisableCoverage []string     `help:"Disables coverage for tests that have any of these labels spcified."`
 		Upload          cli.URL      `help:"URL to upload test results to (in XML format)"`
-		Gzip            bool         `help:"True to upload the test results gzipped."`
+		UploadGzipped   bool         `help:"True to upload the test results gzipped."`
 	} `help:"A config section describing settings related to testing in general."`
 	Sandbox struct {
 		Tool  string   `help:"The location of the tool to use for sandboxing (typically please_sandbox)."`

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -42,7 +42,7 @@ func Test(tid int, state *core.BuildState, label core.BuildLabel, remote bool, r
 		runsAllCompleted := target.CompleteRun(state)
 		if runsAllCompleted && state.Config.Test.Upload != "" {
 			if numUploadFailures < maxUploadFailures {
-				if err := uploadResults(target, state.Config.Test.Upload.String()); err != nil {
+				if err := uploadResults(target, state.Config.Test.Upload.String(), state.Config.Test.Gzip); err != nil {
 					log.Warning("%s", err)
 					if atomic.AddInt64(&numUploadFailures, 1) >= maxUploadFailures {
 						log.Error("Failed to upload test results %d times, giving up", maxUploadFailures)

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -42,7 +42,7 @@ func Test(tid int, state *core.BuildState, label core.BuildLabel, remote bool, r
 		runsAllCompleted := target.CompleteRun(state)
 		if runsAllCompleted && state.Config.Test.Upload != "" {
 			if numUploadFailures < maxUploadFailures {
-				if err := uploadResults(target, state.Config.Test.Upload.String(), state.Config.Test.Gzip); err != nil {
+				if err := uploadResults(target, state.Config.Test.Upload.String(), state.Config.Test.UploadGzipped); err != nil {
 					log.Warning("%s", err)
 					if atomic.AddInt64(&numUploadFailures, 1) >= maxUploadFailures {
 						log.Error("Failed to upload test results %d times, giving up", maxUploadFailures)

--- a/src/test/xml_results.go
+++ b/src/test/xml_results.go
@@ -438,6 +438,7 @@ func SerialiseResultsToXML(target *core.BuildTarget, indent bool) []byte {
 // uploadResults uploads test results to a remote server.
 func uploadResults(target *core.BuildTarget, url string, gzipped bool) error {
 	b := SerialiseResultsToXML(target, true)
+	enc := ""
 	var r io.Reader = bytes.NewReader(b)
 	if gzipped {
 		var buf bytes.Buffer
@@ -448,13 +449,14 @@ func uploadResults(target *core.BuildTarget, url string, gzipped bool) error {
 			return fmt.Errorf("Failed to flush gzip writer: %s", err)
 		}
 		r = &buf
+		enc = "gzip"
 	}
 	req, err := http.NewRequest(http.MethodPost, url, r)
 	if err != nil {
 		return fmt.Errorf("Failed to create HTTP request: %s", err)
 	}
 	req.Header["Content-Type"] = []string{"application/xml"}
-	req.Header["Content-Encoding"] = []string{"gzip"}
+	req.Header["Content-Encoding"] = []string{enc}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("Failed to upload test results: %s", err)


### PR DESCRIPTION
Adds option `test.gzip` to gzip test results before uploading them to the given URL. By default, it doesn't do it to keep things backward-compatible (even if most HTTP servers now probably support gzip compression).