### PR TITLE
Make the $TEST var absolute in rex

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,5 @@
 run:
+  timeout: 5m
   skip-dirs:
     - test_data
 

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -146,7 +146,10 @@ func (c *Client) buildTestCommand(state *core.BuildState, target *core.BuildTarg
 			files = append(files, core.TestResultsFile)
 		}
 	}
-	const commandPrefix = "export TMP_DIR=\"`pwd`\" TEST_DIR=\"`pwd`\" && "
+	commandPrefix := "export TMP_DIR=\"`pwd`\" TEST_DIR=\"`pwd`\" && "
+	if outs := target.Outputs(); len(outs) > 0 {
+		commandPrefix += `export TEST="$TEST_DIR/` + outs[0] + `" && `
+	}
 	cmd, err := core.ReplaceTestSequences(state, target, target.GetTestCommand(state))
 	if len(state.TestArgs) != 0 {
 		cmd += " " + strings.Join(state.TestArgs, " ")


### PR DESCRIPTION
We typically run the test via `$TEST ...` which doesn't work if it is a relative path (Bash tries a path lookup instead).

We don't get this internally because Mettle makes it absolute; eventually we might try to move away from that.