### PR TITLE
Exclude tools by default in jarcat

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-16.0.0-prerelease.10
+16.0.0-prerelease.11

--- a/tools/jarcat/main.go
+++ b/tools/jarcat/main.go
@@ -66,6 +66,7 @@ var opts = struct {
 		Suffix                []string          `short:"s" long:"suffix" default:".jar" description:"Suffix of files to include"`
 		ExcludeSuffix         []string          `short:"e" long:"exclude_suffix" description:"Suffix of files to exclude"`
 		ExcludeJavaPrefixes   bool              `short:"j" long:"exclude_java_prefixes" description:"Use default Java exclusions"`
+		ExcludeTools          []string          `long:"exclude_tools" env:"TOOLS" env-delim:" " description:"Tools to exclude from the generated zipfile"`
 		ExcludeInternalPrefix []string          `short:"x" long:"exclude_internal_prefix" description:"Prefix of files to exclude"`
 		IncludeInternalPrefix []string          `short:"t" long:"include_internal_prefix" description:"Prefix of files to include"`
 		StripPrefix           string            `long:"strip_prefix" description:"Prefix to strip off file names"`
@@ -190,7 +191,7 @@ func main() {
 	f := zip.NewFile(filename, opts.Zip.Strict)
 	f.RenameDirs = opts.Zip.RenameDirs
 	f.Include = opts.Zip.IncludeInternalPrefix
-	f.Exclude = opts.Zip.ExcludeInternalPrefix
+	f.Exclude = append(opts.Zip.ExcludeInternalPrefix, opts.Zip.ExcludeTools...)
 	f.StripPrefix = opts.Zip.StripPrefix
 	f.Suffix = opts.Zip.Suffix
 	f.ExcludeSuffix = opts.Zip.ExcludeSuffix

--- a/tools/jarcat/zip/writer.go
+++ b/tools/jarcat/zip/writer.go
@@ -222,6 +222,12 @@ func (f *File) walk(path string, isDir bool, mode os.FileMode) error {
 	if samePaths(path, f.filename) {
 		return nil
 	} else if !isDir {
+		for _, excl := range f.Exclude {
+			if path == excl {
+				log.Debug("Excluding %s", path)
+				return nil
+			}
+		}
 		if !f.matchesSuffix(path, f.ExcludeSuffix) {
 			if f.matchesSuffix(path, f.Suffix) {
 				log.Debug("Adding zip file %s", path)


### PR DESCRIPTION
Stops them from automatically turning up when we download them during remote execution.