### PR TITLE
Ignore directories more better in jarcat

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-16.0.0-prerelease.11
+16.0.0-prerelease.12

--- a/tools/jarcat/main.go
+++ b/tools/jarcat/main.go
@@ -216,6 +216,8 @@ func main() {
 			}
 		}
 	}
+	// Never descend into the _please dir
+	f.Exclude = append(f.Exclude, "_please")
 
 	if opts.Zip.PreambleFrom != "" {
 		opts.Zip.Preamble = mustReadPreamble(opts.Zip.PreambleFrom)

--- a/tools/jarcat/zip/writer.go
+++ b/tools/jarcat/zip/writer.go
@@ -219,15 +219,18 @@ func (f *File) walk(path string, isDir bool, mode os.FileMode) error {
 			return fs.WalkMode(resolved, f.walk)
 		}
 	}
+	for _, excl := range f.Exclude {
+		if path == excl {
+			log.Debug("Excluding %s", path)
+			if isDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+	}
 	if samePaths(path, f.filename) {
 		return nil
 	} else if !isDir {
-		for _, excl := range f.Exclude {
-			if path == excl {
-				log.Debug("Excluding %s", path)
-				return nil
-			}
-		}
 		if !f.matchesSuffix(path, f.ExcludeSuffix) {
 			if f.matchesSuffix(path, f.Suffix) {
 				log.Debug("Adding zip file %s", path)


### PR DESCRIPTION
Looks like #1676 isn't fixing all cases of this, because the tool variable doesn't necessarily identify all the inputs.
We should separately think how named outputs interact with remote execution but for now I just want this to be fixed.

Unsure how best to test this. Also need some thought on that, now the tools get downloaded it's very tricky to test them in a "real world" scenario.