### PR TITLE
Make rule hash available without stamp = True

### DIFF
--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -131,7 +131,7 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
     """
     shebang = shebang or interpreter or CONFIG.DEFAULT_PYTHON_INTERPRETER
     zipsafe_flag = '' if zip_safe is False else '--zip_safe'
-    cmd = '$TOOLS_PEX -s "%s" -m "%s" %s --interpreter_options="%s" --stamp="$STAMP"' % (
+    cmd = '$TOOLS_PEX -s "%s" -m "%s" %s --interpreter_options="%s" --stamp="$RULE_HASH"' % (
         shebang, CONFIG.PYTHON_MODULE_DIR, zipsafe_flag, CONFIG.PYTHON_INTERPRETER_OPTIONS)
     if site:
         cmd += ' -S'
@@ -165,7 +165,6 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
             'pex': [CONFIG.PEX_TOOL],
         },
         test_only=test_only,
-        stamp=True,  # Used to derive a unique cache-directory for zip-unsafe binaries.
     )
     # This rule concatenates the .pex with all the other precompiled zip files from dependent rules.
     cmd = '$TOOL z -i . -s .pex.zip -s .whl --preamble_from="$SRC" --include_other --add_init_py --strict'
@@ -240,7 +239,7 @@ def python_test(name:str, srcs:list, data:list|dict=[], resources:list=[], deps:
     """
     interpreter = interpreter or CONFIG.DEFAULT_PYTHON_INTERPRETER
     test_runner = test_runner or CONFIG.PYTHON_TEST_RUNNER
-    cmd = '$TOOLS_PEX -t -s "%s" -m "%s" -r "%s" --zip_safe --add_test_runner_deps --interpreter_options="%s" --stamp="$STAMP"' % (
+    cmd = '$TOOLS_PEX -t -s "%s" -m "%s" -r "%s" --zip_safe --add_test_runner_deps --interpreter_options="%s" --stamp="$RULE_HASH"' % (
         interpreter, CONFIG.PYTHON_MODULE_DIR, test_runner,
         CONFIG.PYTHON_INTERPRETER_OPTIONS)
     if site:
@@ -274,7 +273,6 @@ def python_test(name:str, srcs:list, data:list|dict=[], resources:list=[], deps:
             'interpreter': [interpreter or CONFIG.DEFAULT_PYTHON_INTERPRETER],
             'pex': [CONFIG.PEX_TOOL],
         },
-        stamp = True,
         labels = labels,
     )
 

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -259,13 +259,14 @@ func RunEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 // Optionally includes a stamp if the target is marked as such.
 func StampedBuildEnvironment(state *BuildState, target *BuildTarget, stamp []byte, tmpDir string) BuildEnv {
 	env := BuildEnvironment(state, target, tmpDir)
+	encStamp := base64.RawURLEncoding.EncodeToString(stamp)
 	if target.Stamp {
 		stampEnvOnce.Do(initStampEnv)
 		env = append(env, stampEnv...)
 		env = append(env, "STAMP_FILE="+target.StampFileName())
-		return append(env, "STAMP="+base64.RawURLEncoding.EncodeToString(stamp))
+		env = append(env, "STAMP="+encStamp)
 	}
-	return env
+	return append(env, "RULE_HASH="+encStamp)
 }
 
 // stampEnv is the generic (i.e. non-target-specific) environment variables we pass to a

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -122,8 +122,6 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 func (c *Client) stampedBuildEnvironment(state *core.BuildState, target *core.BuildTarget, inputRoot *pb.Directory, stamp bool) []string {
 	if target.IsFilegroup {
 		return core.GeneralBuildEnvironment(state) // filegroups don't need a full build environment
-	} else if !stamp {
-		return core.BuildEnvironment(state, target, ".")
 	}
 	// We generate the stamp ourselves from the input root.
 	// TODO(peterebden): it should include the target properties too...


### PR DESCRIPTION
It's available to everything in the `$RULE_HASH` env var, and remains in `$STAMP` for anything with `stamp = True` (at least for now).

Fixes #1183 