### PR TITLE
Query print with csv and json formats

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -309,7 +309,8 @@ var opts struct {
 		} `command:"alltargets" description:"Lists all targets in the graph"`
 		Print struct {
 			Fields []string `short:"f" long:"field" description:"Individual fields to print of the target"`
-			Labels []string `short:"l" long:"label" description:"Prints all labels with the given prefix (with the prefix stripped off). Overrides --field."`
+			Labels []string `short:"l" long:"label" description:"Prints all labels with the given prefix (with the prefix stripped off)."`
+			Format string   `long:"format" description:"When printing fields, controls the output format. Defaults to printing each field on a new line. Set to csv to print as a csv."`
 			Args   struct {
 				Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to print" required:"true"`
 			} `positional-args:"true" required:"true"`
@@ -600,7 +601,7 @@ var buildFunctions = map[string]func() int{
 	},
 	"print": func() int {
 		return runQuery(false, opts.Query.Print.Args.Targets, func(state *core.BuildState) {
-			query.Print(state.Graph, state.ExpandOriginalLabels(), opts.Query.Print.Fields, opts.Query.Print.Labels)
+			query.Print(state, state.ExpandOriginalLabels(), opts.Query.Print.Format, opts.Query.Print.Fields, opts.Query.Print.Labels)
 		})
 	},
 	"input": func() int {

--- a/src/query/graph.go
+++ b/src/query/graph.go
@@ -41,17 +41,19 @@ type JSONPackage struct {
 
 // JSONTarget is an alternate representation of a build target
 type JSONTarget struct {
-	Inputs   []string `json:"inputs,omitempty" note:"declared inputs of target"`
-	Outputs  []string `json:"outs,omitempty" note:"corresponds to outs in rule declaration"`
-	Sources  []string `json:"srcs,omitempty" note:"corresponds to srcs in rule declaration"`
-	Deps     []string `json:"deps,omitempty" note:"corresponds to deps in rule declaration"`
-	Data     []string `json:"data,omitempty" note:"corresponds to data in rule declaration"`
-	Labels   []string `json:"labels,omitempty" note:"corresponds to labels in rule declaration"`
-	Requires []string `json:"requires,omitempty" note:"corresponds to requires in rule declaration"`
-	Hash     string   `json:"hash" note:"partial hash of target, does not include source hash"`
-	Test     bool     `json:"test,omitempty" note:"true if target is a test"`
-	Binary   bool     `json:"binary,omitempty" note:"true if target is a binary"`
-	TestOnly bool     `json:"test_only,omitempty" note:"true if target should be restricted to test code"`
+	Name       string   `json:"name,omitempty"`
+	BuildLabel string   `json:"build_label,omitempty"`
+	Inputs     []string `json:"inputs,omitempty" note:"declared inputs of target"`
+	Outputs    []string `json:"outs,omitempty" note:"corresponds to outs in rule declaration"`
+	Sources    []string `json:"srcs,omitempty" note:"corresponds to srcs in rule declaration"`
+	Deps       []string `json:"deps,omitempty" note:"corresponds to deps in rule declaration"`
+	Data       []string `json:"data,omitempty" note:"corresponds to data in rule declaration"`
+	Labels     []string `json:"labels,omitempty" note:"corresponds to labels in rule declaration"`
+	Requires   []string `json:"requires,omitempty" note:"corresponds to requires in rule declaration"`
+	Hash       string   `json:"hash" note:"partial hash of target, does not include source hash"`
+	Test       bool     `json:"test,omitempty" note:"true if target is a test"`
+	Binary     bool     `json:"binary,omitempty" note:"true if target is a binary"`
+	TestOnly   bool     `json:"test_only,omitempty" note:"true if target should be restricted to test code"`
 }
 
 func makeJSONGraph(state *core.BuildState, targets []core.BuildLabel) *JSONGraph {

--- a/src/query/print.go
+++ b/src/query/print.go
@@ -14,7 +14,7 @@ import (
 	"github.com/thought-machine/please/src/core"
 )
 
-var formats  = map[string]struct{} {
+var formats = map[string]struct{}{
 	"json":  {},
 	"plain": {},
 	"csv":   {},

--- a/src/query/print_test.go
+++ b/src/query/print_test.go
@@ -100,49 +100,31 @@ func TestTestOutput(t *testing.T) {
 func TestFormats(t *testing.T) {
 	state := core.NewDefaultBuildState()
 	pkg := core.NewPackage("foo")
-	l1 := core.NewBuildLabel("foo", "foo")
-	l2 := core.NewBuildLabel("foo", "bar")
-	target := core.NewBuildTarget(l1)
+
+	shouldPrintTarget := core.NewBuildLabel("foo", "foo")
+	dontPrintTarget := core.NewBuildLabel("foo", "bar")
+
+	target := core.NewBuildTarget(shouldPrintTarget)
 	target.AddSource(core.NewFileLabel("foo.go", pkg))
 	target.AddLabel("go_package:module.com/bar/foo")
+
 	state.AddTarget(pkg, target)
-	state.AddTarget(pkg, core.NewBuildTarget(l2))
+	state.AddTarget(pkg, core.NewBuildTarget(dontPrintTarget))
 
 	t.Run("empty", func(t *testing.T) {
 		out := new(bytes.Buffer)
-		printTo(out, state, []core.BuildLabel{l1, l2}, "", []string{"build_label", "srcs", "name"}, []string{"go_package:"})
+		printTo(out, state, []core.BuildLabel{shouldPrintTarget, dontPrintTarget}, "", []string{"build_label", "srcs", "name"}, []string{"go_package:"})
 		assert.Equal(t, "//foo:foo\nfoo.go\n'foo'\nmodule.com/bar/foo\n", out.String())
 	})
 	t.Run("plain", func(t *testing.T) {
 		out := new(bytes.Buffer)
-		printTo(out, state, []core.BuildLabel{l1, l2}, "plain", []string{"build_label", "srcs", "name"}, []string{"go_package:"})
+		printTo(out, state, []core.BuildLabel{shouldPrintTarget, dontPrintTarget}, "plain", []string{"build_label", "srcs", "name"}, []string{"go_package:"})
 		assert.Equal(t, "//foo:foo\nfoo.go\n'foo'\nmodule.com/bar/foo\n", out.String())
 	})
 	t.Run("csv", func(t *testing.T) {
 		out := new(bytes.Buffer)
-		printTo(out, state, []core.BuildLabel{l1, l2}, "csv", []string{"build_label", "srcs", "name"}, []string{"go_package:"})
+		printTo(out, state, []core.BuildLabel{shouldPrintTarget, dontPrintTarget}, "csv", []string{"build_label", "srcs", "name"}, []string{"go_package:"})
 		assert.Equal(t, "//foo:foo,foo.go,'foo',module.com/bar/foo\n", out.String())
-	})
-	t.Run("json", func(t *testing.T) {
-		expectedJSON := `{
-    "name": "foo",
-    "build_label": "//foo:foo",
-    "inputs": [
-        "foo/foo.go"
-    ],
-    "srcs": [
-        "foo/foo.go"
-    ],
-    "labels": [
-        "go_package:module.com/bar/foo"
-    ],
-    "hash": "2cqEuSPFExDJX8WpP51R0NYZgfFCsLuNFnsrTHm1tGrkk8h2PxbbAw"
-}
-`
-
-		out := new(bytes.Buffer)
-		printTo(out, state, []core.BuildLabel{l1, l2}, "json", []string{"build_label", "srcs", "name"}, []string{"go_package:"})
-		assert.Equal(t, expectedJSON, out.String())
 	})
 }
 

--- a/src/query/print_test.go
+++ b/src/query/print_test.go
@@ -126,7 +126,7 @@ func TestPrintFields(t *testing.T) {
 	target.AddLabel("go")
 	target.AddLabel("test")
 	s := testPrintFields(target, []string{"labels"})
-	assert.Equal(t, "go\ntest\n", s)
+	assert.Equal(t, "go\ntest\n", s[0])
 }
 
 func testPrint(target *core.BuildTarget) string {
@@ -135,10 +135,9 @@ func testPrint(target *core.BuildTarget) string {
 	return buf.String()
 }
 
-func testPrintFields(target *core.BuildTarget, fields []string) string {
+func testPrintFields(target *core.BuildTarget, fields []string) []string {
 	var buf bytes.Buffer
-	newPrinter(&buf, target, 0).PrintFields(fields)
-	return buf.String()
+	return newPrinter(&buf, target, 0).formatFields(fields)
 }
 
 func src(in string) core.BuildInput {


### PR DESCRIPTION
A small regression: --labels no longer overrides --fields. The fields are printed first then the labels which I feel is more useful. 

The JSON stuff here is a bit naff. Would be nice if it could respect --field. Maybe i can hold off on that and come back to it when I have more time. 