### PR TITLE
Fix incorrect results from query changes and revdeps. 

### DIFF
--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -63,7 +63,7 @@ func changedTargets(state *core.BuildState, files []string, changed map[*core.Bu
 		revdeps := map[core.BuildLabel]int{}
 		getRevDepTransitiveLabels(state, labels, revdeps, level)
 
-		for dep, _ := range revdeps {
+		for dep := range revdeps {
 			labels = append(labels, dep)
 		}
 	}

--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -61,7 +61,7 @@ func changedTargets(state *core.BuildState, files []string, changed map[*core.Bu
 		for l, _ := range changed {
 			labels = append(labels, l.Label)
 		}
-		revdeps = getRevDepTransitiveLabels(state, labels, map[core.BuildLabel]struct{}{}, level)
+		revdeps = getRevDepTransitiveLabels(state, labels, map[core.BuildLabel]int{}, level)
 	}
 	labels := make(core.BuildLabels, 0, len(changed))
 	for target := range changed {

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -9,20 +9,20 @@ import (
 
 // ReverseDeps finds all transitive targets that depend on the set of input labels.
 func ReverseDeps(state *core.BuildState, labels []core.BuildLabel, level int, hidden bool) {
-	for _, target := range getRevDepTransitiveLabels(state, labels, map[core.BuildLabel]struct{}{}, level) {
+	for _, target := range getRevDepTransitiveLabels(state, labels, map[core.BuildLabel]int{}, level) {
 		if hidden || target.Name[0] != '_' {
 			fmt.Printf("%s\n", target)
 		}
 	}
 }
 
-func getRevDepTransitiveLabels(state *core.BuildState, labels []core.BuildLabel, done map[core.BuildLabel]struct{}, level int) core.BuildLabels {
+func getRevDepTransitiveLabels(state *core.BuildState, labels []core.BuildLabel, done map[core.BuildLabel]int, level int) core.BuildLabels {
 	if level == 0 {
 		return nil
 	}
 	for _, l := range getRevDepsLabels(state, labels) {
-		if _, present := done[l]; !present {
-			done[l] = struct{}{}
+		if doneLevel, present := done[l]; !present || doneLevel > level {
+			done[l] = level
 			getRevDepTransitiveLabels(state, []core.BuildLabel{l}, done, level-1)
 		}
 	}

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -3,16 +3,24 @@ package query
 import (
 	"fmt"
 	"github.com/thought-machine/please/src/core"
+	"sort"
 )
 
 // ReverseDeps finds all transitive targets that depend on the set of input labels.
 func ReverseDeps(state *core.BuildState, labels []core.BuildLabel, level int, hidden bool) {
 	targets := make(map[core.BuildLabel]int, 100)
 	getRevDepTransitiveLabels(state, labels, targets, level)
+
+	ls := make(core.BuildLabels, 0, len(targets))
 	for target, _ := range targets {
 		if hidden || target.Name[0] != '_' && state.ShouldInclude(state.Graph.TargetOrDie(target)){
-			fmt.Printf("%s\n", target)
+			ls = append(ls, target)
 		}
+	}
+	sort.Sort(ls)
+
+	for _, l := range ls {
+		fmt.Println(l.String())
 	}
 }
 

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -12,8 +12,8 @@ func ReverseDeps(state *core.BuildState, labels []core.BuildLabel, level int, hi
 	getRevDepTransitiveLabels(state, labels, targets, level)
 
 	ls := make(core.BuildLabels, 0, len(targets))
-	for target, _ := range targets {
-		if hidden || target.Name[0] != '_' && state.ShouldInclude(state.Graph.TargetOrDie(target)){
+	for target := range targets {
+		if hidden || target.Name[0] != '_' && state.ShouldInclude(state.Graph.TargetOrDie(target)) {
 			ls = append(ls, target)
 		}
 	}

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -10,7 +10,7 @@ func ReverseDeps(state *core.BuildState, labels []core.BuildLabel, level int, hi
 	targets := make(map[core.BuildLabel]int, 100)
 	getRevDepTransitiveLabels(state, labels, targets, level)
 	for target, _ := range targets {
-		if hidden || target.Name[0] != '_' {
+		if hidden || target.Name[0] != '_' && state.ShouldInclude(state.Graph.TargetOrDie(target)){
 			fmt.Printf("%s\n", target)
 		}
 	}
@@ -26,12 +26,6 @@ func getRevDepTransitiveLabels(state *core.BuildState, labels []core.BuildLabel,
 		if doneLevel, present := done[l]; !present || levelsToGo > doneLevel {
 			done[l] = levelsToGo
 			getRevDepTransitiveLabels(state, []core.BuildLabel{l}, done, levelsToGo-1)
-		}
-	}
-	ret := core.BuildLabels{}
-	for label := range done {
-		if state.ShouldInclude(state.Graph.TargetOrDie(label)) {
-			ret = append(ret, label)
 		}
 	}
 }

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -2,8 +2,9 @@ package query
 
 import (
 	"fmt"
-	"github.com/thought-machine/please/src/core"
 	"sort"
+
+	"github.com/thought-machine/please/src/core"
 )
 
 // ReverseDeps finds all transitive targets that depend on the set of input labels.

--- a/src/query/reverse_deps_test.go
+++ b/src/query/reverse_deps_test.go
@@ -30,11 +30,11 @@ func TestReverseDeps(t *testing.T) {
 	graph.AddPackage(pkg)
 
 	labels := revDepsLabels(state, []core.BuildLabel{branch.Label}, -1)
-	assert.Equal(t, core.BuildLabels{leaf.Label}, labels)
+	assert.ElementsMatch(t, core.BuildLabels{leaf.Label}, labels)
 	labels = revDepsLabels(state, []core.BuildLabel{root.Label}, -1)
-	assert.Equal(t, core.BuildLabels{branch.Label, leaf.Label}, labels)
+	assert.ElementsMatch(t, core.BuildLabels{branch.Label, leaf.Label}, labels)
 	labels = revDepsLabels(state, []core.BuildLabel{root.Label}, 1)
-	assert.Equal(t, core.BuildLabels{branch.Label}, labels)
+	assert.ElementsMatch(t, core.BuildLabels{branch.Label}, labels)
 }
 
 func revDepsLabels(state *core.BuildState, labels []core.BuildLabel, levelsToGo int) core.BuildLabels {
@@ -42,7 +42,7 @@ func revDepsLabels(state *core.BuildState, labels []core.BuildLabel, levelsToGo 
 	getRevDepTransitiveLabels(state, labels, ls, levelsToGo)
 
 	ret := make([]core.BuildLabel, 0, len(ls))
-	for l, _ := range ls {
+	for l := range ls {
 		ret = append(ret, l)
 	}
 	return ret

--- a/src/query/reverse_deps_test.go
+++ b/src/query/reverse_deps_test.go
@@ -29,10 +29,21 @@ func TestReverseDeps(t *testing.T) {
 	pkg.AddTarget(leaf)
 	graph.AddPackage(pkg)
 
-	labels := getRevDepTransitiveLabels(state, []core.BuildLabel{branch.Label}, map[core.BuildLabel]int{}, -1)
+	labels := revDepsLabels(state, []core.BuildLabel{branch.Label}, -1)
 	assert.Equal(t, core.BuildLabels{leaf.Label}, labels)
-	labels = getRevDepTransitiveLabels(state, []core.BuildLabel{root.Label}, map[core.BuildLabel]int{}, -1)
+	labels = revDepsLabels(state, []core.BuildLabel{root.Label}, -1)
 	assert.Equal(t, core.BuildLabels{branch.Label, leaf.Label}, labels)
-	labels = getRevDepTransitiveLabels(state, []core.BuildLabel{root.Label}, map[core.BuildLabel]int{}, 1)
+	labels = revDepsLabels(state, []core.BuildLabel{root.Label}, 1)
 	assert.Equal(t, core.BuildLabels{branch.Label}, labels)
+}
+
+func revDepsLabels(state *core.BuildState, labels []core.BuildLabel, levelsToGo int) core.BuildLabels {
+	ls := map[core.BuildLabel]int{}
+	getRevDepTransitiveLabels(state, labels, ls, levelsToGo)
+
+	ret := make([]core.BuildLabel, 0, len(ls))
+	for l, _ := range ls {
+		ret = append(ret, l)
+	}
+	return ret
 }

--- a/src/query/reverse_deps_test.go
+++ b/src/query/reverse_deps_test.go
@@ -29,10 +29,10 @@ func TestReverseDeps(t *testing.T) {
 	pkg.AddTarget(leaf)
 	graph.AddPackage(pkg)
 
-	labels := getRevDepTransitiveLabels(state, []core.BuildLabel{branch.Label}, map[core.BuildLabel]struct{}{}, -1)
+	labels := getRevDepTransitiveLabels(state, []core.BuildLabel{branch.Label}, map[core.BuildLabel]int{}, -1)
 	assert.Equal(t, core.BuildLabels{leaf.Label}, labels)
-	labels = getRevDepTransitiveLabels(state, []core.BuildLabel{root.Label}, map[core.BuildLabel]struct{}{}, -1)
+	labels = getRevDepTransitiveLabels(state, []core.BuildLabel{root.Label}, map[core.BuildLabel]int{}, -1)
 	assert.Equal(t, core.BuildLabels{branch.Label, leaf.Label}, labels)
-	labels = getRevDepTransitiveLabels(state, []core.BuildLabel{root.Label}, map[core.BuildLabel]struct{}{}, 1)
+	labels = getRevDepTransitiveLabels(state, []core.BuildLabel{root.Label}, map[core.BuildLabel]int{}, 1)
 	assert.Equal(t, core.BuildLabels{branch.Label}, labels)
 }

--- a/test/revdeps/BUILD
+++ b/test/revdeps/BUILD
@@ -45,9 +45,9 @@ plz_e2e_test(
     expected_output = "query_revdeps_single_level_test.txt",
 )
 
-# Test that we always include 4 when querying deps at level 2
-# 3 -> 2 -> 1 -> 4 (4 is at level 3 here so would be excluded)
-# 3 -> 2 -> 4 (but 4 is at level 2 here so should be included)
+# Test that we always include 3 when querying deps at level 2
+# 3 -> 2 -> 1 -> 4 (3 is 3 levels deep here so would be excluded)
+# 3 -> 2 -> 4 (but is at level 2 here so should be included)
 plz_e2e_test(
     name = "query_revdeps_multiple_paths_test",
     cmd = "plz query revdeps --level=2 //test/revdeps:target4",

--- a/test/revdeps/BUILD
+++ b/test/revdeps/BUILD
@@ -2,19 +2,30 @@ subinclude("//test/build_defs")
 
 filegroup(
     name = "target1",
-    labels = ["leaf"],
+    deps = [":target4"],
 )
 
 filegroup(
     name = "target2",
     labels = ["branch"],
-    deps = [":target1"],
+    deps = [
+        ":target1",
+        ":target4",
+    ],
 )
 
 filegroup(
     name = "target3",
     labels = ["root"],
-    deps = [":target2"],
+    deps = [
+        ":target2",
+    ],
+)
+
+filegroup(
+    name = "target4",
+    labels = ["leaf"],
+    deps = [":target1"],
 )
 
 plz_e2e_test(
@@ -33,4 +44,13 @@ plz_e2e_test(
     name = "query_revdeps_single_level_test",
     cmd = "plz query revdeps --level=1 //test/revdeps:target1",
     expected_output = "query_revdeps_single_level_test.txt",
+)
+
+# Test that we always include 4 when querying deps at level 2
+# 3 -> 2 -> 1 -> 4 (4 is at level 3 here so would be excluded)
+# 3 -> 2 -> 4 (but 4 is at level 2 here so should be included)
+plz_e2e_test(
+    name = "query_revdeps_multiple_paths_test",
+    cmd = "plz query revdeps --level=2 //test/revdeps:target3",
+    expected_output = "query_revdeps_multiple_paths_test.txt",
 )

--- a/test/revdeps/BUILD
+++ b/test/revdeps/BUILD
@@ -25,7 +25,6 @@ filegroup(
 filegroup(
     name = "target4",
     labels = ["leaf"],
-    deps = [":target1"],
 )
 
 plz_e2e_test(
@@ -51,6 +50,6 @@ plz_e2e_test(
 # 3 -> 2 -> 4 (but 4 is at level 2 here so should be included)
 plz_e2e_test(
     name = "query_revdeps_multiple_paths_test",
-    cmd = "plz query revdeps --level=2 //test/revdeps:target3",
+    cmd = "plz query revdeps --level=2 //test/revdeps:target4",
     expected_output = "query_revdeps_multiple_paths_test.txt",
 )

--- a/test/revdeps/query_revdeps_multiple_paths_test.txt
+++ b/test/revdeps/query_revdeps_multiple_paths_test.txt
@@ -1,4 +1,3 @@
 //test/revdeps:target1
 //test/revdeps:target2
 //test/revdeps:target3
-//test/revdeps:target4

--- a/test/revdeps/query_revdeps_multiple_paths_test.txt
+++ b/test/revdeps/query_revdeps_multiple_paths_test.txt
@@ -1,0 +1,4 @@
+//test/revdeps:target1
+//test/revdeps:target2
+//test/revdeps:target3
+//test/revdeps:target4


### PR DESCRIPTION
Essentially the problem is with our depth first approach, certain targets can be removed from the open set of targets to explore prematurely, for example: 

a -> b -> c  
a -> c -> e

Once evaluating the first branch, done will contain a, b, and c. When evaluating the second branch, we will skip c -> e because c is already done. If we do a, c, and e first, we will add e. 

NB: reverse dependencies appears to work slightly differently to query changes. It seems that it's more likely to exclude internal labels because it adds dependencies with this logic:

```
	for _, label := range labels {
		for _, child := range graph.PackageOrDie(label).AllChildren(graph.TargetOrDie(label)) {
			for _, target := range graph.ReverseDependencies(child) {
				if parent := target.Parent(graph); parent != nil {
					uniqueTargets[parent] = struct{}{}
				} else {
					uniqueTargets[target] = struct{}{}
				}
			}
		}
	}
```

I think this still makes sense for query changes and it would be best if these two followed the same logic. 

Apart from replacing some hidden targets with their parent targets, I think the old query changes pretty much returns a subset of what it does now. 