### PR TITLE
Add semver_check builtin function

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -228,6 +228,17 @@
         <code class="code">--plain_output</code> flag if intending to use this.
       </span>
     </li>
+    <li>
+      <span>
+        <code class="code"
+          ><span class="fn-name">semver_check</span><span class="fn-p">(</span
+          ><span class="fn-arg">version</span>, <span class="fn-arg">constraint</span>
+          <span class="fn-p">)</span></code
+        >
+        - checks if a <a href="https://semver.org/">semantic version</a> meets a constraint.
+        Supported version and constraint formats are listed on <a href="https://github.com/Masterminds/semver">this</a> site.
+      </span>
+    </li>
   </ul>
 
   <section class="mt4">

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/thought-machine/please
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4 // indirect
 	github.com/bazelbuild/buildtools v0.0.0-20190228125936-4bcdbd1064fc

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -262,3 +262,6 @@ def json(value) -> str:
 def breakpoint():
     """Breaks into an interactive debugging session."""
     pass
+
+def semver_check(version:str, constraint:str) -> bool:
+    pass

--- a/src/parse/asp/BUILD
+++ b/src/parse/asp/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//src/fs",
         "//third_party/go:logging",
         "//third_party/go:promptui",
+        "//third_party/go:semver2",
     ],
 )
 

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -3,13 +3,15 @@ package asp
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/manifoldco/promptui"
 	"io"
 	"path"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/manifoldco/promptui"
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"
@@ -56,6 +58,7 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "set_command", setCommand)
 	setNativeCode(s, "json", valueAsJSON)
 	setNativeCode(s, "breakpoint", breakpoint)
+	setNativeCode(s, "semver_check", semverCheck)
 	stringMethods = map[string]*pyFunc{
 		"join":         setNativeCode(s, "join", strJoin),
 		"split":        setNativeCode(s, "split", strSplit),
@@ -956,4 +959,22 @@ func breakpoint(s *scope, args []pyObject) pyObject {
 	}
 	fmt.Printf("Debugger exited, continuing...\n")
 	return None
+}
+
+func semverCheck(s *scope, args []pyObject) pyObject {
+	v, err := semver.NewVersion(string(args[0].(pyString)))
+	if err != nil {
+		s.Error("failed to parse version: %v", err)
+
+		return newPyBool(false)
+	}
+
+	c, err := semver.NewConstraint(string(args[1].(pyString)))
+	if err != nil {
+		s.Error("failed to parse constraint: %v", err)
+
+		return newPyBool(false)
+	}
+
+	return newPyBool(c.Check(v))
 }

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -374,3 +374,24 @@ func TestFormat(t *testing.T) {
 	assert.EqualValues(t, `LLVM_NATIVE_ARCH=\"x86\"`, s.Lookup("arch"))
 	assert.EqualValues(t, `ARCH="linux_amd64"`, s.Lookup("arch2"))
 }
+
+func TestSemver(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		s, err := parseFile("src/parse/asp/test_data/interpreter/semver.build")
+		assert.NoError(t, err)
+		assert.EqualValues(t, pyBool(true), s.Lookup("c1"))
+		assert.EqualValues(t, pyBool(false), s.Lookup("c2"))
+		assert.EqualValues(t, pyBool(true), s.Lookup("c3"))
+		assert.EqualValues(t, pyBool(true), s.Lookup("c4"))
+	})
+
+	t.Run("InvalidVersion", func(t *testing.T) {
+		_, err := parseFile("src/parse/asp/test_data/interpreter/semver_invalid_version.build")
+		assert.Error(t, err)
+	})
+
+	t.Run("InvalidConstraint", func(t *testing.T) {
+		_, err := parseFile("src/parse/asp/test_data/interpreter/semver_invalid_constraint.build")
+		assert.Error(t, err)
+	})
+}

--- a/src/parse/asp/test_data/interpreter/semver.build
+++ b/src/parse/asp/test_data/interpreter/semver.build
@@ -1,0 +1,4 @@
+c1 = semver_check("v1.5.0", ">=1.4.0")
+c2 = semver_check("v1.3.0", ">=1.4.0")
+c3 = semver_check("v1.0.5", "~1.0.0")
+c4 = semver_check("v1.1.0", "^1.0.0")

--- a/src/parse/asp/test_data/interpreter/semver_invalid_constraint.build
+++ b/src/parse/asp/test_data/interpreter/semver_invalid_constraint.build
@@ -1,0 +1,1 @@
+c1 = semver_check("v1.5.0", ">=one.four.zero")

--- a/src/parse/asp/test_data/interpreter/semver_invalid_version.build
+++ b/src/parse/asp/test_data/interpreter/semver_invalid_version.build
@@ -1,0 +1,1 @@
+c1 = semver_check("one.five.zero", ">=1.4.0")

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -838,3 +838,9 @@ go_module(
         ":zstd",
     ],
 )
+
+go_module(
+    name = "semver2",
+    module = "github.com/Masterminds/semver/v3",
+    version = "v3.1.1",
+)


### PR DESCRIPTION
Closes #1312

Note: this PR adds another semver library to the project. The reasons are listed in #1312, but in a nutshell:

- it's better maintained
- comes with more features
- has a more natural API

We can replace the original semver package in a subsequent PR.

Use case for this builtin function: tools sometimes change their versioning and download URL patterns ([example](https://github.com/sagikazarmark/mypleasings/blob/4b566b24e90ee3ac3899faa762a8895f7e0e6ef4/misc/tools.build_defs#L132-L134)). This function helps tool download build rules to introduce conditional logic based on the tool version to download tools from the right URL.