### PR TITLE
Make imports source relative when the import path is provided

### DIFF
--- a/rules/proto_rules.build_defs
+++ b/rules/proto_rules.build_defs
@@ -260,7 +260,7 @@ def proto_languages():
                 deps = deps,
                 test_only = test_only,
             ),
-            protoc_flags = ['--go_out="$OUT_DIR"', '--plugin=protoc-gen-go="`which $TOOLS_GO`"'],
+            protoc_flags = ['--go_out="$OUT_DIR"', '--plugin=protoc-gen-go="`which $TOOLS_GO`"', '--go_opt=paths=source_relative'],
             tools = [CONFIG.PROTOC_GO_PLUGIN],
             deps = [CONFIG.PROTO_GO_DEP],
             pre_build = _go_path_mapping(False),
@@ -343,9 +343,12 @@ def grpc_languages():
                 '--go_out="$OUT_DIR"',
                 '--plugin=protoc-gen-go="`which $TOOLS_GO`"',
                 '--plugin=protoc-gen-go-grpc="`which $TOOLS_GRPC_GO`"',
+                '--go_opt=paths=source_relative',
+                '--go-grpc_opt=paths=source_relative',
             ] if CONFIG.GRPC_GO_PLUGIN else [
                 '--go_out="$OUT_DIR"',
                 '--plugin=protoc-gen-go="`which $TOOLS_GO`"',
+                '--go_opt=paths=source_relative',
             ],
             tools = {
                 'go': [CONFIG.PROTOC_GO_PLUGIN],

--- a/test/proto_rules/go_grpc_ff/proto/service.proto
+++ b/test/proto_rules/go_grpc_ff/proto/service.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+option go_package = "github.com/thought-machine/please/test/proto_fules/go_frpc_ff/proto/service";
+
 service Service {
   rpc MakeRequest(Request) returns (Response) {};
 }


### PR DESCRIPTION
The old way of applying source relative (on the --go_out flag) no longer worked. It seemed like it wasn't needed as we attempt to collapse the package path when we move outputs to the output directory, so I removed it. Turns out it becomes relevant when applying `option go_package = ...;` as the package path and the import path don't necessarily line up. 

This PR adds the source relative opt back in via the correct flag. 