### PR TITLE
Use a non-deprecated openpgp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/thought-machine/please
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
+	github.com/ProtonMail/go-crypto v0.0.0-20210329181949-3900d675f39b // indirect
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4 // indirect
 	github.com/bazelbuild/buildtools v0.0.0-20190228125936-4bcdbd1064fc

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/ProtonMail/go-crypto v0.0.0-20210329181949-3900d675f39b h1:E0jcApeWTn0zEUOANmwLg2k3IfTIyX4ffz2l95AEIBk=
+github.com/ProtonMail/go-crypto v0.0.0-20210329181949-3900d675f39b/go.mod h1:HTM9X7e9oLwn7RiqLG0UVwVRJenLs3wN+tQ0NPAfwMQ=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=
@@ -419,6 +421,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -438,6 +441,7 @@ golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210217105451-b926d437f341 h1:2/QtM1mL37YmcsT8HaDNHDgTqqFVw+zr8UzMiBVLzYU=
 golang.org/x/sys v0.0.0-20210217105451-b926d437f341/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/update/BUILD
+++ b/src/update/BUILD
@@ -11,10 +11,10 @@ go_library(
         "//src/fs",
         "//src/process",
         "//src/utils",
+        "//third_party/go:go-crypto",
         "//third_party/go:go-retryablehttp",
         "//third_party/go:logging",
         "//third_party/go:semver",
-        "//third_party/go:xcrypto",
         "//third_party/go:xz",
     ],
 )

--- a/src/update/verify.go
+++ b/src/update/verify.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/thought-machine/please/src/cli"
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
 // identity is the signing identity of this key.
@@ -24,7 +24,7 @@ func verifySignature(signed, signature io.Reader) bool {
 	if err != nil {
 		log.Fatalf("%s", err) // Shouldn't happen
 	}
-	signer, err := openpgp.CheckArmoredDetachedSignature(entities, signed, signature)
+	signer, err := openpgp.CheckArmoredDetachedSignature(entities, signed, signature, nil)
 	if err != nil {
 		log.Error("Bad signature: %s", err)
 		return false

--- a/src/update/verify.go
+++ b/src/update/verify.go
@@ -10,8 +10,8 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/thought-machine/please/src/cli"
 	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/thought-machine/please/src/cli"
 )
 
 // identity is the signing identity of this key.

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -19,14 +19,31 @@ go_module(
     install = [
         "ssh/terminal",
         "cast5",
-
-        # TODO(jpoole): consider if requiring this to be explicit is a good idea or if we should do the
-        # `openpgp/openpgp.a` "hack" here
-        "openpgp/...",
-        "openpgp",
     ],
     module = "golang.org/x/crypto",
     version = "7b85b097bf7527677d54d3220065e966a0e3b613",
+)
+
+go_module(
+    name = "go-crypto",
+    module = "github.com/ProtonMail/go-crypto",
+    install = [
+        "bitcurves",
+        "brainpool",
+        "cast5",
+        "curve25519",
+        "eax",
+        "ed25519",
+        "internal/byteutil",
+        "internal/randutil",
+        "internal/syscall/unix",
+        "ocb",
+        "openpgp",
+        "openpgp/...",
+        "rand",
+        "rsa",
+    ],
+    version = "3900d675f39ba9686203d137886d74fad620ae87",
 )
 
 go_module(

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -36,7 +36,7 @@ go_module(
         "ed25519",
         "internal/byteutil",
         "internal/randutil",
-        "internal/syscall/unix",
+        "internal/syscall/...",
         "ocb",
         "openpgp",
         "openpgp/...",

--- a/tools/release_signer/signer/BUILD
+++ b/tools/release_signer/signer/BUILD
@@ -3,7 +3,7 @@ go_library(
     srcs = ["signer.go"],
     visibility = ["//tools/release_signer"],
     deps = [
-        "//third_party/go:xcrypto",
+        "//third_party/go:go-crypto",
     ],
 )
 
@@ -14,6 +14,6 @@ go_test(
     deps = [
         ":signer",
         "//third_party/go:testify",
-        "//third_party/go:xcrypto",
+        "//third_party/go:go-crypto",
     ],
 )

--- a/tools/release_signer/signer/signer.go
+++ b/tools/release_signer/signer/signer.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
 // SignFile creates a detached ASCII-armoured signature for the given file.

--- a/tools/release_signer/signer/signer_test.go
+++ b/tools/release_signer/signer/signer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
 const (
@@ -30,7 +30,7 @@ func verifyFile(signed, signature, keyring string) bool {
 	must(err)
 	entities, err := openpgp.ReadArmoredKeyRing(f3)
 	must(err)
-	_, err = openpgp.CheckArmoredDetachedSignature(entities, f1, f2)
+	_, err = openpgp.CheckArmoredDetachedSignature(entities, f1, f2, nil)
 	return err == nil
 }
 

--- a/tools/release_signer/signer/signer_test.go
+++ b/tools/release_signer/signer/signer_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/stretchr/testify/assert"
 )
 
 const (


### PR DESCRIPTION
Post https://github.com/golang/go/issues/44226 it seems we should not be using `x/crypto/openpgp`. https://github.com/ProtonMail/go-crypto seems like the best alternative.

I've built this locally and run an update which it decodes fine. I assume it will also be compatible for any older versions updating to it.