### PR TITLE
Upload tree blobs

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -315,6 +315,7 @@ func DefaultConfiguration() *Configuration {
 	config.Remote.NumExecutors = 20 // kind of arbitrary
 	config.Remote.Secure = true
 	config.Remote.VerifyOutputs = true
+	config.Remote.UploadDirs = true
 	config.Remote.CacheDuration = cli.Duration(10000 * 24 * time.Hour) // Effectively forever.
 	config.Go.GoTool = "go"
 	config.Go.CgoCCTool = "gcc"
@@ -464,6 +465,7 @@ type Configuration struct {
 		Timeout       cli.Duration `help:"Timeout for connections made to the remote server."`
 		Secure        bool         `help:"Whether to use TLS for communication or not."`
 		VerifyOutputs bool         `help:"Whether to verify all outputs are present after a cached remote execution action. Depending on your server implementation, you may require this to ensure files are really present."`
+		UploadDirs    bool         `help:"Uploads individual directory blobs after build actions. This might not be necessary with some servers, but if you aren't sure, you should leave it on."`
 		Shell         string       `help:"Path to the shell to use to execute actions in. Default looks up bash based on the build.path setting."`
 		Platform      []string     `help:"Platform properties to request from remote workers, in the format key=value."`
 		CacheDuration cli.Duration `help:"Length of time before we re-check locally cached build actions. Default is unlimited."`

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -426,6 +426,19 @@ func (c *Client) verifyActionResult(target *core.BuildTarget, command *pb.Comman
 		}
 	}
 
+	for _, out := range ar.OutputDirectories {
+		tree := &pb.Tree{}
+		if _, err := c.client.ReadProto(context.Background(), digest.NewFromProtoUnvalidated(out.TreeDigest), tree); err != nil {
+			return err
+		}
+		for _, dir := range append(tree.Children, tree.Root) {
+			if _, err := c.client.WriteProto(context.Background(), dir); err != nil {
+				return err
+			}
+		}
+	}
+
+
 	if !verifyRemoteBlobsExist {
 		return nil
 	}

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -465,7 +465,7 @@ func (c *Client) verifyActionResult(target *core.BuildTarget, command *pb.Comman
 	if missing, err := c.client.MissingBlobs(context.Background(), digests); err != nil {
 		return fmt.Errorf("Failed to verify action result outputs: %s", err)
 	} else if len(missing) != 0 {
-		return fmt.Errorf("Action result missing %d blobs", len(missing))
+		return fmt.Errorf("Action result missing %d blobs: %s", len(missing), missing)
 	}
 	log.Debug("Verified action result for %s in %s", target, time.Since(start))
 	return nil

--- a/src/remote/impl_test.go
+++ b/src/remote/impl_test.go
@@ -40,6 +40,7 @@ func newClientInstance(name string) *Client {
 	config.Remote.NumExecutors = 1
 	config.Remote.Instance = name
 	config.Remote.Secure = false
+	config.Remote.VerifyOutputs = false
 	state := core.NewBuildState(config)
 	state.Config.Remote.URL = "127.0.0.1:9987"
 	state.Config.Remote.AssetURL = state.Config.Remote.URL

--- a/src/remote/impl_test.go
+++ b/src/remote/impl_test.go
@@ -40,7 +40,6 @@ func newClientInstance(name string) *Client {
 	config.Remote.NumExecutors = 1
 	config.Remote.Instance = name
 	config.Remote.Secure = false
-	config.Remote.VerifyOutputs = false
 	state := core.NewBuildState(config)
 	state.Config.Remote.URL = "127.0.0.1:9987"
 	state.Config.Remote.AssetURL = state.Config.Remote.URL
@@ -347,6 +346,7 @@ func (s *testServer) Execute(req *pb.ExecuteRequest, srv pb.Execution_ExecuteSer
 			},
 		})
 	} else {
+		s.blobs["aaaf60fab1ff6b3d8147bafa3d29cb3e985cf0265cbf53705372eaabcd76c06b"] = []byte("what is the meaning of life, the universe, and everything?\n")
 		srv.Send(&longrunning.Operation{
 			Name: "geoff",
 			Metadata: mm(&pb.ExecuteOperationMetadata{
@@ -359,8 +359,8 @@ func (s *testServer) Execute(req *pb.ExecuteRequest, srv pb.Execution_ExecuteSer
 						OutputFiles: []*pb.OutputFile{{
 							Path: "out2.txt",
 							Digest: &pb.Digest{
-								Hash:      "5fb3d47e893061ea6627334a8582c37398cfdc68fe7fa59c16912e4a3ab7a5d6",
-								SizeBytes: 19,
+								Hash:      "aaaf60fab1ff6b3d8147bafa3d29cb3e985cf0265cbf53705372eaabcd76c06b",
+								SizeBytes: 60,
 							},
 						}},
 						ExitCode: 0,

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -741,7 +741,7 @@ func (c *Client) reallyExecute(tid int, target *core.BuildTarget, command *pb.Co
 			return nil, nil, err
 		}
 		log.Debug("Completed remote build action for %s", target)
-		if err := c.verifyActionResult(target, command, digest, response.Result, false, isTest); err != nil {
+		if err := c.verifyActionResult(target, command, digest, response.Result, c.state.Config.Remote.VerifyOutputs && !isTest, isTest); err != nil {
 			return metadata, response.Result, err
 		}
 		c.locallyCacheResults(target, digest, metadata, response.Result)


### PR DESCRIPTION
Turns out we are implicitly assuming that servers will do this (probably because we do, and Buildgrid does, so it was fine until now).
However it is not guaranteed by the spec. I am guarding it with a config option since it'll cause a bunch more RPCs which we would prefer not internally.