### PR TITLE
Implement revdeps without lookahead

### DIFF
--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -354,6 +354,11 @@ func (label BuildLabel) Parent() BuildLabel {
 	return label
 }
 
+// IsHidden return whether the target is an intermediate target created by the build definition.
+func (label BuildLabel) IsHidden() bool {
+	return label.Name[0] == '_'
+}
+
 // HasParent returns true if the build label has a parent that's not itself.
 func (label BuildLabel) HasParent() bool {
 	return label.Parent() != label

--- a/src/please.go
+++ b/src/please.go
@@ -674,7 +674,7 @@ var buildFunctions = map[string]func() int{
 			level = -1
 		case direct && (level == -2):
 			level = 1
-		case (level == -2):
+		case level == -2:
 			level = 0
 		}
 		runInexact := func(files []string) int {

--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -59,14 +59,17 @@ func changedTargets(state *core.BuildState, files []string, changed map[*core.Bu
 	for target := range changed {
 		labels = append(labels, target.Label)
 	}
-	if level != 0 {
-		revdeps := map[core.BuildLabel]int{}
-		getRevDepTransitiveLabels(state, labels, revdeps, level)
 
+	if level != 0 {
+		revdeps := FindRevdeps(state, labels, true, level)
 		for dep := range revdeps {
-			labels = append(labels, dep)
+			if _, present := changed[dep]; !present {
+				labels = append(labels, dep.Label)
+			}
 		}
 	}
+
+
 
 	ls := make(core.BuildLabels, 0, len(labels))
 	for _, l := range labels {

--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -69,8 +69,6 @@ func changedTargets(state *core.BuildState, files []string, changed map[*core.Bu
 		}
 	}
 
-
-
 	ls := make(core.BuildLabels, 0, len(labels))
 	for _, l := range labels {
 		if state.ShouldInclude(state.Graph.TargetOrDie(l)) {

--- a/src/query/changes_test.go
+++ b/src/query/changes_test.go
@@ -74,7 +74,7 @@ func TestDiffGraphsIncludeTransitive(t *testing.T) {
 	t1 = addTarget(s2, "//src/core:core", nil, "src/core/core_changed.go")
 	t2 = addTarget(s2, "//src/query:changes", t1, "src/query/changes.go")
 	t3 := addTarget(s2, "//src/query:changes_test", t2, "src/query/changes_test.go")
-	assert.EqualValues(t, []core.BuildLabel{t1.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, nil, -1))
+	assert.EqualValues(t, core.BuildLabels{t1.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, nil, -1))
 }
 
 func TestChangesIncludesDataDirs(t *testing.T) {

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"container/list"
 	"fmt"
 	"sort"
 
@@ -9,13 +10,24 @@ import (
 
 // ReverseDeps finds all transitive targets that depend on the set of input labels.
 func ReverseDeps(state *core.BuildState, labels []core.BuildLabel, level int, hidden bool) {
-	targets := make(map[core.BuildLabel]int, 100)
-	getRevDepTransitiveLabels(state, labels, targets, level)
-
+	targets := FindRevdeps(state, labels, hidden, level)
 	ls := make(core.BuildLabels, 0, len(targets))
+
+	done := make(map[core.BuildLabel]struct{}, len(targets))
 	for target := range targets {
-		if hidden || target.Name[0] != '_' && state.ShouldInclude(state.Graph.TargetOrDie(target)) {
-			ls = append(ls, target)
+		if state.ShouldInclude(target) {
+			label := target.Label
+			// Resolve targets to their parent unless including hidden targets
+			if parent := target.Parent(state.Graph); !hidden && parent != nil {
+				label = parent.Label
+			}
+
+			// Exclude duplicates where we had many children of the same target
+			if _, present := done[label]; present {
+				continue
+			}
+			done[label] = struct{}{}
+			ls = append(ls, label)
 		}
 	}
 	sort.Sort(ls)
@@ -25,53 +37,125 @@ func ReverseDeps(state *core.BuildState, labels []core.BuildLabel, level int, hi
 	}
 }
 
-func getRevDepTransitiveLabels(state *core.BuildState, labels []core.BuildLabel, done map[core.BuildLabel]int, levelsToGo int) {
-	if levelsToGo == 0 {
-		return
-	}
-	for _, l := range getRevDepsLabels(state, labels) {
-		// The level starts high and is decremented, so if we saw this target was a lower level, that means we need to
-		// reprocess it with more levels to go.
-		if doneLevel, present := done[l]; !present || levelsToGo > doneLevel {
-			done[l] = levelsToGo
-			getRevDepTransitiveLabels(state, []core.BuildLabel{l}, done, levelsToGo-1)
-		}
+// node represents a node in the build graph and the depth we visited it at.
+type node struct {
+	target *core.BuildTarget
+	depth  int
+}
+
+// openSet represents the queue of nodes we need to process in the graph
+type openSet struct {
+	items *list.List
+
+	// depths contains a map of labels and the depth we processed them at.
+	// This is used to efficiently push nodes to the queue when we revisit them
+	// at a lower depth
+	depths map[core.BuildLabel]int
+}
+
+// Push implements pushing a node onto the queue of nodes to process. It will only add the node if we need to to process
+// it because either it 1) hasn't been seen before, or 2) has been seen but at a lower level
+func (os *openSet) Push(n *node) {
+	// Add the node to the open set of nodes to process if we've not seen it before or we saw it as a deeper level
+	// and need to reprocess
+	if depth, present := os.depths[n.target.Label]; !present || depth > n.depth {
+		os.depths[n.target.Label] = n.depth
+		os.items.PushBack(n)
 	}
 }
 
-// getRevDepsLabels returns a slice of build labels that are the reverse dependencies of the build labels being passed in
-func getRevDepsLabels(state *core.BuildState, labels []core.BuildLabel) core.BuildLabels {
-	uniqueTargets := map[*core.BuildTarget]struct{}{}
-
-	graph := state.Graph
-	for _, label := range labels {
-		for _, child := range graph.PackageOrDie(label).AllChildren(graph.TargetOrDie(label)) {
-			for _, target := range graph.ReverseDependencies(child) {
-				if parent := target.Parent(graph); parent != nil {
-					uniqueTargets[parent] = struct{}{}
-				} else {
-					uniqueTargets[target] = struct{}{}
-				}
-			}
-		}
+func (os *openSet) Pop() *node {
+	next := os.items.Front()
+	if next == nil {
+		return nil
 	}
-	// Check for anything subincluding this guy too
+	os.items.Remove(next)
+
+	return next.Value.(*node)
+}
+
+type revdeps struct {
+	// subincludes is a map of build labels to the packages that subinclude them
+	subincludes map[core.BuildLabel][]*core.Package
+
+	// os is the open set of targets to process
+	os *openSet
+
+	// hidden is whether to count hidden targets towards the depth budget
+	hidden   bool
+
+	// maxDepth is the depth budget for the search. -1 means unlimited.
+	maxDepth int
+}
+
+// newRevdeps creates a new reverse dependency searcher. revdeps is non-reusable.
+func newRevdeps(graph *core.BuildGraph, hidden bool, maxDepth int) *revdeps {
+	// Initialise a map of labels to the packages that subinclude them upfront so we can include those targets as
+	// dependencies efficiently later
+	subincludes := make(map[core.BuildLabel][]*core.Package)
 	for _, pkg := range graph.PackageMap() {
-		for _, label := range labels {
-			if pkg.HasSubinclude(label) {
-				for _, target := range pkg.AllTargets() {
-					uniqueTargets[target] = struct{}{}
-				}
-			}
+		for _, inc := range pkg.Subincludes {
+			subincludes[inc] = append(subincludes[inc], pkg)
 		}
 	}
 
-	targets := make(core.BuildLabels, 0, len(uniqueTargets))
-	for _, label := range labels {
-		delete(uniqueTargets, graph.TargetOrDie(label))
+	return &revdeps{
+		subincludes: subincludes,
+		os: &openSet{
+			items:  list.New(),
+			depths: map[core.BuildLabel]int{},
+		},
+		hidden:   hidden,
+		maxDepth: maxDepth,
 	}
-	for target := range uniqueTargets {
-		targets = append(targets, target.Label)
+}
+
+// FindRevdeps will return a list of build targets that are reverse dependencies of the provided labels. This may
+// include duplicate targets.
+func FindRevdeps(state *core.BuildState, targets core.BuildLabels, hidden bool, depth int) map[*core.BuildTarget]struct{} {
+	r := newRevdeps(state.Graph, hidden, depth)
+	// Initialise the open set with the original targets
+	for _, t := range targets {
+		r.os.Push(&node{
+			target: state.Graph.TargetOrDie(t),
+			depth:  0,
+		})
 	}
-	return targets
+	return r.findRevdeps(state)
+}
+
+func (r *revdeps) findRevdeps(state *core.BuildState) map[*core.BuildTarget]struct{} {
+	// 1000 is chosen pretty much arbitrarily here
+	ret := make(map[*core.BuildTarget]struct{}, 1000)
+	for next := r.os.Pop(); next != nil; next = r.os.Pop() {
+		ts := state.Graph.ReverseDependencies(next.target)
+
+		for _, p := range r.subincludes[next.target.Label] {
+			ts = append(ts, p.AllTargets()...)
+		}
+
+		for _, t := range ts {
+			depth := next.depth
+			parent := t.Parent(state.Graph)
+
+			// The label shouldn't count towards the depth if it's a child of the last label
+			if r.hidden || parent == nil || parent != next.target {
+				depth++
+			}
+
+			// We can skip adding to the open set if the depth of the next non-child label pushes us over the budget
+			// but we must make sure to add child labels at the current depth.
+			if (next.depth+1) <= r.maxDepth || r.maxDepth == -1 {
+				if r.hidden || !t.Label.IsHidden() {
+					ret[t] = struct{}{}
+				}
+
+				r.os.Push(&node{
+					target: t,
+					depth:  depth,
+				})
+			}
+		}
+	}
+	return ret
 }

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -82,7 +82,7 @@ type revdeps struct {
 	os *openSet
 
 	// hidden is whether to count hidden targets towards the depth budget
-	hidden   bool
+	hidden bool
 
 	// maxDepth is the depth budget for the search. -1 means unlimited.
 	maxDepth int

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -32,7 +32,7 @@ type node struct {
 }
 
 // openSet represents the queue of nodes we need to process in the graph. There are no duplicates in this set and the
-// queue will be ordered low to high by depth.
+// queue will be ordered low to high by depth i.e. in the order they must be processed
 //
 // NB: We don't need to explicitly order this. Paths either cost 1 or 0, but all 0 cost paths are equivalent e.g. paths
 // :lib1 -> :_lib1#foo -> :lib2, lib1 -> :_lib1#foo -> :_lib1#bar -> :lib2, and :lib1 -> lib2 all have a cost of 1 and
@@ -44,17 +44,15 @@ type openSet struct {
 	done map[core.BuildLabel]struct{}
 }
 
-// Push implements pushing a node onto the queue of nodes to process. It will only add the node if we need to to process
-// it because either it 1) hasn't been seen before, or 2) has been seen but at a lower level
+// Push implements pushing a node onto the queue of nodes to process, deduplicating nodes we've seen before.
 func (os *openSet) Push(n *node) {
-	// Add the node to the open set of nodes to process if we've not seen it before or we saw it as a deeper level
-	// and need to reprocess
 	if _, present := os.done[n.target.Label]; !present {
 		os.done[n.target.Label] = struct {}{}
 		os.items.PushBack(n)
 	}
 }
 
+// Pop fetches the next node off the queue for us to process
 func (os *openSet) Pop() *node {
 	next := os.items.Front()
 	if next == nil {

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -47,7 +47,7 @@ type openSet struct {
 // Push implements pushing a node onto the queue of nodes to process, deduplicating nodes we've seen before.
 func (os *openSet) Push(n *node) {
 	if _, present := os.done[n.target.Label]; !present {
-		os.done[n.target.Label] = struct {}{}
+		os.done[n.target.Label] = struct{}{}
 		os.items.PushBack(n)
 	}
 }
@@ -91,8 +91,8 @@ func newRevdeps(graph *core.BuildGraph, hidden bool, maxDepth int) *revdeps {
 	return &revdeps{
 		subincludes: subincludes,
 		os: &openSet{
-			items:  list.New(),
-			done: map[core.BuildLabel]struct{}{},
+			items: list.New(),
+			done:  map[core.BuildLabel]struct{}{},
 		},
 		hidden:   hidden,
 		maxDepth: maxDepth,

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -133,9 +133,6 @@ func (r *revdeps) findRevdeps(state *core.BuildState) map[*core.BuildTarget]stru
 	for next := r.os.Pop(); next != nil; next = r.os.Pop() {
 		ts := state.Graph.ReverseDependencies(next.target)
 
-		nextLabel := fmt.Sprintf("%v -> %v", next.target, ts)
-		_ = nextLabel
-
 		for _, p := range r.subincludes[next.target.Label] {
 			ts = append(ts, p.AllTargets()...)
 		}

--- a/src/query/reverse_deps_test.go
+++ b/src/query/reverse_deps_test.go
@@ -24,21 +24,52 @@ func TestReverseDeps(t *testing.T) {
 	graph.AddDependency(leaf.Label, branch.Label)
 
 	pkg := core.NewPackage("package")
-	pkg.AddTarget(root)
-	pkg.AddTarget(branch)
-	pkg.AddTarget(leaf)
 	graph.AddPackage(pkg)
 
-	labels := revDepsLabels(state, []core.BuildLabel{branch.Label}, -1)
+	labels := revDepsLabels(state, []core.BuildLabel{branch.Label}, false, -1)
 	assert.ElementsMatch(t, core.BuildLabels{leaf.Label}, labels)
-	labels = revDepsLabels(state, []core.BuildLabel{root.Label}, -1)
+	labels = revDepsLabels(state, []core.BuildLabel{root.Label}, false, -1)
 	assert.ElementsMatch(t, core.BuildLabels{branch.Label, leaf.Label}, labels)
-	labels = revDepsLabels(state, []core.BuildLabel{root.Label}, 1)
+	labels = revDepsLabels(state, []core.BuildLabel{root.Label}, false, 1)
 	assert.ElementsMatch(t, core.BuildLabels{branch.Label}, labels)
 }
 
-func revDepsLabels(state *core.BuildState, labels []core.BuildLabel, depth int) core.BuildLabels {
-	ts := FindRevdeps(state, labels, false, depth)
+
+func TestReverseDepsWithHidden(t *testing.T) {
+	state := core.NewDefaultBuildState()
+	graph := state.Graph
+
+	foo := core.NewBuildTarget(core.ParseBuildLabel("//package:foo", ""))
+	fooInter1 := core.NewBuildTarget(core.ParseBuildLabel("//package:_foo#tag1", ""))
+	fooInter2 := core.NewBuildTarget(core.ParseBuildLabel("//package:_foo#tag2", ""))
+	bar := core.NewBuildTarget(core.ParseBuildLabel("//package:bar", ""))
+	foo.AddDependency(fooInter2.Label)
+	fooInter2.AddDependency(fooInter1.Label)
+	fooInter1.AddDependency(bar.Label)
+	graph.AddTarget(foo)
+	graph.AddTarget(fooInter1)
+	graph.AddTarget(fooInter2)
+	graph.AddTarget(bar)
+
+	pkg := core.NewPackage("package")
+	graph.AddPackage(pkg)
+
+	labels := revDepsLabels(state, []core.BuildLabel{bar.Label}, false, 1)
+	assert.ElementsMatch(t, core.BuildLabels{foo.Label}, labels)
+
+	labels = revDepsLabels(state, []core.BuildLabel{bar.Label}, true, 1)
+	assert.ElementsMatch(t, core.BuildLabels{fooInter1.Label}, labels)
+
+	labels = revDepsLabels(state, []core.BuildLabel{bar.Label}, true, 2)
+	assert.ElementsMatch(t, core.BuildLabels{fooInter1.Label, fooInter2.Label}, labels)
+
+	labels = revDepsLabels(state, []core.BuildLabel{bar.Label}, true, 3)
+	assert.ElementsMatch(t, core.BuildLabels{fooInter1.Label, fooInter2.Label, foo.Label}, labels)
+}
+
+
+func revDepsLabels(state *core.BuildState, labels []core.BuildLabel, hidden bool, depth int) core.BuildLabels {
+	ts := FindRevdeps(state, labels, hidden, depth)
 
 	ret := make([]core.BuildLabel, 0, len(ts))
 	for t := range ts {

--- a/src/query/reverse_deps_test.go
+++ b/src/query/reverse_deps_test.go
@@ -34,7 +34,6 @@ func TestReverseDeps(t *testing.T) {
 	assert.ElementsMatch(t, core.BuildLabels{branch.Label}, labels)
 }
 
-
 func TestReverseDepsWithHidden(t *testing.T) {
 	state := core.NewDefaultBuildState()
 	graph := state.Graph
@@ -66,7 +65,6 @@ func TestReverseDepsWithHidden(t *testing.T) {
 	labels = revDepsLabels(state, []core.BuildLabel{bar.Label}, true, 3)
 	assert.ElementsMatch(t, core.BuildLabels{fooInter1.Label, fooInter2.Label, foo.Label}, labels)
 }
-
 
 func revDepsLabels(state *core.BuildState, labels []core.BuildLabel, hidden bool, depth int) core.BuildLabels {
 	ts := FindRevdeps(state, labels, hidden, depth)

--- a/src/query/reverse_deps_test.go
+++ b/src/query/reverse_deps_test.go
@@ -37,13 +37,12 @@ func TestReverseDeps(t *testing.T) {
 	assert.ElementsMatch(t, core.BuildLabels{branch.Label}, labels)
 }
 
-func revDepsLabels(state *core.BuildState, labels []core.BuildLabel, levelsToGo int) core.BuildLabels {
-	ls := map[core.BuildLabel]int{}
-	getRevDepTransitiveLabels(state, labels, ls, levelsToGo)
+func revDepsLabels(state *core.BuildState, labels []core.BuildLabel, depth int) core.BuildLabels {
+	ts := FindRevdeps(state, labels, false, depth)
 
-	ret := make([]core.BuildLabel, 0, len(ls))
-	for l := range ls {
-		ret = append(ret, l)
+	ret := make([]core.BuildLabel, 0, len(ts))
+	for t := range ts {
+		ret = append(ret, t.Label)
 	}
 	return ret
 }

--- a/src/query/somepath.go
+++ b/src/query/somepath.go
@@ -16,7 +16,7 @@ func SomePath(graph *core.BuildGraph, from, to []core.BuildLabel) error {
 		for _, l2 := range expandAllTargets(graph, to) {
 			if path := s.SomePath(graph.TargetOrDie(l1), graph.TargetOrDie(l2)); len(path) != 0 {
 				fmt.Println("Found path:")
-				for _, l := range filterPath(path) {
+				for _, l := range path {
 					fmt.Printf("  %s\n", l)
 				}
 				return nil

--- a/src/query/somepath.go
+++ b/src/query/somepath.go
@@ -16,7 +16,7 @@ func SomePath(graph *core.BuildGraph, from, to []core.BuildLabel) error {
 		for _, l2 := range expandAllTargets(graph, to) {
 			if path := s.SomePath(graph.TargetOrDie(l1), graph.TargetOrDie(l2)); len(path) != 0 {
 				fmt.Println("Found path:")
-				for _, l := range path {
+				for _, l := range filterPath(path) {
 					fmt.Printf("  %s\n", l)
 				}
 				return nil

--- a/test/revdeps/BUILD
+++ b/test/revdeps/BUILD
@@ -45,6 +45,12 @@ plz_e2e_test(
     expected_output = "query_revdeps_single_level_test.txt",
 )
 
+plz_e2e_test(
+    name = "query_revdeps_no_level_test",
+    cmd = "plz query revdeps --level=0 //test/revdeps:target1",
+    expected_output = "query_revdeps_no_level_test.txt",
+)
+
 # Test that we always include 3 when querying deps at level 2
 # 3 -> 2 -> 1 -> 4 (3 is 3 levels deep here so would be excluded)
 # 3 -> 2 -> 4 (but is at level 2 here so should be included)

--- a/test/revdeps/hidden_test/BUILD
+++ b/test/revdeps/hidden_test/BUILD
@@ -1,24 +1,11 @@
 subinclude("//test/build_defs")
 
-# creates a filegroup with two hidden intermediate rules
-def two_intermediate(name:str, deps:list):
-    one = filegroup(
-        name = name,
-        tag = "one",
-        deps = deps,
-    )
+filegroup(
+    name = "two_intermediate",
+    srcs = ["two_intermediate.build_defs"],
+)
 
-    two = filegroup(
-        name = name,
-        tag = "two",
-        deps = [one],
-    )
-
-    return filegroup(
-        name = name,
-        deps = [two],
-    )
-
+subinclude(":two_intermediate")
 
 two_intermediate(
     name = "lvl0",

--- a/test/revdeps/hidden_test/BUILD
+++ b/test/revdeps/hidden_test/BUILD
@@ -1,0 +1,76 @@
+subinclude("//test/build_defs")
+
+# creates a filegroup with two hidden intermediate rules
+def two_intermediate(name:str, deps:list):
+    one = filegroup(
+        name = name,
+        tag = "one",
+        deps = deps,
+    )
+
+    two = filegroup(
+        name = name,
+        tag = "two",
+        deps = [one],
+    )
+
+    return filegroup(
+        name = name,
+        deps = [two],
+    )
+
+
+two_intermediate(
+    name = "lvl0",
+    deps = [],
+)
+
+two_intermediate(
+    name = "lvl1",
+    deps = [":lvl0"],
+)
+
+two_intermediate(
+    name = "lvl2",
+    deps = [":lvl1"],
+)
+
+two_intermediate(
+    name = "lvl3",
+    deps = [":lvl2"],
+)
+
+two_intermediate(
+    name = "lvl4",
+    deps = [":lvl3"],
+)
+
+plz_e2e_test(
+    name = "query_revdeps_level1",
+    cmd = "plz query revdeps --level=1 //test/revdeps/hidden_test:lvl0",
+    expected_output = "lvl1.txt",
+)
+
+plz_e2e_test(
+    name = "query_revdeps_level2",
+    cmd = "plz query revdeps --level=2 //test/revdeps/hidden_test:lvl0",
+    expected_output = "lvl2.txt",
+)
+
+plz_e2e_test(
+    name = "query_revdeps_level3",
+    cmd = "plz query revdeps --level=3 //test/revdeps/hidden_test:lvl0",
+    expected_output = "lvl3.txt",
+)
+
+plz_e2e_test(
+    name = "query_revdeps_level4",
+    cmd = "plz query revdeps --level=4 //test/revdeps/hidden_test:lvl0",
+    expected_output = "lvl4.txt",
+)
+
+plz_e2e_test(
+    name = "query_revdeps_level4_hidden",
+    cmd = "plz query revdeps --level=4 --hidden //test/revdeps/hidden_test:lvl0",
+    expected_output = "lvl4_hidden.txt",
+)

--- a/test/revdeps/hidden_test/lvl1.txt
+++ b/test/revdeps/hidden_test/lvl1.txt
@@ -1,0 +1,1 @@
+//test/revdeps/hidden_test:lvl1

--- a/test/revdeps/hidden_test/lvl2.txt
+++ b/test/revdeps/hidden_test/lvl2.txt
@@ -1,0 +1,2 @@
+//test/revdeps/hidden_test:lvl1
+//test/revdeps/hidden_test:lvl2

--- a/test/revdeps/hidden_test/lvl3.txt
+++ b/test/revdeps/hidden_test/lvl3.txt
@@ -1,0 +1,3 @@
+//test/revdeps/hidden_test:lvl1
+//test/revdeps/hidden_test:lvl2
+//test/revdeps/hidden_test:lvl3

--- a/test/revdeps/hidden_test/lvl4.txt
+++ b/test/revdeps/hidden_test/lvl4.txt
@@ -1,0 +1,4 @@
+//test/revdeps/hidden_test:lvl1
+//test/revdeps/hidden_test:lvl2
+//test/revdeps/hidden_test:lvl3
+//test/revdeps/hidden_test:lvl4

--- a/test/revdeps/hidden_test/lvl4_hidden.txt
+++ b/test/revdeps/hidden_test/lvl4_hidden.txt
@@ -1,5 +1,4 @@
 //test/revdeps/hidden_test:_lvl1#one
 //test/revdeps/hidden_test:_lvl1#two
 //test/revdeps/hidden_test:_lvl2#one
-//test/revdeps/hidden_test:_lvl2#two
 //test/revdeps/hidden_test:lvl1

--- a/test/revdeps/hidden_test/lvl4_hidden.txt
+++ b/test/revdeps/hidden_test/lvl4_hidden.txt
@@ -1,0 +1,5 @@
+//test/revdeps/hidden_test:_lvl1#one
+//test/revdeps/hidden_test:_lvl1#two
+//test/revdeps/hidden_test:_lvl2#one
+//test/revdeps/hidden_test:_lvl2#two
+//test/revdeps/hidden_test:lvl1

--- a/test/revdeps/hidden_test/two_intermediate.build_defs
+++ b/test/revdeps/hidden_test/two_intermediate.build_defs
@@ -1,0 +1,18 @@
+# creates a filegroup with two hidden intermediate rules
+def two_intermediate(name:str, deps:list):
+    one = filegroup(
+        name = name,
+        tag = "one",
+        deps = deps,
+    )
+
+    two = filegroup(
+        name = name,
+        tag = "two",
+        deps = [one],
+    )
+
+    return filegroup(
+        name = name,
+        deps = [two],
+    )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -26,7 +26,6 @@ go_module(
 
 go_module(
     name = "go-crypto",
-    module = "github.com/ProtonMail/go-crypto",
     install = [
         "bitcurves",
         "brainpool",
@@ -43,6 +42,7 @@ go_module(
         "rand",
         "rsa",
     ],
+    module = "github.com/ProtonMail/go-crypto",
     version = "3900d675f39ba9686203d137886d74fad620ae87",
 )
 

--- a/tools/release_signer/signer/BUILD
+++ b/tools/release_signer/signer/BUILD
@@ -13,7 +13,7 @@ go_test(
     data = ["test_data"],
     deps = [
         ":signer",
-        "//third_party/go:testify",
         "//third_party/go:go-crypto",
+        "//third_party/go:testify",
     ],
 )


### PR DESCRIPTION
Before we were doing this:
```
for _, child := range graph.PackageOrDie(label).AllChildren(graph.TargetOrDie(label)) {
	for _, target := range graph.ReverseDependencies(child) {
		if parent := target.Parent(graph); parent != nil {
			uniqueTargets[parent] = struct{}{}
		} else {
			uniqueTargets[target] = struct{}{}
		}
	}
}
```
which was quite slow for `query changes` which would pass in many more targets and evaluate a much larger graph. 

This implements a more traditional breadth first approach which increments the depth only when passing boundaries between rules (ignoring hidden targets of the same rule). 