### PR TITLE
Fix go_get attribute in dependencies docs

### DIFF
--- a/docs/dependencies.html
+++ b/docs/dependencies.html
@@ -120,7 +120,7 @@
     go_get(
         name = 'my_library',
         get = "github.com/me/my_library",
-        version = "1.0.0",
+        revision = "v1.0.0",
     )
         </code>
       </pre>


### PR DESCRIPTION
https://please.build/dependencies.html has the following code for Go:
```
    go_get(
        name = "my_library",
        get = "github.com/me/my_library",
        version = "1.0.0",
    )
```
however go_get uses the revision attribute, not version