### PR TITLE
Don't set outputs on metadata retrieval

### DIFF
--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -201,9 +201,7 @@ func (c *Client) retrieveLocalResults(target *core.BuildTarget, digest *pb.Diges
 		if metadata != nil && len(metadata.RemoteAction) > 0 {
 			ar := &pb.ActionResult{}
 			if err := proto.Unmarshal(metadata.RemoteAction, ar); err == nil {
-				if err := c.setOutputs(target, ar); err == nil {
-					return metadata, ar
-				}
+				return metadata, ar
 			}
 		}
 	}


### PR DESCRIPTION
Some investigation shows that we're doing this twice in most cases (it's also done in `Build`).
It is incorrect to do it for tests though; we end up passing the test outputs into future test runs (can reproduce by doing `plz test -n 50 //something` more than once; the second and subsequent ones see an arbitrary number of those runs fail).