### PR TITLE
Improve user experience around ... in go_module()

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -1107,19 +1107,24 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
             strip = strip,
         )
     outs = []
+
+    # Gets the expected archive name given a target package
+    def archive_name(i):
+        base = basename(i)
+        return f"{i}/{base}.a"
     if not binary:
         if not install:
-            outs = [f"{module}.a"]
+            outs = [archive_name(module)]
         else:
             for i in install:
                 if i == module or i == f"{module}/.":
-                    outs += [module + ".a"]
+                    outs = [archive_name(module)]
                 elif i == "...":
                     outs = [module]
                 elif i.endswith("/..."):
                     outs += [i.removesuffix("/...")]
                 else:
-                    outs += [f"{i}.a"]
+                    outs += [archive_name(i)]
 
     a_rule = _go_install_module(
         name = name,

--- a/test/go_modules/test_repo/third_party/go/BUILD_FILE
+++ b/test/go_modules/test_repo/third_party/go/BUILD_FILE
@@ -35,7 +35,7 @@ go_module(
     name = "terminal",
     module = "golang.org/x/crypto",
     version = "7b85b097bf7527677d54d3220065e966a0e3b613", # Can still use revisions as versions
-    install = ["ssh/terminal"],
+    install = ["ssh/terminal/..."],
 )
 
 go_module(

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -37,7 +37,6 @@ go_module(
         "internal/randutil",
         "internal/syscall/...",
         "ocb",
-        "openpgp",
         "openpgp/...",
         "rand",
         "rsa",
@@ -55,7 +54,6 @@ go_module(
 go_module(
     name = "gcfg",
     install = [
-        ".",
         "...",
     ],
     module = "github.com/peterebden/gcfg",
@@ -123,7 +121,6 @@ go_module(
         "secure/...",
         "unicode/...",
         "transform",
-        "encoding",
         "encoding/...",
     ],
     module = "golang.org/x/text",
@@ -153,7 +150,6 @@ go_module(
         "balancer",
         "balancer/base",
         "balancer/grpclb/...",
-        "balancer/grpclb",
         "balancer/roundrobin",
         "binarylog/...",
         "codes",
@@ -167,7 +163,6 @@ go_module(
         "health",
         "health/grpc_health_v1",
         "internal/...",
-        "internal",
         "keepalive",
         "metadata",
         "peer",
@@ -642,7 +637,6 @@ go_module(
 go_module(
     name = "cmp",
     install = [
-        "cmp",
         "cmp/...",
     ],
     module = "github.com/google/go-cmp",
@@ -703,7 +697,6 @@ go_module(
 go_module(
     name = "promptui",
     install = [
-        ".",
         "...",
     ],
     module = "github.com/manifoldco/promptui",
@@ -723,7 +716,6 @@ go_module(
 go_module(
     name = "ansiterm",
     install = [
-        ".",
         "...",
     ],
     module = "github.com/juju/ansiterm",
@@ -776,7 +768,6 @@ go_module(
     name = "goldmark",
     install = [
         "...",
-        ".",
     ],
     module = "github.com/yuin/goldmark",
     version = "v1.2.1",
@@ -839,7 +830,6 @@ go_module(
     install = [
         "fse",
         "huff0",
-        "zstd",
         "zstd/...",
         "snappy",
     ],

--- a/tools/please_go/install/exec/exec.go
+++ b/tools/please_go/install/exec/exec.go
@@ -21,7 +21,7 @@ type OsExecutor struct {
 // Exec runs the command
 func (e *OsExecutor) Exec(cmdStr string, args ...interface{}) error {
 	cmdStr = fmt.Sprintf(cmdStr, args...)
-	fmt.Fprintf(os.Stderr, "please_go_install -> %v\n", cmdStr)
+	fmt.Fprintf(os.Stderr, "please_go install -> %v\n", cmdStr)
 
 	cmd := exec.Command("bash", "-e", "-c", cmdStr)
 	cmd.Stdout = e.Stdout

--- a/tools/please_go/install/install.go
+++ b/tools/please_go/install/install.go
@@ -206,7 +206,7 @@ func (install *PleaseGoInstall) prepWorkdir(pkg *build.Package, workDir, out str
 // We can get away with this because we don't compile tests so there must be exactly one package per directory.
 func outPath(outDir, target string) string {
 	dirName := filepath.Base(target)
-	return filepath.Join(outDir, filepath.Dir(target), dirName, dirName + ".a")
+	return filepath.Join(outDir, filepath.Dir(target), dirName, dirName+".a")
 }
 
 func (install *PleaseGoInstall) compilePackage(target string, pkg *build.Package) error {

--- a/tools/please_go/install/install.go
+++ b/tools/please_go/install/install.go
@@ -199,12 +199,22 @@ func (install *PleaseGoInstall) prepWorkdir(pkg *build.Package, workDir, out str
 	return install.tc.Exec.Exec("ln %s %s", toolchain.FullPaths(allSrcs, pkg.Dir), workDir)
 }
 
+// outPath returns the path to the .a for a given package. Unlike go build, please_go install will always output to
+// the same location regardless of if the package matches the package dir base e.g. example.com/foo will always produce
+// example.com/foo/foo.a no matter what the package under there is named.
+//
+// We can get away with this because we don't compile tests so there must be exactly one package per directory.
+func outPath(outDir, target string) string {
+	dirName := filepath.Base(target)
+	return filepath.Join(outDir, filepath.Dir(target), dirName, dirName + ".a")
+}
+
 func (install *PleaseGoInstall) compilePackage(target string, pkg *build.Package) error {
 	if len(pkg.GoFiles)+len(pkg.CgoFiles) == 0 {
 		return nil
 	}
 
-	out := fmt.Sprintf("%s/%s.a", install.outDir, target)
+	out := outPath(install.outDir, target)
 	workDir := fmt.Sprintf("_build/%s", target)
 
 	if err := install.prepWorkdir(pkg, workDir, out); err != nil {

--- a/tools/please_go/install/install_test.go
+++ b/tools/please_go/install/install_test.go
@@ -36,7 +36,7 @@ func TestLocalImports(t *testing.T) {
 	err := install.Install([]string{"local_imports/foo"})
 	require.NoError(t, err)
 
-	expectedOut := "out/example.com/local_imports/foo.a"
+	expectedOut := "out/example.com/local_imports/foo/foo.a"
 	require.True(t, fs.FileExists(expectedOut), "output file %s wasn't created", expectedOut)
 }
 


### PR DESCRIPTION
This makes `foo/...` install `foo` as well as everything under `foo`. This avoids having to have:
```
go_module(
   ...
   install = ["foo", "foo/..."],
)
```