### PR TITLE
plz cover --shell implies --nocoverage_report

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -429,7 +429,7 @@ var buildFunctions = map[string]func() int{
 
 		if opts.Cover.LineCoverageReport {
 			output.PrintLineCoverageReport(state, opts.Cover.IncludeFile.AsStrings())
-		} else if !opts.Cover.NoCoverageReport {
+		} else if !opts.Cover.NoCoverageReport && !opts.Cover.Shell {
 			output.PrintCoverage(state, opts.Cover.IncludeFile.AsStrings())
 		}
 		if opts.Cover.Incremental {


### PR DESCRIPTION
Because when you exit the shell, the test is treated as failed, and you don't want to see screeds of files with zero coverage.