### PR TITLE
feat: retrieve optional outs from cache when using wildcard

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -219,6 +219,8 @@ type BuildMetadata struct {
 	// Time this action was written. Used for remote execution to determine if
 	// the action is stale and needs re-checking or not.
 	Timestamp time.Time
+	// Additional optional outputs found from wildcard
+	OptionalOutputs []string
 	// Additional outputs from output directories serialised as a csv
 	OutputDirOuts []string
 	// True if this represents a test run.

--- a/test/optional_outs_test/BUILD
+++ b/test/optional_outs_test/BUILD
@@ -4,6 +4,7 @@ please_repo_e2e_test(
     name = "optional_outs_test",
     expected_output = {
         "plz-out/gen/foo/foo.sym": "",
+        "plz-out/gen/foo/foo.wildcard.sym": "",
     },
     plz_command = "plz build //foo && rm plz-out/gen/foo/* && plz build //foo",
     repo = "test_repo",

--- a/test/optional_outs_test/test_repo/foo/BUILD_FILE
+++ b/test/optional_outs_test/test_repo/foo/BUILD_FILE
@@ -1,6 +1,9 @@
 genrule(
     name = "foo",
     outs = ["foo.a"],
-    optional_outs = ["foo.sym"],
-    cmd = "touch foo.a && touch foo.sym",
+    cmd = "touch foo.a && touch foo.sym && touch foo.wildcard.sym",
+    optional_outs = [
+        "foo.sym",
+        "*.wildcard.sym",
+    ],
 )


### PR DESCRIPTION
This enhance #1727 to also retrieve optional outs that use wildcard.

To do this, exact optional outputs names are added to the target metadata.

What do you think about adding exact optional output filenames in the target metadata?
