### PR TITLE
Fix python cover for macOS

### DIFF
--- a/build_defs/multiversion_wheel.build_defs
+++ b/build_defs/multiversion_wheel.build_defs
@@ -1,59 +1,41 @@
-def python_multiversion_wheel(name, version, repos, hashes=None, package_name=None, outs=None,
-                              subdir='.', licences=None, test_only=False,
-                              visibility=None, deps=[]):
+def python_multiversion_wheel(name, version:str, urls:list, licences:list=None, visibility=None, hashes:list=None):
     """Downloads and combines multiple Python wheels.
-
-    This is an extended version of python_wheel that allows fetching multiple wheels for
-    different Python versions and combining them. For most packages this is unnecessary
-    since they are pure Python, but for packages with binary components those objects are
-    linked to one Python version each. By adding all the .so files for all versions we care
-    about, we can support them all simultaneously.
 
     Note that python 2 does not support versioned object file names, so this can only work
     for one python 2 wheel at a time. For us that's not an issue since we only support 2.7
     (and these days that's nearly always what people are using, so often not a big deal).
 
-    The wheels are downloaded one each from the given list of repo URLs, which work in the
-    same way as python_wheel. Within those directories, the wheels are expected to follow a
-    simple naming scheme which is essentially:
-      <package_name>-<version>-<os>_<arch>.whl
-    Note that non-arch-specific wheels aren't supported since you'd not then need multiple
-    versions of them and python_wheel would suffice.
+    The wheels are downloaded from the given list of URLs Within those directories, and
+    combined into a single wheel. Later files will overwrite earlier files however these
+    common files should be identical if all the wheels are for the same version. The new
+    files will be the platform specific files.
 
     Args:
       name (str): Name of the rule. Also doubles as the name of the package if package_name
             is not set.
-      version (str): Version of the package to install.
-      repos (list): List of repos to download wheels from.
-      hashes (list): List of hashes to verify the package against.
-      package_name (str): If given, overrides `name` for the name of the package to look for.
-      outs (list): List of output files. Defaults to a directory named the same as `name`.
-      subdir (str): Subdirectory to extract into. If not given, defaults to the current directory.
-      licences (list): Licences that this rule is subject to.
-      test_only (bool): If True, this library can only be used by tests.
-      repo (str): Repository to download wheels from.
-      visibility (list): Visibility declaration.
-      deps (list): Dependencies of this rule.
+      urls (list): List of wheels to download.
+      licences (list): Licences that this wheel is subject to.
+      hashes (list): List of hashes to verify the package against. These are applied to all
+                     downloads so don't need to be in any specific order.
     """
-    package_name = package_name or name
-
-    file_rules = [remote_file(
-        name = '_%s#%d' % (name, i + 1),
-        url = '%s/%s-%s-${OS}_${ARCH}.whl' % (repo, package_name, version),
-        out = '%s-%s-%d.whl' % (package_name, version, i + 1),
-    ) for i, repo in enumerate(repos)]
+    file_rules = [
+        remote_file(
+            name = '_%s#%d' % (name, i + 1),
+            url = url,
+            out = basename(url),
+        ) for i, url in enumerate(urls)
+    ]
 
     return build_rule(
         name = name,
         srcs = file_rules,
-        outs = outs or [package_name],
-        cmd = 'mkdir -p %s && for SRC in $SRCS; do $TOOL x -o %s $SRC; done && rm -rf %s/*.egg-info %s/*.dist-info' %
-            (subdir, subdir, subdir, subdir),
+        outs = [name],
+        cmd = 'for SRC in $SRCS; do $TOOL x -o $TMPDIR $SRC; done && rm -rf %s/*.egg-info %s/*.dist-info',
         hashes = hashes,
         building_description = 'Extracting...',
         requires = ['py'],
-        test_only = test_only,
         visibility = visibility,
-        labels = ['whl:%s==%s' % (package_name, version)],
+        labels = ['whl:%s==%s' % (name, version)],
         tools = [CONFIG.JARCAT_TOOL],
+        licences = licences,
     )

--- a/test/python_rules/python_coverage_test.py
+++ b/test/python_rules/python_coverage_test.py
@@ -21,8 +21,8 @@ class PythonCoverageTest(unittest.TestCase):
         import coverage
         self.assertIsNotNone(coverage)
 
-    @unittest.skipIf(sys.platform == 'darwin' and sys.version_info.major < 3,
-                     'Not working on OSX python2 at present due to symbol errors')
+    @unittest.skipIf(sys.version_info.major < 3,
+                     'Not working on python2 as python2 does not support multi-version-wheels')
     def test_can_import_tracer(self):
         """Test we can import the binary tracer module."""
         from coverage import tracer

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -82,24 +82,35 @@ python_wheel(
     deps = [":six"],
 )
 
-if CONFIG.ARCH == "amd64":
-    python_multiversion_wheel(
-        name = "coverage",
-        repos = [
-            "https://get.please.build/third_party/python/py27",
-            "https://get.please.build/third_party/python/py34",
-            "https://get.please.build/third_party/python/py35",
-            "https://get.please.build/third_party/python/py36",
-            "https://get.please.build/third_party/python/py37",
-        ],
-        version = "4.3.4",
-    )
+
+if is_platform(os = "linux", arch = "amd64"):
+    urls = [
+        "https://files.pythonhosted.org/packages/4b/c1/29eb22bece4b97d3ce86101ca5b0f892f05f7f089be48c5ff71f6cab1112/coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl",
+        "https://files.pythonhosted.org/packages/2f/19/4ebe9fe7006d46dd56eacd8cdc800b465590037bffeea17852520613cfaf/coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl",
+        "https://files.pythonhosted.org/packages/42/37/a82863f91b41711203277ea286bc37915063f4d1be179ac34b591bf6d8a5/coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl",
+        "https://files.pythonhosted.org/packages/16/e0/fc9f7bd9b84e6b41d0aad1a113e36714aac0c0a9b307aca5f9af443bc50f/coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl",
+        "https://files.pythonhosted.org/packages/a4/3a/8f7b217265503eae2b0ea97e714e2709e1e84ee13cd3ca6abdff1e99e76c/coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl",
+        "https://files.pythonhosted.org/packages/a4/79/625f1ed5da2a69f52fb44e0b7ca1b470437ff502348c716005a98a71cd49/coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl",
+    ]
+elif is_platform(os = "darwin", arch = "amd64"):
+    urls = [
+        "https://files.pythonhosted.org/packages/f4/ed/0315c94ccc42b8b2e995bd9ed9b3bfa8032b901fc944b444ad4ede12dfda/coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl",
+        "https://files.pythonhosted.org/packages/9f/16/7e0972f8495f6a1b81cfa6579eead931d63dd445e8ecb3114b04a0e36af2/coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl",
+        "https://files.pythonhosted.org/packages/fd/2b/ab03276eb127f8ec7f1cf1499c77944321b125d89859ab51ee7d9f46475f/coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl",
+        "https://files.pythonhosted.org/packages/52/44/5df49f3b462a0f5818a2f6f206d6523ff21ff9b21c1eb2906f8a31aa321c/coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl",
+        "https://files.pythonhosted.org/packages/b6/26/b53bf0fef1b4bce6f7d61fef10fbf924d943987d4c9e53c394ecebff3673/coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl",
+        "https://files.pythonhosted.org/packages/0d/8a/3b13c4e1f241a7083a4ee9986b969f0238f41dcd7a8990c786bc3b4b5b19/coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl",
+    ]
 else:
-    python_wheel(
-        name = "coverage",
-        hashes = ["sha1: 519e737035a8cc3349b66973e8a9c69f1ba1102a"],
-        version = "4.3.4",
-    )
+    urls = [
+        "https://files.pythonhosted.org/packages/93/ac/02bc6a60304a8a58383386f7675f6ebae0d2f49f162dda318e57bd95c746/coverage-5.5-pp37-none-any.whl"
+    ]
+
+python_multiversion_wheel(
+    name = "coverage",
+    urls = urls,
+    version = "5.5",
+)
 
 python_wheel(
     name = "attrs",

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -82,19 +82,22 @@ python_wheel(
     deps = [":six"],
 )
 
-
-if is_platform(os = "linux", arch = "amd64"):
+if is_platform(
+    arch = "amd64",
+    os = "linux",
+):
     urls = [
-        "https://files.pythonhosted.org/packages/4b/c1/29eb22bece4b97d3ce86101ca5b0f892f05f7f089be48c5ff71f6cab1112/coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl",
         "https://files.pythonhosted.org/packages/2f/19/4ebe9fe7006d46dd56eacd8cdc800b465590037bffeea17852520613cfaf/coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl",
         "https://files.pythonhosted.org/packages/42/37/a82863f91b41711203277ea286bc37915063f4d1be179ac34b591bf6d8a5/coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl",
         "https://files.pythonhosted.org/packages/16/e0/fc9f7bd9b84e6b41d0aad1a113e36714aac0c0a9b307aca5f9af443bc50f/coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl",
         "https://files.pythonhosted.org/packages/a4/3a/8f7b217265503eae2b0ea97e714e2709e1e84ee13cd3ca6abdff1e99e76c/coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl",
         "https://files.pythonhosted.org/packages/a4/79/625f1ed5da2a69f52fb44e0b7ca1b470437ff502348c716005a98a71cd49/coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl",
     ]
-elif is_platform(os = "darwin", arch = "amd64"):
+elif is_platform(
+    arch = "amd64",
+    os = "darwin",
+):
     urls = [
-        "https://files.pythonhosted.org/packages/f4/ed/0315c94ccc42b8b2e995bd9ed9b3bfa8032b901fc944b444ad4ede12dfda/coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl",
         "https://files.pythonhosted.org/packages/9f/16/7e0972f8495f6a1b81cfa6579eead931d63dd445e8ecb3114b04a0e36af2/coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl",
         "https://files.pythonhosted.org/packages/fd/2b/ab03276eb127f8ec7f1cf1499c77944321b125d89859ab51ee7d9f46475f/coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl",
         "https://files.pythonhosted.org/packages/52/44/5df49f3b462a0f5818a2f6f206d6523ff21ff9b21c1eb2906f8a31aa321c/coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl",
@@ -103,7 +106,7 @@ elif is_platform(os = "darwin", arch = "amd64"):
     ]
 else:
     urls = [
-        "https://files.pythonhosted.org/packages/93/ac/02bc6a60304a8a58383386f7675f6ebae0d2f49f162dda318e57bd95c746/coverage-5.5-pp37-none-any.whl"
+        "https://files.pythonhosted.org/packages/93/ac/02bc6a60304a8a58383386f7675f6ebae0d2f49f162dda318e57bd95c746/coverage-5.5-pp37-none-any.whl",
     ]
 
 python_multiversion_wheel(


### PR DESCRIPTION
This version of the wheel contained both `coverage/tracer.so` and `coverage/tracer.cpython-34m-darwin.so`, which was being bundled into our multi-version wheel. This meant that python 3.9 was picking up `tracer.so` which presumably only works on 3.4.  

The newer version of this lib seems to be okay. I've tested this against some of the tests in our codebase, and I've run it on both my mac machines. It seems fine. 

Fixes: #1700