### PR TITLE
Fix visibility in sh_cmd()

### DIFF
--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -122,7 +122,7 @@ def genrule(name:str, cmd:str|list|dict, srcs:list|dict=None, out:str=None, outs
         tools = tools,
         secrets = secrets,
         labels = labels,
-        visibility  =  visibility,
+        visibility = visibility,
         output_is_complete = output_is_complete,
         building_description = building_description,
         hashes = hashes,
@@ -140,7 +140,7 @@ def genrule(name:str, cmd:str|list|dict, srcs:list|dict=None, out:str=None, outs
         output_dirs = output_dirs,
         exit_on_error = exit_on_error,
         entry_points = entry_points,
-        env=env,
+        env = env,
         optional_outs = optional_outs,
     )
 

--- a/rules/sh_rules.build_defs
+++ b/rules/sh_rules.build_defs
@@ -139,7 +139,7 @@ def sh_test(name:str, src:str=None, labels:list&features&tags=None, data:list|di
 
 
 def sh_cmd(name:str, cmd:str|dict|list, srcs:list|dict=[], data:list=[], out:str="", shell:str='/bin/sh',
-           labels:list&features&tags=[], deps:list=[], visibility:list=[], expand_env_vars:bool=True,
+           labels:list&features&tags=[], deps:list=[], visibility:list=None, expand_env_vars:bool=True,
            test_only:bool=False):
     """Generates a runnable shell script from a command.
 


### PR DESCRIPTION
Passing visibility to sh_cmd() seems to change the visibility in the parent scope which is worrying. Will investigate further. 