### PR TITLE
Rewrite paths in sandbox binary

### DIFF
--- a/tools/sandbox/sandbox.c
+++ b/tools/sandbox/sandbox.c
@@ -82,16 +82,6 @@ int map_ids(int out_id, const char* path) {
     return 0;
 }
 
-// change_env_vars changes any environment variables prefixed with the old directory to the new one.
-void change_env_vars(char** environ, const char* old_dir, const char* new_dir) {
-  for (char** env = environ; *env; ++env) {
-    const char* equals = strchr(*env, '=');
-    if (equals) {
-      *env = change_path(*env, old_dir, new_dir, equals - *env + 1);
-    }
-  }
-}
-
 // mount_tmp mounts a tmpfs on /tmp for the tests to muck about in and
 // bind mounts the test directory to /tmp/plz_sandbox.
 // If the given string pointer (the argv[0] of the new process) is within the old temp dir
@@ -296,4 +286,14 @@ char* change_path(const char* old_name, const char* old_dir, const char* new_dir
   strcpy(new_name + prefix_len + new_dir_len, old_name + prefix_len + old_dir_len);
   new_name[new_len] = 0;
   return new_name;
+}
+
+// change_env_vars changes any environment variables prefixed with the old directory to the new one.
+void change_env_vars(char** environ, const char* old_dir, const char* new_dir) {
+  for (char** env = environ; *env; ++env) {
+    const char* equals = strchr(*env, '=');
+    if (equals) {
+      *env = change_path(*env, old_dir, new_dir, equals - *env + 1);
+    }
+  }
 }

--- a/tools/sandbox/sandbox.h
+++ b/tools/sandbox/sandbox.h
@@ -9,3 +9,16 @@ int contain(char* argv[], bool net, bool mount);
 // exec_name returns the name of the new binary to exec() as.
 // old_name is the current name; if it's within old_dir it will be re-prefixed to new_dir.
 char* exec_name(const char* old_name, const char* old_dir, const char* new_dir);
+
+// change_path takes a string or environment variable and changes a prefix from one path to another.
+// For example:
+//   old_name:   RESULTS_FILE=/home/peter/git/please/plz-out/tmp/my_test/test.results
+//   old_dir:    /home/peter/git/please/plz-out/tmp/my_test
+//   new_dir:    /tmp/plz_sandbox
+//   prefix_len: 13
+// Result:       RESULTS_FILE=/tmp/plz_sandbox/test.results
+char* change_path(const char* old_name, const char* old_dir, const char* new_dir, int prefix_len);
+
+// change_env_vars changes any environment variables prefixed with the old directory to the new one.
+// The variables are changed in-place within the given array.
+void change_env_vars(char** environ, const char* old_dir, const char* new_dir);

--- a/tools/sandbox/sandbox_test.cc
+++ b/tools/sandbox/sandbox_test.cc
@@ -1,5 +1,7 @@
 #include <UnitTest++/UnitTest++.h>
 
+#include <cstring>
+
 extern "C" {
 #include "tools/sandbox/sandbox.h"
 }
@@ -21,6 +23,37 @@ TEST(ExecNameShorterThanSandboxDir) {
 TEST(SameDir) {
   // We wouldn't normally do this but it should still work fine.
   CHECK_EQUAL("/tmp/plz_sandbox/test.bin", exec_name("/tmp/plz_sandbox/test.bin", "/tmp/plz_sandbox", "/tmp/plz_sandbox"));
+}
+
+TEST(ChangePath) {
+  CHECK_EQUAL("RESULTS_FILE=/tmp/plz_sandbox/test.results", change_path(
+      "RESULTS_FILE=/home/peter/git/please/plz-out/tmp/my_test/test.results",
+      "/home/peter/git/please/plz-out/tmp/my_test",
+      "/tmp/plz_sandbox",
+      strlen("RESULTS_FILE=")));
+}
+
+TEST(ChangeEnvVars) {
+  char* env[] = {
+    strdup("TMP_DIR=/home/peter/git/please/plz-out/tmp/my_test"),
+    strdup("RESULTS_FILE=/home/peter/git/please/plz-out/tmp/my_test/test.results"),
+    strdup("SOME_TOOL=/usr/local/bin/go"),
+    strdup("thirty-five ham and cheese sandwiches"),
+    NULL
+  };
+  char* expected[] = {
+    strdup("TMP_DIR=/tmp/plz_sandbox"),
+    strdup("RESULTS_FILE=/tmp/plz_sandbox/test.results"),
+    strdup("SOME_TOOL=/usr/local/bin/go"),
+    strdup("thirty-five ham and cheese sandwiches"),
+    NULL
+  };
+  change_env_vars(env, "/home/peter/git/please/plz-out/tmp/my_test", "/tmp/plz_sandbox");
+  CHECK_EQUAL(expected[0], env[0]);
+  CHECK_EQUAL(expected[1], env[1]);
+  CHECK_EQUAL(expected[2], env[2]);
+  CHECK_EQUAL(expected[3], env[3]);
+  CHECK_EQUAL(expected[4], env[4]);
 }
 
 }


### PR DESCRIPTION
This lets it fix up a bunch of things like RESULTS_FILE that otherwise point back to the original directory. Also means we will be able to get rid of some hacky code in plz itself (but will break that into a separate PR so it's a bit easier to migrate to)