### PR TITLE
Redo priority queue

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -60,13 +60,7 @@ func Build(tid int, state *core.BuildState, label core.BuildLabel, remote bool) 
 	// Mark the target as having finished building.
 	target.FinishBuild()
 	if target.IsTest && state.NeedTests && state.IsOriginalTarget(target) {
-		if state.TestSequentially {
-			state.AddPendingTest(target, 1)
-		} else {
-			for runNum := 1; runNum <= state.NumTestRuns; runNum++ {
-				state.AddPendingTest(target, runNum)
-			}
-		}
+		state.AddPendingTest(target)
 	}
 }
 

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -61,10 +61,10 @@ func Build(tid int, state *core.BuildState, label core.BuildLabel, remote bool) 
 	target.FinishBuild()
 	if target.IsTest && state.NeedTests && state.IsOriginalTarget(target) {
 		if state.TestSequentially {
-			state.AddPendingTest(target.Label, 1)
+			state.AddPendingTest(target, 1)
 		} else {
 			for runNum := 1; runNum <= state.NumTestRuns; runNum++ {
-				state.AddPendingTest(target.Label, runNum)
+				state.AddPendingTest(target, runNum)
 			}
 		}
 	}

--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -34,7 +34,7 @@ func TestBuildLotsOfTargets(t *testing.T) {
 	for i := 1; i <= size; i++ {
 		addTarget(state, i)
 	}
-	state.TaskDone(true) // Initial target adding counts as one.
+	state.TaskDone() // Initial target adding counts as one.
 
 	results := state.Results()
 	// Consume and discard any results

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -34,7 +34,6 @@ go_library(
         "//third_party/go:godirwalk",
         "//third_party/go:logging",
         "//third_party/go:psutil",
-        "//third_party/go:queue",
         "//third_party/go:semver",
         "//third_party/go:shlex",
         "//third_party/go:xattr",

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -83,9 +83,9 @@ type TargetHasher interface {
 type BuildState struct {
 	Graph *BuildGraph
 	// Streams of pending tasks
-	pendingParses chan ParseTask
+	pendingParses                      chan ParseTask
 	pendingBuilds, pendingRemoteBuilds chan BuildTask
-	pendingTests, pendingRemoteTests chan TestTask
+	pendingTests, pendingRemoteTests   chan TestTask
 	// Stream of results from the build
 	results chan *BuildResult
 	// Timestamp that the build is considered to start at.
@@ -238,7 +238,7 @@ func (state *BuildState) addPendingParse(label, dependent BuildLabel, forSubincl
 	atomic.AddInt64(&state.progress.numPending, 1)
 	go func() {
 		defer func() {
-			recover()  // Prevent death on 'send on closed channel'
+			recover() // Prevent death on 'send on closed channel'
 		}()
 		state.pendingParses <- ParseTask{Label: label, Dependent: dependent, ForSubinclude: forSubinclude}
 	}()
@@ -249,7 +249,7 @@ func (state *BuildState) addPendingBuild(target *BuildTarget) {
 	atomic.AddInt64(&state.progress.numPending, 1)
 	go func() {
 		defer func() {
-			recover()  // Prevent death on 'send on closed channel'
+			recover() // Prevent death on 'send on closed channel'
 		}()
 		if state.anyRemote && !target.Local {
 			state.pendingRemoteBuilds <- target.Label
@@ -272,7 +272,7 @@ func (state *BuildState) addPendingTest(target *BuildTarget, numRuns int) {
 	atomic.AddInt64(&state.progress.numPending, int64(numRuns))
 	go func() {
 		defer func() {
-			recover()  // Prevent death on 'send on closed channel'
+			recover() // Prevent death on 'send on closed channel'
 		}()
 		ch := state.pendingTests
 		if state.anyRemote && !target.Local {
@@ -978,12 +978,12 @@ func NewBuildState(config *Configuration) *BuildState {
 	// Deliberately ignore the error here so we don't require the sandbox tool until it's needed.
 	sandboxTool, _ := LookBuildPath(config.Sandbox.Tool, config)
 	state := &BuildState{
-		Graph:         NewGraph(),
-		pendingParses: make(chan ParseTask, 10000),
-		pendingBuilds: make(chan BuildTask, 1000),
+		Graph:               NewGraph(),
+		pendingParses:       make(chan ParseTask, 10000),
+		pendingBuilds:       make(chan BuildTask, 1000),
 		pendingRemoteBuilds: make(chan BuildTask, 1000),
-		pendingTests: make(chan TestTask, 1000),
-		pendingRemoteTests: make(chan TestTask, 1000),
+		pendingTests:        make(chan TestTask, 1000),
+		pendingRemoteTests:  make(chan TestTask, 1000),
 		hashers: map[string]*fs.PathHasher{
 			// For compatibility reasons the sha1 hasher has no suffix.
 			"sha1":   fs.NewPathHasher(RepoRoot, config.Build.Xattrs, sha1.New, "sha1"),

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -31,14 +31,12 @@ type taskType int
 // The values here are fiddled to make Compare work easily.
 // Essentially we prioritise on the higher bits only and use the lower ones to make
 // the values unique.
-// Subinclude tasks order first, but we're happy for all build / parse / test tasks
+// Subinclude tasks order first, but we're happy for all build / test tasks
 // to be treated equivalently.
 const (
 	Kill            taskType = 0x0000 | 0 //nolint:staticcheck
 	SubincludeBuild          = 0x1000 | 1
-	SubincludeParse          = 0x2000 | 2
 	Build                    = 0x4000 | 3
-	Parse                    = 0x4000 | 4
 	Test                     = 0x4000 | 5
 	Stop                     = 0x8000 | 6
 	priorityMask             = ^0x00FF

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -236,6 +236,9 @@ func (state *BuildState) addPendingParse(label, dependent BuildLabel, forSubincl
 	atomic.AddInt64(&state.progress.numActive, 1)
 	atomic.AddInt64(&state.progress.numPending, 1)
 	go func() {
+		defer func() {
+			recover()  // Prevent death on 'send on closed channel'
+		}()
 		state.pendingParses <- ParseTask{Label: label, Dependent: dependent, ForSubinclude: forSubinclude}
 	}()
 }
@@ -244,6 +247,9 @@ func (state *BuildState) addPendingParse(label, dependent BuildLabel, forSubincl
 func (state *BuildState) addPendingBuild(target *BuildTarget) {
 	atomic.AddInt64(&state.progress.numPending, 1)
 	go func() {
+		defer func() {
+			recover()  // Prevent death on 'send on closed channel'
+		}()
 		if state.anyRemote && !target.Local {
 			state.pendingRemoteBuilds <- target.Label
 		} else {
@@ -264,6 +270,9 @@ func (state *BuildState) AddPendingTest(target *BuildTarget) {
 func (state *BuildState) addPendingTest(target *BuildTarget, numRuns int) {
 	atomic.AddInt64(&state.progress.numPending, int64(numRuns))
 	go func() {
+		defer func() {
+			recover()  // Prevent death on 'send on closed channel'
+		}()
 		ch := state.pendingTests
 		if state.anyRemote && !target.Local {
 			ch = state.pendingRemoteTests

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -91,38 +91,6 @@ func TestExpandOriginalLabelsOrdering(t *testing.T) {
 	assert.Equal(t, expected, state.ExpandOriginalLabels())
 }
 
-func TestComparePendingTasks(t *testing.T) {
-	p := func(taskType taskType) pendingTask { return pendingTask{Type: taskType} }
-	// NB. "Higher priority" means the task comes first, does not refer to numeric values.
-	assertHigherPriority := func(a, b taskType) {
-		// relationship should be commutative
-		assert.True(t, p(a).Compare(p(b)) < 0)
-		assert.True(t, p(b).Compare(p(a)) > 0)
-	}
-	assertEqualPriority := func(a, b taskType) {
-		assert.True(t, p(a).Compare(p(b)) == 0)
-		assert.True(t, p(b).Compare(p(a)) == 0)
-	}
-
-	assertHigherPriority(SubincludeBuild, SubincludeParse)
-	assertHigherPriority(SubincludeParse, Build)
-	assertHigherPriority(SubincludeBuild, Build)
-	assertEqualPriority(Build, Parse)
-	assertEqualPriority(Build, Test)
-	assertEqualPriority(Parse, Test)
-	assertHigherPriority(Build, Stop)
-	assertHigherPriority(Test, Stop)
-	assertHigherPriority(Parse, Stop)
-
-	// sanity check
-	assertEqualPriority(SubincludeBuild, SubincludeBuild)
-	assertEqualPriority(SubincludeParse, SubincludeParse)
-	assertEqualPriority(Build, Build)
-	assertEqualPriority(Parse, Parse)
-	assertEqualPriority(Test, Test)
-	assertEqualPriority(Stop, Stop)
-}
-
 func TestAddDepsToTarget(t *testing.T) {
 	state := NewDefaultBuildState()
 	_, builds, _, _, _ := state.TaskQueues() //nolint:dogsled

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -186,7 +186,7 @@ func assertPendingBuilds(t *testing.T, state *core.BuildState, targets ...string
 }
 
 func getAllPending(state *core.BuildState) ([]string, []string) {
-	parses, builds, tests, _, _ := state.TaskQueues()
+	parses, builds, _, tests, _ := state.TaskQueues()
 	state.Stop()
 	var pendingParses, pendingBuilds []string
 	for parses != nil || builds != nil || tests != nil {

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -47,10 +47,10 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, config *
 		// All parses happen async on separate goroutines so we don't have to worry about them blocking.
 		// They manage concurrency control themselves.
 		for task := range parses {
-			go func() {
+			go func(task core.ParseTask) {
 				parse.Parse(0, state, task.Label, task.Dependent, task.ForSubinclude)
 				state.TaskDone()
-			}()
+			}(task)
 		}
 		wg.Done()
 	}()

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -339,13 +339,6 @@ go_module(
 )
 
 go_module(
-    name = "queue",
-    install = ["queue"],
-    module = "github.com/Workiva/go-datastructures",
-    version = "v1.0.53",
-)
-
-go_module(
     name = "fsnotify",
     module = "github.com/fsnotify/fsnotify",
     version = "a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb",


### PR DESCRIPTION
Basically just uses channels instead of the previous priority queue.
I don't think we were _really_ prioritising things properly anyway (among other things, some of the channels were buffered so they could be filled up by lower-priority tasks) and honestly I'm not sure it matters that much.

Motivation: bit of simplification, also post #1102 the queue has become the highest source of lock contention.