### PR TITLE
Extract please_tools files as ourselves

### DIFF
--- a/src/parse/internal.tmpl
+++ b/src/parse/internal.tmpl
@@ -7,7 +7,7 @@ remote_file(
 genrule(
   name = "please_tools",
   srcs = [":download"],
-  cmd = "tar -xf $SRC",
+  cmd = "tar --no-same-owner -xf $SRC",
   outs = ["please_tools"],
 )
 


### PR DESCRIPTION
Apparently when you're root tar behaves differently and extracts the files as the owner in the tarball, which we have set to nobody:nogroup, which can cause problems:
```
tar: please_tools/jarcat: Cannot change ownership to uid 65534, gid 65534: Invalid argument
```
This should fix. AFAICT this flag exists in both GNU and BSD tar.