### PR TITLE
Add --cmd flag to 'plz run' as an overriding mechanism for the default binary execution

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -168,6 +168,7 @@ var opts struct {
 		InWD       bool   `long:"in_wd" description:"When running locally, stay in the original working directory."`
 		InTempDir  bool   `long:"in_tmp_dir" description:"Runs in a temp directory, setting env variables and copying in runtime data similar to tests."`
 		EntryPoint string `long:"entry_point" short:"e" description:"The entry point of the target to use." default:""`
+		Cmd        string `long:"cmd" description:"Overrides the command to be run. This is useful when the initial command needs to be wrapped in another one." default:""`
 		Parallel   struct {
 			NumTasks       int                `short:"n" long:"num_tasks" default:"10" description:"Maximum number of subtasks to run in parallel"`
 			Quiet          bool               `short:"q" long:"quiet" description:"Deprecated in favour of --output=quiet. Suppress output from successful subprocesses."`
@@ -460,7 +461,7 @@ var buildFunctions = map[string]func() int{
 				log.Fatalf("%v expanded to too many targets: %v", opts.Run.Args.Target, annotatedOutputLabels)
 			}
 
-			run.Run(state, annotatedOutputLabels[0], opts.Run.Args.Args.AsStrings(), opts.Run.Remote, opts.Run.Env, opts.Run.InTempDir, dir)
+			run.Run(state, annotatedOutputLabels[0], opts.Run.Args.Args.AsStrings(), opts.Run.Remote, opts.Run.Env, opts.Run.InTempDir, dir, opts.Run.Cmd)
 		}
 		return 1 // We should never return from run.Run so if we make it here something's wrong.
 	},

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -124,7 +124,8 @@ func run(ctx context.Context, state *core.BuildState, label core.AnnotatedOutput
 	}
 
 	target := state.Graph.TargetOrDie(label.BuildLabel)
-	if !target.IsBinary {
+	// Non binary targets can be run if an override command is passed in
+	if !target.IsBinary && overrideCmd == "" {
 		log.Fatalf("Target %s cannot be run; it's not marked as binary", label)
 	}
 	if label.Annotation == "" && len(target.Outputs()) != 1 {

--- a/test/BUILD
+++ b/test/BUILD
@@ -323,11 +323,11 @@ plz_e2e_test(
 
 plz_e2e_test(
     name = "cyclic_dependency_test",
+    timeout = 30,
     cmd = "plz test //plz-out/tmp/test/cyclic_dependency_test._test/run_1/test/cycle:all",
     data = ["cycle/TEST_BUILD"],
     expect_output_contains = "Dependency cycle found",
     expected_failure = True,
-    timeout = 30,
     pre_cmd = "mv test/cycle/TEST_BUILD test/cycle/BUILD",
 )
 


### PR DESCRIPTION
Add `--cmd` flag to `plz run` as an overriding mechanism for the default binary execution

This will be useful in cases where the binary needs to be executed in a different way, such as having it wrapped in a debugger program for instance.