### PR TITLE
Disable caching for rex-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,8 +242,6 @@ jobs:
        - checkout
        - attach_workspace:
            at: /tmp/workspace
-       - restore_cache:
-           key: elan-v4-{{ checksum "third_party/go/BUILD" }}
        - run:
            name: Test Remote Execution
            command: ./.circleci/rex_test.sh
@@ -251,9 +249,6 @@ jobs:
            path: plz-out/results
        - store_artifacts:
            path: plz-out/log
-       - save_cache:
-           key: elan-v4-{{ checksum "third_party/go/BUILD" }}
-           paths: [ "plz-out/elan" ]
 
    test-http-cache:
      working_directory: ~/please


### PR DESCRIPTION
Not sure if this is really the issue or not but I want to see if it makes it more stable (if it does, it will help us figure out why we see issues in this test but not elsewhere)