### PR TITLE
Make --repo_root absolute

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -974,7 +974,11 @@ func readConfigAndSetRoot(forceUpdate bool) *core.Configuration {
 	if opts.BuildFlags.RepoRoot == "" {
 		log.Debug("Found repo root at %s", core.MustFindRepoRoot())
 	} else {
-		core.RepoRoot = string(opts.BuildFlags.RepoRoot)
+		abs, err := filepath.Abs(string(opts.BuildFlags.RepoRoot))
+		if err != nil {
+			log.Fatalf("Cannot make --repo_root absolute: %s", err)
+		}
+		core.RepoRoot = abs
 	}
 
 	// Save the current working directory before moving to root


### PR DESCRIPTION
It doesn't seem to work if I do `plz --repo_root tree query print //assets/assets` (where "tree" is a directory containing a valid plz repo, from the perftest stuff).

Not 100% certain what's going on - it seems to work with e.g. `--repo_root ../please-servers`, but I can't think what would care about that kind of distinction. Nonetheless, I think it makes sense for `core.RepoRoot` to be absolute.