### PR TITLE
Set perftest concurrency

### DIFF
--- a/tools/performance/parse_perf_test.py
+++ b/tools/performance/parse_perf_test.py
@@ -18,6 +18,7 @@ log.addHandler(handler)
 log.propagate = False  # Needed to stop double logging?
 
 flags.DEFINE_string('plz', 'plz', 'Binary to run to invoke plz')
+flags.DEFINE_integer('num_threads', 10, 'Number of parallel threads to give plz')
 flags.DEFINE_string('output', 'results.json', 'File to write results to')
 flags.DEFINE_string('revision', 'unknown', 'Git revision')
 flags.DEFINE_integer('number', 5, 'Number of times to run test')
@@ -25,12 +26,21 @@ flags.DEFINE_string('root', 'tree', 'Directory to run in')
 FLAGS = flags.FLAGS
 
 
+def plz() -> list:
+    """Returns the plz invocation for a subprocess."""
+    return [
+        FLAGS.plz,
+        '--repo_root', FLAGS.root,
+        '--num_threads', str(FLAGS.num_threads),
+        'query', 'alltargets',
+    ]
+
+
 def run(i: int):
     """Run once and return the length of time taken."""
     log.info('Run %d of %d', i + 1, FLAGS.number)
     start = time.time()
-    subprocess.check_call([FLAGS.plz, '--repo_root', FLAGS.root, 'query', 'alltargets'],
-                          stdout=subprocess.DEVNULL)
+    subprocess.check_call(plz(), stdout=subprocess.DEVNULL)
     duration = time.time() - start
     log.info('Complete in %0.2fs', duration)
     return duration
@@ -44,8 +54,7 @@ def main(argv):
     log.info('Complete, median time: %0.2f', median)
     log.info('Running again to generate profiling info')
     profile_file = os.path.join(os.getcwd(), 'plz.prof')
-    subprocess.check_call([FLAGS.plz, '--repo_root', FLAGS.root, 'query', 'alltargets',
-                           '--profile_file', profile_file], stdout=subprocess.DEVNULL)
+    subprocess.check_call(plz() + ['--profile_file', profile_file], stdout=subprocess.DEVNULL)
     log.info('Generating results')
     with open(FLAGS.output, 'w') as f:
         json.dump({


### PR DESCRIPTION
Seeing wild swings in the results between runs (which I'm certain are not code changes). Not very sure what is going wrong, but it is possible we are picking different levels of parallelism based on the container being scheduled on a bigger / smaller box (wild theory...).