### PR TITLE
Add error bars to graph

### DIFF
--- a/tools/performance/report.html
+++ b/tools/performance/report.html
@@ -16,8 +16,15 @@
                   cols: [
                       {id: 'revision', label: 'Revision', type: 'string'},
                       {id: 'time', label: 'Time', type: 'number'},
+                      {id: 'min', label: 'Min', type: 'number', role: 'interval'},
+                      {id: 'max', label: 'Max', type: 'number', role: 'interval'},
                   ],
-                  rows: results.map(r => ({c:[{v: r.revision}, {v: r.parse.median}]})),
+                  rows: results.map(r => ({c:[
+                      {v: r.revision},
+                      {v: r.parse.median},
+                      {v: Math.min(...r.parse.raw)},
+                      {v: Math.max(...r.parse.raw)},
+                  ]})),
               });
               const chart = new google.visualization.LineChart(document.getElementById('parse_chart'));
               chart.draw(dt, {


### PR DESCRIPTION
Turns out you can do this easily enough, and it's useful to see given we have more than one run at each commit.