### PR TITLE
Fix linking an already compiled package with go_module()

### DIFF
--- a/test/go_modules/BUILD
+++ b/test/go_modules/BUILD
@@ -9,6 +9,15 @@ please_repo_e2e_test(
     repo = "test_repo",
 )
 
+please_repo_e2e_test(
+    name = "go_install_build",
+    labels = [
+        "no-musl",
+    ],
+    plz_command = "plz build //third_party/...",
+    repo = "test_repo",
+)
+
 target = "darwin_amd64" if CONFIG.OS == "linux_amd64" else "linux_amd64"
 
 please_repo_e2e_test(

--- a/test/go_modules/test_repo/third_party/go/BUILD_FILE
+++ b/test/go_modules/test_repo/third_party/go/BUILD_FILE
@@ -65,3 +65,26 @@ go_module(
     module = "github.com/golang/snappy",
     version = "v0.0.2",
 )
+
+go_mod_download(
+    name = "go-fuzz-download",
+    module = "github.com/dvyukov/go-fuzz",
+    version = "445b00a1141b27425541ee8d7dc2f524faf202a9",
+)
+
+# Split the compile and link into two targets to test that works
+go_module(
+    name = "go-fuzz-compile",
+    download = ":go-fuzz-download",
+    install = ["go-fuzz-build", "go-fuzz-defs"],
+    module = "github.com/dvyukov/go-fuzz",
+)
+
+go_module(
+    name = "go-fuzz-build",
+    binary = True,
+    download = ":go-fuzz-download",
+    install = ["go-fuzz-build"],
+    module = "github.com/dvyukov/go-fuzz",
+    deps = [":go-fuzz-compile"],
+)

--- a/test/go_rules/double_path_import/BUILD
+++ b/test/go_rules/double_path_import/BUILD
@@ -1,0 +1,8 @@
+go_test(
+    name = "double_path_import_test",
+    srcs = ["double_path_import_test.go"],
+    deps = [
+        "//test/go_rules/double_path_import/bar/bar:baz",
+        "//test/go_rules/double_path_import/foo/foo",
+    ]
+)

--- a/test/go_rules/double_path_import/bar/bar/BUILD
+++ b/test/go_rules/double_path_import/bar/bar/BUILD
@@ -1,0 +1,5 @@
+go_library(
+    name = "baz",
+    srcs = ["baz.go"],
+    visibility=["//test/go_rules/double_path_import/..."]
+)

--- a/test/go_rules/double_path_import/bar/bar/baz.go
+++ b/test/go_rules/double_path_import/bar/bar/baz.go
@@ -1,0 +1,5 @@
+package baz
+
+func Baz() string {
+	return "Baz"
+}

--- a/test/go_rules/double_path_import/double_path_import_test.go
+++ b/test/go_rules/double_path_import/double_path_import_test.go
@@ -1,0 +1,17 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/thought-machine/please/test/go_rules/double_path_import/bar/bar/baz"
+	"github.com/thought-machine/please/test/go_rules/double_path_import/foo/foo"
+)
+
+func TestImports(t *testing.T) {
+	if foo.Foo() != "Foo" {
+		t.Fatal("Foo imported but was incorrect")
+	}
+	if baz.Baz() != "Baz" {
+		t.Fatal("Baz imported but was incorrect")
+	}
+}

--- a/test/go_rules/double_path_import/foo/foo/BUILD
+++ b/test/go_rules/double_path_import/foo/foo/BUILD
@@ -1,0 +1,5 @@
+go_library(
+    name = "foo",
+    srcs = ["foo.go"],
+    visibility=["//test/go_rules/double_path_import/..."]
+)

--- a/test/go_rules/double_path_import/foo/foo/foo.go
+++ b/test/go_rules/double_path_import/foo/foo/foo.go
@@ -1,0 +1,5 @@
+package foo
+
+func Foo() string {
+	return "Foo"
+}

--- a/tools/please_go/install/install.go
+++ b/tools/please_go/install/install.go
@@ -24,7 +24,7 @@ type PleaseGoInstall struct {
 
 	tc *toolchain.Toolchain
 
-	compiledPackages map[string]bool
+	compiledPackages map[string]string
 }
 
 // New creates a new PleaseGoInstall
@@ -65,11 +65,31 @@ func (install *PleaseGoInstall) Install(packages []string) error {
 			if err != nil {
 				return err
 			}
-		} else if err := install.compile([]string{}, target); err != nil {
-			return fmt.Errorf("failed to compile %v: %w", target, err)
+		} else {
+			if err := install.compile([]string{}, target); err != nil {
+				return fmt.Errorf("failed to compile %v: %w", target, err)
+			}
+
+			pkg, err := install.importDir(target)
+			if err != nil {
+				return err
+			}
+			if pkg.IsCommand() {
+				if err := install.linkPackage(target); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil
+}
+
+func (install *PleaseGoInstall) linkPackage(target string) error {
+	out := install.compiledPackages[target]
+	filename := strings.TrimSuffix(filepath.Base(out), ".a")
+	binName := filepath.Join(install.outDir, "bin", filename)
+
+	return install.tc.Link(out, binName, install.importConfig, install.ldFlags)
 }
 
 // compileAll walks the provided directory looking for go packages to compile. Unlike compile(), this will skip any
@@ -113,9 +133,9 @@ func (install *PleaseGoInstall) pkgDir(target string) string {
 }
 
 func (install *PleaseGoInstall) parseImportConfig() error {
-	install.compiledPackages = map[string]bool{
-		"unsafe": true, // Not sure how many other packages like this I need to handle
-		"C":      true, // Pseudo-package for cgo symbols
+	install.compiledPackages = map[string]string{
+		"unsafe": "", // Not sure how many other packages like this I need to handle
+		"C":      "", // Pseudo-package for cgo symbols
 	}
 
 	if install.importConfig != "" {
@@ -129,7 +149,7 @@ func (install *PleaseGoInstall) parseImportConfig() error {
 		for importCfg.Scan() {
 			line := importCfg.Text()
 			parts := strings.Split(strings.TrimPrefix(line, "packagefile "), "=")
-			install.compiledPackages[parts[0]] = true
+			install.compiledPackages[parts[0]] = parts[1]
 		}
 	}
 	return nil
@@ -145,8 +165,18 @@ func checkCycle(path []string, next string) ([]string, error) {
 	return append(path, next), nil
 }
 
+func (install *PleaseGoInstall) importDir(target string) (*build.Package, error) {
+	pkgDir := install.pkgDir(target)
+	// The package name can differ from the directory it lives in, in which case the parent directory is the one we want
+	if _, err := os.Lstat(pkgDir); os.IsNotExist(err) {
+		pkgDir = filepath.Dir(pkgDir)
+	}
+
+	return build.ImportDir(pkgDir, build.ImportComment)
+}
+
 func (install *PleaseGoInstall) compile(from []string, target string) error {
-	if done := install.compiledPackages[target]; done {
+	if _, done := install.compiledPackages[target]; done {
 		return nil
 	}
 	fmt.Fprintf(os.Stderr, "Compiling package %s from %v\n", target, from)
@@ -156,17 +186,7 @@ func (install *PleaseGoInstall) compile(from []string, target string) error {
 		return err
 	}
 
-	pkgDir := install.pkgDir(target)
-	// The package name can differ from the directory it lives in, in which case the parent directory is the one we want
-	if _, err := os.Lstat(pkgDir); os.IsNotExist(err) {
-		pkgDir = filepath.Dir(pkgDir)
-	}
-
-	// TODO(jpoole): is import vendor the correct thing to do here?
-	pkg, err := build.ImportDir(pkgDir, build.ImportComment)
-	if err != nil {
-		return err
-	}
+	pkg, err := install.importDir(target)
 
 	for _, i := range pkg.Imports {
 		err := install.compile(from, i)
@@ -183,7 +203,6 @@ func (install *PleaseGoInstall) compile(from []string, target string) error {
 	if err != nil {
 		return err
 	}
-	install.compiledPackages[target] = true
 	return nil
 }
 
@@ -282,12 +301,6 @@ func (install *PleaseGoInstall) compilePackage(target string, pkg *build.Package
 			return err
 		}
 	}
-
-	if pkg.IsCommand() {
-		filename := strings.TrimSuffix(filepath.Base(out), ".a")
-		binName := filepath.Join(install.outDir, "bin", filename)
-
-		return install.tc.Link(out, binName, install.importConfig, install.ldFlags)
-	}
+	install.compiledPackages[target] = out
 	return nil
 }

--- a/tools/please_go/install/install.go
+++ b/tools/please_go/install/install.go
@@ -72,11 +72,11 @@ func (install *PleaseGoInstall) Install(packages []string) error {
 
 			pkg, err := install.importDir(target)
 			if err != nil {
-				return err
+				panic(fmt.Sprintf("import dir failed after successful compilation: %v", err))
 			}
 			if pkg.IsCommand() {
 				if err := install.linkPackage(target); err != nil {
-					return err
+					return fmt.Errorf("failed to link %v: %w", target, err)
 				}
 			}
 		}
@@ -187,6 +187,9 @@ func (install *PleaseGoInstall) compile(from []string, target string) error {
 	}
 
 	pkg, err := install.importDir(target)
+	if err != nil {
+		return err
+	}
 
 	for _, i := range pkg.Imports {
 		err := install.compile(from, i)


### PR DESCRIPTION
Found some issues when migrating the pleasings repo to use `go_module()`

We used to do nothing as the package was already in the import config. This change allows us to compile the package in one `go_module()` rule and then link it into the binary in another. 

I was also investigating an issue with importing `github.com/thought-machine/pleasings/java/maven/maven` however that seems to have dissapeared between v16.0.0 and the latest beta release :thinking: I think the tests are worth keeping though. 