### PR TITLE
Cleanup legacy constructs in `pleasew` wrapper script

### DIFF
--- a/pleasew
+++ b/pleasew
@@ -8,7 +8,7 @@ RESET="\x1B[0m"
 
 DEFAULT_URL_BASE="https://get.please.build"
 # We might already have it downloaded...
-LOCATION=`grep -i "^location" .plzconfig 2>/dev/null | cut -d '=' -f 2 | tr -d ' '`
+LOCATION=$(grep -i "^location" .plzconfig 2>/dev/null | cut -d '=' -f 2 | tr -d ' ')
 if [ -z "$LOCATION" ]; then
     if [ -z "$HOME" ]; then
 	    echo -e >&2 "${RED}\$HOME not set, not sure where to look for Please.${RESET}"
@@ -25,24 +25,24 @@ if [ -f "$TARGET" ]; then
     exec "$TARGET" ${PLZ_ARGS:-} "$@"
 fi
 
-URL_BASE="`grep -i "^downloadlocation" .plzconfig | cut -d '=' -f 2 | tr -d ' '`"
+URL_BASE="$(grep -i "^downloadlocation" .plzconfig | cut -d '=' -f 2 | tr -d ' ')"
 if [ -z "$URL_BASE" ]; then
     URL_BASE=$DEFAULT_URL_BASE
 fi
 URL_BASE="${URL_BASE%/}"
 
-VERSION="`grep -i "^version[^a-z]" .plzconfig`"
+VERSION="$(grep -i "^version[^a-z]" .plzconfig)"
 VERSION="${VERSION#*=}"    # Strip until after first =
 VERSION="${VERSION/ /}"    # Remove all spaces
 VERSION="${VERSION#>=}"    # Strip any initial >=
 if [ -z "$VERSION" ]; then
     echo -e >&2 "${YELLOW}Can't determine version, will use latest.${RESET}"
-    VERSION=`curl -fsSL ${URL_BASE}/latest_version`
+    VERSION=$(curl -fsSL ${URL_BASE}/latest_version)
 fi
 
 # Find the os / arch to download. You can do this quite nicely with go env
 # but we use this script on machines that don't necessarily have Go itself.
-OS=`uname`
+OS=$(uname)
 if [ "$OS" = "Linux" ]; then
     GOOS="linux"
 elif [ "$OS" = "Darwin" ]; then
@@ -64,7 +64,7 @@ echo -e >&2 "${GREEN}Downloading Please ${VERSION} to ${DIR}...${RESET}"
 mkdir -p "$DIR"
 curl -fsSL "${PLEASE_URL}" | tar -xJpf- --strip-components=1 -C "$DIR"
 # Link it all back up a dir
-for x in `ls "$DIR"`; do
+for x in $(ls "$DIR"); do
     ln -sf "${DIR}/${x}" "$LOCATION"
 done
 echo -e >&2 "${GREEN}Should be good to go now, running plz...${RESET}"

--- a/pleasew
+++ b/pleasew
@@ -11,8 +11,8 @@ DEFAULT_URL_BASE="https://get.please.build"
 LOCATION=$(grep -i "^location" .plzconfig 2>/dev/null | cut -d '=' -f 2 | tr -d ' ')
 if [ -z "$LOCATION" ]; then
     if [ -z "$HOME" ]; then
-	    echo -e >&2 "${RED}\$HOME not set, not sure where to look for Please.${RESET}"
-	    exit 1
+        echo -e >&2 "${RED}\$HOME not set, not sure where to look for Please.${RESET}"
+        exit 1
     fi
     LOCATION="${HOME}/.please"
 else


### PR DESCRIPTION
As per issue #1827, this replaces backtick subshell notation with dollar parenthesis in accordance with shellcheck lint tip [SC2006](https://github.com/koalaman/shellcheck/wiki/SC2006). This has primarily been done to remove the most noticeable embedded shellcheck hints in editors. Unlike adding additional quoting `""` around assignments and existing subshells, it won't change existing behavior whatsoever