### PR TITLE
Implement a graceful stop on the remote execution client

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -66,6 +66,8 @@ type RemoteClient interface {
 	PrintHashes(target *BuildTarget, isTest bool)
 	// DataRate returns an estimate of the current in/out RPC data rates and totals so far in bytes per second.
 	DataRate() (int, int, int, int)
+	// Disconnect disconnects from the remote execution server.
+	Disconnect() error
 }
 
 // A TargetHasher is a thing that knows how to create hashes for targets.

--- a/src/please.go
+++ b/src/please.go
@@ -911,6 +911,9 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	}
 
 	runPlease(state, targets)
+	if state.RemoteClient != nil && !opts.Run.Remote {
+		defer state.RemoteClient.Disconnect()
+	}
 	return state.Successful(), state
 }
 

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -144,6 +144,12 @@ func (c *Client) CheckInitialised() error {
 	return c.err
 }
 
+// Disconnect disconnects this client from the remote server.
+func (c *Client) Disconnect() error {
+	log.Debug("Disconnecting from remote execution server...")
+	return c.client.Close()
+}
+
 // init is passed to the sync.Once to do the actual initialisation.
 func (c *Client) init() {
 	// Change grpc to log using our implementation


### PR DESCRIPTION
Occasionally see `connection reset by peer` errors on the server; I think this helps (and is a little more polite as a client)