### PR TITLE
Copy node properties between directory nodes for remote execution

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -283,6 +283,7 @@ func (c *Client) addChildDirs(b *dirBuilder, name string, dg *pb.Digest) error {
 	d.Directories = append(d.Directories, dir.Directories...)
 	d.Files = append(d.Files, dir.Files...)
 	d.Symlinks = append(d.Symlinks, dir.Symlinks...)
+	d.NodeProperties = dir.NodeProperties
 	for _, subdir := range dir.Directories {
 		if err := c.addChildDirs(b, path.Join(name, subdir.Name), subdir.Digest); err != nil {
 			return err


### PR DESCRIPTION
If the server attaches these, we should honour them; it is pretty important to make sure we have the right representation of the directory later on too or it might not be found.