### PR TITLE
Reduce some allocations in parser

### DIFF
--- a/src/parse/asp/BUILD
+++ b/src/parse/asp/BUILD
@@ -3,6 +3,7 @@ go_library(
     srcs = glob(
         ["*.go"],
         exclude = [
+            "*_benchmark.go",
             "*_test.go",
             "*.bindata.go",
         ],
@@ -70,5 +71,16 @@ go_test(
         ":asp",
         "//src/core",
         "//third_party/go:testify",
+    ],
+)
+
+go_benchmark(
+    name = "interpreter_benchmark",
+    srcs = ["interpreter_benchmark.go"],
+    data = ["test_data"],
+    deps = [
+        ":asp",
+        "//rules",
+        "//src/core",
     ],
 )

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -85,7 +85,7 @@ func (i *interpreter) loadBuiltinStatements(s *scope, statements []*Statement, e
 // interpretAll runs a series of statements in the context of the given package.
 // The first return value is for testing only.
 func (i *interpreter) interpretAll(pkg *core.Package, statements []*Statement) (s *scope, err error) {
-	s = i.scope.NewPackagedScope(pkg)
+	s = i.scope.NewPackagedScope(pkg, 1)
 	// Config needs a little separate tweaking.
 	// Annoyingly we'd like to not have to do this at all, but it's very hard to handle
 	// mutating operations like .setdefault() otherwise.
@@ -214,11 +214,12 @@ type scope struct {
 
 // NewScope creates a new child scope of this one.
 func (s *scope) NewScope() *scope {
-	return s.NewPackagedScope(s.pkg)
+	return s.NewPackagedScope(s.pkg, 0)
 }
 
 // NewPackagedScope creates a new child scope of this one pointing to the given package.
-func (s *scope) NewPackagedScope(pkg *core.Package) *scope {
+// hint is a size hint for the new set of locals.
+func (s *scope) NewPackagedScope(pkg *core.Package, hint int) *scope {
 	s2 := &scope{
 		ctx:         s.ctx,
 		interpreter: s.interpreter,
@@ -226,7 +227,7 @@ func (s *scope) NewPackagedScope(pkg *core.Package) *scope {
 		pkg:         pkg,
 		contextPkg:  pkg,
 		parent:      s,
-		locals:      pyDict{},
+		locals:      make(pyDict, hint),
 		config:      s.config,
 		Callback:    s.Callback,
 	}

--- a/src/parse/asp/interpreter_benchmark.go
+++ b/src/parse/asp/interpreter_benchmark.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/rules"
+	"github.com/thought-machine/please/src/core"
 )
 
 func BenchmarkParseFile(b *testing.B) {

--- a/src/parse/asp/interpreter_benchmark.go
+++ b/src/parse/asp/interpreter_benchmark.go
@@ -1,0 +1,28 @@
+package asp
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/rules"
+)
+
+func BenchmarkParseFile(b *testing.B) {
+	b.ReportAllocs()
+	state := core.NewDefaultBuildState()
+	parser := NewParser(state)
+	dir, _ := rules.AllAssets()
+	sort.Strings(dir)
+	for _, filename := range dir {
+		src, _ := rules.ReadAsset(filename)
+		parser.MustLoadBuiltins(filename, src)
+	}
+	for i := 0; i < b.N; i++ {
+		pkg := core.NewPackage(fmt.Sprintf("benchmark_%d", i))
+		if err := parser.ParseFile(pkg, "src/parse/asp/test_data/benchmark_parse_file.build", ""); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -612,7 +612,7 @@ func (f *pyFunc) Call(ctx context.Context, s *scope, c *Call) pyObject {
 		}
 		return f.callNative(s, c)
 	}
-	s2 := f.scope.NewPackagedScope(s.pkg)
+	s2 := f.scope.NewPackagedScope(s.pkg, len(f.args)+1)
 	s2.ctx = ctx
 	s2.config = s.config
 	s2.Set("CONFIG", s.config) // This needs to be copied across too :(

--- a/src/parse/asp/parser.go
+++ b/src/parse/asp/parser.go
@@ -1,6 +1,6 @@
-// Package asp implements an experimental BUILD-language parser.
-// Parsing is doing using Participle (github.com/alecthomas/participle) in native Go,
-// with a custom and also native partial Python interpreter.
+// Package asp implements the BUILD language parser for Please.
+// Asp is a syntactic subset of Python, with the lexer, parser and interpreter all
+// implemented natively in Go.
 package asp
 
 import (

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -522,7 +522,7 @@ type preBuildFunction struct {
 }
 
 func (f *preBuildFunction) Call(target *core.BuildTarget) error {
-	s := f.f.scope.NewPackagedScope(f.f.scope.state.Graph.PackageOrDie(target.Label))
+	s := f.f.scope.NewPackagedScope(f.f.scope.state.Graph.PackageOrDie(target.Label), 1)
 	s.Callback = true
 	s.Set(f.f.args[0], pyString(target.Label.Name))
 	_, err := s.interpreter.interpretStatements(s, f.f.code)
@@ -540,7 +540,7 @@ type postBuildFunction struct {
 }
 
 func (f *postBuildFunction) Call(target *core.BuildTarget, output string) error {
-	s := f.f.scope.NewPackagedScope(f.f.scope.state.Graph.PackageOrDie(target.Label))
+	s := f.f.scope.NewPackagedScope(f.f.scope.state.Graph.PackageOrDie(target.Label), 2)
 	s.Callback = true
 	s.Set(f.f.args[0], pyString(target.Label.Name))
 	s.Set(f.f.args[1], fromStringList(strings.Split(strings.TrimSpace(output), "\n")))

--- a/src/parse/asp/test_data/benchmark_parse_file.build
+++ b/src/parse/asp/test_data/benchmark_parse_file.build
@@ -1,0 +1,175 @@
+genrule(
+    name = "version",
+    srcs = {
+        "go": ["version.go"],
+        "version": ["//:version"],
+    },
+    outs = ["versioned.go"],
+    cmd = "sed \"s/1.0.9999/`cat $SRCS_VERSION`/\" $SRCS_GO > \"$OUT\"",
+)
+
+go_library(
+    name = "core",
+    srcs = ["core.go"] + [
+        ":version",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        "//src/cli",
+        "//src/fs",
+        "//src/process",
+        "//src/scm",
+        "//third_party/go:blake3",
+        "//third_party/go:cmap",
+        "//third_party/go:errgroup",
+        "//third_party/go:gcfg",
+        "//third_party/go:go-flags",
+        "//third_party/go:godirwalk",
+        "//third_party/go:logging",
+        "//third_party/go:psutil",
+        "//third_party/go:semver",
+        "//third_party/go:shlex",
+        "//third_party/go:xattr",
+    ],
+)
+
+go_test(
+    name = "config_test",
+    srcs = ["config_test.go"],
+    data = ["test_data"],
+    filter_srcs = False,  # As above
+    deps = [
+        ":core",
+        "//src/cli",
+        "//third_party/go:go-flags",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "label_parse_test",
+    srcs = ["label_parse_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "graph_test",
+    srcs = ["graph_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "state_test",
+    srcs = ["state_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "build_target_test",
+    srcs = ["build_target_test.go"],
+    data = ["test_data"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "package_test",
+    srcs = ["package_test.go"],
+    data = ["test_data"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "build_env_test",
+    srcs = ["build_env_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "utils_test",
+    srcs = ["utils_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "lock_test",
+    srcs = ["lock_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "build_label_test",
+    srcs = ["build_label_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "test_results_test",
+    srcs = ["test_results_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "build_input_test",
+    srcs = ["build_input_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "subrepo_test",
+    srcs = ["subrepo_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "command_replacements_test",
+    srcs = ["command_replacements_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
+    name = "stamp_test",
+    srcs = ["stamp_test.go"],
+    deps = [
+        ":core",
+        "//third_party/go:testify",
+    ],
+)


### PR DESCRIPTION
Attempts to size scopes a little more accurately, and parses some expressions in-place rather than creating a new struct and copying.