### PR TITLE
Correct defines on cc_binary so it can be a dict as well

### DIFF
--- a/rules/cc_rules.build_defs
+++ b/rules/cc_rules.build_defs
@@ -482,7 +482,7 @@ def cc_module(name:str, srcs:list=[], hdrs:list=[], interfaces:list=[], private_
 
 def cc_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[],
               compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
-              deps:list=[], visibility:list=None, pkg_config_libs:list=[], includes:list=[], defines:list=[],
+              deps:list=[], visibility:list=None, pkg_config_libs:list=[], includes:list=[], defines:list|dict=[],
               pkg_config_cflags:list=[], test_only:bool&testonly=False, static:bool=False, _c=False,
               linkstatic:bool=False):
     """Builds a binary from a collection of C++ rules.


### PR DESCRIPTION
This is allowed everywhere else, including in the comment, but atm you can't do it because the type annotation doesn't allow for it here.