### PR TITLE
Fix target own inputs check

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -851,13 +851,13 @@ func (target *BuildTarget) CheckTargetOwnsBuildOutputs(state *BuildState) error 
 
 // CheckTargetOwnsBuildInputs checks that any file inputs to this rule belong to this package.
 func (target *BuildTarget) CheckTargetOwnsBuildInputs(state *BuildState) error {
-	for _, input := range target.Sources {
+	for _, input := range target.AllSources() {
 		if err := target.checkTargetOwnsBuildInput(state, input); err != nil {
 			return err
 		}
 	}
 
-	for _, input := range target.Data {
+	for _, input := range target.AllData() {
 		if err := target.checkTargetOwnsBuildInput(state, input); err != nil {
 			return err
 		}

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -647,7 +647,8 @@ func TestExternalDependencies(t *testing.T) {
 
 func TestBuildTargetOwnBuildInputs(t *testing.T) {
 	buildFiles := []string{"BUILD_FILE"}
-	t.Run("file is in package", func(t *testing.T) {
+
+	t.Run("file as source is in package", func(t *testing.T) {
 		state := NewDefaultBuildState()
 		state.Config.Parse.BuildFileName = buildFiles
 
@@ -663,7 +664,23 @@ func TestBuildTargetOwnBuildInputs(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("file is subpackage", func(t *testing.T) {
+	t.Run("file as named source is in package", func(t *testing.T) {
+		state := NewDefaultBuildState()
+		state.Config.Parse.BuildFileName = buildFiles
+
+		target := makeTarget1("//src/core/test_data/project", "PUBLIC")
+		target.AddNamedSource("srcs", FileLabel{
+			File:    "project.file",
+			Package: "src/core/test_data/project",
+		})
+
+		target = state.Graph.AddTarget(target)
+
+		err := target.CheckTargetOwnsBuildInputs(state)
+		assert.NoError(t, err)
+	})
+
+	t.Run("file as source is subpackage", func(t *testing.T) {
 		state := NewDefaultBuildState()
 		state.Config.Parse.BuildFileName = buildFiles
 
@@ -679,12 +696,140 @@ func TestBuildTargetOwnBuildInputs(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("file is in subpackage", func(t *testing.T) {
+	t.Run("file as named source is subpackage", func(t *testing.T) {
+		state := NewDefaultBuildState()
+		state.Config.Parse.BuildFileName = buildFiles
+
+		target := makeTarget1("//src/core/test_data/project", "PUBLIC")
+		target.AddNamedSource("srcs", FileLabel{
+			File:    "sub_package",
+			Package: "src/core/test_data/project",
+		})
+
+		target = state.Graph.AddTarget(target)
+
+		err := target.CheckTargetOwnsBuildInputs(state)
+		assert.Error(t, err)
+	})
+
+	t.Run("file as source is in subpackage", func(t *testing.T) {
 		state := NewDefaultBuildState()
 		state.Config.Parse.BuildFileName = buildFiles
 
 		target := makeTarget1("//src/core/test_data/project", "PUBLIC")
 		target.AddSource(FileLabel{
+			File:    "sub_package/sub_package.file",
+			Package: "src/core/test_data/project",
+		})
+
+		target = state.Graph.AddTarget(target)
+
+		err := target.CheckTargetOwnsBuildInputs(state)
+		assert.Error(t, err)
+	})
+
+	t.Run("file as named source is in subpackage", func(t *testing.T) {
+		state := NewDefaultBuildState()
+		state.Config.Parse.BuildFileName = buildFiles
+
+		target := makeTarget1("//src/core/test_data/project", "PUBLIC")
+		target.AddNamedSource("srcs", FileLabel{
+			File:    "sub_package/sub_package.file",
+			Package: "src/core/test_data/project",
+		})
+
+		target = state.Graph.AddTarget(target)
+
+		err := target.CheckTargetOwnsBuildInputs(state)
+		assert.Error(t, err)
+	})
+
+	t.Run("file as data is in package", func(t *testing.T) {
+		state := NewDefaultBuildState()
+		state.Config.Parse.BuildFileName = buildFiles
+
+		target := makeTarget1("//src/core/test_data/project", "PUBLIC")
+		target.AddDatum(FileLabel{
+			File:    "project.file",
+			Package: "src/core/test_data/project",
+		})
+
+		target = state.Graph.AddTarget(target)
+
+		err := target.CheckTargetOwnsBuildInputs(state)
+		assert.NoError(t, err)
+	})
+
+	t.Run("file as named data is in package", func(t *testing.T) {
+		state := NewDefaultBuildState()
+		state.Config.Parse.BuildFileName = buildFiles
+
+		target := makeTarget1("//src/core/test_data/project", "PUBLIC")
+		target.AddNamedDatum("srcs", FileLabel{
+			File:    "project.file",
+			Package: "src/core/test_data/project",
+		})
+
+		target = state.Graph.AddTarget(target)
+
+		err := target.CheckTargetOwnsBuildInputs(state)
+		assert.NoError(t, err)
+	})
+
+	t.Run("file as data is subpackage", func(t *testing.T) {
+		state := NewDefaultBuildState()
+		state.Config.Parse.BuildFileName = buildFiles
+
+		target := makeTarget1("//src/core/test_data/project", "PUBLIC")
+		target.AddDatum(FileLabel{
+			File:    "sub_package",
+			Package: "src/core/test_data/project",
+		})
+
+		target = state.Graph.AddTarget(target)
+
+		err := target.CheckTargetOwnsBuildInputs(state)
+		assert.Error(t, err)
+	})
+
+	t.Run("file as named data is subpackage", func(t *testing.T) {
+		state := NewDefaultBuildState()
+		state.Config.Parse.BuildFileName = buildFiles
+
+		target := makeTarget1("//src/core/test_data/project", "PUBLIC")
+		target.AddNamedDatum("srcs", FileLabel{
+			File:    "sub_package",
+			Package: "src/core/test_data/project",
+		})
+
+		target = state.Graph.AddTarget(target)
+
+		err := target.CheckTargetOwnsBuildInputs(state)
+		assert.Error(t, err)
+	})
+
+	t.Run("file as data is in subpackage", func(t *testing.T) {
+		state := NewDefaultBuildState()
+		state.Config.Parse.BuildFileName = buildFiles
+
+		target := makeTarget1("//src/core/test_data/project", "PUBLIC")
+		target.AddDatum(FileLabel{
+			File:    "sub_package/sub_package.file",
+			Package: "src/core/test_data/project",
+		})
+
+		target = state.Graph.AddTarget(target)
+
+		err := target.CheckTargetOwnsBuildInputs(state)
+		assert.Error(t, err)
+	})
+
+	t.Run("file as named data is in subpackage", func(t *testing.T) {
+		state := NewDefaultBuildState()
+		state.Config.Parse.BuildFileName = buildFiles
+
+		target := makeTarget1("//src/core/test_data/project", "PUBLIC")
+		target.AddNamedDatum("srcs", FileLabel{
 			File:    "sub_package/sub_package.file",
 			Package: "src/core/test_data/project",
 		})


### PR DESCRIPTION
This fixes the check on targets' own inputs where named sources and data were not being considered. This caused named input sources belonging to a different package to be used as sources without an error happening.