### PR TITLE
Fix log filenames from asp

### DIFF
--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -139,10 +139,10 @@ func setLogCode(s *scope, name string, f func(format string, args ...interface{}
 			for i, arg := range args {
 				l[i] = arg
 			}
-			f("//%s: %s", s.pkgFilename(), fmt.Sprintf(string(str), l[1:]...))
+			f("//%s: %s", s.pkgName(), fmt.Sprintf(string(str), l[1:]...))
 			return None
 		}
-		f("//%s: %s", s.pkgFilename(), args)
+		f("//%s: %s", s.pkgName(), args)
 		return None
 	}).varargs = true
 }

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -775,10 +775,10 @@ func (s *scope) Constant(expr *Expression) pyObject {
 	return nil
 }
 
-// pkgFilename returns the filename of the current package, or the empty string if there is none.
-func (s *scope) pkgFilename() string {
+// pkgName returns the name of the current package, or the empty string if there is none.
+func (s *scope) pkgName() string {
 	if s.pkg != nil {
-		return s.pkg.Filename
+		return s.pkg.Name
 	}
 	return ""
 }


### PR DESCRIPTION
Was coming out like 
```
09:17:53.949 WARNING: ///home/pebers/git/please/test/go_rules/BUILD: hello
```
Now is:
```
09:19:47.371 WARNING: //test/go_rules: hello
```

I'm sure this did work like the latter once upon a time but I can't see anything relevant that's changed 🤔