### PR TITLE
Make package filenames relative

### DIFF
--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -235,7 +235,7 @@ func buildFileName(state *core.BuildState, pkgName string, subrepo *core.Subrepo
 		return "WORKSPACE", ""
 	}
 	for _, buildFileName := range config.Parse.BuildFileName {
-		if filename := path.Join(core.RepoRoot, pkgName, buildFileName); fs.FileExists(filename) {
+		if filename := path.Join(pkgName, buildFileName); fs.FileExists(filename) {
 			return filename, pkgName
 		}
 	}


### PR DESCRIPTION
The original motivation here was fixing asp log messages like
```
09:31:28.240 WARNING: ///home/pebers/git/please/test/go_rules/BUILD: hello
```
to
```
09:31:28.240 WARNING: //test/go_rules/BUILD: hello
```
I think it should be fine generally for these to be relative though? The location of the repo shouldn't need to show up in this stuff.