### PR TITLE
Don't close the result channel until the workers shut down

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -316,7 +316,6 @@ func (state *BuildState) Stop() {
 		close(state.pendingTests)
 		close(state.pendingRemoteTests)
 	})
-	state.CloseResults()
 }
 
 // CloseResults closes the result channels.


### PR DESCRIPTION
We were closing the result channel which meant we couldn't process results to update the workers. We still close the results channel after the workers flush their queues and exit. 