### PR TITLE
Change BuildInput to return (BuildLabel, bool) instead of *BuildLabel

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -90,8 +90,8 @@ func validateBuildTargetBeforeBuild(state *core.BuildState, target *core.BuildTa
 func findFilegroupSourcesWithTmpDir(target *core.BuildTarget) []core.BuildLabel {
 	srcs := make([]core.BuildLabel, 0, len(target.Sources))
 	for _, src := range target.Sources {
-		if src.Label() != nil {
-			srcs = append(srcs, *src.Label())
+		if l, ok := src.Label(); ok {
+			srcs = append(srcs, l)
 		}
 	}
 	return srcs

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -498,8 +498,8 @@ func PrintHashes(state *core.BuildState, target *core.BuildTarget) {
 		fmt.Printf("  Source: %s: %s\n", source.Src, b64(state.PathHasher.MustHash(source.Src)))
 	}
 	for _, tool := range target.AllTools() {
-		if label := tool.Label(); label != nil {
-			fmt.Printf("    Tool: %s: %s\n", *label, b64(mustShortTargetHash(state, state.Graph.TargetOrDie(*label))))
+		if label, ok := tool.Label(); ok {
+			fmt.Printf("    Tool: %s: %s\n", label, b64(mustShortTargetHash(state, state.Graph.TargetOrDie(label))))
 		} else {
 			fmt.Printf("    Tool: %s: %s\n", tool, b64(state.PathHasher.MustHash(tool.FullPaths(state.Graph)[0])))
 		}

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -313,12 +313,12 @@ func initStampEnv() {
 }
 
 func toolPath(state *BuildState, tool BuildInput, abs bool) string {
-	if label := tool.Label(); label != nil {
+	if label, ok := tool.Label(); ok {
 		entryPoint := ""
 		if o, ok := tool.(AnnotatedOutputLabel); ok {
 			entryPoint = o.Annotation
 		}
-		path := state.Graph.TargetOrDie(*label).toolPath(abs, entryPoint)
+		path := state.Graph.TargetOrDie(label).toolPath(abs, entryPoint)
 		if !strings.Contains(path, "/") {
 			path = "./" + path
 		}

--- a/src/core/build_input.go
+++ b/src/core/build_input.go
@@ -18,12 +18,12 @@ type BuildInput interface {
 	FullPaths(graph *BuildGraph) []string
 	// LocalPaths returns paths within the local package
 	LocalPaths(graph *BuildGraph) []string
-	// Label returns the build label associated with this input, or nil if it doesn't have one (eg. it's just a file).
-	Label() *BuildLabel
+	// Label returns the build label associated with this input, or false if it doesn't have one.
+	Label() (BuildLabel, bool)
 	// nonOutputLabel returns the build label associated with this input, or nil if it doesn't have
 	// one or is a specific output of a rule.
 	// This is fiddly enough that we don't want to expose it outside the package right now.
-	nonOutputLabel() *BuildLabel
+	nonOutputLabel() (BuildLabel, bool)
 	// String returns a string representation of this input
 	String() string
 }
@@ -52,12 +52,12 @@ func (label FileLabel) LocalPaths(graph *BuildGraph) []string {
 }
 
 // Label returns the build rule associated with this input. For a FileLabel it's always nil.
-func (label FileLabel) Label() *BuildLabel {
-	return nil
+func (label FileLabel) Label() (BuildLabel, bool) {
+	return BuildLabel{}, false
 }
 
-func (label FileLabel) nonOutputLabel() *BuildLabel {
-	return nil
+func (label FileLabel) nonOutputLabel() (BuildLabel, bool) {
+	return BuildLabel{}, false
 }
 
 // String returns a string representation of this input.
@@ -91,12 +91,12 @@ func (label SubrepoFileLabel) LocalPaths(graph *BuildGraph) []string {
 }
 
 // Label returns the build rule associated with this input. For a SubrepoFileLabel it's always nil.
-func (label SubrepoFileLabel) Label() *BuildLabel {
-	return nil
+func (label SubrepoFileLabel) Label() (BuildLabel, bool) {
+	return BuildLabel{}, false
 }
 
-func (label SubrepoFileLabel) nonOutputLabel() *BuildLabel {
-	return nil
+func (label SubrepoFileLabel) nonOutputLabel() (BuildLabel, bool) {
+	return BuildLabel{}, false
 }
 
 // String returns a string representation of this input.
@@ -138,12 +138,12 @@ func (label SystemFileLabel) LocalPaths(graph *BuildGraph) []string {
 }
 
 // Label returns the build rule associated with this input. For a SystemFileLabel it's always nil.
-func (label SystemFileLabel) Label() *BuildLabel {
-	return nil
+func (label SystemFileLabel) Label() (BuildLabel, bool) {
+	return BuildLabel{}, false
 }
 
-func (label SystemFileLabel) nonOutputLabel() *BuildLabel {
-	return nil
+func (label SystemFileLabel) nonOutputLabel() (BuildLabel, bool) {
+	return BuildLabel{}, false
 }
 
 // String returns a string representation of this input.
@@ -181,12 +181,12 @@ func (label SystemPathLabel) LocalPaths(graph *BuildGraph) []string {
 }
 
 // Label returns the build rule associated with this input. For a SystemPathLabel it's always nil.
-func (label SystemPathLabel) Label() *BuildLabel {
-	return nil
+func (label SystemPathLabel) Label() (BuildLabel, bool) {
+	return BuildLabel{}, false
 }
 
-func (label SystemPathLabel) nonOutputLabel() *BuildLabel {
-	return nil
+func (label SystemPathLabel) nonOutputLabel() (BuildLabel, bool) {
+	return BuildLabel{}, false
 }
 
 // String returns a string representation of this input.
@@ -230,12 +230,12 @@ func (label AnnotatedOutputLabel) LocalPaths(graph *BuildGraph) []string {
 }
 
 // Label returns the build rule associated with this input. For a AnnotatedOutputLabel it's always non-nil.
-func (label AnnotatedOutputLabel) Label() *BuildLabel {
-	return &label.BuildLabel
+func (label AnnotatedOutputLabel) Label() (BuildLabel, bool) {
+	return label.BuildLabel, true
 }
 
-func (label AnnotatedOutputLabel) nonOutputLabel() *BuildLabel {
-	return nil
+func (label AnnotatedOutputLabel) nonOutputLabel() (BuildLabel, bool) {
+	return BuildLabel{}, false
 }
 
 // String returns a string representation of this input.
@@ -294,12 +294,12 @@ func (label URLLabel) LocalPaths(graph *BuildGraph) []string {
 }
 
 // Label returns the build rule associated with this input. For a URLLabel it's always nil.
-func (label URLLabel) Label() *BuildLabel {
-	return nil
+func (label URLLabel) Label() (BuildLabel, bool) {
+	return BuildLabel{}, false
 }
 
-func (label URLLabel) nonOutputLabel() *BuildLabel {
-	return nil
+func (label URLLabel) nonOutputLabel() (BuildLabel, bool) {
+	return BuildLabel{}, false
 }
 
 // String returns a string representation of this input.

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -308,12 +308,12 @@ func (label BuildLabel) LocalPaths(graph *BuildGraph) []string {
 }
 
 // Label is an implementation of BuildInput interface. It always returns this label.
-func (label BuildLabel) Label() *BuildLabel {
-	return &label
+func (label BuildLabel) Label() (BuildLabel, bool) {
+	return label, true
 }
 
-func (label BuildLabel) nonOutputLabel() *BuildLabel {
-	return &label
+func (label BuildLabel) nonOutputLabel() (BuildLabel, bool) {
+	return label, true
 }
 
 // UnmarshalFlag unmarshals a build label from a command line flag. Implementation of flags.Unmarshaler interface.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -667,10 +667,10 @@ func (target *BuildTarget) Outputs() []string {
 				for _, dep := range target.DependenciesFor(namedLabel.BuildLabel) {
 					ret = append(ret, dep.NamedOutputs(namedLabel.Annotation)...)
 				}
-			} else if label := src.nonOutputLabel(); label == nil {
+			} else if label, ok := src.nonOutputLabel(); !ok {
 				ret = append(ret, src.LocalPaths(nil)[0])
 			} else {
-				for _, dep := range target.DependenciesFor(*label) {
+				for _, dep := range target.DependenciesFor(label) {
 					ret = append(ret, dep.Outputs()...)
 				}
 			}
@@ -773,9 +773,9 @@ func (target *BuildTarget) SourcePaths(graph *BuildGraph, sources []BuildInput) 
 
 // sourcePaths returns the source paths for a single source.
 func (target *BuildTarget) sourcePaths(graph *BuildGraph, source BuildInput, f buildPathsFunc) []string {
-	if label := source.nonOutputLabel(); label != nil {
+	if label, ok := source.nonOutputLabel(); ok {
 		ret := []string{}
-		for _, providedLabel := range graph.TargetOrDie(*label).ProvideFor(target) {
+		for _, providedLabel := range graph.TargetOrDie(label).ProvideFor(target) {
 			ret = append(ret, f(providedLabel, graph)...)
 		}
 		return ret
@@ -1084,7 +1084,7 @@ func (target *BuildTarget) provideFor(other *BuildTarget) []BuildLabel {
 	}
 	// Never do this if the other target has a data or tool dependency on us.
 	for _, data := range other.Data {
-		if label := data.Label(); label != nil && *label == target.Label {
+		if label, ok := data.Label(); ok && label == target.Label {
 			return nil
 		}
 	}
@@ -1128,8 +1128,8 @@ func (target *BuildTarget) addSource(sources []BuildInput, source BuildInput) []
 		}
 	}
 	// Add a dependency if this is not just a file.
-	if label := source.Label(); label != nil {
-		target.AddMaybeExportedDependency(*label, false, true, false)
+	if label, ok := source.Label(); ok {
+		target.AddMaybeExportedDependency(label, false, true, false)
 	}
 	return append(sources, source)
 }
@@ -1172,16 +1172,16 @@ func (target *BuildTarget) AddNamedSecret(name string, secret string) {
 // AddTool adds a new tool to the target.
 func (target *BuildTarget) AddTool(tool BuildInput) {
 	target.Tools = append(target.Tools, tool)
-	if label := tool.Label(); label != nil {
-		target.AddDependency(*label)
+	if label, ok := tool.Label(); ok {
+		target.AddDependency(label)
 	}
 }
 
 // AddTestTool adds a new test tool to the target.
 func (target *BuildTarget) AddTestTool(tool BuildInput) {
 	target.testTools = append(target.testTools, tool)
-	if label := tool.Label(); label != nil {
-		target.AddDependency(*label)
+	if label, ok := tool.Label(); ok {
+		target.AddDependency(label)
 	}
 }
 
@@ -1208,9 +1208,9 @@ func (target *BuildTarget) NamedTestTools() map[string][]BuildInput {
 // AddDatum adds a new item of data to the target.
 func (target *BuildTarget) AddDatum(datum BuildInput) {
 	target.Data = append(target.Data, datum)
-	if label := datum.Label(); label != nil {
-		target.AddDependency(*label)
-		target.dependencyInfo(*label).data = true
+	if label, ok := datum.Label(); ok {
+		target.AddDependency(label)
+		target.dependencyInfo(label).data = true
 	}
 }
 
@@ -1221,9 +1221,9 @@ func (target *BuildTarget) AddNamedDatum(name string, datum BuildInput) {
 	} else {
 		target.namedData[name] = append(target.namedData[name], datum)
 	}
-	if label := datum.Label(); label != nil {
-		target.AddDependency(*label)
-		target.dependencyInfo(*label).data = true
+	if label, ok := datum.Label(); ok {
+		target.AddDependency(label)
+		target.dependencyInfo(label).data = true
 	}
 }
 
@@ -1234,8 +1234,8 @@ func (target *BuildTarget) AddNamedTool(name string, tool BuildInput) {
 	} else {
 		target.namedTools[name] = append(target.namedTools[name], tool)
 	}
-	if label := tool.Label(); label != nil {
-		target.AddDependency(*label)
+	if label, ok := tool.Label(); ok {
+		target.AddDependency(label)
 	}
 }
 
@@ -1246,8 +1246,8 @@ func (target *BuildTarget) AddNamedTestTool(name string, tool BuildInput) {
 	} else {
 		target.namedTestTools[name] = append(target.namedTestTools[name], tool)
 	}
-	if label := tool.Label(); label != nil {
-		target.AddDependency(*label)
+	if label, ok := tool.Label(); ok {
+		target.AddDependency(label)
 	}
 }
 
@@ -1446,13 +1446,13 @@ func (target *BuildTarget) AddMaybeExportedDependency(dep BuildLabel, exported, 
 // IsTool returns true if the given build label is a tool used by this target.
 func (target *BuildTarget) IsTool(tool BuildLabel) bool {
 	for _, t := range target.Tools {
-		if t.Label() != nil && *t.Label() == tool {
+		if label, ok := t.Label(); ok && label == tool {
 			return true
 		}
 	}
 	for _, tools := range target.namedTools {
 		for _, t := range tools {
-			if t.Label() != nil && *t.Label() == tool {
+			if label, ok := t.Label(); ok && label == tool {
 				return true
 			}
 		}

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -903,7 +903,9 @@ func TestIsTool(t *testing.T) {
 	target.AddTool(withEP)
 
 	assert.True(t, target.IsTool(noEP))
-	assert.True(t, target.IsTool(*withEP.Label()))
+	l, ok := withEP.Label()
+	assert.True(t, ok)
+	assert.True(t, target.IsTool(l))
 }
 
 func makeTarget1(label, visibility string, deps ...*BuildTarget) *BuildTarget {

--- a/src/core/command_replacements.go
+++ b/src/core/command_replacements.go
@@ -191,8 +191,8 @@ func replaceSequence(state *BuildState, target *BuildTarget, in string, runnable
 		return replaceSequenceLabel(state, target, label, ep, in, runnable, multiple, dir, outPrefix, hash, test, true)
 	}
 	for _, src := range sourcesOrTools(target, runnable) {
-		if label := src.Label(); label != nil && src.String() == in {
-			return replaceSequenceLabel(state, target, *label, "", in, runnable, multiple, dir, outPrefix, hash, test, false)
+		if label, ok := src.Label(); ok && src.String() == in {
+			return replaceSequenceLabel(state, target, label, "", in, runnable, multiple, dir, outPrefix, hash, test, false)
 		} else if runnable && src.String() == in {
 			return src.String()
 		}

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -933,8 +933,8 @@ func (state *BuildState) DownloadInputsIfNeeded(tid int, target *BuildTarget, ru
 	if state.RemoteClient != nil {
 		state.LogBuildResult(tid, target.Label, TargetBuilding, "Downloading inputs...")
 		for input := range state.IterInputs(target, runtime) {
-			if l := input.Label(); l != nil {
-				dep := state.Graph.TargetOrDie(*l)
+			if l, ok := input.Label(); ok {
+				dep := state.Graph.TargetOrDie(l)
 				if s := dep.State(); s == BuiltRemotely || s == ReusedRemotely {
 					if err := state.RemoteClient.Download(dep); err != nil {
 						return err

--- a/src/export/export.go
+++ b/src/export/export.go
@@ -53,7 +53,7 @@ func export(graph *core.BuildGraph, dir string, target *core.BuildTarget, done m
 		return
 	}
 	for _, src := range target.AllSources() {
-		if src.Label() == nil { // We'll handle these dependencies later
+		if _, ok := src.Label(); !ok { // We'll handle these dependencies later
 			for _, p := range src.FullPaths(graph) {
 				if !strings.HasPrefix(p, "/") { // Don't copy system file deps.
 					if err := fs.RecursiveCopy(p, path.Join(dir, p), 0); err != nil {

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -475,8 +475,8 @@ func parseSource(s *scope, src string, systemAllowed, tool bool) core.BuildInput
 			}
 		}
 		label := core.MustParseNamedOutputLabel(src, pkg)
-		if l := label.Label(); l != nil {
-			checkLabel(s, *l)
+		if l, ok := label.Label(); ok {
+			checkLabel(s, l)
 		}
 		return label
 	}

--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -106,7 +106,7 @@ func sourceHash(state *core.BuildState, target *core.BuildTarget) (hash []byte, 
 	}()
 	h := sha1.New()
 	for _, tool := range target.AllTools() {
-		if tool.Label() != nil {
+		if _, ok := tool.Label(); ok {
 			continue // Skip in-repo tools, that will be handled via revdeps.
 		}
 		for _, path := range tool.FullPaths(state.Graph) {

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -201,24 +201,24 @@ func (c *Client) uploadInputs(ch chan<- *uploadinfo.Entry, target *core.BuildTar
 func (c *Client) uploadInputDir(ch chan<- *uploadinfo.Entry, target *core.BuildTarget, isTest bool) (*dirBuilder, error) {
 	b := newDirBuilder(c)
 	for input := range c.state.IterInputs(target, isTest) {
-		if l := input.Label(); l != nil {
-			o := c.targetOutputs(*l)
+		if l, ok := input.Label(); ok {
+			o := c.targetOutputs(l)
 			if o == nil {
-				if dep := c.state.Graph.TargetOrDie(*l); dep.Local {
+				if dep := c.state.Graph.TargetOrDie(l); dep.Local {
 					// We have built this locally, need to upload its outputs
 					if err := c.uploadLocalTarget(dep); err != nil {
 						return nil, err
 					}
-					o = c.targetOutputs(*l)
+					o = c.targetOutputs(l)
 				} else {
 					// Classic "we shouldn't get here" stuff
-					return nil, fmt.Errorf("Outputs not known for %s (should be built by now)", *l)
+					return nil, fmt.Errorf("Outputs not known for %s (should be built by now)", l)
 				}
 			}
 			pkgName := l.PackageName
 			if target.IsFilegroup {
 				pkgName = target.Label.PackageName
-			} else if isTest && *l == target.Label {
+			} else if isTest && l == target.Label {
 				// At test time the target itself is put at the root rather than in the normal dir.
 				// This is just How Things Are, so mimic it here.
 				pkgName = "."

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -334,8 +334,8 @@ func (c *Client) Build(tid int, target *core.BuildTarget) (*core.BuildMetadata, 
 func (c *Client) downloadData(target *core.BuildTarget) error {
 	var g errgroup.Group
 	for _, datum := range target.AllData() {
-		if l := datum.Label(); l != nil {
-			t := c.state.Graph.TargetOrDie(*l)
+		if l, ok := datum.Label(); ok {
+			t := c.state.Graph.TargetOrDie(l)
 			g.Go(func() error {
 				if err := c.Download(t); err != nil {
 					return err

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -118,7 +118,7 @@ func startWatching(watcher *fsnotify.Watcher, state *core.BuildState, labels []c
 }
 
 func addSource(watcher *fsnotify.Watcher, state *core.BuildState, source core.BuildInput, dirs map[string]struct{}, files cmap.ConcurrentMap) {
-	if source.Label() == nil {
+	if _, ok := source.Label(); !ok {
 		for _, src := range source.Paths(state.Graph) {
 			if err := fs.Walk(src, func(src string, isDir bool) error {
 				files.Set(src, struct{}{})

--- a/tools/please_go/test/test_data/main/example_test_main.go
+++ b/tools/please_go/test/test_data/main/example_test_main.go
@@ -14,16 +14,16 @@ import (
 
 func TestParseSourceBuildLabel(t *testing.T) {
 	src := parseSource("//src/parse/test_data/test_subfolder4:test_py", "src/parse")
-	label := src.Label()
-	assert.NotNil(t, label)
+	label, ok := src.Label()
+	assert.True(t, ok)
 	assert.Equal(t, label.PackageName, "src/parse/test_data/test_subfolder4")
 	assert.Equal(t, label.Name, "test_py")
 }
 
 func TestParseSourceRelativeBuildLabel(t *testing.T) {
 	src := parseSource(":builtin_rules", "src/parse")
-	label := src.Label()
-	assert.NotNil(t, label)
+	label, ok := src.Label()
+	assert.True(t, ok)
 	assert.Equal(t, "src/parse", label.PackageName)
 	assert.Equal(t, "builtin_rules", label.Name)
 }
@@ -31,7 +31,8 @@ func TestParseSourceRelativeBuildLabel(t *testing.T) {
 // Test parsing from a subdirectory that does not contain a build file.
 func TestParseSourceFromSubdirectory(t *testing.T) {
 	src := parseSource("test_subfolder3/test_py", "src/parse/test_data")
-	assert.Nil(t, src.Label())
+	_, ok := src.Label()
+	assert.False(t, ok)
 	paths := src.Paths(nil)
 	assert.Equal(t, 1, len(paths))
 	assert.Equal(t, "src/parse/test_data/test_subfolder3/test_py", paths[0])


### PR DESCRIPTION
This seems to save an allocation when called:
Before:
```
BenchmarkProvideFor
BenchmarkProvideFor/Simple
BenchmarkProvideFor/Simple-12           63322402                18.81 ns/op            0 B/op          0 allocs/op
BenchmarkProvideFor/NoMatch
BenchmarkProvideFor/NoMatch-12          31253348                38.50 ns/op            0 B/op          0 allocs/op
BenchmarkProvideFor/OneMatch
BenchmarkProvideFor/OneMatch-12          8090606               145.7 ns/op            48 B/op          1 allocs/op
BenchmarkProvideFor/TwoMatches
BenchmarkProvideFor/TwoMatches-12        4717500               247.8 ns/op            96 B/op          1 allocs/op
BenchmarkProvideFor/IsData
BenchmarkProvideFor/IsData-12            8401734               128.9 ns/op            48 B/op          1 allocs/op
```
After:
```
BenchmarkProvideFor
BenchmarkProvideFor/Simple
BenchmarkProvideFor/Simple-12           64205665                18.43 ns/op            0 B/op          0 allocs/op
BenchmarkProvideFor/NoMatch
BenchmarkProvideFor/NoMatch-12          32368802                36.85 ns/op            0 B/op          0 allocs/op
BenchmarkProvideFor/OneMatch
BenchmarkProvideFor/OneMatch-12          6848133               152.0 ns/op            48 B/op          1 allocs/op
BenchmarkProvideFor/TwoMatches
BenchmarkProvideFor/TwoMatches-12        4521673               249.3 ns/op            96 B/op          1 allocs/op
BenchmarkProvideFor/IsData
BenchmarkProvideFor/IsData-12           36188140                31.77 ns/op            0 B/op          0 allocs/op
```
i.e. we save an alloc in the last path where we call `.Label()`. 

This obviously touches a lot of files but should be a fairly straightforward refactor (and that suggests there are a bunch more places that will get mild benefits from this too).