### PR TITLE
Exclude the new benchmark from the core lib

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -13,7 +13,7 @@ go_library(
     srcs = glob(
         ["*.go"],
         exclude = [
-            "stub.go",
+            "*_benchmark.go",
             "*_test.go",
             "version.go",
         ],


### PR DESCRIPTION
Realised (for unrelated reasons, luckily) that it is getting compiled in. I don't think there is any huge penalty but obviously is generally undesirable.