### PR TITLE
Fix config state presented to pre/post build functions

### DIFF
--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -523,6 +523,8 @@ type preBuildFunction struct {
 
 func (f *preBuildFunction) Call(target *core.BuildTarget) error {
 	s := f.f.scope.NewPackagedScope(f.f.scope.state.Graph.PackageOrDie(target.Label))
+	s.config = f.s.config
+	s.Set("CONFIG", f.s.config)
 	s.Callback = true
 	s.Set(f.f.args[0], pyString(target.Label.Name))
 	_, err := s.interpreter.interpretStatements(s, f.f.code)
@@ -541,6 +543,8 @@ type postBuildFunction struct {
 
 func (f *postBuildFunction) Call(target *core.BuildTarget, output string) error {
 	s := f.f.scope.NewPackagedScope(f.f.scope.state.Graph.PackageOrDie(target.Label))
+	s.config = f.s.config
+	s.Set("CONFIG", f.s.config)
 	s.Callback = true
 	s.Set(f.f.args[0], pyString(target.Label.Name))
 	s.Set(f.f.args[1], fromStringList(strings.Split(strings.TrimSpace(output), "\n")))

--- a/test/parse/BUILD
+++ b/test/parse/BUILD
@@ -11,3 +11,8 @@ plz_e2e_test(
     name = "inline_subinclude_test",
     cmd = "plz query alltargets //test/parse/inline_subinclude:all",
 )
+
+plz_e2e_test(
+    name = "pre_post_build_config_test",
+    cmd = "plz build //test/parse/pre_post_build_config:target",
+)

--- a/test/parse/pre_post_build_config/BUILD.test
+++ b/test/parse/pre_post_build_config/BUILD.test
@@ -1,0 +1,6 @@
+package(GO_TOOL = "foo")
+
+subinclude("//test/parse/pre_post_build_config/build_defs:build_foo")
+
+build_foo(name = "target")
+

--- a/test/parse/pre_post_build_config/build_defs/BUILD.test
+++ b/test/parse/pre_post_build_config/build_defs/BUILD.test
@@ -1,0 +1,6 @@
+filegroup(
+    name = "build_foo",
+    srcs = ["build_foo.build_defs"],
+    visibility = ["PUBLIC"],
+)
+

--- a/test/parse/pre_post_build_config/build_defs/build_foo.build_defs
+++ b/test/parse/pre_post_build_config/build_defs/build_foo.build_defs
@@ -1,0 +1,14 @@
+def _prebuild(x):
+    assert CONFIG.GO_TOOL == "foo"
+
+def _postbuild(x, y):
+    assert CONFIG.GO_TOOL == "foo"
+
+def build_foo(name):
+    return build_rule(
+        name = name,
+        cmd = "true",
+        pre_build = _prebuild,
+        post_build = _postbuild,
+    )
+


### PR DESCRIPTION
This fixes https://github.com/thought-machine/please/issues/1553 where the scope config presented to the pre/post build functions at the time of their execution was incorrect. The scope config of the function declaration parsing was being used, instead of the one that triggered the build rule execution.