### PR TITLE
Try to size fstring buffers appropriately before we format

### DIFF
--- a/src/parse/asp/grammar.go
+++ b/src/parse/asp/grammar.go
@@ -145,16 +145,19 @@ type ValueExpression struct {
 	Call     *Call
 }
 
-// A FString represents a minimal version of a Python literal format string.
+// An FString represents a minimal version of a Python literal format string.
 // Note that we only support a very small subset of what Python allows there; essentially only
 // variable substitution, which gives a much simpler AST structure here.
 type FString struct {
-	Vars []struct {
-		Prefix string // Preceding string bit
-		Var    string // Variable name to interpolate
-		Config string // Config variable to look up
-	}
+	Vars   []FStringVar
 	Suffix string // Following string bit
+}
+
+// An FStringVar represents a single variable in an FString.
+type FStringVar struct {
+	Prefix string // Preceding string bit
+	Var    string // Variable name to interpolate
+	Config string // Config variable to look up
 }
 
 // A UnaryOp represents a unary operation - in our case the only ones we support are negation and not.

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -538,14 +538,21 @@ func (s *scope) interpretValueExpressionPart(expr *ValueExpression) pyObject {
 }
 
 func (s *scope) interpretFString(f *FString) pyObject {
+	stringVar := func(v FStringVar) string {
+		if v.Config != "" {
+			return s.config.MustGet(v.Config).String()
+		}
+		return s.Lookup(v.Var).String()
+	}
 	var b strings.Builder
+	size := len(f.Suffix)
+	for _, v := range f.Vars {
+		size += len(v.Prefix) + len(stringVar(v))
+	}
+	b.Grow(size)
 	for _, v := range f.Vars {
 		b.WriteString(v.Prefix)
-		if v.Config != "" {
-			b.WriteString(s.config.MustGet(v.Config).String())
-		} else {
-			b.WriteString(s.Lookup(v.Var).String())
-		}
+		b.WriteString(stringVar(v))
 	}
 	b.WriteString(f.Suffix)
 	return pyString(b.String())

--- a/src/parse/asp/parser_test.go
+++ b/src/parse/asp/parser_test.go
@@ -670,11 +670,7 @@ func TestFStringConcat(t *testing.T) {
 
 		rhs := &ValueExpression{
 			FString: &FString{
-				Vars: []struct {
-					Prefix string
-					Var    string
-					Config string
-				}{
+				Vars: []FStringVar{
 					{
 						Prefix: " this is the rhs: ",
 						Var:    "rhs",
@@ -697,11 +693,7 @@ func TestFStringConcat(t *testing.T) {
 	t.Run("lhs fstring, rhs string", func(t *testing.T) {
 		lhs := &ValueExpression{
 			FString: &FString{
-				Vars: []struct {
-					Prefix string
-					Var    string
-					Config string
-				}{
+				Vars: []FStringVar{
 					{
 						Prefix: "this is the lhs: ",
 						Var:    "lhs",
@@ -728,11 +720,7 @@ func TestFStringConcat(t *testing.T) {
 	t.Run("both fstring", func(t *testing.T) {
 		lhs := &ValueExpression{
 			FString: &FString{
-				Vars: []struct {
-					Prefix string
-					Var    string
-					Config string
-				}{
+				Vars: []FStringVar{
 					{
 						Prefix: "this is the lhs: ",
 						Var:    "lhs",
@@ -745,11 +733,7 @@ func TestFStringConcat(t *testing.T) {
 
 		rhs := &ValueExpression{
 			FString: &FString{
-				Vars: []struct {
-					Prefix string
-					Var    string
-					Config string
-				}{
+				Vars: []FStringVar{
 					{
 						Prefix: " this is the rhs: ",
 						Var:    "rhs",


### PR DESCRIPTION
Benchmark before:
```
BenchmarkParseFile
BenchmarkParseFile-12    	     260	   4416824 ns/op	 1582518 B/op	   16353 allocs/op
```
After:
```
BenchmarkParseFile
BenchmarkParseFile-12    	     254	   4349845 ns/op	 1500073 B/op	   15833 allocs/op
```
that's about 3% of allocations in the parser so seems worth a little more complexity.