### PR TITLE
Reject subrepo labels with a colon

### DIFF
--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -206,6 +206,9 @@ func parseBuildLabelSubrepo(target, currentPath string) (string, string, string)
 			return "", target, target
 		}
 	}
+	if strings.ContainsRune(target[:idx], ':') {
+		return "", "", ""
+	}
 	pkg, name, _ := parseBuildLabelParts(target[idx:], currentPath, "")
 	return pkg, name, target[:idx]
 }

--- a/src/core/build_label_test.go
+++ b/src/core/build_label_test.go
@@ -130,6 +130,11 @@ func TestParseBuildLabelParts(t *testing.T) {
 	assert.Equal(t, subrepo2, "unittest_cpp")
 }
 
+func TestParseSubrepoLabelWithExtraColon(t *testing.T) {
+	_, err := TryParseBuildLabel("///python/psycopg2:psycopg2//:wheel", "", "")
+	assert.Error(t, err)
+}
+
 func TestMain(m *testing.M) {
 	// Used to support TestComplete, the function it's testing re-execs
 	// itself thinking that it's actually plz.


### PR DESCRIPTION
See the example in the test; it should not have a `:` before the `//`.
Open to debate whether that might be a more intuitive way of doing it, but right now it does the wrong thing in a confusing way.