### PR TITLE
Save a little space in BuildTarget

### DIFF
--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -80,7 +80,6 @@ var KnownFields = map[string]bool{
 	"TestTimeout":            true,
 	"state":                  true,
 	"Results":                true, // Recall that unsuccessful test results aren't cached...
-	"resultsMux":             true,
 	"completedRuns":          true,
 	"BuildingDescription":    true,
 	"ShowProgress":           true,


### PR DESCRIPTION
This saves 8 bytes by reusing the other mutex (which should be fine, there shouldn't be any contention between the different use cases)