### PR TITLE
Don't create the stamped environment when asked not to

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -480,7 +480,7 @@ func runBuildCommand(state *core.BuildState, target *core.BuildTarget, command s
 	if target.IsTextFile {
 		return nil, buildTextFile(state, target)
 	}
-	env := core.StampedBuildEnvironment(state, target, inputHash, path.Join(core.RepoRoot, target.TmpDir()))
+	env := core.StampedBuildEnvironment(state, target, inputHash, path.Join(core.RepoRoot, target.TmpDir()), target.Stamp)
 	log.Debug("Building target %s\nENVIRONMENT:\n%s\n%s", target.Label, env, command)
 	out, combined, err := state.ProcessExecutor.ExecWithTimeoutShell(target, target.TmpDir(), env, target.BuildTimeout, state.ShowAllOutput, target.Sandbox, command)
 	if err != nil {

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -272,11 +272,11 @@ func RunEnvironment(state *BuildState, target *BuildTarget, inTmpDir bool) Build
 }
 
 // StampedBuildEnvironment returns the shell env vars to be passed into exec.Command.
-// Optionally includes a stamp if the target is marked as such.
-func StampedBuildEnvironment(state *BuildState, target *BuildTarget, stamp []byte, tmpDir string) BuildEnv {
+// Optionally includes a stamp if asked.
+func StampedBuildEnvironment(state *BuildState, target *BuildTarget, stamp []byte, tmpDir string, shouldStamp bool) BuildEnv {
 	env := BuildEnvironment(state, target, tmpDir)
 	encStamp := base64.RawURLEncoding.EncodeToString(stamp)
-	if target.Stamp {
+	if shouldStamp {
 		stampEnvOnce.Do(initStampEnv)
 		env = append(env, stampEnv...)
 		env = append(env, "STAMP_FILE="+target.StampFileName())

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -490,7 +490,7 @@ func printTempDirs(state *core.BuildState, duration time.Duration) {
 		target := state.Graph.TargetOrDie(label)
 		cmd := target.GetCommand(state)
 		dir := target.TmpDir()
-		env := core.StampedBuildEnvironment(state, target, nil, path.Join(core.RepoRoot, target.TmpDir()))
+		env := core.StampedBuildEnvironment(state, target, nil, path.Join(core.RepoRoot, target.TmpDir()), target.Stamp)
 		shouldSandbox := target.Sandbox
 		if state.NeedTests {
 			cmd = target.GetTestCommand(state)

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -128,7 +128,7 @@ func (c *Client) stampedBuildEnvironment(state *core.BuildState, target *core.Bu
 	// We generate the stamp ourselves from the input root.
 	// TODO(peterebden): it should include the target properties too...
 	hash := c.sum(mustMarshal(inputRoot))
-	return core.StampedBuildEnvironment(state, target, hash, ".")
+	return core.StampedBuildEnvironment(state, target, hash, ".", stamp && target.Stamp)
 }
 
 // buildTestCommand builds a command for a target when testing.


### PR DESCRIPTION
Found out that we basically always do it for a stamped target in remote execution, but we should honour the request not to.

Will improve cache lookups & no-op execution speeds.