### PR TITLE
Streamline & simplify grammar a bit

### DIFF
--- a/src/parse/asp/grammar.go
+++ b/src/parse/asp/grammar.go
@@ -138,7 +138,6 @@ type ValueExpression struct {
 	// True if the Int field is set; this helps us distinguish values of 0.
 	IsInt    bool
 	Int      int
-	Bool     string
 	List     *List
 	Dict     *Dict
 	Tuple    *List

--- a/src/parse/asp/grammar.go
+++ b/src/parse/asp/grammar.go
@@ -131,9 +131,13 @@ type OpExpression struct {
 type ValueExpression struct {
 	String  string
 	FString *FString
-	Int     *struct {
-		Int int
-	} // Should just be *int, but https://github.com/golang/go/issues/23498 :(
+	// These are true if this represents one of the boolean singletons
+	True  bool
+	False bool
+	None  bool
+	// True if the Int field is set; this helps us distinguish values of 0.
+	IsInt    bool
+	Int      int
 	Bool     string
 	List     *List
 	Dict     *Dict

--- a/src/parse/asp/grammar_parse.go
+++ b/src/parse/asp/grammar_parse.go
@@ -719,8 +719,9 @@ func (p *parser) parseFString() *FString {
 	p.endPos = tok.EndPos()
 	tok.Pos.Column++ // track position in case of error
 	for idx := p.findBrace(s); idx != -1; idx = p.findBrace(s) {
-		v := &f.Vars[p.newElement(&f.Vars)]
-		v.Prefix = strings.ReplaceAll(strings.ReplaceAll(s[:idx], "{{", "{"), "}}", "}")
+		v := FStringVar{
+			Prefix: strings.ReplaceAll(strings.ReplaceAll(s[:idx], "{{", "{"), "}}", "}"),
+		}
 		s = s[idx+1:]
 		tok.Pos.Column += idx + 1
 		idx = strings.IndexByte(s, '}')
@@ -730,6 +731,7 @@ func (p *parser) parseFString() *FString {
 		} else {
 			v.Var = varname
 		}
+		f.Vars = append(f.Vars, v)
 		s = s[idx+1:]
 		tok.Pos.Column += idx + 1
 	}

--- a/src/parse/asp/grammar_parse.go
+++ b/src/parse/asp/grammar_parse.go
@@ -480,13 +480,19 @@ func (p *parser) parseValueExpression() *ValueExpression {
 		}
 	} else if tok.Type == Int {
 		p.assert(len(tok.Value) < 19, tok, "int literal is too large: %s", tok)
-		p.initField(&ve.Int)
 		i, err := strconv.Atoi(tok.Value)
 		p.assert(err == nil, tok, "invalid int value %s", tok) // Theoretically the lexer shouldn't have fed us this...
-		ve.Int.Int = i
+		ve.Int = i
+		ve.IsInt = true
 		p.endPos = p.l.Next().EndPos()
-	} else if tok.Value == "False" || tok.Value == "True" || tok.Value == "None" {
-		ve.Bool = tok.Value
+	} else if tok.Value == "False" {
+		ve.False = true // hmmm...
+		p.endPos = p.l.Next().EndPos()
+	} else if tok.Value == "True" {
+		ve.True = true
+		p.endPos = p.l.Next().EndPos()
+	} else if tok.Value == "None" {
+		ve.None = true
 		p.endPos = p.l.Next().EndPos()
 	} else if tok.Type == '[' {
 		ve.List = p.parseList('[', ']')

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -513,10 +513,14 @@ func (s *scope) interpretValueExpressionPart(expr *ValueExpression) pyObject {
 		return pyString(stringLiteral(expr.String))
 	} else if expr.FString != nil {
 		return s.interpretFString(expr.FString)
-	} else if expr.Int != nil {
-		return pyInt(expr.Int.Int)
-	} else if expr.Bool != "" {
-		return s.Lookup(expr.Bool)
+	} else if expr.IsInt {
+		return pyInt(expr.Int)
+	} else if expr.True {
+		return True
+	} else if expr.False {
+		return False
+	} else if expr.None {
+		return None
 	} else if expr.List != nil {
 		return s.interpretList(expr.List)
 	} else if expr.Dict != nil {
@@ -769,7 +773,7 @@ func (s *scope) Constant(expr *Expression) pyObject {
 		return expr.Optimised.Constant
 	} else if expr.Val == nil || len(expr.Val.Slices) != 0 || expr.Val.Property != nil || expr.Val.Call != nil || expr.Op != nil || expr.If != nil {
 		return nil
-	} else if expr.Val.Bool != "" || expr.Val.String != "" || expr.Val.Int != nil {
+	} else if expr.Val.True || expr.Val.False || expr.Val.None || expr.Val.IsInt || expr.Val.String != "" {
 		return s.interpretValueExpression(expr.Val)
 	} else if expr.Val.List != nil && expr.Val.List.Comprehension == nil {
 		// Lists can be constant if all their elements are also.

--- a/src/parse/asp/parser_test.go
+++ b/src/parse/asp/parser_test.go
@@ -38,9 +38,10 @@ func TestParseDefaultArguments(t *testing.T) {
 	assert.Equal(t, "name", args[0].Name)
 	assert.Equal(t, "\"name\"", args[0].Value.Val.String)
 	assert.Equal(t, "timeout", args[1].Name)
-	assert.Equal(t, 10, args[1].Value.Val.Int.Int)
+	assert.True(t, args[1].Value.Val.IsInt)
+	assert.Equal(t, 10, args[1].Value.Val.Int)
 	assert.Equal(t, "args", args[2].Name)
-	assert.Equal(t, "None", args[2].Value.Val.Bool)
+	assert.True(t, args[2].Value.Val.None)
 
 	// Test for Endpos
 	assert.Equal(t, 9, statements[0].EndPos.Column)
@@ -107,7 +108,7 @@ func TestParseAssignments(t *testing.T) {
 	assert.NotNil(t, ass)
 	assert.Equal(t, 3, len(ass.Items))
 	assert.Equal(t, "\"mickey\"", ass.Items[0].Key.Val.String)
-	assert.Equal(t, 3, ass.Items[0].Value.Val.Int.Int)
+	assert.Equal(t, 3, ass.Items[0].Value.Val.Int)
 	assert.Equal(t, "\"donald\"", ass.Items[1].Key.Val.String)
 	assert.Equal(t, "\"sora\"", ass.Items[1].Value.Val.String)
 	assert.Equal(t, "\"goofy\"", ass.Items[2].Key.Val.String)
@@ -181,7 +182,7 @@ func TestIndexing(t *testing.T) {
 	assert.NotNil(t, statements[1].Ident.Action.Assign)
 	assert.Equal(t, "x", statements[1].Ident.Action.Assign.Val.Ident.Name)
 	assert.Equal(t, 1, len(statements[1].Ident.Action.Assign.Val.Slices))
-	assert.Equal(t, 2, statements[1].Ident.Action.Assign.Val.Slices[0].Start.Val.Int.Int)
+	assert.Equal(t, 2, statements[1].Ident.Action.Assign.Val.Slices[0].Start.Val.Int)
 	assert.Equal(t, "", statements[1].Ident.Action.Assign.Val.Slices[0].Colon)
 	assert.Nil(t, statements[1].Ident.Action.Assign.Val.Slices[0].End)
 
@@ -189,15 +190,15 @@ func TestIndexing(t *testing.T) {
 	assert.NotNil(t, statements[2].Ident.Action.Assign)
 	assert.Equal(t, "x", statements[2].Ident.Action.Assign.Val.Ident.Name)
 	assert.Equal(t, 1, len(statements[2].Ident.Action.Assign.Val.Slices))
-	assert.Equal(t, 1, statements[2].Ident.Action.Assign.Val.Slices[0].Start.Val.Int.Int)
+	assert.Equal(t, 1, statements[2].Ident.Action.Assign.Val.Slices[0].Start.Val.Int)
 	assert.Equal(t, ":", statements[2].Ident.Action.Assign.Val.Slices[0].Colon)
-	assert.Equal(t, -1, statements[2].Ident.Action.Assign.Val.Slices[0].End.Val.Int.Int)
+	assert.Equal(t, -1, statements[2].Ident.Action.Assign.Val.Slices[0].End.Val.Int)
 
 	assert.Equal(t, "a", statements[3].Ident.Name)
 	assert.NotNil(t, statements[3].Ident.Action.Assign)
 	assert.Equal(t, "x", statements[3].Ident.Action.Assign.Val.Ident.Name)
 	assert.Equal(t, 1, len(statements[3].Ident.Action.Assign.Val.Slices))
-	assert.Equal(t, 2, statements[3].Ident.Action.Assign.Val.Slices[0].Start.Val.Int.Int)
+	assert.Equal(t, 2, statements[3].Ident.Action.Assign.Val.Slices[0].Start.Val.Int)
 	assert.Equal(t, ":", statements[3].Ident.Action.Assign.Val.Slices[0].Colon)
 	assert.Nil(t, statements[3].Ident.Action.Assign.Val.Slices[0].End)
 
@@ -207,7 +208,7 @@ func TestIndexing(t *testing.T) {
 	assert.Equal(t, 1, len(statements[4].Ident.Action.Assign.Val.Slices))
 	assert.Nil(t, statements[4].Ident.Action.Assign.Val.Slices[0].Start)
 	assert.Equal(t, ":", statements[4].Ident.Action.Assign.Val.Slices[0].Colon)
-	assert.Equal(t, 2, statements[4].Ident.Action.Assign.Val.Slices[0].End.Val.Int.Int)
+	assert.Equal(t, 2, statements[4].Ident.Action.Assign.Val.Slices[0].End.Val.Int)
 
 	assert.Equal(t, "c", statements[5].Ident.Name)
 	assert.NotNil(t, statements[5].Ident.Action.Assign)
@@ -285,7 +286,7 @@ func TestInlineIf(t *testing.T) {
 	assert.NotNil(t, ass.If)
 	assert.Equal(t, "y", ass.If.Condition.Val.Ident.Name)
 	assert.EqualValues(t, Is, ass.If.Condition.Op[0].Op)
-	assert.Equal(t, "None", ass.If.Condition.Op[0].Expr.Val.Bool)
+	assert.True(t, ass.If.Condition.Op[0].Expr.Val.None)
 	assert.NotNil(t, ass.If.Else.Val.List)
 	assert.Equal(t, 1, len(ass.If.Else.Val.List.Values))
 

--- a/tools/build_langserver/lsp/symbols.go
+++ b/tools/build_langserver/lsp/symbols.go
@@ -56,13 +56,14 @@ func exprToSymbol(expr *asp.Expression) (string, lsp.SymbolKind) {
 		return stringLiteral(v.String), lsp.SKString
 	} else if v.FString != nil {
 		return reconstructFString(v.FString), lsp.SKString
-	} else if v.Int != nil {
-		return strconv.Itoa(v.Int.Int), lsp.SKNumber
-	} else if v.Bool != "" {
-		if v.Bool == "None" {
-			return "None", lsp.SKConstant
-		}
-		return v.Bool, lsp.SKBoolean
+	} else if v.IsInt {
+		return strconv.Itoa(v.Int), lsp.SKNumber
+	} else if v.True {
+		return "True", lsp.SKBoolean
+	} else if v.False {
+		return "False", lsp.SKBoolean
+	} else if v.None {
+		return "None", lsp.SKConstant
 	} else if v.List != nil || v.Tuple != nil {
 		return "list", lsp.SKArray
 	} else if v.Dict != nil {


### PR DESCRIPTION
Now we've got rid of the gobbing, we don't need the layer of struct indirection (although in a slightly ugly fashion we need a sentinel to check if we really have an int). Also mark the boolean singletons explicitly rather than using their string representation.