### PR TITLE
Remove reflective operations from parser

### DIFF
--- a/src/parse/asp/grammar.go
+++ b/src/parse/asp/grammar.go
@@ -79,13 +79,16 @@ type ForStatement struct {
 
 // An IfStatement implements the if-elif-else statement.
 type IfStatement struct {
+	Condition      Expression
+	Statements     []*Statement
+	Elif           []IfStatementElif
+	ElseStatements []*Statement
+}
+
+// An IfStatementElif holds an elif clause in the if-elif-else statement.
+type IfStatementElif struct {
 	Condition  Expression
 	Statements []*Statement
-	Elif       []struct {
-		Condition  Expression
-		Statements []*Statement
-	}
-	ElseStatements []*Statement
 }
 
 // An Argument represents an argument to a function definition.
@@ -208,10 +211,13 @@ type IdentExpr struct {
 	Pos    Position
 	EndPos Position
 	Name   string
-	Action []struct {
-		Property *IdentExpr
-		Call     *Call
-	}
+	Action []IdentExprAction
+}
+
+// An IdentExprAction represents an Action within an IdentExpr.
+type IdentExprAction struct {
+	Property *IdentExpr
+	Call     *Call
 }
 
 // A Call represents a call site of a function.
@@ -261,11 +267,14 @@ type InlineIf struct {
 type Comprehension struct {
 	Names  []string
 	Expr   *Expression
-	Second *struct {
-		Names []string
-		Expr  *Expression
-	}
-	If *Expression
+	Second *SecondComprehension
+	If     *Expression
+}
+
+// A SecondComprehension represents a second 'for' clause in a list or dict comprehension.
+type SecondComprehension struct {
+	Names []string
+	Expr  *Expression
 }
 
 // A Lambda is the inline lambda function.

--- a/src/parse/asp/grammar.go
+++ b/src/parse/asp/grammar.go
@@ -26,21 +26,24 @@ func (pos Position) String() string {
 // support backoff (i.e. if an earlier entry matches to its completion but can't consume
 // following tokens, it doesn't then make another choice :( )
 type Statement struct {
-	Pos     Position
-	EndPos  Position
-	FuncDef *FuncDef
-	For     *ForStatement
-	If      *IfStatement
-	Return  *ReturnStatement
-	Raise   *Expression // Deprecated
-	Assert  *struct {
-		Expr    *Expression
-		Message *Expression
-	}
+	Pos      Position
+	EndPos   Position
+	FuncDef  *FuncDef
+	For      *ForStatement
+	If       *IfStatement
+	Return   *ReturnStatement
+	Raise    *Expression // Deprecated
+	Assert   *AssertStatement
 	Ident    *IdentStatement
 	Literal  *Expression
 	Pass     bool
 	Continue bool
+}
+
+// An AssertStatement implements the 'assert' statement.
+type AssertStatement struct {
+	Expr    *Expression
+	Message *Expression
 }
 
 // A ReturnStatement implements the Python 'return' statement.
@@ -173,16 +176,22 @@ type UnaryOp struct {
 // starts off with a variable name). It is a little fiddly due to parser limitations.
 type IdentStatement struct {
 	Name   string
-	Unpack *struct {
-		Names []string
-		Expr  *Expression
-	}
-	Index *struct {
-		Expr      *Expression
-		Assign    *Expression
-		AugAssign *Expression
-	}
+	Unpack *IdentStatementUnpack
+	Index  *IdentStatementIndex
 	Action *IdentStatementAction
+}
+
+// An IdentStatementUnpack implements unpacking on an IdentStatement.
+type IdentStatementUnpack struct {
+	Names []string
+	Expr  *Expression
+}
+
+// An IdentStatementIndex implements indexing on an IdentStatement.
+type IdentStatementIndex struct {
+	Expr      *Expression
+	Assign    *Expression
+	AugAssign *Expression
 }
 
 // An IdentStatementAction implements actions on an IdentStatement.

--- a/src/parse/asp/grammar_parse.go
+++ b/src/parse/asp/grammar_parse.go
@@ -307,10 +307,7 @@ func (p *parser) parseIf() *IfStatement {
 	i.Statements = p.parseStatements()
 
 	for p.optionalv("elif") {
-		elif := struct {
-			Condition  Expression
-			Statements []*Statement
-		}{}
+		elif := IfStatementElif{}
 		p.parseExpressionInPlace(&elif.Condition)
 		p.next(':')
 		p.next(EOL)
@@ -571,10 +568,7 @@ func (p *parser) parseIdentExpr() *IdentExpr {
 	}
 	for tok := p.l.Peek(); tok.Type == '.' || tok.Type == '('; tok = p.l.Peek() {
 		tok := p.l.Next()
-		action := struct {
-			Property *IdentExpr
-			Call     *Call
-		}{}
+		action := IdentExprAction{}
 		if tok.Type == '.' {
 			action.Property = p.parseIdentExpr()
 			ie.EndPos = action.Property.EndPos
@@ -682,10 +676,7 @@ func (p *parser) parseComprehension() *Comprehension {
 	p.nextv("in")
 	c.Expr = p.parseUnconditionalExpression()
 	if p.optionalv("for") {
-		c.Second = &struct {
-			Names []string
-			Expr  *Expression
-		}{
+		c.Second = &SecondComprehension{
 			Names: p.parseIdentList(),
 		}
 		p.nextv("in")

--- a/src/parse/asp/grammar_parse.go
+++ b/src/parse/asp/grammar_parse.go
@@ -546,19 +546,23 @@ func (p *parser) parseIdentStatement() *IdentStatement {
 			i.Index.AugAssign = p.parseExpression()
 		}
 	case '.':
-		p.initField(&i.Action)
-		i.Action.Property = p.parseIdentExpr()
+		i.Action = &IdentStatementAction{
+			Property: p.parseIdentExpr(),
+		}
 		p.endPos = i.Action.Property.EndPos
 	case '(':
-		p.initField(&i.Action)
-		i.Action.Call = p.parseCall()
+		i.Action = &IdentStatementAction{
+			Call: p.parseCall(),
+		}
 	case '=':
-		p.initField(&i.Action)
-		i.Action.Assign = p.parseExpression()
+		i.Action = &IdentStatementAction{
+			Assign: p.parseExpression(),
+		}
 	default:
 		p.assert(tok.Value == "+=", tok, "Unexpected token %s, expected one of , [ . ( = +=", tok)
-		p.initField(&i.Action)
-		i.Action.AugAssign = p.parseExpression()
+		i.Action = &IdentStatementAction{
+			AugAssign: p.parseExpression(),
+		}
 	}
 	return i
 }

--- a/src/parse/asp/grammar_parse.go
+++ b/src/parse/asp/grammar_parse.go
@@ -532,13 +532,22 @@ func (p *parser) parseIdentStatement() *IdentStatement {
 	tok = p.l.Next()
 	switch tok.Type {
 	case ',':
-		p.initField(&i.Unpack)
-		i.Unpack.Names = p.parseIdentList()
+		i.Unpack = &struct {
+			Names []string
+			Expr  *Expression
+		}{
+			Names: p.parseIdentList(),
+		}
 		p.next('=')
 		i.Unpack.Expr = p.parseExpression()
 	case '[':
-		p.initField(&i.Index)
-		i.Index.Expr = p.parseExpression()
+		i.Index = &struct {
+			Expr      *Expression
+			Assign    *Expression
+			AugAssign *Expression
+		}{
+			Expr: p.parseExpression(),
+		}
 		p.endPos = p.next(']').EndPos()
 		if tok := p.oneofval("=", "+="); tok.Type == '=' {
 			i.Index.Assign = p.parseExpression()


### PR DESCRIPTION
This breaks the last of the anonymous embedded structs out of the grammar to named types, and removes the reflection-based hackery that was being used before.

(It's also possible to use anonymous structs in the parser for this; can't remember if that was possible when I wrote the reflection, but regardless I think it's nicer not to have to)