### PR TITLE
Limit how often we issue errors about test result uploads

### DIFF
--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -44,10 +44,10 @@ func Test(tid int, state *core.BuildState, label core.BuildLabel, remote bool, r
 		if runsAllCompleted && state.Config.Test.Upload != "" {
 			if numUploadFailures < maxUploadFailures {
 				if err := uploadResults(target, state.Config.Test.Upload.String(), state.Config.Test.UploadGzipped, state.Config.Test.StoreTestOutputOnSuccess); err != nil {
-					if atomic.AddInt64(&numUploadFailures, 1) == maxUploadFailures {
-						log.Error("Failed to upload test results %d times, giving up", maxUploadFailures)
-					} else {
+					if failures := atomic.AddInt64(&numUploadFailures, 1); failures < maxUploadFailures {
 						log.Warning("%s", err)
+					} else if failures == maxUploadFailures {
+						log.Error("Failed to upload test results %d times, giving up", maxUploadFailures)
 					}
 				}
 			}

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -34,6 +35,8 @@ var numUploadFailures int64
 
 const maxUploadFailures int64 = 10
 
+var uploadFailureOnce sync.Once
+
 // Test runs the tests for a single target.
 func Test(tid int, state *core.BuildState, label core.BuildLabel, remote bool, run int) {
 	target := state.Graph.TargetOrDie(label)
@@ -44,9 +47,13 @@ func Test(tid int, state *core.BuildState, label core.BuildLabel, remote bool, r
 		if runsAllCompleted && state.Config.Test.Upload != "" {
 			if numUploadFailures < maxUploadFailures {
 				if err := uploadResults(target, state.Config.Test.Upload.String(), state.Config.Test.UploadGzipped, state.Config.Test.StoreTestOutputOnSuccess); err != nil {
-					log.Warning("%s", err)
+					if numUploadFailures < maxUploadFailures {
+						log.Warning("%s", err)
+					}
 					if atomic.AddInt64(&numUploadFailures, 1) >= maxUploadFailures {
-						log.Error("Failed to upload test results %d times, giving up", maxUploadFailures)
+						uploadFailureOnce.Do(func() {
+							log.Error("Failed to upload test results %d times, giving up", maxUploadFailures)
+						})
 					}
 				}
 			}


### PR DESCRIPTION
Stops it from re-issuing warnings after it's said it is giving up (happens because some are already in flight, but it looks a bit silly).