### PR TITLE
`github_repo`: implement semver check using `is_semver`

### DIFF
--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -174,9 +174,7 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
 
     # If it looks like semver, we need to remove the v from it because github formats their zips differently for semver
     # tags
-    #
-    # TODO(jpoole): if we ever add semver or regex to asp, we can do a better job of this
-    if len(revision.split('.')) == 3:
+    if is_semver(revision):
         prefix = revision.removeprefix('v')
     else:
         prefix = revision


### PR DESCRIPTION
Use the new `is_semver` builtin to evaluate whether the revision parameter in a `github_repo` target is a semantic version.