### PR TITLE
Remove link to Masterminds/semver repository in `is_semver` docs

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -236,8 +236,7 @@
           <span class="fn-p">)</span></code
         >
         - returns true if <code class="code">s</code> is a <a href="https://semver.org/">semantic version</a> (either
-        with or without a leading &quot;v&quot;), or false if not. Supported version formats are listed on
-        <a href="https://github.com/Masterminds/semver">this</a> site.
+        with or without a leading &quot;v&quot;), or false if not.
       </span>
     </li>
     <li>


### PR DESCRIPTION
There's no need for the `is_semver` documentation to link to the Go package we use to implement that builtin, since it's an internal implementation detail.