### PR TITLE
`c_binary`: allow `defines` to be a dict

### DIFF
--- a/rules/c_rules.build_defs
+++ b/rules/c_rules.build_defs
@@ -187,7 +187,7 @@ def c_shared_object(name:str, srcs:list=[], hdrs:list=[], out:str='', compiler_f
 
 def c_binary(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], compiler_flags:list&cflags&copts=[],
              linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None, pkg_config_libs:list=[],
-             pkg_config_cflags:list=[], test_only:bool&testonly=False, static:bool=False, includes:list=[], defines:list=[]):
+             pkg_config_cflags:list=[], test_only:bool&testonly=False, static:bool=False, includes:list=[], defines:list|dict=[]):
     """Builds a binary from a collection of C rules.
 
     Args:


### PR DESCRIPTION
The documentation for `c_binary` says this is already allowed (and the `cc_binary` rule upon which `c_binary` is based also allows it), but it produces a type error at run-time because of `c_binary`'s type signature.