### PR TITLE
don't generate debug symbols in pip install 

### DIFF
--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -375,7 +375,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None,
 
     pip_cmd = (
         f'mkdir {pip_target_dir} && '
-        f'PIP_CONFIG_FILE=/dev/null {pip_tool} install --isolated --no-deps --prefix= --no-compile '
+        f'PIP_CONFIG_FILE=/dev/null  CFLAGS=" -Wl,--build-id=none -g0 " LDFLAGS=" -Wl,--build-id=none " {pip_tool} install --isolated --no-deps --prefix= --no-compile '
         f'--no-cache-dir --default-timeout=60 --target={target}'
     )
 


### PR DESCRIPTION

Without this the packages like: 

```
pip_library(
    name = "wrapt",
    version = "1.12.1",
)
```

will generate a different hash after each fresh build (`plz clean`).

