### PR TITLE
Strip out parts of PATH that contain the user's home dir for remote execution

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -533,7 +533,7 @@ func (c *Client) buildEnv(target *core.BuildTarget, env []string, sandbox bool) 
 					replaced = append(replaced, part)
 				}
 			}
-			v = strings.Join(parts, ":")
+			v = strings.Join(replaced, ":")
 		}
 		vars[i] = &pb.Command_EnvironmentVariable{
 			Name:  name,

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -521,9 +521,23 @@ func (c *Client) buildEnv(target *core.BuildTarget, env []string, sandbox bool) 
 	vars := make([]*pb.Command_EnvironmentVariable, len(env))
 	for i, e := range env {
 		idx := strings.IndexByte(e, '=')
+		name := e[:idx]
+		v := e[idx+1:]
+		if name == "PATH" {
+			// Strip out anything prefixed with the local user's home directory; it can't be
+			// useful remotely but will affect determinism of the action.
+			parts := strings.Split(v, ":")
+			replaced := make([]string, 0, len(parts))
+			for _, part := range parts {
+				if !strings.HasPrefix(part, c.userHome) {
+					replaced = append(replaced, part)
+				}
+			}
+			v = strings.Join(parts, ":")
+		}
 		vars[i] = &pb.Command_EnvironmentVariable{
-			Name:  e[:idx],
-			Value: e[idx+1:],
+			Name:  name,
+			Value: v,
 		}
 	}
 	return vars

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -81,6 +81,9 @@ type Client struct {
 	// Path to the shell to use to execute actions in.
 	shellPath string
 
+	// User's home directory.
+	userHome string
+
 	// Stats used to report RPC data rates
 	byteRateIn, byteRateOut, totalBytesIn, totalBytesOut int
 	stats                                                *statsHandler
@@ -232,7 +235,12 @@ func (c *Client) initExec() error {
 		}
 		c.shellPath = bash
 	}
-	log.Debug("Remote execution client initialised for storage")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("Failed to determine user home dir: %s", err)
+	}
+	c.userHome = home
+
 	// Now check if it can do remote execution
 	if resp.ExecutionCapabilities == nil {
 		return fmt.Errorf("Remote execution is configured but the build server doesn't support it")
@@ -243,7 +251,7 @@ func (c *Client) initExec() error {
 		return fmt.Errorf("Remote execution not enabled for this server")
 	}
 	c.platform = convertPlatform(c.state.Config.Remote.Platform)
-	log.Debug("Remote execution client initialised for execution")
+	log.Debug("Remote execution client initialised")
 	if c.state.Config.Remote.AssetURL == "" {
 		c.fetchClient = fpb.NewFetchClient(client.Connection)
 	}


### PR DESCRIPTION
This is a bit grungy but should work until we can figure out something nicer.