### PR TITLE
Reduce size of structs in cycle detector

### DIFF
--- a/src/core/cycle_detector_benchmark_test.go
+++ b/src/core/cycle_detector_benchmark_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func buildTree(levels, width int, from BuildLabel) []dependencyLink {
+func buildTree(levels, width int, from *BuildLabel) []dependencyLink {
 	if levels == 0 {
 		return []dependencyLink{}
 	}
@@ -14,8 +14,8 @@ func buildTree(levels, width int, from BuildLabel) []dependencyLink {
 	var links []dependencyLink
 	for i := 0; i < width; i++ {
 		to := ParseBuildLabel(fmt.Sprintf("%v_%v", from, i), "")
-		links = append(links, dependencyLink{from: from, to: to})
-		links = append(links, buildTree(levels-1, width, to)...)
+		links = append(links, dependencyLink{from: from, to: &to})
+		links = append(links, buildTree(levels-1, width, &to)...)
 	}
 	return links
 }
@@ -37,7 +37,7 @@ func BenchmarkCycles(b *testing.B) {
 func benchmarkCycleDetector(b *testing.B, graphLevels int) {
 	from := ParseBuildLabel("//src:root", "")
 	// Generates a tree of almost 20k targets for large (level 6)
-	links := buildTree(graphLevels, 5, from)
+	links := buildTree(graphLevels, 5, &from)
 
 	cycleDetectors := make([]*cycleDetector, b.N)
 	for n := 0; n < b.N; n++ {

--- a/src/core/cycle_detector_test.go
+++ b/src/core/cycle_detector_test.go
@@ -13,19 +13,19 @@ func TestCycleDetector(t *testing.T) {
 	targetC := ParseBuildLabel("//src:c", "")
 
 	t.Run("Add dep first dep", func(t *testing.T) {
-		err := cd.addDep(dependencyLink{from: targetA, to: targetB})
+		err := cd.addDep(dependencyLink{from: &targetA, to: &targetB})
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, cd.deps[targetA], []BuildLabel{targetB})
+		assert.ElementsMatch(t, cd.deps[&targetA], []*BuildLabel{&targetB})
 	})
 
 	t.Run("Add second dep", func(t *testing.T) {
-		err := cd.addDep(dependencyLink{from: targetA, to: targetC})
+		err := cd.addDep(dependencyLink{from: &targetA, to: &targetC})
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, cd.deps[targetA], []BuildLabel{targetB, targetC})
+		assert.ElementsMatch(t, cd.deps[&targetA], []*BuildLabel{&targetB, &targetC})
 	})
 
 	t.Run("Add cycle", func(t *testing.T) {
-		err := cd.addDep(dependencyLink{from: targetC, to: targetA})
+		err := cd.addDep(dependencyLink{from: &targetC, to: &targetA})
 		assert.Error(t, err, "didn't detect cycle from :c -> :a")
 	})
 }

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -843,7 +843,7 @@ func (state *BuildState) queueTargetAsync(target *BuildTarget, rescan, forceBuil
 		called := false
 		if err := target.resolveDependencies(state.Graph, func(t *BuildTarget) error {
 			called = true
-			state.Graph.cycleDetector.AddDependency(target.Label, t.Label)
+			state.Graph.cycleDetector.AddDependency(&target.Label, &t.Label)
 			return state.queueResolvedTarget(t, rescan, forceBuild, false)
 		}); err != nil {
 			state.asyncError(target.Label, err)


### PR DESCRIPTION
Uses pointers to the `BuildTarget.Label` instead of a copy. This has a twofold effect as we stored these labels in the channel as well as in the map.    


Also the benchmark looks about 3x faster:

Before:
```
cpu: Intel(R) Xeon(R) E-2136 CPU @ 3.30GHz
BenchmarkCycles
BenchmarkCycles/Small
BenchmarkCycles/Small-12         	   59798	     19901 ns/op	      1508 links/ms	    4320 B/op	      24 allocs/op
BenchmarkCycles/Medium
BenchmarkCycles/Medium-12        	    7424	    171838 ns/op	      4542 links/ms	  112320 B/op	     624 allocs/op
BenchmarkCycles/Large
BenchmarkCycles/Large-12         	     225	   4975127 ns/op	      3927 links/ms	 3850493 B/op	   15724 allocs/op
```

After:
```
BenchmarkCycles
BenchmarkCycles/Small
BenchmarkCycles/Small-12                  109609             11853 ns/op              2531 links/ms          720 B/op         24 allocs/op
BenchmarkCycles/Medium
BenchmarkCycles/Medium-12                  19951             59710 ns/op             13066 links/ms        18720 B/op        624 allocs/op
BenchmarkCycles/Large
BenchmarkCycles/Large-12                     687           1711116 ns/op             11419 links/ms       943490 B/op      15681 allocs/op
```