### PR TITLE
Stop cycle checker re-checking stuff

### DIFF
--- a/src/core/cycle_detector.go
+++ b/src/core/cycle_detector.go
@@ -45,11 +45,11 @@ func (c *cycleDetector) AddDependency(from *BuildLabel, to *BuildLabel) {
 
 // checkForCycle just checks to see if there's a dependency cycle. It doesn't compute the cycle to avoid excess
 // allocations. buildCycle can be used to reconstruct the cycle once one has been found.
-func (c *cycleDetector) checkForCycle(head, tail *BuildLabel, done map[string]struct{}) bool {
-	if _, ok := done[tail.String()]; ok {
+func (c *cycleDetector) checkForCycle(head, tail *BuildLabel, done map[BuildLabel]struct{}) bool {
+	if _, ok := done[*tail]; ok {
 		return false
 	}
-	done[tail.String()] = struct{}{}
+	done[*tail] = struct{}{}
 	if tailDeps, ok := c.deps[tail]; ok {
 		for _, dep := range tailDeps {
 			if dep == head {
@@ -66,10 +66,14 @@ func (c *cycleDetector) checkForCycle(head, tail *BuildLabel, done map[string]st
 }
 
 // buildCycle is used to actually reconstruct the cycle after we've found one
-func (c *cycleDetector) buildCycle(chain []*BuildLabel) []*BuildLabel {
+func (c *cycleDetector) buildCycle(chain []*BuildLabel, done map[BuildLabel]struct{}) []*BuildLabel {
 	tail := chain[len(chain)-1]
 	head := chain[0]
 
+	if _, ok := done[*tail]; ok {
+		return nil
+	}
+	done[*tail] = struct{}{}
 	if tailDeps, ok := c.deps[tail]; ok {
 		for _, dep := range tailDeps {
 			if dep == head {
@@ -77,7 +81,7 @@ func (c *cycleDetector) buildCycle(chain []*BuildLabel) []*BuildLabel {
 				return append(chain, dep)
 			}
 
-			if newChain := c.buildCycle(append(chain, dep)); newChain != nil {
+			if newChain := c.buildCycle(append(chain, dep), done); newChain != nil {
 				return newChain
 			}
 		}
@@ -86,8 +90,8 @@ func (c *cycleDetector) buildCycle(chain []*BuildLabel) []*BuildLabel {
 }
 
 func (c *cycleDetector) addDep(link dependencyLink) error {
-	if c.checkForCycle(link.from, link.to, make(map[string]struct{})) {
-		return failWithGraphCycle(c.buildCycle([]*BuildLabel{link.from, link.to}))
+	if c.checkForCycle(link.from, link.to, make(map[BuildLabel]struct{})) {
+		return failWithGraphCycle(c.buildCycle([]*BuildLabel{link.from, link.to}, make(map[BuildLabel]struct{})))
 	}
 	c.deps[link.from] = append(c.deps[link.from], link.to)
 	return nil
@@ -100,9 +104,12 @@ func failWithGraphCycle(cycle dependencyChain) error {
 func (c *cycleDetector) run() {
 	go func() {
 		for next := range c.queue {
+			log.Warningf("starting %v -> %v", next.from, next.to)
 			if err := c.addDep(next); err != nil {
 				log.Fatalf("Dependency cycle found:\n %v", err)
 			}
+			log.Warningf("fin %v -> %v", next.from, next.to)
+
 		}
 	}()
 }

--- a/src/core/cycle_detector.go
+++ b/src/core/cycle_detector.go
@@ -104,12 +104,9 @@ func failWithGraphCycle(cycle dependencyChain) error {
 func (c *cycleDetector) run() {
 	go func() {
 		for next := range c.queue {
-			log.Warningf("starting %v -> %v", next.from, next.to)
 			if err := c.addDep(next); err != nil {
 				log.Fatalf("Dependency cycle found:\n %v", err)
 			}
-			log.Warningf("fin %v -> %v", next.from, next.to)
-
 		}
 	}()
 }


### PR DESCRIPTION
It was taking minutes to process each target before. While it only had around 4k dependencies, those 4k dependencies appeared many times in the tree which meant we were looping over them many times. I think it must have been N! before or something silly. 