### PR TITLE
Enable maligned 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,8 +42,8 @@ linters:
     - prealloc
     - unconvert
     - whitespace
+    - maligned
 
     # To consider enabling in future (once we fix errors etc):
-    # - maligned
     # - errcheck
     # - scopelint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,13 @@ issues:
       linters:
         - errcheck
         - dupl
+        - maligned
+    - path: src/core/config.go # The config struct is big & complex and there's usually only one.
+      linters:
+        - maligned
+    - path: src/please.go # Similarly for flags.
+      linters:
+        - maligned
 linters:
   disable-all: true
   enable:

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -129,10 +129,10 @@ type BuildState struct {
 	// The architecture this state is for. This might change as we re-parse packages for different architectures e.g.
 	// for tools that run on the host vs. outputs that are compiled for the target arch above.
 	Arch cli.Arch
-	// True if we require rule hashes to be correctly verified (usually the case).
-	VerifyHashes bool
 	// Aggregated coverage for this run
 	Coverage TestCoverage
+	// True if we require rule hashes to be correctly verified (usually the case).
+	VerifyHashes bool
 	// True if >= 1 target has failed to build
 	BuildFailed bool
 	// True if >= 1 target has failed test cases
@@ -159,8 +159,6 @@ type BuildState struct {
 	ParsePackageOnly bool
 	// True if this build is triggered by watching for changes
 	Watch bool
-	// Number of times to run each test target. 1 == once each, plus flakes if necessary.
-	NumTestRuns int
 	// Whether to run multiple test runs sequentially or across multiple workers (can be useful if tests bind to ports
 	// or similar)
 	TestSequentially bool
@@ -180,6 +178,8 @@ type BuildState struct {
 	XattrsSupported bool
 	// True if we have any remote executors configured.
 	anyRemote bool
+	// Number of times to run each test target. 1 == once each, plus flakes if necessary.
+	NumTestRuns int
 	// Experimental directories
 	experimentalLabels []BuildLabel
 	// Various items for tracking progress.

--- a/src/core/test_results.go
+++ b/src/core/test_results.go
@@ -18,8 +18,8 @@ type TestSuites struct {
 type TestSuite struct {
 	Package    string            // The package name of the test suite (usually the first part of the target label).
 	Name       string            // The name of the test suite (usually the last part of the target label).
-	Cached     bool              // True if the test results were retrieved from cache.
 	Duration   time.Duration     // The length of time it took to run this target (may be different from the sum of times of test cases).
+	Cached     bool              // True if the test results were retrieved from cache.
 	TimedOut   bool              // True if the test failed because we timed it out.
 	TestCases  TestCases         // The test cases that ran during execution of this target.
 	Properties map[string]string // The system properties at the time of the test.

--- a/src/help/rules.go
+++ b/src/help/rules.go
@@ -139,8 +139,8 @@ type function struct {
 // A functionArg represents a single argument to a function.
 type functionArg struct {
 	Comment    string   `json:"comment,omitempty"`
-	Deprecated bool     `json:"deprecated,omitempty"`
 	Name       string   `json:"name"`
+	Deprecated bool     `json:"deprecated,omitempty"`
 	Required   bool     `json:"required,omitempty"`
 	Types      []string `json:"types"`
 }

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -37,14 +37,14 @@ type buildingTargetData struct {
 	Started      time.Time
 	Finished     time.Time
 	Description  string
-	Active       bool
-	Failed       bool
-	Cached       bool
 	Err          error
 	Colour       string
 	Target       *core.BuildTarget
-	LastProgress float32
 	Eta          time.Duration
+	Active       bool
+	Failed       bool
+	Cached       bool
+	LastProgress float32
 }
 
 // MonitorState monitors the build while it's running and prints output.

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -70,11 +70,11 @@ type revdeps struct {
 	subincludes       map[core.BuildLabel][]*core.Package
 	followSubincludes bool
 
-	// os is the open set of targets to process
-	os *openSet
-
 	// hidden is whether to count hidden targets towards the depth budget
 	hidden bool
+
+	// os is the open set of targets to process
+	os *openSet
 
 	// maxDepth is the depth budget for the search. -1 means unlimited.
 	maxDepth int

--- a/tools/jarcat/main.go
+++ b/tools/jarcat/main.go
@@ -66,7 +66,6 @@ var opts = struct {
 		Out                   string            `short:"o" long:"output" env:"OUT" description:"Output filename" required:"true"`
 		Suffix                []string          `short:"s" long:"suffix" default:".jar" description:"Suffix of files to include"`
 		ExcludeSuffix         []string          `short:"e" long:"exclude_suffix" description:"Suffix of files to exclude"`
-		ExcludeJavaPrefixes   bool              `short:"j" long:"exclude_java_prefixes" description:"Use default Java exclusions"`
 		ExcludeTools          []string          `long:"exclude_tools" env:"TOOLS" env-delim:" " description:"Tools to exclude from the generated zipfile"`
 		ExcludeInternalPrefix []string          `short:"x" long:"exclude_internal_prefix" description:"Prefix of files to exclude"`
 		IncludeInternalPrefix []string          `short:"t" long:"include_internal_prefix" description:"Prefix of files to include"`
@@ -77,6 +76,7 @@ var opts = struct {
 		MainClass             string            `short:"m" long:"main_class" description:"Write a Java manifest file containing the given main class."`
 		Manifest              string            `long:"manifest" description:"Use the given file as a Java manifest"`
 		Align                 int               `short:"a" long:"align" description:"Align zip members to a multiple of this number of bytes."`
+		ExcludeJavaPrefixes   bool              `short:"j" long:"exclude_java_prefixes" description:"Use default Java exclusions"`
 		Strict                bool              `long:"strict" description:"Disallow duplicate files"`
 		IncludeOther          bool              `long:"include_other" description:"Add files that are not jar files as well"`
 		AddInitPy             bool              `long:"add_init_py" description:"Adds __init__.py files to all directories"`
@@ -91,10 +91,10 @@ var opts = struct {
 	Tar struct {
 		Gzip        bool     `short:"z" long:"gzip" description:"Apply gzip compression to the tar file."`
 		Xzip        bool     `short:"x" long:"xzip" description:"Apply gzip compression to the tar file."`
+		Flatten     bool     `long:"flatten" description:"Whether to flatten internal tar structure."`
 		Out         string   `short:"o" long:"output" env:"OUT" description:"Output filename" required:"true"`
 		Srcs        []string `long:"srcs" env:"SRCS" env-delim:" " description:"Source files for the tarball."`
 		Prefix      string   `long:"prefix" description:"Prefix all entries with this directory name."`
-		Flatten     bool     `long:"flatten" description:"Whether to flatten internal tar structure."`
 		StripPrefix string   `long:"strip-prefix" description:"Prefix to remove from files. Only affects non-flattened tarballs."`
 	} `command:"tar" alias:"t" description:"Builds a tarball instead of a zipfile."`
 

--- a/tools/jarcat/zip/writer.go
+++ b/tools/jarcat/zip/writer.go
@@ -35,10 +35,6 @@ type File struct {
 	input    string
 	// Include and Exclude are prefixes of filenames to include or exclude from the zipfile.
 	Include, Exclude []string
-	// Strict controls whether we deny duplicate files or not.
-	// Zipfiles can readily contain duplicates, if this is true we reject them unless they are identical.
-	// If false we allow duplicates and leave it to someone else to handle.
-	Strict bool
 	// RenameDirs is a map of directories to rename, from the old name to the new one.
 	RenameDirs map[string]string
 	// StripPrefix is a prefix that is stripped off any files added with AddFiles.
@@ -49,6 +45,10 @@ type File struct {
 	ExcludeSuffix []string
 	// StoreSuffix is a list of file suffixes that will be stored instead of deflated.
 	StoreSuffix []string
+	// Strict controls whether we deny duplicate files or not.
+	// Zipfiles can readily contain duplicates, if this is true we reject them unless they are identical.
+	// If false we allow duplicates and leave it to someone else to handle.
+	Strict bool
 	// IncludeOther will make the file scan include other files that are not part of a zip file.
 	IncludeOther bool
 	// AddInitPy will make the writer add __init__.py files to all directories that don't already have one on close.

--- a/tools/please_pex/pex_main.go
+++ b/tools/please_pex/pex_main.go
@@ -17,14 +17,14 @@ var opts = struct {
 	EntryPoint         string        `short:"e" long:"entry_point" env:"SRC" description:"Entry point to pex file"`
 	ModuleDir          string        `short:"m" long:"module_dir" description:"Python module dir to implicitly load modules from"`
 	TestSrcs           []string      `long:"test_srcs" env:"SRCS" env-delim:" " description:"Test source files"`
-	Test               bool          `short:"t" long:"test" description:"True if we're to build a test"`
 	Interpreter        string        `short:"i" long:"interpreter" env:"TOOLS_INTERPRETER" description:"Python interpreter to use"`
 	TestRunner         string        `short:"r" long:"test_runner" default:"unittest" description:"Test runner to use"`
 	Shebang            string        `short:"s" long:"shebang" description:"Explicitly set shebang to this"`
-	Site               bool          `short:"S" long:"site" description:"Allow the pex to import site at startup"`
-	ZipSafe            bool          `long:"zip_safe" description:"Marks this pex as zip-safe"`
 	Stamp              string        `long:"stamp" description:"Unique value used to derive cache directory for pex"`
 	InterpreterOptions string        `long:"interpreter_options" description:"Options-string to pass to the python interpreter"`
+	Test               bool          `short:"t" long:"test" description:"True if we're to build a test"`
+	Site               bool          `short:"S" long:"site" description:"Allow the pex to import site at startup"`
+	ZipSafe            bool          `long:"zip_safe" description:"Marks this pex as zip-safe"`
 	AddTestRunnerDeps  bool          `long:"add_test_runner_deps" description:"True if test-runner dependencies should be baked into test binaries"`
 }{
 	Usage: `


### PR DESCRIPTION
Turns the linter on & optimises a few structs it highlights.

Have disabled it for config & flags which are both big with lots of sub-structs, and each singletons so we are unlikely to gain much from optimising them. No particular problem if someone wants to but I don't feel like it right now :)