### PR TITLE
Update godirwalk fixing excess heap allocation

### DIFF
--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -499,7 +499,7 @@ go_module(
         "testdata",
         "vendor",
     ],
-    version = "v1.7.0",
+    version = "v1.16.1",
     deps = [":errors"],
 )
 


### PR DESCRIPTION
The version of this library seems to keep 200+mb of heap allocated memory in our parse test. The newer version doesn't keep any heap allocated memory around massively reducing mem usage. 

Before:
```
INFO: Run 1 of 5
INFO: Complete in 10.81s, using 3351968 KB
INFO: Run 2 of 5
INFO: Complete in 10.77s, using 3417804 KB
INFO: Run 3 of 5
INFO: Complete in 11.00s, using 3441592 KB
INFO: Run 4 of 5
INFO: Complete in 12.21s, using 3256560 KB
INFO: Run 5 of 5
INFO: Complete in 11.73s, using 3463292 KB
INFO: Complete, median time: 11.00s, median mem: 3417804.00 KB
```


After:
```
INFO: Run 1 of 5
INFO: Complete in 9.94s, using 2991608 KB
INFO: Run 2 of 5
INFO: Complete in 10.67s, using 2922288 KB
INFO: Run 3 of 5
INFO: Complete in 12.05s, using 3060568 KB
INFO: Run 4 of 5
INFO: Complete in 12.58s, using 3199712 KB
INFO: Run 5 of 5
INFO: Complete in 11.92s, using 3025948 KB
INFO: Complete, median time: 11.92s, median mem: 3025948.00 KB
```