### PR TITLE
Make the depinfo store a reference to the build label of the resolved target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,7 @@ __pycache__
 # For local testing
 .local
 
+# The parse perf test repo
+/tree
+
 

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -249,7 +249,7 @@ type PostBuildFunction interface {
 }
 
 type depInfo struct {
-	declared BuildLabel     // the originally declared dependency
+	declared *BuildLabel     // the originally declared dependency
 	deps     []*BuildTarget // list of actual deps
 	resolved bool           // has the graph resolved it
 	exported bool           // is it an exported dependency
@@ -490,10 +490,11 @@ func (target *BuildTarget) resolveDependencies(graph *BuildGraph, callback func(
 }
 
 func (target *BuildTarget) resolveOneDependency(graph *BuildGraph, dep *depInfo) error {
-	t := graph.WaitForTarget(dep.declared)
+	t := graph.WaitForTarget(*dep.declared)
 	if t == nil {
 		return fmt.Errorf("Couldn't find dependency %s", dep.declared)
 	}
+	dep.declared = &t.Label // saves memory by not storing the label twice once resolved
 	labels := t.provideFor(target)
 	if len(labels) == 0 {
 		// Small optimisation to avoid re-looking-up the same target again.
@@ -522,7 +523,7 @@ func (target *BuildTarget) DeclaredDependencies() []BuildLabel {
 	defer target.mutex.RUnlock()
 	ret := make(BuildLabels, len(target.dependencies))
 	for i, dep := range target.dependencies {
-		ret[i] = dep.declared
+		ret[i] = *dep.declared
 	}
 	sort.Sort(ret)
 	return ret
@@ -534,8 +535,8 @@ func (target *BuildTarget) DeclaredDependenciesStrict() []BuildLabel {
 	defer target.mutex.RUnlock()
 	ret := make(BuildLabels, 0, len(target.dependencies))
 	for _, dep := range target.dependencies {
-		if !dep.exported && !dep.source && !target.IsTool(dep.declared) {
-			ret = append(ret, dep.declared)
+		if !dep.exported && !dep.source && !target.IsTool(*dep.declared) {
+			ret = append(ret, *dep.declared)
 		}
 	}
 	sort.Sort(ret)
@@ -597,7 +598,7 @@ func (target *BuildTarget) ExportedDependencies() []BuildLabel {
 	ret := make(BuildLabels, 0, len(target.dependencies))
 	for _, info := range target.dependencies {
 		if info.exported {
-			ret = append(ret, info.declared)
+			ret = append(ret, *info.declared)
 		}
 	}
 	return ret
@@ -790,7 +791,7 @@ func (target *BuildTarget) CanSee(state *BuildState, dep *BuildTarget) bool {
 // Returns an error if not, or nil if all's well.
 func (target *BuildTarget) CheckDependencyVisibility(state *BuildState) error {
 	for _, d := range target.dependencies {
-		dep := state.Graph.TargetOrDie(d.declared)
+		dep := state.Graph.TargetOrDie(*d.declared)
 		if !target.CanSee(state, dep) {
 			return fmt.Errorf("Target %s isn't visible to %s", dep.Label, target.Label)
 		} else if dep.TestOnly && !(target.IsTest || target.TestOnly) {
@@ -937,7 +938,7 @@ func (target *BuildTarget) resolveDependency(label BuildLabel, dep *BuildTarget)
 	defer target.mutex.Unlock()
 	info := target.dependencyInfo(label)
 	if info == nil {
-		target.dependencies = append(target.dependencies, depInfo{declared: label})
+		target.dependencies = append(target.dependencies, depInfo{declared: &label})
 		info = &target.dependencies[len(target.dependencies)-1]
 	}
 	if dep != nil {
@@ -949,7 +950,7 @@ func (target *BuildTarget) resolveDependency(label BuildLabel, dep *BuildTarget)
 // dependencyInfo returns the information about a declared dependency, or nil if the target doesn't have it.
 func (target *BuildTarget) dependencyInfo(label BuildLabel) *depInfo {
 	for i, info := range target.dependencies {
-		if info.declared == label {
+		if *info.declared == label {
 			return &target.dependencies[i]
 		}
 	}
@@ -1419,7 +1420,7 @@ func (target *BuildTarget) AddMaybeExportedDependency(dep BuildLabel, exported, 
 	}
 	info := target.dependencyInfo(dep)
 	if info == nil {
-		target.dependencies = append(target.dependencies, depInfo{declared: dep, exported: exported, source: source, internal: internal})
+		target.dependencies = append(target.dependencies, depInfo{declared: &dep, exported: exported, source: source, internal: internal})
 	} else {
 		info.exported = info.exported || exported
 		info.source = info.source && source

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -249,7 +249,7 @@ type PostBuildFunction interface {
 }
 
 type depInfo struct {
-	declared *BuildLabel     // the originally declared dependency
+	declared *BuildLabel    // the originally declared dependency
 	deps     []*BuildTarget // list of actual deps
 	resolved bool           // has the graph resolved it
 	exported bool           // is it an exported dependency


### PR DESCRIPTION
By making the label in depinfo a pointer, and make that point to the label on the target when resolving a dep, we can save a bit of memory by not keeping references to identical build labels. Not sure this shows up very well but:

Before:
```
INFO: Run 1 of 5
INFO: Complete in 34.42s, using 7991108 KB
INFO: Run 2 of 5
INFO: Complete in 33.59s, using 6608208 KB
INFO: Run 3 of 5
INFO: Complete in 36.81s, using 7607492 KB
INFO: Run 4 of 5
INFO: Complete in 32.83s, using 5988300 KB
INFO: Run 5 of 5
INFO: Complete in 37.91s, using 8020256 KB
INFO: Complete, median time: 34.42s, median mem: 7607492.00 
```

After:
```
INFO: Run 1 of 5
INFO: Complete in 35.41s, using 7097212 KB
INFO: Run 2 of 5
INFO: Complete in 37.32s, using 7993552 KB
INFO: Run 3 of 5
INFO: Complete in 38.47s, using 6600676 KB
INFO: Run 4 of 5
INFO: Complete in 31.63s, using 6482448 KB
INFO: Run 5 of 5
INFO: Complete in 34.70s, using 7365568 KB
INFO: Complete, median time: 35.41s, median mem: 7097212.00 KB
```

The `inuse_space` profile shows it better:

Heap use from allocations that happen in `AddMaybeExportedDependency` drops from 400mb to 200mb and total heap used drops by the same amount. 