### PR TITLE
Size deps slice to the precise capacity

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -500,6 +500,7 @@ func (target *BuildTarget) resolveOneDependency(graph *BuildGraph, dep *depInfo)
 		dep.deps = []*BuildTarget{t}
 		return nil
 	}
+	dep.deps = make([]*BuildTarget, 0, len(labels))
 	for _, l := range labels {
 		t := graph.WaitForTarget(l)
 		if t == nil {


### PR DESCRIPTION
Should save a few allocations & a bit of memory. Doesn't seem to be enough to break through the noise of system-level benchmarks but should have no downside.