### PR TITLE
Remove pendingTargets map from graph

### DIFF
--- a/src/core/cmap_packages.go
+++ b/src/core/cmap_packages.go
@@ -82,7 +82,7 @@ func (lm *packageLMap) Set(key packageKey, pkg *Package) bool {
 	defer lm.l.Unlock()
 	if existing, present := lm.m[key]; present {
 		if existing.Package != nil {
-			return false  // already added
+			return false // already added
 		}
 		// Hasn't been added, but something is waiting for it to be.
 		lm.m[key] = packagePair{Package: pkg}

--- a/src/core/cmap_packages.go
+++ b/src/core/cmap_packages.go
@@ -1,0 +1,122 @@
+// This is similar to cmap_targets.go.
+// TODO(peterebden, jpoole): When we get generics in 1.18 this would be a prime use case for them.
+
+package core
+
+import (
+	"sync"
+
+	"github.com/OneOfOne/cmap/hashers"
+)
+
+// packageMap is a concurrent safe sharded map to scale on multiple cores.
+// It's a fully specialised version of cmap.CMap for our most commonly used types.
+type packageMap struct {
+	shards []*packageLMap
+}
+
+// newPackageMap creates a new packageMap.
+func newPackageMap() *packageMap {
+	cm := &packageMap{
+		shards: make([]*packageLMap, shardCount),
+	}
+	for i := range cm.shards {
+		cm.shards[i] = newPackageLMapSize(shardCount)
+	}
+	return cm
+}
+
+// Set is the equivalent of `map[key] = val`.
+// It returns true if the item was inserted, false if it already existed (in which case it won't be inserted)
+func (cm *packageMap) Set(key packageKey, pkg *Package) bool {
+	h := hashPackage(key)
+	return cm.shards[h&shardMask].Set(key, pkg)
+}
+
+// Get returns the package or, if the package isn't present, a channel that it can be waited on for.
+// Exactly one of the package or channel will be returned.
+func (cm *packageMap) Get(key packageKey) (val *Package, wait <-chan struct{}) {
+	h := hashPackage(key)
+	return cm.shards[h&shardMask].Get(key)
+}
+
+// Values returns a slice of all the current values in the map.
+// This is a view that an observer could potentially have had at some point around the calling of this function,
+// but no particular consistency guarantees are made.
+func (cm *packageMap) Values() []*Package {
+	ret := []*Package{}
+	for _, lm := range cm.shards {
+		ret = append(ret, lm.Values()...)
+	}
+	return ret
+}
+
+func hashPackage(key packageKey) uint32 {
+	return hashers.Fnv32(key.Subrepo) ^ hashers.Fnv32(key.Name)
+}
+
+// A packagePair represents a build package & an awaitable channel for one to exist.
+type packagePair struct {
+	Package *Package
+	Wait    chan struct{}
+}
+
+// packageLMap is a simple sync.Mutex locked map.
+// Used by packageMap internally for sharding.
+type packageLMap struct {
+	m map[packageKey]packagePair
+	l sync.Mutex
+}
+
+// newPackageLMapSize is the equivalent of `m := make(map[BuildLabel]packagePair, cap)`
+func newPackageLMapSize(cap int) *packageLMap {
+	return &packageLMap{
+		m: make(map[packageKey]packagePair, cap),
+	}
+}
+
+// Set is the equivalent of `map[key] = val`.
+// It returns true if the item was inserted, false if it already existed (in which case it won't be inserted)
+func (lm *packageLMap) Set(key packageKey, pkg *Package) bool {
+	lm.l.Lock()
+	defer lm.l.Unlock()
+	if existing, present := lm.m[key]; present {
+		if existing.Package != nil {
+			return false  // already added
+		}
+		// Hasn't been added, but something is waiting for it to be.
+		lm.m[key] = packagePair{Package: pkg}
+		if existing.Wait != nil {
+			close(existing.Wait)
+		}
+		return true
+	}
+	lm.m[key] = packagePair{Package: pkg}
+	return true
+}
+
+// Get returns the package or, if the package isn't present, a channel that it can be waited on for.
+// Exactly one of the package or channel will be returned.
+func (lm *packageLMap) Get(key packageKey) (*Package, <-chan struct{}) {
+	lm.l.Lock()
+	defer lm.l.Unlock()
+	if v, ok := lm.m[key]; ok {
+		return v.Package, v.Wait
+	}
+	ch := make(chan struct{})
+	lm.m[key] = packagePair{Wait: ch}
+	return nil, ch
+}
+
+// Values returns a copy of all the packages currently in the map.
+func (lm *packageLMap) Values() []*Package {
+	lm.l.Lock()
+	defer lm.l.Unlock()
+	ret := make([]*Package, 0, len(lm.m))
+	for _, v := range lm.m {
+		if v.Package != nil {
+			ret = append(ret, v.Package)
+		}
+	}
+	return ret
+}

--- a/src/core/cmap_targets.go
+++ b/src/core/cmap_targets.go
@@ -90,7 +90,7 @@ func (lm *targetLMap) Set(target *BuildTarget) bool {
 	defer lm.l.Unlock()
 	if existing, present := lm.m[target.Label]; present {
 		if existing.Target != nil {
-			return false  // already added
+			return false // already added
 		}
 		// Hasn't been added, but something is waiting for it to be.
 		lm.m[target.Label] = buildTargetPair{Target: target}

--- a/src/core/graph.go
+++ b/src/core/graph.go
@@ -169,9 +169,9 @@ func (graph *BuildGraph) PackageMap() map[string]*Package {
 // NewGraph constructs and returns a new BuildGraph.
 func NewGraph() *BuildGraph {
 	g := &BuildGraph{
-		targets:        newTargetMap(),
-		packages:       newPackageMap(),
-		subrepos:       cmap.New(),
+		targets:  newTargetMap(),
+		packages: newPackageMap(),
+		subrepos: cmap.New(),
 	}
 	return g
 }


### PR DESCRIPTION
This unifies the map of pending targets / packages with the target & package maps themselves. Hence adding a target doesn't require modifying a second map & waiting on it is also cleaner.

Does mean we've got a second custom map type but I think we should just suck that up and refactor them into one common thing once we get generics (which is not so far away now).

Benchmark before:
```
BenchmarkAddingTargets
BenchmarkAddingTargets-12        	  757390	      1852 ns/op	     509 B/op	       3 allocs/op
BenchmarkTargetLookup
BenchmarkTargetLookup/Simple
BenchmarkTargetLookup/Simple-12  	 3883336	       301.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkTargetLookup/WaitForTargetFast
BenchmarkTargetLookup/WaitForTargetFast-12         	 4017552	       304.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkWaitForTargetSlow
BenchmarkWaitForTargetSlow-12                      	 1699608	       889.5 ns/op	     604 B/op	       3 allocs/op
```
After:
```
BenchmarkAddingTargets
BenchmarkAddingTargets-12        	 1387692	       729.8 ns/op	     215 B/op	       0 allocs/op
BenchmarkTargetLookup
BenchmarkTargetLookup/Simple
BenchmarkTargetLookup/Simple-12  	 3927500	       298.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkTargetLookup/WaitForTargetFast
BenchmarkTargetLookup/WaitForTargetFast-12         	 3866668	       297.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkWaitForTargetSlow
BenchmarkWaitForTargetSlow-12                      	 2161027	       660.0 ns/op	     283 B/op	       0 allocs/op
```
i.e. addition is 2-3x faster, waiting is a bit faster, and both allocate less.