### PR TITLE
Don't do the check on built targets if we're not building.

### DIFF
--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -90,14 +90,16 @@ func MonitorState(ctx context.Context, state *core.BuildState, plainOutput, deta
 		printFailedBuildResults(failedNonTests, failedTargetMap, duration)
 		return
 	}
-	// Check all the targets we wanted to build actually have been built.
-	for _, label := range state.ExpandOriginalLabels() {
-		if target := state.Graph.Target(label); target == nil {
-			log.Fatalf("Target %s doesn't exist in build graph", label)
-		} else if (state.NeedHashesOnly || state.PrepareOnly || state.PrepareShell) && target.State() == core.Stopped {
-			// Do nothing, we will output about this shortly.
-		} else if state.NeedBuild && target.State() < core.Built && len(failedTargetMap) == 0 && !target.AddedPostBuild {
-			log.Fatalf("Target %s hasn't built but we have no pending tasks left.\n%s", label, unbuiltTargetsMessage(state.Graph))
+	if state.NeedBuild {
+		// Check all the targets we wanted to build actually have been built.
+		for _, label := range state.ExpandOriginalLabels() {
+			if target := state.Graph.Target(label); target == nil {
+				log.Fatalf("Target %s doesn't exist in build graph", label)
+			} else if (state.NeedHashesOnly || state.PrepareOnly || state.PrepareShell) && target.State() == core.Stopped {
+				// Do nothing, we will output about this shortly.
+			} else if state.NeedBuild && target.State() < core.Built && len(failedTargetMap) == 0 && !target.AddedPostBuild {
+				log.Fatalf("Target %s hasn't built but we have no pending tasks left.\n%s", label, unbuiltTargetsMessage(state.Graph))
+			}
 		}
 	}
 	if state.NeedBuild && len(failedNonTests) == 0 {

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -97,7 +97,7 @@ func MonitorState(ctx context.Context, state *core.BuildState, plainOutput, deta
 				log.Fatalf("Target %s doesn't exist in build graph", label)
 			} else if (state.NeedHashesOnly || state.PrepareOnly || state.PrepareShell) && target.State() == core.Stopped {
 				// Do nothing, we will output about this shortly.
-			} else if state.NeedBuild && target.State() < core.Built && len(failedTargetMap) == 0 && !target.AddedPostBuild {
+			} else if target.State() < core.Built && len(failedTargetMap) == 0 && !target.AddedPostBuild {
 				log.Fatalf("Target %s hasn't built but we have no pending tasks left.\n%s", label, unbuiltTargetsMessage(state.Graph))
 			}
 		}


### PR DESCRIPTION
I don't think any of this is very relevant for parsing and it actually takes several hundred ms on a big graph (because it churns through all the packages one by one).