### PR TITLE
Buffer interactive output to stderr

### DIFF
--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -24,6 +24,7 @@ type displayer struct {
 	numWorkers, maxWorkers, numRemote, maxRows, maxCols int
 	stats                                               bool
 	lines, lastLines                                    int // mutable - records how many rows we've printed this time
+	buf, lineBuf                                        bytes.Buffer
 }
 
 func display(ctx context.Context, state *core.BuildState, buildingTargets []buildingTarget) {
@@ -44,7 +45,7 @@ func display(ctx context.Context, state *core.BuildState, buildingTargets []buil
 	setWindowTitle(state, false)
 	// Clear it all out.
 	d.moveToFirstLine()
-	printf("${CLEAR_END}")
+	d.printf("${CLEAR_END}")
 }
 
 func (d *displayer) run(ctx context.Context) {
@@ -60,44 +61,47 @@ func (d *displayer) run(ctx context.Context) {
 			d.moveToFirstLine()
 			d.printLines()
 			for _, line := range cli.CurrentBackend.Output() {
-				printf("${ERASE_AFTER}%s\n", line)
+				d.printf("${ERASE_AFTER}%s\n", line)
 				d.lines++
 			}
 			// Clean out any lines that were visible last time but are not now.
 			if d.lines < d.lastLines {
 				for i := d.lines; i < d.lastLines; i++ {
-					printf("${ERASE_AFTER}\n")
+					d.printf("${ERASE_AFTER}\n")
 				}
-				printf("\x1b[%dA", d.lastLines-d.lines) // Move back up again
+				d.printf("\x1b[%dA", d.lastLines-d.lines) // Move back up again
 			}
 			setWindowTitle(d.state, true)
+			os.Stderr.Write(d.buf.Bytes())
+			os.Stderr.Sync()
+			d.buf.Reset()
 		}
 	}
 }
 
 // moveToFirstLine resets back to the first line.
 func (d *displayer) moveToFirstLine() {
-	printf("\x1b[%dA", d.lines)
+	d.printf("\x1b[%dA", d.lines)
 	d.lastLines = d.lines
 	d.lines = 0
 }
 
 func (d *displayer) printLines() {
 	now := time.Now()
-	printf("Building [%d/%d, %3.1fs]:\n", d.state.NumDone(), d.state.NumActive(), time.Since(d.state.StartTime).Seconds())
+	d.printf("Building [%d/%d, %3.1fs]:\n", d.state.NumDone(), d.state.NumActive(), time.Since(d.state.StartTime).Seconds())
 	d.lines++
 	if d.stats {
-		printStat("CPU use", d.state.Stats.CPU.Used, d.state.Stats.CPU.Count)
-		printStat("I/O", d.state.Stats.CPU.IOWait, d.state.Stats.CPU.Count)
-		printStat("Mem use", d.state.Stats.Memory.UsedPercent, 1)
+		d.printStat("CPU use", d.state.Stats.CPU.Used, d.state.Stats.CPU.Count)
+		d.printStat("I/O", d.state.Stats.CPU.IOWait, d.state.Stats.CPU.Count)
+		d.printStat("Mem use", d.state.Stats.Memory.UsedPercent, 1)
 		if d.state.Stats.NumWorkerProcesses > 0 {
-			printf("  ${BOLD_WHITE}Worker processes: %d${RESET}", d.state.Stats.NumWorkerProcesses)
+			d.printf("  ${BOLD_WHITE}Worker processes: %d${RESET}", d.state.Stats.NumWorkerProcesses)
 		}
 		if d.state.RemoteClient != nil {
 			in, out, _, _ := d.state.RemoteClient.DataRate()
-			printf("  ${BOLD_WHITE}RPC data in: %6s/s out: %6s/s${RESET}", humanize.Bytes(uint64(in)), humanize.Bytes(uint64(out)))
+			d.printf("  ${BOLD_WHITE}RPC data in: %6s/s out: %6s/s${RESET}", humanize.Bytes(uint64(in)), humanize.Bytes(uint64(out)))
 		}
-		printf("${ERASE_AFTER}\n")
+		d.printf("${ERASE_AFTER}\n")
 		d.lines++
 	}
 	workers := 0
@@ -108,18 +112,18 @@ func (d *displayer) printLines() {
 	}
 	if anyRemote {
 		active := d.numRemoteActive()
-		printf("Remote processes [%3d/%3d active]:   ${ERASE_AFTER}\n", active, d.numRemote)
+		d.printf("Remote processes [%3d/%3d active]:   ${ERASE_AFTER}\n", active, d.numRemote)
 		d.lines++
 		for i := 0; i < d.numRemote && d.lines < d.maxRows && workers < d.maxWorkers; i++ {
 			workers += d.printRow(d.numWorkers+i, now, true)
 			d.lines++
 		}
 		if workers < active {
-			printf("${RESET}   [%2d more...]${ERASE_AFTER}\n", active-workers)
+			d.printf("${RESET}   [%2d more...]${ERASE_AFTER}\n", active-workers)
 			d.lines++
 		}
 	}
-	printf("${RESET}")
+	d.printf("${RESET}")
 }
 
 func (d *displayer) numRemoteActive() int {
@@ -171,7 +175,7 @@ func (d *displayer) printRow(i int, now time.Time, remote bool) int {
 				duration, target.Colour, label, target.Description)
 		}
 	} else if !remote {
-		printf("${BOLD_GREY}=|${ERASE_AFTER}\n")
+		d.printf("${BOLD_GREY}=|${ERASE_AFTER}\n")
 	} else {
 		d.lines-- // Didn't print it
 		return 0
@@ -180,51 +184,52 @@ func (d *displayer) printRow(i int, now time.Time, remote bool) int {
 }
 
 // printStat prints a single statistic with appropriate colours.
-func printStat(caption string, stat float64, multiplier int) {
+func (d *displayer) printStat(caption string, stat float64, multiplier int) {
 	colour := "${BOLD_GREEN}"
 	if stat > 80.0*float64(multiplier) {
 		colour = "${BOLD_RED}"
 	} else if stat > 60.0*float64(multiplier) {
 		colour = "${BOLD_YELLOW}"
 	}
-	printf("  ${BOLD_WHITE}%s:${RESET} %s%5.1f%%${RESET}", caption, colour, stat)
+	d.printf("  ${BOLD_WHITE}%s:${RESET} %s%5.1f%%${RESET}", caption, colour, stat)
 }
 
 // Limited-length printf that respects current window width.
 // Output is truncated at the middle to fit within 'cols'.
 func (d *displayer) printf(format string, args ...interface{}) {
-	fmt.Fprint(os.Stderr, lprintfPrepare(d.maxCols, os.Expand(fmt.Sprintf(format, args...), replace)))
+
+	fmt.Fprint(&d.buf, d.lprintfPrepare(d.maxCols, os.Expand(fmt.Sprintf(format, args...), replace)))
 }
 
-func lprintfPrepare(cols int, s string) string {
+func (d *displayer) lprintfPrepare(cols int, s string) string {
 	if len(s) < cols {
 		return s // it's short enough, nice and simple
 	}
 	// Okay, it's too long. Tricky thing: ANSI escape codes don't count for width
 	// so we need to count without those. Bonus: make an effort to be unicode-aware.
-	var b bytes.Buffer
 	written := 0
 	inAnsiCode := false
+	d.lineBuf.Reset()
 	for _, rune := range s {
 		if inAnsiCode {
-			b.WriteRune(rune)
+			d.lineBuf.WriteRune(rune)
 			if rune == 'm' {
 				inAnsiCode = false
 			}
 		} else if rune == '\x1b' {
-			b.WriteRune(rune)
+			d.lineBuf.WriteRune(rune)
 			inAnsiCode = true
 		} else if rune == '\n' {
-			b.WriteRune(rune)
+			d.lineBuf.WriteRune(rune)
 		} else if written == cols-3 {
-			b.WriteString("...")
+			d.lineBuf.WriteString("...")
 			written += 3
 		} else if written < cols-3 {
-			b.WriteRune(rune)
+			d.lineBuf.WriteRune(rune)
 			written++
 		}
 	}
-	return b.String()
+	return d.lineBuf.String()
 }
 
 // setWindowTitle sets the title of the current shell window based on the current build state.

--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -196,7 +196,6 @@ func (d *displayer) printStat(caption string, stat float64, multiplier int) {
 // Limited-length printf that respects current window width.
 // Output is truncated at the middle to fit within 'cols'.
 func (d *displayer) printf(format string, args ...interface{}) {
-
 	fmt.Fprint(&d.buf, d.lprintfPrepare(d.maxCols, os.Expand(fmt.Sprintf(format, args...), replace)))
 }
 

--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -73,7 +73,6 @@ func (d *displayer) run(ctx context.Context) {
 			}
 			setWindowTitle(d.state, true)
 			os.Stderr.Write(d.buf.Bytes())
-			os.Stderr.Sync()
 			d.buf.Reset()
 		}
 	}

--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -46,6 +46,7 @@ func display(ctx context.Context, state *core.BuildState, buildingTargets []buil
 	// Clear it all out.
 	d.moveToFirstLine()
 	d.printf("${CLEAR_END}")
+	d.flush()
 }
 
 func (d *displayer) run(ctx context.Context) {
@@ -72,8 +73,7 @@ func (d *displayer) run(ctx context.Context) {
 				d.printf("\x1b[%dA", d.lastLines-d.lines) // Move back up again
 			}
 			setWindowTitle(d.state, true)
-			os.Stderr.Write(d.buf.Bytes())
-			d.buf.Reset()
+			d.flush()
 		}
 	}
 }
@@ -197,6 +197,12 @@ func (d *displayer) printStat(caption string, stat float64, multiplier int) {
 // Output is truncated at the middle to fit within 'cols'.
 func (d *displayer) printf(format string, args ...interface{}) {
 	fmt.Fprint(&d.buf, d.lprintfPrepare(d.maxCols, os.Expand(fmt.Sprintf(format, args...), replace)))
+}
+
+// flush prints the current buffer to stderr and resets it.
+func (d *displayer) flush() {
+	os.Stderr.Write(d.buf.Bytes())
+	d.buf.Reset()
 }
 
 func (d *displayer) lprintfPrepare(cols int, s string) string {

--- a/src/output/interactive_display_test.go
+++ b/src/output/interactive_display_test.go
@@ -7,23 +7,28 @@ import (
 )
 
 func TestLimitedPrintfSimple(t *testing.T) {
-	assert.Equal(t, "wibble wobble", lprintfPrepare(20, "wibble wobble"))
+	var d displayer
+	assert.Equal(t, "wibble wobble", d.lprintfPrepare(20, "wibble wobble"))
 }
 
 func TestLimitedPrintfMore(t *testing.T) {
-	assert.Equal(t, "wibble ...", lprintfPrepare(10, "wibble wobble"))
+	var d displayer
+	assert.Equal(t, "wibble ...", d.lprintfPrepare(10, "wibble wobble"))
 }
 
 func TestLimitedPrintfAnsi(t *testing.T) {
+	var d displayer
 	// Should be unchanged because without escape sequences it's under the limit.
-	assert.Equal(t, "\x1b[30mwibble wobble\x1b[1m", lprintfPrepare(20, "\x1b[30mwibble wobble\x1b[1m"))
+	assert.Equal(t, "\x1b[30mwibble wobble\x1b[1m", d.lprintfPrepare(20, "\x1b[30mwibble wobble\x1b[1m"))
 }
 
 func TestLimitedPrintfAnsiNotCountedWhenReducing(t *testing.T) {
-	assert.Equal(t, "\x1b[30mwibble ...\x1b[1m", lprintfPrepare(10, "\x1b[30mwibble wobble\x1b[1m"))
+	var d displayer
+	assert.Equal(t, "\x1b[30mwibble ...\x1b[1m", d.lprintfPrepare(10, "\x1b[30mwibble wobble\x1b[1m"))
 }
 
 func TestNewlinesStillWritte(t *testing.T) {
+	var d displayer
 	// Test that newline still gets written (it doesn't count as horizontal space and is Very Important)
-	assert.Equal(t, "\x1b[30mwibble ...\x1b[1m\n", lprintfPrepare(10, "\x1b[30mwibble wobble\x1b[1m\n"))
+	assert.Equal(t, "\x1b[30mwibble ...\x1b[1m\n", d.lprintfPrepare(10, "\x1b[30mwibble wobble\x1b[1m\n"))
 }


### PR DESCRIPTION
Rather than printing every line individually, buffer up the whole lot and dump it in one go. 

Empirically this "feels" a little nicer over SSH (e.g. I don't see ghosts of the cursor jumping around lines). Not sure if it's a massive difference but I think it makes sense to limit the number of writes.