### PR TITLE
Revert "Implement per-function profiling metrics for asp (#1774)"

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -578,9 +578,6 @@ type Configuration struct {
 	PleaseLocation string
 	// buildEnvStored is a cached form of BuildEnv.
 	buildEnvStored *storedBuildEnv
-	// Profiling can be set to true by a caller to enable CPU profiling in any areas that might
-	// want to take special effort about it.
-	Profiling bool
 
 	FeatureFlags struct {
 		JavaBinaryExecutableByDefault bool `help:"Makes java_binary rules self executable by default. Target release version 16." var:"FF_JAVA_SELF_EXEC"`

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -1,7 +1,6 @@
 package asp
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -605,7 +604,7 @@ func (f *pyFunc) String() string {
 	return fmt.Sprintf("<function %s>", f.name)
 }
 
-func (f *pyFunc) Call(ctx context.Context, s *scope, c *Call) pyObject {
+func (f *pyFunc) Call(s *scope, c *Call) pyObject {
 	if f.nativeCode != nil {
 		if f.kwargs {
 			return f.callNative(s.NewScope(), c)
@@ -613,7 +612,6 @@ func (f *pyFunc) Call(ctx context.Context, s *scope, c *Call) pyObject {
 		return f.callNative(s, c)
 	}
 	s2 := f.scope.NewPackagedScope(s.pkg, len(f.args)+1)
-	s2.ctx = ctx
 	s2.config = s.config
 	s2.Set("CONFIG", s.config) // This needs to be copied across too :(
 	s2.Callback = s.Callback

--- a/src/please.go
+++ b/src/please.go
@@ -1078,7 +1078,6 @@ func readConfigAndSetRoot(forceUpdate bool) *core.Configuration {
 	}
 	config := readConfig(forceUpdate)
 	// Now apply any flags that override this
-	config.Profiling = opts.Profile != ""
 	if opts.Update.Latest || opts.Update.LatestPrerelease {
 		config.Please.Version.Unset()
 	} else if opts.Update.Version.IsSet {


### PR DESCRIPTION
This reverts commit 444a626645424258096d9e05aecd6b367a864a59.

I'm not finding this drastically useful; a lot of the time seems to remain unlabelled, and it's probably better not to have profiling-specific paths.