### PR TITLE
Print original targets more nicely

### DIFF
--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -45,6 +45,8 @@ func (label BuildLabel) String() string {
 	zero := BuildLabel{}
 	if label == zero {
 		return ""
+	} else if label == OriginalTarget {
+		return "command-line targets"
 	}
 	s := "//" + label.PackageName
 	if label.Subrepo != "" {


### PR DESCRIPTION
Before:
```
Subrepo third_party/cc/unittest_cpp is not defined (referenced by //:_ORIGINAL)
```
After:
```
Subrepo third_party/cc/unittest_cpp is not defined (referenced by command-line targets)
```
