### PR TITLE
Move all docker workloads to /mnt/ramdisk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
      docker:
        - image: thoughtmachine/please_alpine:20210406
      resource_class: large
+     working_directory: /mnt/ramdisk
      environment:
        PLZ_ARGS: "-p --profile ci --profile alpine --exclude no-musl"
      steps:
@@ -50,6 +51,7 @@ jobs:
      docker:
        - image: thoughtmachine/please_ubuntu:20210720
      resource_class: large
+     working_directory: /mnt/ramdisk
      environment:
        PLZ_ARGS: "-p --profile ci"
      steps:
@@ -100,6 +102,7 @@ jobs:
      docker:
        - image: thoughtmachine/please_ubuntu_alt:20210316
      resource_class: large
+     working_directory: /mnt/ramdisk
      environment:
        PLZ_ARGS: "-p -c cover --profile ci-alt"
        PLZ_COVER: "cover --nocoverage_report"
@@ -138,6 +141,7 @@ jobs:
      docker:
        - image: thoughtmachine/please_ubuntu:20210720
      resource_class: large
+     working_directory: /mnt/ramdisk
      steps:
        - checkout
        - attach_workspace:
@@ -165,6 +169,7 @@ jobs:
      docker:
        - image: thoughtmachine/please_freebsd_builder:20200820
      resource_class: large
+     working_directory: /mnt/ramdisk
      steps:
        - checkout
        - attach_workspace:
@@ -257,6 +262,7 @@ jobs:
      docker:
        - image: thoughtmachine/please_ubuntu:20210720
      resource_class: large
+     working_directory: /mnt/ramdisk
      steps:
        - checkout
        - attach_workspace:
@@ -272,6 +278,7 @@ jobs:
    release:
      docker:
        - image: thoughtmachine/please_docs:20200930
+     working_directory: /mnt/ramdisk
      steps:
        - attach_workspace:
            at: /tmp/workspace
@@ -284,6 +291,7 @@ jobs:
    release-s3:
      docker:
        - image: thoughtmachine/please_docs:20200930
+     working_directory: /mnt/ramdisk
      steps:
        - checkout
        - attach_workspace:
@@ -294,6 +302,7 @@ jobs:
    perf-test:
      docker:
        - image: thoughtmachine/please_ubuntu:20210720
+     working_directory: /mnt/ramdisk
      resource_class: xlarge  # Want to run these tests with a significant amount of parallelism
      steps:
        - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 jobs:
    build-alpine:
-     working_directory: ~/please
      docker:
        - image: thoughtmachine/please_alpine:20210406
      resource_class: large
@@ -47,7 +46,6 @@ jobs:
            paths: [ ".plz-cache/test/java_rules/java_toolchain" ]
 
    build-linux:
-     working_directory: ~/please
      docker:
        - image: thoughtmachine/please_ubuntu:20210720
      resource_class: large
@@ -98,7 +96,6 @@ jobs:
            paths: [ ".plz-cache/test/java_rules/java_toolchain" ]
 
    build-linux-alt:
-     working_directory: ~/please
      docker:
        - image: thoughtmachine/please_ubuntu_alt:20210316
      resource_class: large
@@ -137,7 +134,6 @@ jobs:
            key: python-linux-alt-v2-{{ checksum "third_party/python/BUILD" }}
            paths: [ ".plz-cache/third_party/python" ]
    build-darwin-arm64:
-     working_directory: ~/please
      docker:
        - image: thoughtmachine/please_ubuntu:20210720
      resource_class: large
@@ -165,7 +161,6 @@ jobs:
            paths: [ ".plz-cache/third_party/go" ]
 
    build-freebsd:
-     working_directory: ~/please
      docker:
        - image: thoughtmachine/please_freebsd_builder:20200820
      resource_class: large
@@ -241,7 +236,6 @@ jobs:
            paths: [ ".plz-cache/test/java_rules/java_toolchain" ]
 
    test-rex:
-     working_directory: ~/please
      docker:
        - image: thoughtmachine/please_ubuntu:20210720
      resource_class: large
@@ -258,7 +252,6 @@ jobs:
            path: plz-out/log
 
    test-http-cache:
-     working_directory: ~/please
      docker:
        - image: thoughtmachine/please_ubuntu:20210720
      resource_class: large


### PR DESCRIPTION
Just following https://circleci.com/docs/2.0/executor-types/#ram-disks 

It's possible we'll hit memory limits. Think we should just try and see; hopefully it will reduce those poxy ETXTBUSY errors.