### PR TITLE
Properly singleflight all subinclude() calls

### DIFF
--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -17,9 +17,8 @@ import (
 type interpreter struct {
 	scope           *scope
 	parser          *Parser
-	subincludes     map[string]pyDict
+	subincludes     subincludeMap
 	config          map[*core.Configuration]*pyConfig
-	mutex           sync.RWMutex
 	configMutex     sync.RWMutex
 	breakpointMutex sync.Mutex
 	limiter         semaphore
@@ -37,7 +36,7 @@ func newInterpreter(state *core.BuildState, p *Parser) *interpreter {
 	i := &interpreter{
 		scope:       s,
 		parser:      p,
-		subincludes: map[string]pyDict{},
+		subincludes: subincludeMap{m: map[string]subincludeResult{}},
 		config:      map[*core.Configuration]*pyConfig{},
 		limiter:     make(semaphore, state.Config.Parse.NumThreads),
 		profiling:   state.Config.Profiling,
@@ -121,16 +120,17 @@ func (i *interpreter) interpretStatements(s *scope, statements []*Statement) (re
 
 // Subinclude returns the global values corresponding to subincluding the given file.
 func (i *interpreter) Subinclude(path string, label core.BuildLabel, pkg *core.Package) pyDict {
-	i.mutex.RLock()
-	globals, present := i.subincludes[path]
-	i.mutex.RUnlock()
-	if present {
+	globals, wait, first := i.subincludes.Get(path)
+	if globals != nil {
+		return globals
+	} else if !first {
+		i.limiter.Release()
+		defer i.limiter.Acquire()
+		<-wait
+		globals, _, _ := i.subincludes.Get(path)
 		return globals
 	}
-	// If we get here, it's not been subincluded already. Parse it now.
-	// Note that there is a race here whereby it's possible for two packages to parse the same
-	// subinclude simultaneously - this doesn't matter since they'll get different but equivalent
-	// scopes, and sooner or later things will sort themselves out.
+	// If we get here, it falls to us to parse this.
 	stmts, err := i.parser.parse(path)
 	if err != nil {
 		panic(err) // We're already inside another interpreter, which will handle this for us.
@@ -148,10 +148,8 @@ func (i *interpreter) Subinclude(path string, label core.BuildLabel, pkg *core.P
 	if s.config.overlay == nil {
 		delete(locals, "CONFIG") // Config doesn't have any local modifications
 	}
-	i.mutex.Lock()
-	defer i.mutex.Unlock()
-	i.subincludes[path] = locals
-	return s.locals
+	i.subincludes.Set(path, locals)
+	return locals
 }
 
 // getConfig returns a new configuration object for the given configuration object.

--- a/src/parse/asp/subinclude.go
+++ b/src/parse/asp/subinclude.go
@@ -12,7 +12,7 @@ type subincludeResult struct {
 
 // A subincludeMap stores the results of subinclude calls in a way that they
 // can be waited on.
-type subincludeMap struct{
+type subincludeMap struct {
 	m map[string]subincludeResult
 	l sync.Mutex
 }

--- a/src/parse/asp/subinclude.go
+++ b/src/parse/asp/subinclude.go
@@ -1,0 +1,47 @@
+package asp
+
+import (
+	"sync"
+)
+
+// A subincludeResult holds the value in a subincludeMap.
+type subincludeResult struct {
+	Globals pyDict
+	Wait    chan struct{}
+}
+
+// A subincludeMap stores the results of subinclude calls in a way that they
+// can be waited on.
+type subincludeMap struct{
+	m map[string]subincludeResult
+	l sync.Mutex
+}
+
+// Set is the equivalent of `map[key] = val`.
+func (m *subincludeMap) Set(key string, val pyDict) {
+	m.l.Lock()
+	defer m.l.Unlock()
+	if existing, present := m.m[key]; present {
+		// Hasn't been added, but something is waiting for it to be.
+		m.m[key] = subincludeResult{Globals: val}
+		if existing.Wait != nil {
+			close(existing.Wait)
+		}
+		return
+	}
+	m.m[key] = subincludeResult{Globals: val}
+}
+
+// Get returns the subinclude globals or, if it hasn't been parsed yet, a channel that it can be waited on for.
+// Exactly one of the globals or channel will be returned.
+// The final return value is true if this was the first request awaiting this key.
+func (m *subincludeMap) Get(key string) (pyDict, <-chan struct{}, bool) {
+	m.l.Lock()
+	defer m.l.Unlock()
+	if v, ok := m.m[key]; ok {
+		return v.Globals, v.Wait, false
+	}
+	ch := make(chan struct{})
+	m.m[key] = subincludeResult{Wait: ch}
+	return nil, ch, true
+}


### PR DESCRIPTION
The old implementation let them race, but it turns out that happens too often. Here we enforce that each one is parsed exactly once.

I have another shot at this using x/sync/singleflight but while that helps it doesn't seem to fully deduplicate them. This is slightly more code on our side (although still hoping for generics to fix that since we could share some with the maps in src/core).

This is about 10% faster internally. I don't know if we'll see it on our synthetic benchmark, it might not be so heavy on `subinclude()`