### PR TITLE
Remove duplicate map lookup

### DIFF
--- a/src/core/cmap_targets.go
+++ b/src/core/cmap_targets.go
@@ -111,10 +111,6 @@ func (lm *targetLMap) Get(key BuildLabel) (*BuildTarget, <-chan struct{}) {
 	if v, ok := lm.m[key]; ok {
 		return v.Target, v.Wait
 	}
-	// Need to check again; something else could have added this.
-	if v, ok := lm.m[key]; ok {
-		return v.Target, v.Wait
-	}
 	ch := make(chan struct{})
 	lm.m[key] = buildTargetPair{Wait: ch}
 	return nil, ch


### PR DESCRIPTION
I think this is from an older version where it used to have an RWMutex which required it to look up again once it had the writer lock. Eventually got rid of that and so this is completely redundant.