### PR TITLE
Remove all the modified targets and rescan stuff

### DIFF
--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -68,7 +68,7 @@ func addTarget(state *core.BuildState, i int) *core.BuildTarget {
 			}
 		} else {
 			// These are buildable now
-			state.QueueTarget(target.Label, core.OriginalTarget, false, false)
+			state.QueueTarget(target.Label, core.OriginalTarget, false)
 		}
 	}
 	return target

--- a/src/core/cycle_detector_test.go
+++ b/src/core/cycle_detector_test.go
@@ -15,7 +15,7 @@ func TestCycleDetector(t *testing.T) {
 			target.AddDependency(ParseBuildLabel(dep, ""))
 		}
 		state.Graph.AddTarget(target)
-		state.QueueTarget(target.Label, OriginalTarget, false, true)
+		state.QueueTarget(target.Label, OriginalTarget, true)
 		return target
 	}
 

--- a/src/core/package.go
+++ b/src/core/package.go
@@ -30,10 +30,6 @@ type Package struct {
 	Outputs map[string]*BuildTarget
 	// Protects access to above
 	mutex sync.RWMutex
-	// Used to arbitrate a single post-build function running at a time.
-	// It would be sort of conceptually nice if they ran simultaneously but it'd
-	// be far too hard to ensure consistency in any case where they can interact with one another.
-	buildCallbackMutex sync.Mutex
 }
 
 // NewPackage constructs a new package with the given name.

--- a/src/core/package.go
+++ b/src/core/package.go
@@ -30,8 +30,6 @@ type Package struct {
 	Outputs map[string]*BuildTarget
 	// Protects access to above
 	mutex sync.RWMutex
-	// Targets whose dependencies got modified during a pre or post-build function.
-	modifiedTargets map[*BuildTarget]struct{}
 	// Used to arbitrate a single post-build function running at a time.
 	// It would be sort of conceptually nice if they ran simultaneously but it'd
 	// be far too hard to ensure consistency in any case where they can interact with one another.
@@ -179,26 +177,6 @@ func (pkg *Package) AllChildren(target *BuildTarget) []*BuildTarget {
 // e.g. //src/... includes the packages src and src/core but not src2.
 func (pkg *Package) IsIncludedIn(label BuildLabel) bool {
 	return pkg.Name == label.PackageName || strings.HasPrefix(pkg.Name, label.PackageName+"/")
-}
-
-// EnterBuildCallback is used to arbitrate access to build callbacks & track changes to targets.
-// The supplied function will be called & a set of modified targets, along with any errors, is returned.
-func (pkg *Package) EnterBuildCallback(f func() error) (map[*BuildTarget]struct{}, error) {
-	pkg.buildCallbackMutex.Lock()
-	defer pkg.buildCallbackMutex.Unlock()
-	m := map[*BuildTarget]struct{}{}
-	pkg.modifiedTargets = m
-	err := f()
-	pkg.modifiedTargets = nil
-	return m, err
-}
-
-// MarkTargetModified marks a single target as being modified during a pre- or post- build function.
-// Correct usage of EnterBuildCallback must have been observed.
-func (pkg *Package) MarkTargetModified(target *BuildTarget) {
-	if pkg.modifiedTargets != nil {
-		pkg.modifiedTargets[target] = struct{}{}
-	}
 }
 
 // Label returns a build label uniquely identifying this package.

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -763,7 +763,7 @@ func (state *BuildState) WaitForBuiltTarget(l, dependent BuildLabel) *BuildTarge
 		<-ch
 		return state.Graph.Target(l)
 	}
-	if err := state.queueTarget(l, dependent, false, true, true); err != nil {
+	if err := state.queueTarget(l, dependent, true, true); err != nil {
 		log.Fatalf("%v", err)
 	}
 
@@ -837,11 +837,11 @@ func (state *BuildState) WaitForTargetAndEnsureDownload(l, dependent BuildLabel)
 }
 
 // QueueTarget adds a single target to the build queue.
-func (state *BuildState) QueueTarget(label, dependent BuildLabel, rescan, forceBuild bool) error {
-	return state.queueTarget(label, dependent, rescan, forceBuild, false)
+func (state *BuildState) QueueTarget(label, dependent BuildLabel, forceBuild bool) error {
+	return state.queueTarget(label, dependent, forceBuild, false)
 }
 
-func (state *BuildState) queueTarget(label, dependent BuildLabel, rescan, forceBuild, neededForSubinclude bool) error {
+func (state *BuildState) queueTarget(label, dependent BuildLabel, forceBuild, neededForSubinclude bool) error {
 	target := state.Graph.Target(label)
 	if target == nil {
 		// If the package isn't loaded yet, we need to queue a parse for it.
@@ -856,14 +856,14 @@ func (state *BuildState) queueTarget(label, dependent BuildLabel, rescan, forceB
 		}
 	}
 	if dependent.IsAllTargets() || dependent == OriginalTarget {
-		return state.queueResolvedTarget(target, rescan, forceBuild, neededForSubinclude)
+		return state.queueResolvedTarget(target, forceBuild, neededForSubinclude)
 	}
 	for _, l := range target.ProvideFor(state.Graph.TargetOrDie(dependent)) {
 		if l == label {
-			if err := state.queueResolvedTarget(target, rescan, forceBuild, neededForSubinclude); err != nil {
+			if err := state.queueResolvedTarget(target, forceBuild, neededForSubinclude); err != nil {
 				return err
 			}
-		} else if err := state.queueTarget(l, dependent, rescan, forceBuild, neededForSubinclude); err != nil {
+		} else if err := state.queueTarget(l, dependent, forceBuild, neededForSubinclude); err != nil {
 			return err
 		}
 	}
@@ -885,9 +885,9 @@ func (state *BuildState) queueTestTarget(target *BuildTarget) {
 }
 
 // queueResolvedTarget is like queueTarget but once we have a resolved target.
-func (state *BuildState) queueResolvedTarget(target *BuildTarget, rescan, forceBuild, neededForSubinclude bool) error {
+func (state *BuildState) queueResolvedTarget(target *BuildTarget, forceBuild, neededForSubinclude bool) error {
 	target.NeededForSubinclude = target.NeededForSubinclude || neededForSubinclude
-	if target.State() >= Active && !rescan && !forceBuild {
+	if target.State() >= Active && !forceBuild {
 		return nil // Target is already tagged to be built and likely on the queue.
 	}
 
@@ -904,7 +904,7 @@ func (state *BuildState) queueResolvedTarget(target *BuildTarget, rescan, forceB
 		}
 		// Actual queuing stuff now happens asynchronously in here.
 		atomic.AddInt64(&state.progress.numPending, 1)
-		go state.queueTargetAsync(target, rescan, forceBuild, shouldBuild)
+		go state.queueTargetAsync(target, forceBuild, shouldBuild)
 	}
 
 	// Here we want to ensure we don't queue the target every time; ideally we only do it once.
@@ -921,10 +921,10 @@ func (state *BuildState) queueResolvedTarget(target *BuildTarget, rescan, forceB
 }
 
 // queueTarget enqueues a target's dependencies and the target itself once they are done.
-func (state *BuildState) queueTargetAsync(target *BuildTarget, rescan, forceBuild, building bool) {
+func (state *BuildState) queueTargetAsync(target *BuildTarget, forceBuild, building bool) {
 	defer state.taskDone(true)
 	for _, dep := range target.DeclaredDependencies() {
-		if err := state.queueTarget(dep, target.Label, rescan, forceBuild, false); err != nil {
+		if err := state.queueTarget(dep, target.Label, forceBuild, false); err != nil {
 			state.asyncError(dep, err)
 			return
 		}
@@ -933,7 +933,7 @@ func (state *BuildState) queueTargetAsync(target *BuildTarget, rescan, forceBuil
 		called := false
 		if err := target.resolveDependencies(state.Graph, func(t *BuildTarget) error {
 			called = true
-			return state.queueResolvedTarget(t, rescan, forceBuild, false)
+			return state.queueResolvedTarget(t, forceBuild, false)
 		}); err != nil {
 			state.asyncError(target.Label, err)
 			return

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -98,7 +98,7 @@ func TestAddDepsToTarget(t *testing.T) {
 	target1 := addTargetDeps(state, pkg, "//src/core:target1", "//src/core:target2")
 	target2 := addTargetDeps(state, pkg, "//src/core:target2")
 	state.Graph.AddPackage(pkg)
-	state.QueueTarget(target1.Label, OriginalTarget, false, false)
+	state.QueueTarget(target1.Label, OriginalTarget, false)
 	task := <-builds
 	assert.Equal(t, target2.Label, task)
 	// Now simulate target2 being built and adding a new dep to target1 in its post-build function.

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -756,7 +756,7 @@ func addDatumToTargetAndMaybeQueue(s *scope, target *core.BuildTarget, datum cor
 	target.AddDatum(datum)
 	// Queue this dependency if it'll be needed.
 	if l, ok := datum.Label(); ok && target.State() > core.Inactive {
-		err := s.state.QueueTarget(l, target.Label, true, false)
+		err := s.state.QueueTarget(l, target.Label, false)
 		s.Assert(err == nil, "%s", err)
 	}
 }
@@ -765,7 +765,7 @@ func addNamedDatumToTargetAndMaybeQueue(s *scope, name string, target *core.Buil
 	target.AddNamedDatum(name, datum)
 	// Queue this dependency if it'll be needed.
 	if l, ok := datum.Label(); ok && target.State() > core.Inactive {
-		err := s.state.QueueTarget(l, target.Label, true, false)
+		err := s.state.QueueTarget(l, target.Label, false)
 		s.Assert(err == nil, "%s", err)
 	}
 }
@@ -803,9 +803,6 @@ func addData(s *scope, args []pyObject) pyObject {
 	} else {
 		log.Fatal("Unrecognised data type passed to add_data")
 	}
-
-	// TODO(peterebden): Do we even need the following any more?
-	s.pkg.MarkTargetModified(target)
 	return None
 }
 

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -746,7 +746,7 @@ func addDep(s *scope, args []pyObject) pyObject {
 	target.AddMaybeExportedDependency(dep, exported, false, false)
 	// Queue this dependency if it'll be needed.
 	if target.State() > core.Inactive {
-		err := s.state.QueueTarget(dep, target.Label, true, false)
+		err := s.state.QueueTarget(dep, target.Label, false)
 		s.Assert(err == nil, "%s", err)
 	}
 	return None

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -169,7 +169,6 @@ func buildRule(s *scope, args []pyObject) pyObject {
 	s.state.AddTarget(s.pkg, target)
 	if s.Callback {
 		target.AddedPostBuild = true
-		s.pkg.MarkTargetModified(target)
 	}
 	return pyString(":" + target.Label.Name)
 }
@@ -750,8 +749,6 @@ func addDep(s *scope, args []pyObject) pyObject {
 		err := s.state.QueueTarget(dep, target.Label, true, false)
 		s.Assert(err == nil, "%s", err)
 	}
-	// TODO(peterebden): Do we even need the following any more?
-	s.pkg.MarkTargetModified(target)
 	return None
 }
 

--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -115,7 +115,7 @@ func (p *aspParser) runBuildFunction(tid int, state *core.BuildState, target *co
 		state.LogBuildError(tid, target.Label, core.ParseFailed, err, "Failed %s-build function for %s", callbackType, target.Label)
 		return err
 	}
-	state.LogBuildResult(tid, target.Label, core.TargetBuilding, fmt.Sprintf("Finished %s-build function for %s", callbackType, target.Label))
+	state.LogBuildResult(tid, target, core.TargetBuilding, fmt.Sprintf("Finished %s-build function for %s", callbackType, target.Label))
 	return nil
 }
 

--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -111,17 +111,12 @@ func (p *aspParser) BuildRuleArgOrder() map[string]int {
 // runBuildFunction runs either the pre- or post-build function.
 func (p *aspParser) runBuildFunction(tid int, state *core.BuildState, target *core.BuildTarget, callbackType string, f func() error) error {
 	state.LogBuildResult(tid, target, core.PackageParsing, fmt.Sprintf("Running %s-build function for %s", callbackType, target.Label))
-	pkg := state.SyncParsePackage(target.Label)
-	changed, err := pkg.EnterBuildCallback(f)
-	if err != nil {
+	if err := f(); err != nil {
 		state.LogBuildError(tid, target.Label, core.ParseFailed, err, "Failed %s-build function for %s", callbackType, target.Label)
-	} else {
-		if err := rescanDeps(state, changed); err != nil {
-			return err
-		}
-		state.LogBuildResult(tid, target, core.TargetBuilding, fmt.Sprintf("Finished %s-build function for %s", callbackType, target.Label))
+		return err
 	}
-	return err
+	state.LogBuildResult(tid, target.Label, core.TargetBuilding, fmt.Sprintf("Finished %s-build function for %s", callbackType, target.Label))
+	return nil
 }
 
 func createBazelSubrepo(state *core.BuildState) {

--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -111,6 +111,7 @@ func (p *aspParser) BuildRuleArgOrder() map[string]int {
 // runBuildFunction runs either the pre- or post-build function.
 func (p *aspParser) runBuildFunction(tid int, state *core.BuildState, target *core.BuildTarget, callbackType string, f func() error) error {
 	state.LogBuildResult(tid, target, core.PackageParsing, fmt.Sprintf("Running %s-build function for %s", callbackType, target.Label))
+	state.SyncParsePackage(target.Label)
 	if err := f(); err != nil {
 		state.LogBuildError(tid, target.Label, core.ParseFailed, err, "Failed %s-build function for %s", callbackType, target.Label)
 		return err

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -157,7 +157,7 @@ func activateTarget(tid int, state *core.BuildState, pkg *core.Package, label, d
 					// Must always do this for coverage because we need to calculate sources of
 					// non-test targets later on.
 					if !state.NeedTests || target.IsTest() || state.NeedCoverage {
-						if err := state.QueueTarget(target.Label, dependent, false, dependent.IsAllTargets()); err != nil {
+						if err := state.QueueTarget(target.Label, dependent, dependent.IsAllTargets()); err != nil {
 							return err
 						}
 					}
@@ -167,7 +167,7 @@ func activateTarget(tid int, state *core.BuildState, pkg *core.Package, label, d
 	} else {
 		for _, l := range state.Graph.DependentTargets(dependent, label) {
 			// We use :all to indicate a dependency needed for parse.
-			if err := state.QueueTarget(l, dependent, false, forSubinclude || dependent.IsAllTargets()); err != nil {
+			if err := state.QueueTarget(l, dependent, forSubinclude || dependent.IsAllTargets()); err != nil {
 				return err
 			}
 		}

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -242,18 +242,6 @@ func buildFileName(state *core.BuildState, pkgName string, subrepo *core.Subrepo
 	return "", pkgName
 }
 
-func rescanDeps(state *core.BuildState, changed map[*core.BuildTarget]struct{}) error {
-	// Run over all the changed targets in this package and ensure that any newly added dependencies enter the build queue.
-	for target := range changed {
-		if s := target.State(); s < core.Built && s > core.Inactive {
-			if err := state.QueueTarget(target.Label, core.OriginalTarget, true, false); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // exportFile adds a single-file export target. This is primarily used for Bazel compat.
 func exportFile(state *core.BuildState, pkg *core.Package, label core.BuildLabel) {
 	t := core.NewBuildTarget(label)

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -103,7 +103,7 @@ func TestAddDepRescan(t *testing.T) {
 	assertPendingBuilds(t, state) // Note that the earlier call to assertPendingBuilds cleared it.
 
 	// Now running this should activate it
-	rescanDeps(state, map[*core.BuildTarget]struct{}{target1: {}})
+	//rescanDeps(state, map[*core.BuildTarget]struct{}{target1: {}})
 	time.Sleep(time.Millisecond * 100)
 
 	assertPendingBuilds(t, state, "//package1:target4")

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -103,7 +103,7 @@ func TestAddDepRescan(t *testing.T) {
 	assertPendingBuilds(t, state) // Note that the earlier call to assertPendingBuilds cleared it.
 
 	// Now running this should activate it
-	//rescanDeps(state, map[*core.BuildTarget]struct{}{target1: {}})
+	// rescanDeps(state, map[*core.BuildTarget]struct{}{target1: {}})
 	time.Sleep(time.Millisecond * 100)
 
 	assertPendingBuilds(t, state, "//package1:target4")

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -98,7 +98,7 @@ func TestAddDepRescan(t *testing.T) {
 	target1.AddDependency(buildLabel("//package1:target4"))
 
 	// Fake test: calling this now should have no effect because rescan is not true.
-	state.QueueTarget(buildLabel("//package1:target1"), core.OriginalTarget, false, false)
+	state.QueueTarget(buildLabel("//package1:target1"), core.OriginalTarget, false)
 	assertPendingParses(t, state)
 	assertPendingBuilds(t, state) // Note that the earlier call to assertPendingBuilds cleared it.
 


### PR DESCRIPTION
I don't think this is necessary any more. With the newer dependency setup they should be triggered as needed.

Haven't been able to test much locally due to my machine basically just refusing to do things (Eset really is a horrible piece of shit...) but we'll see what CircleCI says.