### PR TITLE
Set a reasonable timeout on xml test result upload

### DIFF
--- a/src/test/xml_results.go
+++ b/src/test/xml_results.go
@@ -20,7 +20,7 @@ import (
 )
 
 var client = &http.Client{
-	Timeout: time.Minute,
+	Timeout: 5*time.Minute,
 }
 
 func looksLikeJUnitXMLTestResults(b []byte) bool {

--- a/src/test/xml_results.go
+++ b/src/test/xml_results.go
@@ -20,7 +20,7 @@ import (
 )
 
 var client = &http.Client{
-	Timeout: 5*time.Minute,
+	Timeout: time.Minute,
 }
 
 func looksLikeJUnitXMLTestResults(b []byte) bool {

--- a/src/test/xml_results.go
+++ b/src/test/xml_results.go
@@ -19,6 +19,10 @@ import (
 	"github.com/thought-machine/please/src/core"
 )
 
+var client = &http.Client{
+	Timeout: time.Minute,
+}
+
 func looksLikeJUnitXMLTestResults(b []byte) bool {
 	return bytes.HasPrefix(b, []byte{'<', '?', 'x', 'm', 'l'}) || bytes.HasPrefix(b, []byte{'<', 't', 'e', 's', 't'})
 }
@@ -457,7 +461,7 @@ func uploadResults(target *core.BuildTarget, url string, gzipped, storeOutputOnS
 	}
 	req.Header["Content-Type"] = []string{"application/xml"}
 	req.Header["Content-Encoding"] = []string{enc}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("Failed to upload test results: %s", err)
 	}


### PR DESCRIPTION
I'm allowing a bit of time for slower networks here as it's not configurable. I guess we could set this lower if we made it configurable, however if it takes more than a min, that would be cripplingly slow. 