### PR TITLE
Added condition to set no linker flags for macOS for pip_cmd

### DIFF
--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -373,9 +373,12 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None,
 
     pip_tool = "$TOOLS_PIP" if CONFIG.PIP_TOOL else '$TOOLS_PYTHON -m pip'
 
+    # Unset these compiler and linker flags as macOS doesn't have all these options.
+    pip_compile_flags = 'CFLAGS=" -Wl,--build-id=none -g0 " LDFLAGS=" -Wl,--build-id=none "' if CONFIG.HOSTOS != 'darwin' else ''
+
     pip_cmd = (
         f'mkdir {pip_target_dir} && '
-        f'PIP_CONFIG_FILE=/dev/null  CFLAGS=" -Wl,--build-id=none -g0 " LDFLAGS=" -Wl,--build-id=none " {pip_tool} install --isolated --no-deps --prefix= --no-compile '
+        f'PIP_CONFIG_FILE=/dev/null {pip_compile_flags} {pip_tool} install --isolated --no-deps --prefix= --no-compile '
         f'--no-cache-dir --default-timeout=60 --target={target}'
     )
 

--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -374,7 +374,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None,
     pip_tool = "$TOOLS_PIP" if CONFIG.PIP_TOOL else '$TOOLS_PYTHON -m pip'
 
     # Unset these compiler and linker flags as macOS doesn't have all these options.
-    pip_compile_flags = 'CFLAGS=" -Wl,--build-id=none -g0 " LDFLAGS=" -Wl,--build-id=none "' if CONFIG.HOSTOS != 'darwin' else ''
+    pip_compile_flags = 'CFLAGS=" -Wl,--build-id=none -g0 " LDFLAGS=" -Wl,--build-id=none"' if CONFIG.HOSTOS != 'darwin' else 'CFLAGS=" -g0"'
 
     pip_cmd = (
         f'mkdir {pip_target_dir} && '

--- a/test/python_rules/BUILD
+++ b/test/python_rules/BUILD
@@ -215,3 +215,13 @@ plz_e2e_test(
     labels = ["py3"],
     deps = ["//third_party/python:grpcio"],
 )
+
+python_test(
+    name = "cx_oracle_darwin_build_test",
+    srcs = ["cx_oracle_darwin_build_test.py"],
+    labels = [
+        "py3",
+        "pip",
+    ],
+    deps = ["//third_party/python:cx_oracle"],
+)

--- a/test/python_rules/cx_oracle_darwin_build_test.py
+++ b/test/python_rules/cx_oracle_darwin_build_test.py
@@ -2,10 +2,10 @@ import time
 import unittest
 
 
-class TensorflowTest(unittest.TestCase):
+class CxOracleTest(unittest.TestCase):
 
     def test_import(self):
         start = time.time()
         import cx_Oracle
         end = time.time()
-        print('Imported tensorflow version %s in %0.2fs' % (cx_Oracle.__version__, end - start))
+        print('Imported cx_Oracle version %s in %0.2fs' % (cx_Oracle.__version__, end - start))

--- a/test/python_rules/cx_oracle_darwin_build_test.py
+++ b/test/python_rules/cx_oracle_darwin_build_test.py
@@ -1,0 +1,11 @@
+import time
+import unittest
+
+
+class TensorflowTest(unittest.TestCase):
+
+    def test_import(self):
+        start = time.time()
+        import cx_Oracle
+        end = time.time()
+        print('Imported tensorflow version %s in %0.2fs' % (cx_Oracle.__version__, end - start))

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -448,3 +448,9 @@ pip_library(
     name = "progress",
     version = "1.5",
 )
+
+pip_library(
+    name = "cx_oracle",
+    package_name = "cx-Oracle",
+    version = "8.2.1"
+)


### PR DESCRIPTION
This PR seeks to address #2007 by primarily adding an additional check of the OS for darwin and for the time being removes the CFLAGS and LD_FLAGS just for macOS specifically.

Feedback would be welcome on whether to look into alternative flags that might be used to achieve a similar result as it does on Linux.

Also, feedback welcome on whether additional tests are needed to capture the issue introduced in #2007 