### PR TITLE
Use the os.SameFile for cross platform support

### DIFF
--- a/src/fs/fs.go
+++ b/src/fs/fs.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"syscall"
 
 	"github.com/thought-machine/please/src/process"
 
@@ -64,24 +63,21 @@ func IsSymlink(filename string) bool {
 	return err == nil && (info.Mode()&os.ModeSymlink) != 0
 }
 
-// IsSameFile returns true if two filenames describe the same underlying file (i.e. inode)
+// IsSameFile returns true if two filenames describe the same underlying file
+// (i.e. inode for Unix and potentially file path names for other OS's)
 func IsSameFile(a, b string) bool {
-	i1, err1 := getInode(a)
-	i2, err2 := getInode(b)
-	return err1 == nil && err2 == nil && i1 == i2
+	i1, err1 := getFileInfo(a)
+	i2, err2 := getFileInfo(b)
+	return err1 == nil && err2 == nil && os.SameFile(i1, i2)
 }
 
-// getInode returns the inode of a file.
-func getInode(filename string) (uint64, error) {
+// getFileInfo returns the FileInfo of a file.
+func getFileInfo(filename string) (os.FileInfo, error) {
 	fi, err := os.Stat(filename)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	s, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		return 0, fmt.Errorf("Not a syscall.Stat_t")
-	}
-	return s.Ino, nil
+	return fi, nil
 }
 
 // CopyFile copies a file from 'from' to 'to', with an attempt to perform a copy & rename


### PR DESCRIPTION
In order to help enable better cross platform support (i.e. Windows) I'm trying to figure out what may already be built into existing libraries to enable that.

inode is not a concept in Windows, and I noticed the `os.SameFile` call seems it should be doing the same thing
```
SameFile reports whether fi1 and fi2 describe the same file. For example, on Unix this means that the device and inode fields of the two underlying structures are identical; on other systems the decision may be based on the path names. SameFile only applies to results returned by this package's Stat. It returns false in other cases.
```

It probably makes more sense to use this instead since it defers OS level checks to the library