### PR TITLE
Cleanup output code a bit

### DIFF
--- a/src/output/interactive_display_test.go
+++ b/src/output/interactive_display_test.go
@@ -7,28 +7,28 @@ import (
 )
 
 func TestLimitedPrintfSimple(t *testing.T) {
-	var d displayer
+	var d interactiveDisplay
 	assert.Equal(t, "wibble wobble", d.lprintfPrepare(20, "wibble wobble"))
 }
 
 func TestLimitedPrintfMore(t *testing.T) {
-	var d displayer
+	var d interactiveDisplay
 	assert.Equal(t, "wibble ...", d.lprintfPrepare(10, "wibble wobble"))
 }
 
 func TestLimitedPrintfAnsi(t *testing.T) {
-	var d displayer
+	var d interactiveDisplay
 	// Should be unchanged because without escape sequences it's under the limit.
 	assert.Equal(t, "\x1b[30mwibble wobble\x1b[1m", d.lprintfPrepare(20, "\x1b[30mwibble wobble\x1b[1m"))
 }
 
 func TestLimitedPrintfAnsiNotCountedWhenReducing(t *testing.T) {
-	var d displayer
+	var d interactiveDisplay
 	assert.Equal(t, "\x1b[30mwibble ...\x1b[1m", d.lprintfPrepare(10, "\x1b[30mwibble wobble\x1b[1m"))
 }
 
 func TestNewlinesStillWritte(t *testing.T) {
-	var d displayer
+	var d interactiveDisplay
 	// Test that newline still gets written (it doesn't count as horizontal space and is Very Important)
 	assert.Equal(t, "\x1b[30mwibble ...\x1b[1m\n", d.lprintfPrepare(10, "\x1b[30mwibble wobble\x1b[1m\n"))
 }

--- a/src/please.go
+++ b/src/please.go
@@ -1006,13 +1006,11 @@ func runPlease(state *core.BuildState, targets []core.BuildLabel) {
 	state.Results() // important this is called now, don't ask...
 	var wg sync.WaitGroup
 	wg.Add(1)
-	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		output.MonitorState(ctx, state, !pretty, detailedTests, streamTests, string(opts.OutputFlags.TraceFile))
+		output.MonitorState(state, !pretty, detailedTests, streamTests, string(opts.OutputFlags.TraceFile))
 		wg.Done()
 	}()
 	plz.Run(targets, opts.BuildFlags.PreTargets, state, config, state.TargetArch)
-	cancel()
 	wg.Wait()
 }
 


### PR DESCRIPTION
I have some other ideas in this space but this is enough for one PR.

Basically this encapsulates the interactive / plain display logic in a little interface, and handles all the updates on one goroutine (previously there were two with some slightly shonky data sharing between them).
It simplifies the lifetime of it by having it terminate when the results channel is closed & removing the context (so one less thing to keep track of).