### PR TITLE
Add go_benchmark documentation to the docs

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -1163,6 +1163,7 @@
   {{ template "lexicon_entry.html" .Named "cgo_library" }}
   {{ template "lexicon_entry.html" .Named "go_binary" }}
   {{ template "lexicon_entry.html" .Named "go_test" }}
+  {{ template "lexicon_entry.html" .Named "go_benchmark" }}
   {{ template "lexicon_entry.html" .Named "cgo_test" }}
   {{ template "lexicon_entry.html" .Named "go_test_main" }}
   {{ template "lexicon_entry.html" .Named "go_module" }}

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -847,14 +847,15 @@ def go_test_main(name:str, srcs:list, test_package:str="", test_only:bool=False,
     a separate go_library rule.
 
     Args:
-      name: Name of the rule
-      srcs: Source .go files that define the tests.
-      test_package: This is the import path of the package to be tested. Defaults to the import path of the current
+      name (str): Name of the rule
+      srcs (list): Source .go files that define the tests.
+      test_package (str): This is the import path of the package to be tested. Defaults to the import path of the current
                     directory.
-      test_only: If True, can only be consumed by tests (or other test_only rules).
-      deps: Any additional dependencies
-      visibility: Visibility of the rule.
-      labels: Any labels to apply to this rule.
+      test_only (bool): If True, can only be consumed by tests (or other test_only rules).
+      deps (list): Any additional dependencies
+      visibility (list): Visibility of the rule.
+      benchmark (bool): If True, it will run benchmarks instead of tests.
+      labels (list): Any labels to apply to this rule.
     """
     test_package = test_package or _get_import_path()
     external_flag = " --external" if external else ""


### PR DESCRIPTION
This change adds `go_benchmark` to the documentation. Also tweaks the doc strings.