### PR TITLE
More output refactoring

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1190,13 +1190,18 @@ func (s BuildResultStatus) Category() string {
 	switch s {
 	case PackageParsing, PackageParsed, ParseFailed:
 		return "Parse"
-	case TargetBuilding, TargetBuildStopped, TargetBuilt, TargetBuildFailed:
+	case TargetBuilding, TargetBuildStopped, TargetBuilt, TargetCached, TargetBuildFailed:
 		return "Build"
 	case TargetTesting, TargetTestStopped, TargetTested, TargetTestFailed:
 		return "Test"
 	default:
 		return "Other"
 	}
+}
+
+// IsParse returns true if this status is a parse event
+func (s BuildResultStatus) IsParse() bool {
+	return s == PackageParsing || s == PackageParsed || s == ParseFailed
 }
 
 // IsFailure returns true if this status represents a failure.

--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -99,9 +99,11 @@ func (d *interactiveDisplay) Update(targets []buildingTarget) {
 
 // moveToFirstLine resets back to the first line.
 func (d *interactiveDisplay) moveToFirstLine() {
-	d.printf("\x1b[%dA", d.lines)
-	d.lastLines = d.lines
-	d.lines = 0
+	if d.lines > 0 {
+		d.printf("\x1b[%dA", d.lines)
+		d.lastLines = d.lines
+		d.lines = 0
+	}
 }
 
 func (d *interactiveDisplay) printLines(targets []buildingTarget) {

--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -29,7 +29,6 @@ func setupDisplayer(state *core.BuildState, plain bool) displayer {
 		return &plainDisplay{state: state}
 	}
 	cli.CurrentBackend.SetPassthrough(false, state.Config.Display.MaxWorkers)
-	defer cli.CurrentBackend.SetPassthrough(true, state.Config.Display.MaxWorkers)
 	return &interactiveDisplay{
 		state:      state,
 		numWorkers: state.Config.Please.NumThreads,
@@ -78,6 +77,7 @@ func (d *interactiveDisplay) Close() {
 	d.moveToFirstLine()
 	d.printf("${CLEAR_END}")
 	d.flush()
+	cli.CurrentBackend.SetPassthrough(true, d.state.Config.Display.MaxWorkers)
 }
 
 func (d *interactiveDisplay) Frequency() time.Duration {

--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -19,7 +19,7 @@ var terminalClaimsToBeXterm = strings.HasPrefix(os.Getenv("TERM"), "xterm")
 
 // A displayer is the interface to display things on screen while a build is running.
 type displayer interface {
-	Update(targets []buildingTarget)
+	Update(local, remote []buildingTarget)
 	Close()
 	Frequency() time.Duration
 }
@@ -43,14 +43,20 @@ type plainDisplay struct {
 	state *core.BuildState
 }
 
-func (d *plainDisplay) Update(targets []buildingTarget) {
+func (d *plainDisplay) Update(local, remote []buildingTarget) {
+	localbusy := countActive(local)
+	remotebusy := countActive(remote)
+	log.Notice("Build running for %s, %d / %d tasks done, %s busy", time.Since(d.state.StartTime).Round(time.Second), d.state.NumDone(), d.state.NumActive(), pluralise(localbusy+remotebusy, "worker", "workers"))
+}
+
+func countActive(targets []buildingTarget) int {
 	busy := 0
 	for _, t := range targets {
 		if t.Active {
 			busy++
 		}
 	}
-	log.Notice("Build running for %s, %d / %d tasks done, %s busy", time.Since(d.state.StartTime).Round(time.Second), d.state.NumDone(), d.state.NumActive(), pluralise(busy, "worker", "workers"))
+	return busy
 }
 
 func (d *plainDisplay) Frequency() time.Duration {
@@ -78,10 +84,10 @@ func (d *interactiveDisplay) Frequency() time.Duration {
 	return 50 * time.Millisecond
 }
 
-func (d *interactiveDisplay) Update(targets []buildingTarget) {
+func (d *interactiveDisplay) Update(local, remote []buildingTarget) {
 	d.maxRows, d.maxCols = cli.CurrentBackend.MaxDimensions()
 	d.moveToFirstLine()
-	d.printLines(targets)
+	d.printLines(local, remote)
 	for _, line := range cli.CurrentBackend.Output() {
 		d.printf("${ERASE_AFTER}%s\n", line)
 		d.lines++
@@ -106,7 +112,7 @@ func (d *interactiveDisplay) moveToFirstLine() {
 	}
 }
 
-func (d *interactiveDisplay) printLines(targets []buildingTarget) {
+func (d *interactiveDisplay) printLines(local, remote []buildingTarget) {
 	now := time.Now()
 	d.printf("Building [%d/%d, %3.1fs]:\n", d.state.NumDone(), d.state.NumActive(), time.Since(d.state.StartTime).Seconds())
 	d.lines++
@@ -127,15 +133,15 @@ func (d *interactiveDisplay) printLines(targets []buildingTarget) {
 	workers := 0
 	anyRemote := d.numRemote > 0
 	for i := 0; i < d.numWorkers && i < d.maxRows && workers < d.maxWorkers; i++ {
-		workers += d.printRow(&targets[i], now, anyRemote)
+		workers += d.printRow(&local[i], now, anyRemote)
 		d.lines++
 	}
 	if anyRemote {
-		active := d.numRemoteActive(targets)
+		active := countActive(remote)
 		d.printf("Remote processes [%3d/%3d active]:   ${ERASE_AFTER}\n", active, d.numRemote)
 		d.lines++
 		for i := 0; i < d.numRemote && d.lines < d.maxRows && workers < d.maxWorkers; i++ {
-			workers += d.printRow(&targets[d.numWorkers+i], now, true)
+			workers += d.printRow(&remote[i], now, true)
 			d.lines++
 		}
 		if workers < active {
@@ -144,16 +150,6 @@ func (d *interactiveDisplay) printLines(targets []buildingTarget) {
 		}
 	}
 	d.printf("${RESET}")
-}
-
-func (d *interactiveDisplay) numRemoteActive(targets []buildingTarget) int {
-	count := 0
-	for i := 0; i < d.numRemote; i++ {
-		if targets[d.numWorkers+i].Active {
-			count++
-		}
-	}
-	return count
 }
 
 func (d *interactiveDisplay) printRow(target *buildingTarget, now time.Time, remote bool) int {

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -62,7 +62,7 @@ loop:
 				os.Stdout.Write([]byte{'\n'})
 			}
 		case <-t.C:
-			displayer.Update(bt.Targets)
+			displayer.Update(bt.Targets())
 		}
 	}
 	displayer.Close()

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -24,43 +25,27 @@ import (
 const durationGranularity = 10 * time.Millisecond
 const testDurationGranularity = time.Millisecond
 
-// Used to track currently building targets.
-type buildingTarget struct {
-	Label        core.BuildLabel
-	Started      time.Time
-	Finished     time.Time
-	Description  string
-	Err          error
-	Colour       string
-	Target       *core.BuildTarget
-	Eta          time.Duration
-	Active       bool
-	Failed       bool
-	Cached       bool
-	LastProgress float32
-}
-
 // MonitorState monitors the build while it's running and prints output until the results
 // channel of state has completed.
 func MonitorState(state *core.BuildState, plainOutput, detailedTests, streamTestResults bool, traceFile string) {
 	initPrintf(state.Config)
-	failedTargetMap := map[core.BuildLabel]error{}
-	buildingTargets := make([]buildingTarget, state.Config.Please.NumThreads+state.Config.NumRemoteExecutors())
 
 	if len(state.Config.Please.Motd) != 0 {
 		r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 		printf("%s\n", state.Config.Please.Motd[r.Intn(len(state.Config.Please.Motd))])
 	}
 
-	tw := newTraceWriter(traceFile)
-	defer tw.Close()
+	var tw *traceWriter
+	if traceFile != "" {
+		tw = newTraceWriter(traceFile)
+		defer tw.Close()
+	}
 
 	displayer := setupDisplayer(state, plainOutput)
 	t := time.NewTicker(displayer.Frequency())
-	results := state.Results()
 	defer t.Stop()
-	failedTargets := []core.BuildLabel{}
-	failedNonTests := []core.BuildLabel{}
+	results := state.Results()
+	bt := newBuildingTargets(state, plainOutput)
 loop:
 	for {
 		select {
@@ -68,16 +53,23 @@ loop:
 			if !ok || (state.DebugTests && result.Status == core.TargetTesting) {
 				break loop
 			}
-			processResult(state, result, buildingTargets, plainOutput, &failedTargets, &failedNonTests, failedTargetMap, tw, streamTestResults)
+			prev := bt.ProcessResult(result)
+			if tw != nil && !result.Status.IsParse() {
+				tw.AddTrace(result, prev, result.Status.IsActive())
+			}
+			if streamTestResults && (result.Status == core.TargetTested || result.Status == core.TargetTestFailed) {
+				os.Stdout.Write(test.SerialiseResultsToXML(state.Graph.TargetOrDie(result.Label), false, state.Config.Test.StoreTestOutputOnSuccess))
+				os.Stdout.Write([]byte{'\n'})
+			}
 		case <-t.C:
-			displayer.Update(buildingTargets)
+			displayer.Update(bt.Targets)
 		}
 	}
 	displayer.Close()
 
 	duration := time.Since(state.StartTime).Round(durationGranularity)
-	if len(failedNonTests) > 0 { // Something failed in the build step.
-		printFailedBuildResults(failedNonTests, failedTargetMap, duration)
+	if len(bt.FailedNonTests) > 0 { // Something failed in the build step.
+		printFailedBuildResults(bt.FailedNonTests, bt.FailedTargets, duration)
 		return
 	}
 	if state.NeedBuild {
@@ -87,16 +79,16 @@ loop:
 				log.Fatalf("Target %s doesn't exist in build graph", label)
 			} else if (state.NeedHashesOnly || state.PrepareOnly || state.PrepareShell) && target.State() == core.Stopped {
 				// Do nothing, we will output about this shortly.
-			} else if target.State() < core.Built && len(failedTargetMap) == 0 && !target.AddedPostBuild {
+			} else if target.State() < core.Built && len(bt.FailedTargets) == 0 && !target.AddedPostBuild {
 				log.Fatalf("Target %s hasn't built but we have no pending tasks left.\n%s", label, unbuiltTargetsMessage(state.Graph))
 			}
 		}
 	}
-	if state.NeedBuild && len(failedNonTests) == 0 {
+	if state.NeedBuild && len(bt.FailedNonTests) == 0 {
 		if state.PrepareOnly || state.PrepareShell {
 			printTempDirs(state, duration)
 		} else if state.NeedTests { // Got to the test phase, report their results.
-			printTestResults(state, failedTargets, failedTargetMap, duration, detailedTests)
+			printTestResults(state, bt.FailedTargets, duration, detailedTests)
 		} else if state.NeedHashesOnly {
 			printHashes(state, duration)
 		} else if !state.NeedRun { // Must be plz build or similar, report build outputs.
@@ -153,68 +145,19 @@ func yesNo(b bool) string {
 	return "no"
 }
 
-func processResult(state *core.BuildState, result *core.BuildResult, buildingTargets []buildingTarget, plainOutput bool,
-	failedTargets, failedNonTests *[]core.BuildLabel, failedTargetMap map[core.BuildLabel]error, tw *traceWriter, streamTestResults bool) {
-	label := result.Label
-	active := result.Status.IsActive()
-	failed := result.Status.IsFailure()
-	cached := result.Status == core.TargetCached || result.Tests.Cached
-	stopped := result.Status == core.TargetBuildStopped
-	parse := result.Status == core.PackageParsing || result.Status == core.PackageParsed || result.Status == core.ParseFailed
-	// Parse events can overlap in weird ways that mess up the display.
-	if !parse {
-		tw.AddTrace(result, buildingTargets[result.ThreadID].Label, active)
-	}
-	target := state.Graph.Target(label)
-	if !parse { // Parse tasks happen on a different set of threads.
-		updateTarget(state, plainOutput, &buildingTargets[result.ThreadID], label, active, failed, cached, result.Description, result.Err, targetColour(target), target)
-	}
-	if failed {
-		failedTargetMap[label] = result.Err
-		// Don't stop here after test failure, aggregate them for later.
-		if result.Status != core.TargetTestFailed {
-			// Reset colour so the entire compiler error output doesn't appear red.
-			log.Errorf("%s failed:\x1b[0m\n%s", result.Label, shortError(result.Err))
-			state.Stop()
-		} else if msg := shortError(result.Err); msg != "" {
-			log.Errorf("%s failed: %s", result.Label, msg)
-		} else {
-			log.Errorf("%s failed", result.Label)
-		}
-		*failedTargets = append(*failedTargets, label)
-		if result.Status != core.TargetTestFailed {
-			*failedNonTests = append(*failedNonTests, label)
-		}
-	} else if stopped {
-		failedTargetMap[result.Label] = nil
-	} else if plainOutput && state.ShowTestOutput && result.Status == core.TargetTested && target != nil {
-		// If using interactive output we'll print it afterwards.
-		for _, testCase := range target.Test.Results.TestCases {
-			printf("Finished test %s:\n", testCase.Name)
-			for _, testExecution := range testCase.Executions {
-				showExecutionOutput(testExecution)
-			}
-		}
-	}
-	if streamTestResults && (result.Status == core.TargetTested || result.Status == core.TargetTestFailed) {
-		os.Stdout.Write(test.SerialiseResultsToXML(target, false, state.Config.Test.StoreTestOutputOnSuccess))
-		os.Stdout.Write([]byte{'\n'})
-	}
-}
-
-func printTestResults(state *core.BuildState, failedTargets []core.BuildLabel, failedTargetsMap map[core.BuildLabel]error, duration time.Duration, detailed bool) {
+func printTestResults(state *core.BuildState, failedTargets map[core.BuildLabel]error, duration time.Duration, detailed bool) {
 	if len(failedTargets) > 0 {
-		done := map[core.BuildLabel]bool{}
-		for _, failed := range failedTargets {
-			if done[failed] {
-				continue
-			}
-			done[failed] = true
+		targets := make(core.BuildLabels, 0, len(failedTargets))
+		for t := range failedTargets {
+			targets = append(targets, t)
+		}
+		sort.Sort(targets)
+		for _, failed := range targets {
 			target := state.Graph.TargetOrDie(failed)
 			if target.Test.Results.Failures() == 0 && target.Test.Results.Errors() == 0 {
 				if target.Test.Results.TimedOut {
 				} else {
-					err := failedTargetsMap[target.Label]
+					err := failedTargets[failed]
 					printf("${WHITE_ON_RED}Fail:${RED_NO_BG} %s ${WHITE_ON_RED}Failed to run test${RESET}: %v\n", target.Label, err)
 					target.Test.Results.TestCases = append(target.Test.Results.TestCases, core.TestCase{
 						Executions: []core.TestExecution{
@@ -524,57 +467,6 @@ func printFailedBuildResults(failedTargets []core.BuildLabel, failedTargetMap ma
 			printf("    ${BOLD_RED}%s${RESET}\n", label)
 		}
 	}
-}
-
-func updateTarget(state *core.BuildState, plainOutput bool, buildingTarget *buildingTarget, label core.BuildLabel,
-	active bool, failed bool, cached bool, description string, err error, colour string, target *core.BuildTarget) {
-	updateTarget2(buildingTarget, label, active, failed, cached, description, err, colour, target)
-	if plainOutput {
-		if !active {
-			active := pluralise(state.NumActive(), "task", "tasks")
-			log.Info("[%d/%s] %s: %s [%3.1fs]", state.NumDone(), active, label.String(), description, time.Since(buildingTarget.Started).Seconds())
-		} else {
-			log.Info("%s: %s", label.String(), description)
-		}
-	}
-}
-
-func updateTarget2(target *buildingTarget, label core.BuildLabel, active bool, failed bool, cached bool, description string, err error, colour string, t *core.BuildTarget) {
-	target.Label = label
-	target.Description = description
-	if !target.Active {
-		// Starting to build now.
-		target.Started = time.Now()
-		target.Finished = target.Started
-	} else if !active {
-		// finished building
-		target.Finished = time.Now()
-	}
-	target.Active = active
-	target.Failed = failed
-	target.Cached = cached
-	target.Err = err
-	target.Colour = colour
-	target.Target = t
-}
-
-func targetColour(target *core.BuildTarget) string {
-	if target == nil {
-		return "${BOLD_CYAN}" // unknown
-	} else if target.IsBinary {
-		return "${BOLD}" + targetColour2(target)
-	} else {
-		return targetColour2(target)
-	}
-}
-
-func targetColour2(target *core.BuildTarget) string {
-	for _, require := range target.Requires {
-		if colour, present := replacements[require]; present {
-			return colour
-		}
-	}
-	return "${WHITE}"
 }
 
 // Since this is a gentleman's build tool, we'll make an effort to get plurals correct

--- a/src/output/targets.go
+++ b/src/output/targets.go
@@ -1,0 +1,128 @@
+package output
+
+import (
+	"time"
+
+	"github.com/thought-machine/please/src/core"
+)
+
+// Represents the current state of a single currently building target.
+type buildingTarget struct {
+	Label        core.BuildLabel
+	Started      time.Time
+	Finished     time.Time
+	Description  string
+	Err          error
+	Colour       string
+	Target       *core.BuildTarget
+	Eta          time.Duration
+	Active       bool
+	Failed       bool
+	Cached       bool
+	LastProgress float32
+}
+
+// Collects all the currently building targets.
+type buildingTargets struct {
+	plain          bool
+	state          *core.BuildState
+	Targets        []buildingTarget
+	FailedTargets  map[core.BuildLabel]error
+	FailedNonTests []core.BuildLabel
+}
+
+func newBuildingTargets(state *core.BuildState, plainOutput bool) *buildingTargets {
+	return &buildingTargets{
+		plain:         plainOutput,
+		state:         state,
+		Targets:       make([]buildingTarget, state.Config.Please.NumThreads+state.Config.NumRemoteExecutors()),
+		FailedTargets: map[core.BuildLabel]error{},
+	}
+}
+
+// ProcessResult updates with a single result.
+// It returns the label that was in this slot previously.
+func (bt *buildingTargets) ProcessResult(result *core.BuildResult) core.BuildLabel {
+	label := result.Label
+	prev := bt.Targets[result.ThreadID].Label
+	if !result.Status.IsParse() { // Parse tasks happen on a different set of threads.
+		bt.updateTarget(result, bt.state.Graph.TargetOrDie(label))
+	}
+	if result.Status.IsFailure() {
+		bt.FailedTargets[label] = result.Err
+		// Don't stop here after test failure, aggregate them for later.
+		if result.Status != core.TargetTestFailed {
+			// Reset colour so the entire compiler error output doesn't appear red.
+			log.Errorf("%s failed:\x1b[0m\n%s", label, shortError(result.Err))
+			bt.state.Stop()
+		} else if msg := shortError(result.Err); msg != "" {
+			log.Errorf("%s failed: %s", result.Label, msg)
+		} else {
+			log.Errorf("%s failed", label)
+		}
+		if result.Status != core.TargetTestFailed {
+			bt.FailedNonTests = append(bt.FailedNonTests, label)
+		}
+	} else if result.Status == core.TargetBuildStopped {
+		bt.FailedTargets[label] = nil
+	} else if bt.plain && bt.state.ShowTestOutput && result.Status == core.TargetTested {
+		// If using interactive output we'll print it afterwards.
+		for _, testCase := range bt.state.Graph.TargetOrDie(label).Test.Results.TestCases {
+			printf("Finished test %s:\n", testCase.Name)
+			for _, testExecution := range testCase.Executions {
+				showExecutionOutput(testExecution)
+			}
+		}
+	}
+	return prev
+}
+
+// updateTarget updates a single target with a new result.
+func (bt *buildingTargets) updateTarget(result *core.BuildResult, t *core.BuildTarget) {
+	target := &bt.Targets[result.ThreadID]
+	target.Label = result.Label
+	target.Description = result.Description
+	active := result.Status.IsActive()
+	if !target.Active {
+		// Starting to build now.
+		target.Started = time.Now()
+		target.Finished = target.Started
+	} else if !active {
+		// finished building
+		target.Finished = time.Now()
+	}
+	target.Active = active
+	target.Failed = result.Status.IsFailure()
+	target.Cached = result.Status == core.TargetCached || result.Tests.Cached
+	target.Err = result.Err
+	target.Colour = targetColour(t)
+	target.Target = t
+
+	if bt.plain {
+		if !active {
+			active := pluralise(bt.state.NumActive(), "task", "tasks")
+			log.Info("[%d/%s] %s: %s [%3.1fs]", bt.state.NumDone(), active, result.Label, result.Description, time.Since(target.Started).Seconds())
+		} else {
+			log.Info("%s: %s", result.Label, result.Description)
+		}
+	}
+}
+
+func targetColour(target *core.BuildTarget) string {
+	if target == nil {
+		return "${BOLD_CYAN}" // unknown
+	} else if target.IsBinary {
+		return "${BOLD}" + targetColour2(target)
+	} else {
+		return targetColour2(target)
+	}
+}
+
+func targetColour2(target *core.BuildTarget) string {
+	for _, require := range target.Requires {
+		if colour, present := replacements[require]; present {
+			return colour
+		}
+	}
+	return "${WHITE}"
+}

--- a/src/output/trace.go
+++ b/src/output/trace.go
@@ -26,9 +26,6 @@ type traceWriter struct {
 // newTraceWriter returns a new traceWriter writing to the given file.
 // The filename may be empty in which case it will silently discard all information given.
 func newTraceWriter(filename string) *traceWriter {
-	if filename == "" {
-		return &traceWriter{}
-	}
 	f, err := os.Create(filename)
 	if err != nil {
 		log.Errorf("Couldn't create trace file: %s", err)
@@ -46,9 +43,7 @@ func newTraceWriter(filename string) *traceWriter {
 
 // Close closes this write and any associated files.
 func (tw *traceWriter) Close() error {
-	if tw.b == nil {
-		return nil
-	} else if _, err := tw.b.Write([]byte{'\n', ']', '\n'}); err != nil {
+	if _, err := tw.b.Write([]byte{'\n', ']', '\n'}); err != nil {
 		return err
 	} else if err := tw.b.Flush(); err != nil {
 		return err
@@ -59,9 +54,7 @@ func (tw *traceWriter) Close() error {
 // AddTrace adds a single trace to this writer.
 func (tw *traceWriter) AddTrace(result *core.BuildResult, previous core.BuildLabel, active bool) {
 	// It's a bit fiddly to keep all the phases in line here.
-	if tw.b == nil {
-		return
-	} else if !active {
+	if !active {
 		tw.writeEvent(result, "E")
 	} else if result.Label != previous {
 		tw.writeEvent(result, "B")


### PR DESCRIPTION
This does four main things:
 - Encapsulates more of the logic about tracking results into its own type, removing some of the weirdness about passing around pointers to slices
 - Moves the trace writer logic and gets rid of the thing where it can be created but not do anything when no file is given
 - Breaks up the local and remote actions as passed to the output writers.
 - And a small fix to the previous PR where it sometimes eats the line above.

Again, this isn't the main thing I want to get to, but another good step along the way (think I should be ready after this).