### PR TITLE
Fix typo in docs for HOSTOS and HOSTARCH

### DIFF
--- a/docs/cross_compiling.html
+++ b/docs/cross_compiling.html
@@ -39,8 +39,8 @@
     <code class="code">CONFIG.OS</code> properties will be set to the target
     architecture. Similarly, when the rule builds, the
     <code class="code">OS</code> and <code class="code">ARCH</code> environment
-    variables will also be set. The <code class="code">CONFIG.HOST_OS</code> and
-    <code class="code">CONFIG.HOST_ARCH</code> contain the host machines
+    variables will also be set. The <code class="code">CONFIG.HOSTOS</code> and
+    <code class="code">CONFIG.HOSTARCH</code> contain the host machines
     operating system and CPU architecture.
   </p>
 


### PR DESCRIPTION
Ran into this just now, but `CONFIG.HOST_OS` and `CONFIG.HOST_ARCH` don't exist. Updated the docs appropriately.