### PR TITLE
Fix srcdir by importing via abs path

### DIFF
--- a/tools/please_go/install/BUILD
+++ b/tools/please_go/install/BUILD
@@ -1,6 +1,3 @@
-# We want to work out the of the test_data dir and this makes it slightly easier
-package(go_test_root_compat = True)
-
 go_library(
     name = "install",
     srcs = [

--- a/tools/please_go/install/install.go
+++ b/tools/please_go/install/install.go
@@ -231,8 +231,7 @@ func (install *PleaseGoInstall) importDir(target string) (*build.Package, error)
 	if _, err := os.Lstat(pkgDir); os.IsNotExist(err) {
 		pkgDir = filepath.Dir(pkgDir)
 	}
-
-	return install.buildContext.ImportDir(pkgDir, build.ImportComment)
+	return install.buildContext.ImportDir(filepath.Join(os.Getenv("TMP_DIR"), pkgDir), build.ImportComment)
 }
 
 func (install *PleaseGoInstall) compile(from []string, target string) error {

--- a/tools/please_go/install/install_test.go
+++ b/tools/please_go/install/install_test.go
@@ -30,7 +30,7 @@ func TestNoSources(t *testing.T) {
 
 	err := install.Install([]string{"no_sources"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to compile example.com/no_sources: no buildable Go source files in test_data/example.com/no_sources")
+	assert.Contains(t, err.Error(), "failed to compile example.com/no_sources: no buildable Go source files")
 }
 
 func TestLocalImports(t *testing.T) {
@@ -44,7 +44,7 @@ func TestLocalImports(t *testing.T) {
 }
 
 func newInstall() (*PleaseGoInstall, *bytes.Buffer, *bytes.Buffer) {
-	install := New([]string{}, "test_data/example.com", "example.com", "test_data/empty.importcfg", "", "", "go", "cc", "pkg-config", "out", "")
+	install := New([]string{}, "tools/please_go/install/test_data/example.com", "example.com", "tools/please_go/install/test_data/empty.importcfg", "", "", "go", "cc", "pkg-config", "out", "")
 
 	stdOut := &bytes.Buffer{}
 	stdIn := &bytes.Buffer{}
@@ -56,7 +56,7 @@ func newInstall() (*PleaseGoInstall, *bytes.Buffer, *bytes.Buffer) {
 }
 
 func TestMain(m *testing.M) {
-	f, err := os.Create("test_data/empty.importcfg")
+	f, err := os.Create("tools/please_go/install/test_data/empty.importcfg")
 	if err != nil {
 		panic(err)
 	}

--- a/tools/please_go/install/toolchain/toolchain.go
+++ b/tools/please_go/install/toolchain/toolchain.go
@@ -43,7 +43,7 @@ func (tc *Toolchain) CGO(sourceDir string, objectDir string, cFlags []string, cg
 		cFiles = append(cFiles, strings.TrimSuffix(cgoFile, ".go")+".cgo2.c")
 	}
 
-	if err := tc.Exec.Run("(cd %s; %s tool cgo -objdir $OLDPWD/%s -- %s %s)", sourceDir, tc.GoTool, objectDir, strings.Join(cFlags, " "), paths(cgoFiles)); err != nil {
+	if err := tc.Exec.Run("%s tool cgo -objdir %s -srcdir %s -- %s %s", tc.GoTool, objectDir, sourceDir, strings.Join(cFlags, " "), paths(cgoFiles)); err != nil {
 		return nil, nil, err
 	}
 

--- a/tools/please_go/install/toolchain/toolchain.go
+++ b/tools/please_go/install/toolchain/toolchain.go
@@ -43,7 +43,7 @@ func (tc *Toolchain) CGO(sourceDir string, objectDir string, cFlags []string, cg
 		cFiles = append(cFiles, strings.TrimSuffix(cgoFile, ".go")+".cgo2.c")
 	}
 
-	if err := tc.Exec.Run("%s tool cgo -objdir %s -srcdir %s -- %s %s", tc.GoTool, objectDir, sourceDir, strings.Join(cFlags, " "), paths(cgoFiles)); err != nil {
+	if err := tc.Exec.Run("(cd %s; %s tool cgo -objdir $OLDPWD/%s -- %s %s)", sourceDir, tc.GoTool, objectDir, strings.Join(cFlags, " "), paths(cgoFiles)); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
The import dir sets the `${SRCDIR}` template variable that's available to the `#cgo` things. This PR makes this absolute so it's not the relative package path which would be evaluated relative to the src files.  

https://github.com/wasmerio/wasmer-go/blob/master/wasmer/cgo.go

^ the ${SRCDIR} here was being set to `third_party/go/wasmer-go/wasmer/third_party/go/wasmer-go/wasmer`