### PR TITLE
sandbox: ignore non-existent directories in `SANDBOX_DIRS`

### DIFF
--- a/tools/sandbox/sandbox.c
+++ b/tools/sandbox/sandbox.c
@@ -117,7 +117,7 @@ int mount_tmp(char** argv0) {
       char *token = strtok(dirs, ",");
       while(token) {
         if (mount("tmpfs", token, "tmpfs", flags | MS_RDONLY, NULL) != 0) {
-          if (errno == ENOTDIR) {
+          if (errno == ENOENT || errno == ENOTDIR) {
             // This isn't fatal, it's OK for them not to exist (in that case we just have nothing to sandbox).
             fprintf(stderr, "Not mounting over %s since it isn't a directory\n", token);
           } else {


### PR DESCRIPTION
`mount()` sets `errno` to `ENOENT` when the target doesn't exist, which causes the sandbox to error fatally when it is asked to mask a directory that doesn't exist on the host. Instead, output the existing "Not mounting over <target> since it isn't a directory" warning that is shown when the given target is a non-directory file, and continue.

Fixes #2040.