### PR TITLE
Handle relative paths for config.Please.Location and some clean up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
            command: tar -xzf /tmp/workspace/darwin_amd64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch darwin_arm64 -o go.cgoenabled:1 -o go.cgocctool:clang -o "go.cflags:-target arm64-apple-macos11" //package:release_files
+           command: ./please/please build -p --profile ci --arch darwin_arm64 -o go.cgoenabled:1 -o go.cgocctool:clang -o "go.cflags:-target arm64-apple-macos11" -o please.location:./please //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:
@@ -175,7 +175,7 @@ jobs:
            command: tar -xzf /tmp/workspace/linux_amd64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch freebsd_amd64 //package:release_files
+           command: ./please/please build -p --profile ci --arch freebsd_amd64 -o please.location:./please //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
            command: tar -xzf /tmp/workspace/darwin_amd64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch darwin_arm64 -o go.cgoenabled:1 -o go.cgocctool:clang -o "go.cflags:-target arm64-apple-macos11" -o please.location:./please //package:release_files
+           command: ./please/please build -p --profile ci --arch darwin_arm64 -o go.cgoenabled:1 -o go.cgocctool:clang -o "go.cflags:-target arm64-apple-macos11" -o please.location:~/please/please //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:
@@ -175,7 +175,7 @@ jobs:
            command: tar -xzf /tmp/workspace/linux_amd64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch freebsd_amd64 -o please.location:./please //package:release_files
+           command: ./please/please build -p --profile ci --arch freebsd_amd64 -o please.location:~/please/please //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:

--- a/.circleci/http_cache_test.sh
+++ b/.circleci/http_cache_test.sh
@@ -14,13 +14,13 @@ ln -s "${DIR}/please" "${DIR}/plz"
 export PATH="$DIR:$PATH"
 
 # Start the server in the background
-plz run parallel -p -v notice --colour --detach //tools/http_cache:run_local
+plz run parallel -p -o please.location:$DIR -v notice --colour --detach //tools/http_cache:run_local
 
 # Test we can rebuild plz itself.
-plz test --profile localcache -p -v notice --colour //src/...
+plz test --profile localcache -p -o please.location:$DIR -v notice --colour //src/...
 
 # Clean out plz-out and the dir cache. This doesn't clean the http cache.
 plz clean -f
 
 # Run that again to make sure cache restoration works
-plz test --profile localcache -p -v notice --colour //src/...
+plz test --profile localcache -p -o please.location:$DIR -v notice --colour //src/...

--- a/.circleci/rex_test.sh
+++ b/.circleci/rex_test.sh
@@ -16,7 +16,7 @@ export PATH="$DIR:$PATH"
 
 # Start the servers in the background
 echo "Starting servers..."
-plz run parallel -p -v notice --colour --detach -o build.passenv:PATH //test/remote:run_elan //test/remote:run_zeal //test/remote:run_mettle
+plz run parallel -p -v notice --colour --detach -o please.location:$DIR -o build.passenv:PATH //test/remote:run_elan //test/remote:run_zeal //test/remote:run_mettle
 
 echo "Waiting for servers to come up..."
 # Give the servers a chance to start up.

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '^1.17'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.41.1
+          version: v1.42.0
           args: src/... tools/...

--- a/.plzconfig
+++ b/.plzconfig
@@ -1,3 +1,6 @@
+[please]
+location = ./plz-out/please
+
 [python]
 ; We use the in-repo please_pex tool to build other pexes within this repo.
 ; Other projects using Please wouldn't normally need to do anything like this.

--- a/go.mod
+++ b/go.mod
@@ -59,4 +59,4 @@ require (
 	lukechampine.com/blake3 v1.1.5
 )
 
-go 1.17
+go 1.16

--- a/go.mod
+++ b/go.mod
@@ -59,4 +59,4 @@ require (
 	lukechampine.com/blake3 v1.1.5
 )
 
-go 1.16
+go 1.17

--- a/src/cli/winch_other.go
+++ b/src/cli/winch_other.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package cli

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"bytes"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -166,12 +165,13 @@ func TestPleaseRelativeLocationOverride(t *testing.T) {
 }
 
 func TestPleaseTildeLocationOverride(t *testing.T) {
+	t.Setenv("HOME", "/path/to/home")
+
 	config := DefaultConfiguration()
-	home := os.Getenv("HOME")
 
 	err := config.ApplyOverrides(map[string]string{"please.location": "~/please-location"})
 	assert.NoError(t, err)
-	assert.Equal(t, filepath.Join(home, "please-location"), config.Please.Location)
+	assert.Equal(t, "/path/to/home/please-location", config.Please.Location)
 }
 
 func TestReadSemver(t *testing.T) {
@@ -380,6 +380,8 @@ func TestGetTags(t *testing.T) {
 }
 
 func TestEnsurePleaseLocation(t *testing.T) {
+	t.Setenv("HOME", "/path/to/home")
+
 	config := DefaultConfiguration()
 
 	// Empty please location config resolves to this executable's directory
@@ -390,7 +392,7 @@ func TestEnsurePleaseLocation(t *testing.T) {
 	// Expands ~
 	config.Please.Location = "~"
 	config.EnsurePleaseLocation()
-	assert.Equal(t, os.Getenv("HOME"), config.Please.Location)
+	assert.Equal(t, "/path/to/home", config.Please.Location)
 
 	// Resolves relative path to repo root
 	RepoRoot = "/repo/root"

--- a/src/core/test_data/working.plzconfig
+++ b/src/core/test_data/working.plzconfig
@@ -1,3 +1,6 @@
+[please]
+location = ./plz-out/please
+
 [python]
 pextool = pexmabob
 

--- a/src/fs/home.go
+++ b/src/fs/home.go
@@ -6,12 +6,11 @@ import (
 	"strings"
 )
 
-var home = os.Getenv("HOME")
 var homeRex = regexp.MustCompile("(?:^|:)(~(?:[/:]|$))")
 
 // ExpandHomePath expands all prefixes of ~ without a user specifier to $HOME.
 func ExpandHomePath(path string) string {
-	return ExpandHomePathTo(path, home)
+	return ExpandHomePathTo(path, os.Getenv("HOME"))
 }
 
 // ExpandHomePathTo expands all prefixes of ~ without a user specifier to the given string.

--- a/src/process/exec_other.go
+++ b/src/process/exec_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package process

--- a/src/sandbox/sandbox_linux.go
+++ b/src/sandbox/sandbox_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package sandbox

--- a/src/sandbox/sandbox_other.go
+++ b/src/sandbox/sandbox_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package sandbox

--- a/src/update/clean.go
+++ b/src/update/clean.go
@@ -11,13 +11,11 @@ import (
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"
-	"github.com/thought-machine/please/src/fs"
 )
 
 // clean checks for any stale versions in the download directory and wipes them out if OK.
 func clean(config *core.Configuration, manualUpdate bool) {
-	location := fs.ExpandHomePath(config.Please.Location)
-	dir, _ := ioutil.ReadDir(location)
+	dir, _ := ioutil.ReadDir(config.Please.Location)
 	versions := make(semver.Versions, 0, len(dir))
 	// Convert these to semver
 	for _, entry := range dir {
@@ -43,7 +41,7 @@ func clean(config *core.Configuration, manualUpdate bool) {
 	sort.Sort(versions)
 	for _, version := range versions[:numToClean] {
 		log.Notice("Cleaning old version %s...", version)
-		if err := os.RemoveAll(path.Join(location, version.String())); err != nil {
+		if err := os.RemoveAll(path.Join(config.Please.Location, version.String())); err != nil {
 			log.Error("Couldn't remove %s: %s", version, err)
 		}
 	}

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -75,7 +75,7 @@ func CheckAndUpdate(config *core.Configuration, updatesEnabled, updateCommand, f
 	defer core.AcquireSharedRepoLock()
 
 	// If the destination exists and the user passed --force, remove it to force a redownload.
-	newDir := fs.ExpandHomePath(path.Join(config.Please.Location, config.Please.Version.VersionString()))
+	newDir := path.Join(config.Please.Location, config.Please.Version.VersionString())
 	if forceUpdate && core.PathExists(newDir) {
 		if err := os.RemoveAll(newDir); err != nil {
 			log.Fatalf("Failed to remove existing directory: %s", err)
@@ -186,7 +186,6 @@ func shouldUpdate(config *core.Configuration, updatesEnabled, updateCommand, pre
 // downloadAndLinkPlease downloads a new Please version and links it into place, if needed.
 // It returns the new location and dies on failure.
 func downloadAndLinkPlease(config *core.Configuration, verify bool, progress bool) string {
-	config.Please.Location = fs.ExpandHomePath(config.Please.Location)
 	newPlease := path.Join(config.Please.Location, config.Please.Version.VersionString(), "please")
 
 	if !core.PathExists(newPlease) {

--- a/tools/please_go/install/test_data/example.com/no_sources/invlid.go
+++ b/tools/please_go/install/test_data/example.com/no_sources/invlid.go
@@ -1,4 +1,5 @@
-//+build nothing
+//go:build nothing
+// +build nothing
 
 // Build constraints on this package should mean there's no valid sources
 package no_sources

--- a/tools/please_go/test/find_cover_vars.go
+++ b/tools/please_go/test/find_cover_vars.go
@@ -1,4 +1,4 @@
-// Package gotest contains utilities used by plz_go_test.
+// Package test contains utilities used by plz_go_test.
 package test
 
 import (


### PR DESCRIPTION
- Handle relative paths for `config.Please.Location`
- Expand `config.Please.Location` to its full path during read, so it's done only once.