### PR TITLE
Introduce a DeferredRegexp type

### DIFF
--- a/src/core/deferred_regexp.go
+++ b/src/core/deferred_regexp.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"regexp"
+	"sync"
+)
+
+// A DeferredRegexp is like a normal regexp but defers its initialisation until first use.
+// This helps avoid spending lots of time initialising things at init time.
+//
+// The interface mimics the subset of regexp.Regexp that we find relevant right now.
+//
+// Note that it generally uses MustCompile internally in order to mimic the regexp interface,
+// so you only want to use it for static regexes that you know are valid (which is the only real
+// use case anyway).
+type DeferredRegexp struct {
+	Re   string
+	once sync.Once
+	re   *regexp.Regexp
+}
+
+func (dr *DeferredRegexp) init() {
+	dr.once.Do(func() {
+		dr.re = regexp.MustCompile(dr.Re)
+	})
+}
+
+func (dr *DeferredRegexp) ReplaceAllStringFunc(src string, repl func(string) string) string {
+	dr.init()
+	return dr.re.ReplaceAllStringFunc(src, repl)
+}
+
+func (dr *DeferredRegexp) FindStringSubmatch(s string) []string {
+	dr.init()
+	return dr.re.FindStringSubmatch(s)
+}
+
+func (dr *DeferredRegexp) FindSubmatch(b []byte) [][]byte {
+	dr.init()
+	return dr.re.FindSubmatch(b)
+}

--- a/src/help/config.go
+++ b/src/help/config.go
@@ -3,14 +3,13 @@ package help
 import (
 	"fmt"
 	"reflect"
-	"regexp"
 	"runtime"
 	"strings"
 
 	"github.com/thought-machine/please/src/core"
 )
 
-var urlRegex = regexp.MustCompile("https?://[^ ]+[^.]")
+var urlRegex = core.DeferredRegexp{Re: "https?://[^ ]+[^.]"}
 
 // ExampleValue returns an example value for a config field based on its type.
 func ExampleValue(f reflect.Value, name string, t reflect.Type, example, options string) string {

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -604,7 +603,7 @@ func colouriseError(err error) error {
 }
 
 // errorMessageRe is a regex to find lines that look like they're specifying a file.
-var errorMessageRe = regexp.MustCompile(`^([^ ]+\.[^: /]+):([0-9]+):(?:([0-9]+):)? *(?:([a-z-_ ]+):)? (.*)$`)
+var errorMessageRe = core.DeferredRegexp{Re: `^([^ ]+\.[^: /]+):([0-9]+):(?:([0-9]+):)? *(?:([a-z-_ ]+):)? (.*)$`}
 
 // unbuiltTargetsMessage returns a message for any targets that are supposed to build but haven't yet.
 func unbuiltTargetsMessage(graph *core.BuildGraph) string {

--- a/src/test/go_results.go
+++ b/src/test/go_results.go
@@ -9,26 +9,18 @@ package test
 import (
 	"bytes"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/thought-machine/please/src/core"
 )
 
 // Not sure what the -6 suffixes are about.
-var testStart *regexp.Regexp
-var testResult *regexp.Regexp
-var regexOnce sync.Once
+var testStart = core.DeferredRegexp{Re: `^=== RUN (.*)(?:-6)?$`}
+var testResult = core.DeferredRegexp{Re: `^ *--- (PASS|FAIL|SKIP): (.*)(?:-6)? \(([0-9]+\.[0-9]+)s\)$`}
 
 func parseGoTestResults(data []byte) (core.TestSuite, error) {
-	regexOnce.Do(func() {
-		testStart = regexp.MustCompile(`^=== RUN (.*)(?:-6)?$`)
-		testResult = regexp.MustCompile(`^ *--- (PASS|FAIL|SKIP): (.*)(?:-6)? \(([0-9]+\.[0-9]+)s\)$`)
-	})
-
 	results := core.TestSuite{}
 	lines := bytes.Split(data, []byte{'\n'})
 	testsStarted := map[string]bool{}


### PR DESCRIPTION
This is basically a cleanup of #2044 so we don't have to explicitly manage a sync.Once per regexp (or group of them).

If this looks like a good idea I think it might be worth doing a separate module for it (there are a few other cases I can't use it for since this is sitting in `core` rn)