### PR TITLE
Allow build files as inputs to rules

### DIFF
--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -497,10 +497,6 @@ func parseSource(s *scope, src string, systemAllowed, tool bool) core.BuildInput
 		return core.SystemPathLabel{Name: src, Path: s.state.Config.Path()}
 	}
 	src = strings.TrimPrefix(src, "./")
-	// Make sure it's not the actual build file.
-	for _, filename := range s.state.Config.Parse.BuildFileName {
-		s.Assert(filename != src, "You can't specify the BUILD file as an input to a rule")
-	}
 	return core.NewFileLabel(src, s.pkg)
 }
 


### PR DESCRIPTION
I can't see any reason not to allow this. Please ignores BUILD files in plz-out anyway. I suppose this might cause some issues if we somehow inject a BUILD file into a subrepo in `plz-out`. I can't think of a way to do that right now though. 

Fixes: #2050