### PR TITLE
Fix the module name for the go_module() e2e

### DIFF
--- a/test/go_modules/test_repo/go.mod
+++ b/test/go_modules/test_repo/go.mod
@@ -1,1 +1,1 @@
-module example
+module module_test


### PR DESCRIPTION
This technically doesn't matter but it would be nice if it actually matched what was in the .plzconfig