### PR TITLE
Erase message history during plz watch

### DIFF
--- a/src/cli/logging.go
+++ b/src/cli/logging.go
@@ -203,6 +203,7 @@ func (backend *LogBackend) SetPassthrough(passthrough bool, interactiveRows int)
 	backend.passthrough = passthrough
 	backend.interactiveRows = interactiveRows
 	backend.messageHistory = list.New()
+	backend.messageCount = 0
 	backend.mutex.Unlock()
 	if passthrough {
 		go notifyOnWindowResize(backend.recalcWindowSize)

--- a/src/cli/logging.go
+++ b/src/cli/logging.go
@@ -202,6 +202,7 @@ func (backend *LogBackend) SetPassthrough(passthrough bool, interactiveRows int)
 	backend.mutex.Lock()
 	backend.passthrough = passthrough
 	backend.interactiveRows = interactiveRows
+	backend.messageHistory = list.New()
 	backend.mutex.Unlock()
 	if passthrough {
 		go notifyOnWindowResize(backend.recalcWindowSize)


### PR DESCRIPTION
Currently it re-prints messages from previous watch runs at completion of the new one, which is not what you expect.