### PR TITLE
Don't use %w in log messages

### DIFF
--- a/src/core/previous_op.go
+++ b/src/core/previous_op.go
@@ -21,9 +21,9 @@ func StoreCurrentOperation() {
 
 	previousOp := strings.Join(os.Args[1:], " ")
 	if err := file.Truncate(0); err != nil {
-		log.Errorf("Unable to truncate %s to store current operation: %w", previousOpFilePath, err)
+		log.Errorf("Unable to truncate %s to store current operation: %s", previousOpFilePath, err)
 	} else if _, err := file.WriteAt([]byte(previousOp+"\n"), 0); err != nil {
-		log.Errorf("Unable to store current operation to  %s: %w", previousOpFilePath, err)
+		log.Errorf("Unable to store current operation to  %s: %s", previousOpFilePath, err)
 	}
 
 	if err := file.Close(); err != nil {


### PR DESCRIPTION
It doesn't print very nicely:
```
13:14:52.596   ERROR: Unable to store current operation to  plz-out/.previous_op: %!w(*fs.PathError=&{write plz-out/.previous_op 28})
```
I think this should be better. Can't test the exact thing so readily now tho.