### PR TITLE
Exclude the subinclude targets' package from preloading

### DIFF
--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -40,9 +40,16 @@ func buildPreamble(state *core.BuildState, pkg *core.Package) string {
 	subincludes := make([]string, 0, len(state.Config.Parse.PreloadSubincludes))
 	for _, inc := range state.Config.Parse.PreloadSubincludes {
 		l := core.ParseBuildLabel(inc, pkg.Name)
-		if l.Subrepo == "" || l.SubrepoLabel().PackageName != pkg.Name {
-			subincludes = append(subincludes, fmt.Sprintf("\"%s\"", inc))
+		if l.Subrepo == "" {
+			if pkg.SubrepoName == "" && l.PackageName == pkg.Name {
+				// We're in the package that contains the subinclude target. Skip.
+				continue
+			}
+		} else if l.SubrepoLabel().PackageName == pkg.Name {
+			// We're in the package that contains the subrepo of the subinclude target. Skip.
+			continue
 		}
+		subincludes = append(subincludes, fmt.Sprintf("\"%s\"", inc))
 	}
 
 	if len(subincludes) > 0 {

--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -40,20 +40,23 @@ func buildPreamble(state *core.BuildState, pkg *core.Package) string {
 	subincludes := make([]string, 0, len(state.Config.Parse.PreloadSubincludes))
 	for _, inc := range state.Config.Parse.PreloadSubincludes {
 		l := core.ParseBuildLabel(inc, pkg.Name)
-		if l.Subrepo == "" {
-			if pkg.SubrepoName == "" && l.PackageName == pkg.Name {
-				// We're in the package that contains the subinclude target. Skip.
-				continue
-			}
-		} else if l.SubrepoLabel().PackageName == pkg.Name {
-			// We're in the package that contains the subrepo of the subinclude target. Skip.
-			continue
+		// If pkg is the package we're pre-loading subincludes from, or if it contains it's subrepo, skip.
+		// N.B. we can't cross subincludes so we have to exclude all subincludes, not just the one defined in this
+		// package
+		pkgName := l.SubrepoLabel().PackageName
+		if pkgName == "" {
+			pkgName = l.PackageName
 		}
+
+		if pkg.Name == pkgName {
+			return ""
+		}
+
 		subincludes = append(subincludes, fmt.Sprintf("\"%s\"", inc))
 	}
 
 	if len(subincludes) > 0 {
-		return fmt.Sprintf("subinclude(%s)", strings.Join(subincludes, " "))
+		return fmt.Sprintf("subinclude(%s)", strings.Join(subincludes, ", "))
 	}
 	return ""
 }

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -106,7 +106,7 @@ func checkSubrepo(tid int, state *core.BuildState, label, dependent core.BuildLa
 		return nil, fmt.Errorf("Subrepo %s is not defined (referenced by %s)", label.Subrepo, dependent)
 	}
 	// For local subincludes, the subrepo has to already be defined at this point in the BUILD file
-	return nil, fmt.Errorf("%s -> %s", dependent, label)
+	return nil, fmt.Errorf("Subrepo %v is not defined yet. It must appear before it is used by subinclude()", sl)
 }
 
 // parseSubrepoPackage parses a package to make sure subrepos are available.

--- a/test/preloaded_subinc/test_repo/.plzconfig
+++ b/test/preloaded_subinc/test_repo/.plzconfig
@@ -2,3 +2,4 @@
 BuildFileName = BUILD_FILE
 BuildFileName = BUILD
 PreloadSubincludes = ///pleasings2/pleasings2//k8s
+PreloadSubincludes = //build_defs:foo

--- a/test/preloaded_subinc/test_repo/build_defs/BUILD_FILE
+++ b/test/preloaded_subinc/test_repo/build_defs/BUILD_FILE
@@ -1,0 +1,5 @@
+filegroup(
+    name = "foo",
+    srcs = ["foo.build_defs"],
+    visibility = ["PUBLIC"],
+)

--- a/test/preloaded_subinc/test_repo/build_defs/foo.build_defs
+++ b/test/preloaded_subinc/test_repo/build_defs/foo.build_defs
@@ -1,0 +1,2 @@
+def foo():
+    pass

--- a/test/preloaded_subinc/test_repo/src/BUILD_FILE
+++ b/test/preloaded_subinc/test_repo/src/BUILD_FILE
@@ -4,3 +4,5 @@ k8s_config(
         "service.yaml",
     ],
 )
+
+foo()


### PR DESCRIPTION
This small fix allows us to preload subincludes for targets in the host repo. 