### PR TITLE
Updawte go deps to v0.3.1

### DIFF
--- a/third_party/binary/BUILD
+++ b/third_party/binary/BUILD
@@ -19,7 +19,7 @@ remote_file(
     ),
 )
 
-GO_DEPS_VERSION = "v0.3.0"
+GO_DEPS_VERSION = "v0.3.1"
 
 # TODO(jpoole): this should support other platforms than just linux_amd64
 remote_file(


### PR DESCRIPTION
Just provides better error messages when your get path isn't fully resolved. Forwards the `go get` suggestions from the call to `go list` to the user. 