### PR TITLE
Tune singletons to not need extra allocations

### DIFF
--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -477,7 +477,7 @@ func (s *scope) interpretIs(obj pyObject, op OpExpression) pyObject {
 	}
 }
 
-func (s *scope) negate(obj pyObject) pyBool {
+func (s *scope) negate(obj pyObject) pyObject {
 	if obj.IsTruthy() {
 		return False
 	}

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -38,8 +38,8 @@ type pyBool bool
 
 // True and False are the singletons representing those values.
 var (
-	True  pyBool = true
-	False pyBool = false
+	True  pyObject = pyBool(true)
+	False pyObject = pyBool(false)
 )
 
 // newPyBool creates a new bool. It's a minor optimisation to treat them as singletons
@@ -88,7 +88,7 @@ func (b pyBool) MarshalJSON() ([]byte, error) {
 type pyNone struct{}
 
 // None is the singleton representing None; there can be only one etc.
-var None = pyNone{}
+var None pyObject = pyNone{}
 
 func (n pyNone) Type() string {
 	return "none"

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -69,7 +69,7 @@ const (
 // createTarget creates a new build target as part of build_rule().
 func createTarget(s *scope, args []pyObject) *core.BuildTarget {
 	isTruthy := func(i int) bool {
-		return args[i] != nil && args[i] != None && (args[i] == &True || args[i].IsTruthy())
+		return args[i] != nil && args[i] != None && args[i].IsTruthy()
 	}
 	name := string(args[nameBuildRuleArgIdx].(pyString))
 	testCmd := args[testCMDBuildRuleArgIdx]


### PR DESCRIPTION
Currently they have to do one in simple cases like `return True` because we have to create a temporary interface object; this makes them interfaces so that's not necessary.