### PR TITLE
Forcibly 'inline' Assert call here

### DIFF
--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -702,7 +702,11 @@ func (f *pyFunc) defaultArg(s *scope, i int, arg string) pyObject {
 	if f.constants[i] != nil {
 		return f.constants[i]
 	}
-	s.Assert(f.defaults != nil && f.defaults[i] != nil, "Missing required argument to %s: %s", f.name, arg)
+	// Deliberately does not use Assert since it doesn't get inlined here (weirdly it does
+	// in _many_ other places) and this function is pretty hot.
+	if f.defaults == nil || f.defaults[i] == nil {
+		s.Error("Missing required argument to %s: %s", f.name, arg)
+	}
 	return s.interpretExpression(f.defaults[i])
 }
 


### PR DESCRIPTION
Some investigation suggests we're allocating here quite a lot (mostly just because it's called a lot), because `f.name` and `arg` escape. I think the root cause is that it's not inlined, although I don't know why not (`Assert` gets inlined into about a hundred other places, unfortunately it doesn't say why not here). Hence manually inlining the condition which has the following result:
```
$ plz run //src/parse/asp:interpreter_benchmark_benchmark
goos: linux
goarch: amd64
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
BenchmarkParseFile
BenchmarkParseFile-12                324           3507117 ns/op         1437578 B/op      16665 allocs/op
PASS
```
to
```
goos: linux
goarch: amd64
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
BenchmarkParseFile
BenchmarkParseFile-12                331           3381277 ns/op         1406060 B/op      14870 allocs/op
PASS
```
i.e. about 10.8% reduction which seems significant enough to be worth grungifying the code slightly.