### PR TITLE
Asp allocation optimisations

### DIFF
--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -27,23 +27,25 @@ type nativeFunc func(*scope, []pyObject) pyObject
 
 // registerBuiltins sets up the "special" builtins that map to native code.
 func registerBuiltins(s *scope) {
+	const varargs = true
+	const kwargs = true
 	setNativeCode(s, "build_rule", buildRule)
 	setNativeCode(s, "subrepo", subrepo)
 	setNativeCode(s, "fail", builtinFail)
-	setNativeCode(s, "subinclude", subinclude).varargs = true
-	setNativeCode(s, "load", bazelLoad).varargs = true
-	setNativeCode(s, "package", pkg).kwargs = true
+	setNativeCode(s, "subinclude", subinclude, varargs)
+	setNativeCode(s, "load", bazelLoad, varargs)
+	setNativeCode(s, "package", pkg, false, kwargs)
 	setNativeCode(s, "sorted", sorted)
 	setNativeCode(s, "isinstance", isinstance)
 	setNativeCode(s, "range", pyRange)
 	setNativeCode(s, "enumerate", enumerate)
-	setNativeCode(s, "zip", zip).varargs = true
+	setNativeCode(s, "zip", zip, varargs)
 	setNativeCode(s, "len", lenFunc)
 	setNativeCode(s, "glob", glob)
 	setNativeCode(s, "bool", boolType)
 	setNativeCode(s, "int", intType)
 	setNativeCode(s, "str", strType)
-	setNativeCode(s, "join_path", joinPath).varargs = true
+	setNativeCode(s, "join_path", joinPath, varargs)
 	setNativeCode(s, "get_base_path", packageName)
 	setNativeCode(s, "package_name", packageName)
 	setNativeCode(s, "subrepo_name", subrepoName)
@@ -127,14 +129,19 @@ func registerSubincludePackage(s *scope) {
 	f.types = buildRule.types
 }
 
-func setNativeCode(s *scope, name string, code nativeFunc) *pyFunc {
+func setNativeCode(s *scope, name string, code nativeFunc, flags ...bool) *pyFunc {
 	f := s.Lookup(name).(*pyFunc)
 	f.nativeCode = code
 	f.code = nil // Might as well save a little memory here
-	f.argPool = &sync.Pool{
-		New: func() interface{} {
-			return make([]pyObject, len(f.args))
-		},
+	if len(flags) != 0 {
+		f.varargs = flags[0]
+		f.kwargs = len(flags) > 1 && flags[1]
+	} else {
+		f.argPool = &sync.Pool{
+			New: func() interface{} {
+				return make([]pyObject, len(f.args))
+			},
+		}
 	}
 	return f
 }

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/manifoldco/promptui"
@@ -130,6 +131,11 @@ func setNativeCode(s *scope, name string, code nativeFunc) *pyFunc {
 	f := s.Lookup(name).(*pyFunc)
 	f.nativeCode = code
 	f.code = nil // Might as well save a little memory here
+	f.argPool = &sync.Pool{
+		New: func() interface{} {
+			return make([]pyObject, len(f.args))
+		},
+	}
 	return f
 }
 

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -524,6 +524,10 @@ func (s *scope) interpretValueExpressionPart(expr *ValueExpression) pyObject {
 	} else if expr.None {
 		return None
 	} else if expr.List != nil {
+		// Special-case the empty list (which is a fairly common and safe case)
+		if expr.List.Comprehension == nil && len(expr.List.Values) == 0 {
+			return emptyList
+		}
 		return s.interpretList(expr.List)
 	} else if expr.Dict != nil {
 		return s.interpretDict(expr.Dict)

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -307,7 +307,7 @@ func (s pyString) String() string {
 
 type pyList []pyObject
 
-var emptyList pyObject = make(pyList, 0, 0) // want this to explicitly have zero capacity
+var emptyList pyObject = make(pyList, 0) // want this to explicitly have zero capacity
 
 func (l pyList) Type() string {
 	return "list"
@@ -676,7 +676,7 @@ func (f *pyFunc) callNative(s *scope, c *Call) pyObject {
 			for i := range args {
 				args[i] = nil
 			}
-			f.argPool.Put(args)
+			f.argPool.Put(args) //nolint:staticcheck
 		}()
 	} else {
 		args = make([]pyObject, len(f.args))

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -632,14 +632,19 @@ func (f *pyFunc) Call(ctx context.Context, s *scope, c *Call) pyObject {
 		if a.Name != "" { // Named argument
 			name := a.Name
 			idx, present := f.argIndices[name]
-			s.Assert(present || f.kwargs, "Unknown argument to %s: %s", f.name, name)
+			if !present && !f.kwargs {
+				s.Error("Unknown argument to %s: %s", f.name, name)
+			}
 			if present {
 				name = f.args[idx]
 			}
 			s2.Set(name, f.validateType(s, idx, &a.Value))
 		} else {
-			s.NAssert(i >= len(f.args), "Too many arguments to %s", f.name)
-			s.NAssert(f.kwargsonly, "Function %s can only be called with keyword arguments", f.name)
+			if i >= len(f.args) {
+				s.Error("Too many arguments to %s", f.name)
+			} else if f.kwargsonly {
+				s.Error("Function %s can only be called with keyword arguments", f.name)
+			}
 			s2.Set(f.args[i], f.validateType(s, i, &a.Value))
 		}
 	}

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -306,6 +306,8 @@ func (s pyString) String() string {
 
 type pyList []pyObject
 
+var emptyList pyObject = make(pyList, 0, 0)  // want this to explicitly have zero capacity
+
 func (l pyList) Type() string {
 	return "list"
 }

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -307,7 +307,7 @@ func (s pyString) String() string {
 
 type pyList []pyObject
 
-var emptyList pyObject = make(pyList, 0, 0)  // want this to explicitly have zero capacity
+var emptyList pyObject = make(pyList, 0, 0) // want this to explicitly have zero capacity
 
 func (l pyList) Type() string {
 	return "list"
@@ -670,7 +670,7 @@ func (f *pyFunc) Call(ctx context.Context, s *scope, c *Call) pyObject {
 // they receive their arguments as a slice, in which unpassed arguments are nil.
 func (f *pyFunc) callNative(s *scope, c *Call) pyObject {
 	var args []pyObject
-	if f.argPool != nil && !f.varargs && !f.kwargs {
+	if f.argPool != nil {
 		args = f.argPool.Get().([]pyObject)
 		defer func() {
 			for i := range args {

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -699,7 +699,9 @@ func (f *pyFunc) callNative(s *scope, c *Call) pyObject {
 			s.Assert(f.varargs, "Too many arguments to %s", f.name)
 			args = append(args, s.interpretExpression(&a.Value))
 		} else {
-			s.NAssert(f.kwargsonly, "Function %s can only be called with keyword arguments", f.name)
+			if f.kwargsonly {
+				s.Error("Function %s can only be called with keyword arguments", f.name)
+			}
 			if i+offset >= len(args) {
 				args = append(args, f.validateType(s, i+offset, &a.Value))
 			} else {

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -419,10 +419,14 @@ func addDependencies(s *scope, name string, obj pyObject, target *core.BuildTarg
 func addStrings(s *scope, name string, obj pyObject, f func(string)) {
 	if obj != nil && obj != None {
 		l, ok := asList(obj)
-		s.Assert(ok, "Argument %s must be a list, not %s", name, obj.Type())
+		if !ok {
+			s.Error("Argument %s must be a list, not %s", name, obj.Type())
+		}
 		for _, li := range l {
 			str, ok := li.(pyString)
-			s.Assert(ok || li == None, "%s must be strings", name)
+			if !ok && li != None {
+				s.Error("%s must be strings", name)
+			}
 			if str != "" && li != None {
 				f(string(str))
 			}


### PR DESCRIPTION
Main things are
- Add a pool for allocation of arguments for native functions. This cuts down on bytes allocated quite a lot although not the actual number of them.
- Add an singleton for the empty list
- 'Inline' a few things. I've tried to create a reduced test case for this since it _feels_ like the compiler isn't being as optimal as it could be here, unfortunately my case doesn't want to reproduce it.

Before:
```
goos: linux
goarch: amd64
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
BenchmarkParseFile
BenchmarkParseFile-12    	     322	   3575864 ns/op	 1409836 B/op	   14877 allocs/op
PASS
```
After:
```
goos: linux
goarch: amd64
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
BenchmarkParseFile
BenchmarkParseFile-12    	     343	   3504449 ns/op	 1236679 B/op	   11284 allocs/op
PASS
```
i.e. that's about 25% fewer allocations, 12% fewer bytes allocated and 2% faster.