### PR TITLE
Fix issue with loading plugin config on subinclude

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -615,6 +615,15 @@ type Plugin struct {
 	ExtraValues map[string][]string `help:"A section of arbitrary key-value properties for the plugin." gcfg:"extra_values"`
 }
 
+func (plugin Plugin) copyPlugin() *Plugin {
+	values := map[string][]string{}
+	for k, v := range plugin.ExtraValues {
+		values[k] = v
+	}
+	plugin.ExtraValues = values
+	return &plugin
+}
+
 // A Size represents a named size in the config.
 type Size struct {
 	Timeout     cli.Duration `help:"Timeout for targets of this size"`
@@ -928,6 +937,16 @@ func (config *Configuration) NumRemoteExecutors() int {
 		return 0
 	}
 	return config.Remote.NumExecutors
+}
+
+func (config Configuration) copyConfig() *Configuration {
+	config.buildEnvStored = &storedBuildEnv{}
+	plugins := map[string]*Plugin{}
+	for name, plugin := range config.Plugin {
+		plugins[name] = plugin.copyPlugin()
+	}
+	config.Plugin = plugins
+	return &config
 }
 
 // A ConfigProfile is a string that knows how to handle completions given all the possible config file locations.

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1020,31 +1020,12 @@ func (state *BuildState) findArch(arch cli.Arch) *BuildState {
 	return nil
 }
 
-func copyPlugin(plugin Plugin) *Plugin {
-	values := map[string][]string{}
-	for k, v := range plugin.ExtraValues {
-		values[k] = v
-	}
-	plugin.ExtraValues = values
-	return &plugin
-}
-
-func copyConfig(config Configuration) *Configuration {
-	config.buildEnvStored = &storedBuildEnv{}
-	plugins := map[string]*Plugin{}
-	for name, plugin := range config.Plugin {
-		plugins[name] = copyPlugin(*plugin)
-	}
-	config.Plugin = plugins
-	return &config
-}
-
 // forConfig creates a copy of this BuildState based on the given config files.
 func (state *BuildState) forConfig(config ...string) *BuildState {
 	state.progress.mutex.Lock()
 	defer state.progress.mutex.Unlock()
 	// Duplicate & alter configuration
-	c := copyConfig(*state.Config)
+	c := state.Config.copyConfig()
 	for _, filename := range config {
 		if err := readConfigFile(c, filename); err != nil {
 			log.Fatalf("Failed to read config file %s: %s", filename, err)

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -150,7 +150,6 @@ func addTargetDeps(state *BuildState, pkg *Package, name string, deps ...string)
 	return target
 }
 
-
 func TestCopyPlugin(t *testing.T) {
 	plugin := &Plugin{
 		ExtraValues: map[string][]string{

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -149,3 +149,18 @@ func addTargetDeps(state *BuildState, pkg *Package, name string, deps ...string)
 	state.Graph.AddTarget(target)
 	return target
 }
+
+
+func TestCopyPlugin(t *testing.T) {
+	plugin := &Plugin{
+		ExtraValues: map[string][]string{
+			"foo": {"foo"},
+		},
+	}
+
+	newPlugin := copyPlugin(*plugin)
+
+	newPlugin.ExtraValues["foo"] = []string{"bar"}
+
+	assert.NotEqual(t, plugin.ExtraValues["foo"], newPlugin.ExtraValues["foo"])
+}

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -157,7 +157,9 @@ func TestCopyPlugin(t *testing.T) {
 		},
 	}
 
-	newPlugin := copyPlugin(*plugin)
+	newPlugin := plugin.copyPlugin()
+
+	assert.False(t, plugin == newPlugin)
 
 	newPlugin.ExtraValues["foo"] = []string{"bar"}
 

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -141,7 +141,7 @@ func (i *interpreter) Subinclude(path string, label core.BuildLabel, pkg *core.P
 	s.subincludeLabel = &label
 	if label.Subrepo != "" {
 		subrepo := i.scope.state.Graph.SubrepoOrDie(label.Subrepo)
-		loadPluginConfig(subrepo.State, s.config.base)
+		loadPluginConfig(subrepo.State.Config, s.state, s.config.base)
 	}
 	// Scope needs a local version of CONFIG
 	s.config = i.scope.config.Copy()

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -915,25 +915,25 @@ func newConfig(state *core.BuildState) *pyConfig {
 	c["TARGET_ARCH"] = pyString(state.TargetArch.Arch)
 	c["BUILD_CONFIG"] = pyString(state.Config.Build.Config)
 
-	loadPluginConfig(state, c)
+	loadPluginConfig(state.Config, state, c)
 
 	return &pyConfig{base: c}
 }
 
-func loadPluginConfig(state *core.BuildState, c pyDict) {
-	pluginName := state.Config.PluginDefinition.Name
+func loadPluginConfig(subrepoConfig *core.Configuration, packageState *core.BuildState, c pyDict) {
+	pluginName := subrepoConfig.PluginDefinition.Name
 	if pluginName == "" {
 		return
 	}
 
 	extraVals := map[string][]string{}
-	if config := state.Config.Plugin[pluginName]; config != nil {
+	if config := packageState.Config.Plugin[pluginName]; config != nil {
 		extraVals = config.ExtraValues
 	}
 
 	pluginNamespace := pyDict{}
-	contextPackage := &core.Package{SubrepoName: state.CurrentSubrepo}
-	configValueDefinitions := state.Config.PluginConfig
+	contextPackage := &core.Package{SubrepoName: packageState.CurrentSubrepo}
+	configValueDefinitions := subrepoConfig.PluginConfig
 	for key, definition := range configValueDefinitions {
 		fullConfigKey := fmt.Sprintf("%v.%v", pluginName, definition.ConfigKey)
 		value, ok := extraVals[strings.ToLower(definition.ConfigKey)]


### PR DESCRIPTION
This fixes a few issues with loading config from subrepos. 

1. We were doing a shallow copy of the Plugin map. This PR makes sure that we have new Plugin structs when loading in the subrepo config into it's config. 
2. We were applying the config values from the subrepos state when loading plugin config for the host repo's package when doing a subinclude. This change makes sure that we read the plugin definition from the subrepo's config but the values from the host repo's config. This used to mostly work because the subrepo's config is layered ontop of the host repos config. however breaks down when they differ. 