### PR TITLE
Don't assume target exists in output code

### DIFF
--- a/src/output/targets.go
+++ b/src/output/targets.go
@@ -52,7 +52,9 @@ func (bt *buildingTargets) ProcessResult(result *core.BuildResult) core.BuildLab
 	label := result.Label
 	prev := bt.targets[result.ThreadID].Label
 	if !result.Status.IsParse() { // Parse tasks happen on a different set of threads.
-		bt.updateTarget(result, bt.state.Graph.TargetOrDie(label))
+		if t := bt.state.Graph.Target(label); t != nil {
+			bt.updateTarget(result, t)
+		}
 	}
 	if result.Status.IsFailure() {
 		bt.FailedTargets[label] = result.Err


### PR DESCRIPTION
This doesn't cause failures on its own but does obscure the cause a bit (because you just get `CRITICAL: Target //third_party/go:go-bindata not found in build graph` rather than the detailed message about what depended on it).