### PR TITLE
Fix concurrent map write in BuildConfig

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -943,6 +943,11 @@ func (config *Configuration) NumRemoteExecutors() int {
 }
 
 func (config Configuration) copyConfig() *Configuration {
+	buildConfig := config.BuildConfig
+	config.BuildConfig = make(map[string]string, len(buildConfig))
+	for k, v := range buildConfig {
+		config.BuildConfig[k] = v
+	}
 	config.buildEnvStored = &storedBuildEnv{}
 	plugins := map[string]*Plugin{}
 	for name, plugin := range config.Plugin {


### PR DESCRIPTION
Saw this in a recent CircleCI build; looks like we are unintentionally sharing the BuildConfig map between subrepos (so I think you could also use this to leak values between them, which would have been way harder to debug)