### PR TITLE
Remove SingleSHA1Hash

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -40,5 +40,5 @@ sh_cmd(
 github_repo(
     name = "pleasings",
     repo = "thought-machine/pleasings",
-    revision = "v1.0.0",
+    revision = "v1.1.0",
 )

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -519,6 +519,25 @@ func TestSha1SingleHash(t *testing.T) {
 	}
 }
 
+func newStateWithHashCheckers(label, hashFunction string, hashCheckers ...string) (*core.BuildState, *core.BuildTarget) {
+       config, _ := core.ReadConfigFiles(nil, nil)
+       if hashFunction != "" {
+               config.Build.HashFunction = hashFunction
+       }
+       if len(hashCheckers) > 0 {
+               config.Build.HashCheckers = hashCheckers
+       }
+       state := core.NewBuildState(config)
+       state.Config.Parse.BuildFileName = []string{"BUILD_FILE"}
+       target := core.NewBuildTarget(core.ParseBuildLabel(label, ""))
+       target.Command = fmt.Sprintf("echo 'output of %s' > $OUT", target.Label)
+       target.BuildTimeout = 100 * time.Second
+       state.Graph.AddTarget(target)
+       state.Parser = &fakeParser{}
+       Init(state)
+       return state, target
+}
+
 func newStateWithHashFunc(label, hashFunc string) (*core.BuildState, *core.BuildTarget) {
 	config, _ := core.ReadConfigFiles(nil, nil)
 	config.Build.HashFunction = hashFunc

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -520,22 +520,22 @@ func TestSha1SingleHash(t *testing.T) {
 }
 
 func newStateWithHashCheckers(label, hashFunction string, hashCheckers ...string) (*core.BuildState, *core.BuildTarget) {
-       config, _ := core.ReadConfigFiles(nil, nil)
-       if hashFunction != "" {
-               config.Build.HashFunction = hashFunction
-       }
-       if len(hashCheckers) > 0 {
-               config.Build.HashCheckers = hashCheckers
-       }
-       state := core.NewBuildState(config)
-       state.Config.Parse.BuildFileName = []string{"BUILD_FILE"}
-       target := core.NewBuildTarget(core.ParseBuildLabel(label, ""))
-       target.Command = fmt.Sprintf("echo 'output of %s' > $OUT", target.Label)
-       target.BuildTimeout = 100 * time.Second
-       state.Graph.AddTarget(target)
-       state.Parser = &fakeParser{}
-       Init(state)
-       return state, target
+	config, _ := core.ReadConfigFiles(nil, nil)
+	if hashFunction != "" {
+		config.Build.HashFunction = hashFunction
+	}
+	if len(hashCheckers) > 0 {
+		config.Build.HashCheckers = hashCheckers
+	}
+	state := core.NewBuildState(config)
+	state.Config.Parse.BuildFileName = []string{"BUILD_FILE"}
+	target := core.NewBuildTarget(core.ParseBuildLabel(label, ""))
+	target.Command = fmt.Sprintf("echo 'output of %s' > $OUT", target.Label)
+	target.BuildTimeout = 100 * time.Second
+	state.Graph.AddTarget(target)
+	state.Parser = &fakeParser{}
+	Init(state)
+	return state, target
 }
 
 func newStateWithHashFunc(label, hashFunc string) (*core.BuildState, *core.BuildTarget) {

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -691,7 +691,6 @@ type Configuration struct {
 
 	FeatureFlags struct {
 		JavaBinaryExecutableByDefault bool `help:"Makes java_binary rules self executable by default. Target release version 16." var:"FF_JAVA_SELF_EXEC"`
-		SingleSHA1Hash                bool `help:"Stop combining sha1 with the empty hash when there's a single output (just like SHA256 and the other hash functions do) "`
 		PackageOutputsStrictness      bool `help:"Prevents certain combinations of target outputs within a package that result in nondeterminist behaviour"`
 		PythonWheelHashing            bool `help:"This hashes the internal build rule that downloads the wheel instead" var:"FF_PYTHON_WHEEL_HASHING"`
 		NoIterSourcesMarked           bool `help:"Don't mark sources as done when iterating inputs" var:"FF_NO_ITER_SOURCES_MARKED"`


### PR DESCRIPTION
Bit of coding to pass the time on the plane.
Removes the SingleSHA1 fflag and associated code. This simplifies these code paths a bit for the next change (which is the real thing I wanted, but split this out to simplify it a bit).

Should be a v17 change since we never made this the default in v16.