### PR TITLE
Make shebang optional for sh_binary

### DIFF
--- a/rules/sh_rules.build_defs
+++ b/rules/sh_rules.build_defs
@@ -62,8 +62,8 @@ def sh_binary(name:str, main:str|list&srcs, out:str="", deps:list=None, data:lis
     # No need to go through zip/unzip and injecting code if there are no dependencies
     if deps:
         cmds = ' && '.join([
-            # Use the same shebang as the original script
-            'head -1 "$SRCS" > "$TMPDIR"/_tmp.txt',
+            # If set, use the same shebang as the original script
+            'head -1 "$SRCS" | { grep "^#\!" || true; } > "$TMPDIR"/_tmp.txt',
             # Inject bash code to untar the compressed files.
             f'echo "{_SH_BINARY_TMPL_PREFIX}" >> "$TMPDIR"/_tmp.txt',
             # Inject the user defined script.

--- a/test/sh_rules/BUILD
+++ b/test/sh_rules/BUILD
@@ -59,3 +59,17 @@ sh_test(
     name = "no_shebang_test",
     src = ":no_shebang",
 )
+
+sh_binary(
+    name = "shebang",
+    main = "shebang.sh",
+    deps = [
+        # Although not used by `shebang.sh` directly, the shebang is currently reused when `deps` are provided.
+        ":sh_lib",
+    ],
+)
+
+sh_test(
+    name = "shebang_test",
+    src = ":shebang",
+)

--- a/test/sh_rules/BUILD
+++ b/test/sh_rules/BUILD
@@ -45,3 +45,17 @@ sh_test(
     name = "sh_cmd_unexpanded_test",
     src = ":sh_cmd_unexpanded",
 )
+
+sh_binary(
+    name = "no_shebang",
+    main = "no_shebang.sh",
+    deps = [
+        # Although not used by `no_shebang.sh` directly, the shebang is currently reused when `deps` are provided.
+        ":sh_lib",
+    ],
+)
+
+sh_test(
+    name = "no_shebang_test",
+    src = ":no_shebang",
+)

--- a/test/sh_rules/no_shebang.sh
+++ b/test/sh_rules/no_shebang.sh
@@ -1,0 +1,8 @@
+true
+
+# This checks that the top line of the script isn't reused for building the target unless it's a shebang.
+if ! grep -ax "true" $0 | wc -l | grep -x "1" >/dev/null; then
+    echo "The top line of the file is being reused and it's not a shebang" >&2
+    exit 1
+fi
+

--- a/test/sh_rules/no_shebang.sh
+++ b/test/sh_rules/no_shebang.sh
@@ -1,8 +1,8 @@
 true
 
-# This checks that the top line of the script isn't reused for building the target unless it's a shebang.
-if ! grep -ax "true" $0 | wc -l | grep -x "1" >/dev/null; then
-    echo "The top line of the file is being reused and it's not a shebang" >&2
+# This checks that the top line of the script isn't reused for building the target as it's not a shebang.
+if [ "`grep -axc "true" $0`" != "1" ]; then
+    echo "The top line of the original file is being reused and it's not a shebang" >&2
     exit 1
 fi
 

--- a/test/sh_rules/shebang.sh
+++ b/test/sh_rules/shebang.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ "`head -1 $0`" != "#!/usr/bin/env bash" ]; then
+    echo "Shebang of the original file isn't the first line of the produced artefact" >&2
+    exit 1
+fi
+


### PR DESCRIPTION
This was causing issues where the first line of the script was being repeated even if it wasn't a shebang.