### PR TITLE
Make the targets containing subrepos output into plz-out/subrepos

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -12,7 +12,8 @@ def build_rule(name:str, cmd:str|dict='', test_cmd:str|dict='', debug_cmd:str=''
                post_build:function=None, requires:list=None, provides:dict=None, licences:list=CONFIG.DEFAULT_LICENCES,
                test_outputs:list=None, system_srcs:list=None, stamp:bool=False, tag:str='', optional_outs:list=None, progress:bool=False,
                size:str=None, _urls:list=None, internal_deps:list=None, pass_env:list=None, local:bool=False, output_dirs:list=[],
-               exit_on_error:bool=CONFIG.EXIT_ON_ERROR, entry_points:dict={}, env:dict={}, _file_content:str=None):
+               exit_on_error:bool=CONFIG.EXIT_ON_ERROR, entry_points:dict={}, env:dict={}, _file_content:str=None,
+               _subrepo:bool=False):
     pass
 
 

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -114,6 +114,7 @@ def new_http_archive(name:str, urls:list, build_file:str=None, build_file_conten
         tools = [CONFIG.JARCAT_TOOL],
         outs = [name],
         cmd = cmd,
+        _subrepo = True,
     )
     return subrepo(
         name = name,

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -222,6 +222,7 @@ func ruleHash(state *core.BuildState, target *core.BuildTarget, runtime bool) []
 		h.Write([]byte(secret))
 	}
 	hashBool(h, target.IsBinary)
+	hashOptionalBool(h, target.IsSubrepo)
 	hashOptionalBool(h, target.Sandbox)
 
 	// Note that we only hash the current command here; whatever's set in commands that we're not going

--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -22,6 +22,7 @@ var KnownFields = map[string]bool{
 	"Sources":                     true,
 	"NamedSources":                true,
 	"IsBinary":                    true,
+	"IsSubrepo":                   true,
 	"IsFilegroup":                 true,
 	"IsTextFile":                  true,
 	"FileContent":                 true,

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -29,7 +29,7 @@ const GenDir string = "plz-out/gen"
 const BinDir string = "plz-out/bin"
 
 // SubrepoDir is the output directory for targets that define subrepos.
-const SubrepoDir = "plz-out/sub"
+const SubrepoDir = "plz-out/subrepos"
 
 // DefaultBuildingDescription is the default description for targets when they're building.
 const DefaultBuildingDescription = "Building..."

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -28,6 +28,9 @@ const GenDir string = "plz-out/gen"
 // BinDir is the output directory for binary targets.
 const BinDir string = "plz-out/bin"
 
+// SubrepoDir is the output directory for targets that define subrepos.
+const SubrepoDir = "plz-out/sub"
+
 // DefaultBuildingDescription is the default description for targets when they're building.
 const DefaultBuildingDescription = "Building..."
 
@@ -199,6 +202,8 @@ type BuildTarget struct {
 	completedRuns uint16 `print:"false"`
 	// True if this target is a binary (ie. runnable, will appear in plz-out/bin)
 	IsBinary bool `name:"binary"`
+	// True if this target is an input for a subrepo; if so outputs will appear in plz-out/sub.
+	IsSubrepo bool `name:"subrepo"`
 	// Indicates that the target can only be depended on by tests or other rules with this set.
 	// Used to restrict non-deployable code and also affects coverage detection.
 	TestOnly bool `name:"test_only"`
@@ -384,7 +389,9 @@ func (target *BuildTarget) BuildLockFile() string {
 // OutDir returns the output directory for this target, eg.
 // //mickey/donald:goofy -> plz-out/gen/mickey/donald (or plz-out/bin if it's a binary)
 func (target *BuildTarget) OutDir() string {
-	if target.IsBinary {
+	if target.IsSubrepo {
+		return path.Join(SubrepoDir, target.Label.Subrepo, target.Label.PackageName)
+	} else if target.IsBinary {
 		return path.Join(BinDir, target.Label.Subrepo, target.Label.PackageName)
 	}
 	return path.Join(GenDir, target.Label.Subrepo, target.Label.PackageName)

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -65,6 +65,7 @@ const (
 	entryPointsArgIdx
 	envArgIdx
 	fileContentArgIdx
+	subrepoArgIdx
 )
 
 // createTarget creates a new build target as part of build_rule().
@@ -93,6 +94,7 @@ func createTarget(s *scope, args []pyObject) *core.BuildTarget {
 	target := core.NewBuildTarget(label)
 	target.Subrepo = s.pkg.Subrepo
 	target.IsBinary = isTruthy(binaryBuildRuleArgIdx)
+	target.IsSubrepo = isTruthy(subrepoArgIdx)
 	target.NeedsTransitiveDependencies = isTruthy(needsTransitiveDepsBuildRuleArgIdx)
 	target.OutputIsComplete = isTruthy(outputIsCompleteBuildRuleArgIdx)
 	target.Sandbox = isTruthy(sandboxBuildRuleArgIdx)


### PR DESCRIPTION
There are some subtle errors that can come up with the existing setup; one I have seen is that `glob` can behave differently between runs (for example if something outputs a file that would be caught by the glob, on the first run it doesn't exist, on a later run maybe it does and then the build behaves differently or fails).

This puts the subrepo trees in `plz-out/sub` where they should be less subject to change. I don't think there is a lot of cost to that (we create another name in `plz-out` but it's not like we're about to run out there).