### PR TITLE
Remove two unused arguments from build_rule

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -7,11 +7,11 @@ def build_rule(name:str, cmd:str|dict='', test_cmd:str|dict='', debug_cmd:str=''
                tools:str|list|dict=None, test_tools:str|list|dict=None, debug_tools:str|list|dict=None, labels:list=None,
                visibility:list=CONFIG.DEFAULT_VISIBILITY, hashes:list=None, binary:bool=False, test:bool=False,
                test_only:bool=CONFIG.DEFAULT_TESTONLY, building_description:str=None, needs_transitive_deps:bool=False,
-               output_is_complete:bool=False, _=None, sandbox:bool=CONFIG.BUILD_SANDBOX, test_sandbox:bool=CONFIG.TEST_SANDBOX,
+               output_is_complete:bool=False, sandbox:bool=CONFIG.BUILD_SANDBOX, test_sandbox:bool=CONFIG.TEST_SANDBOX,
                no_test_output:bool=False, flaky:bool|int=0, build_timeout:int|str=0, test_timeout:int|str=0, pre_build:function=None,
                post_build:function=None, requires:list=None, provides:dict=None, licences:list=CONFIG.DEFAULT_LICENCES,
                test_outputs:list=None, system_srcs:list=None, stamp:bool=False, tag:str='', optional_outs:list=None, progress:bool=False,
-               size:str=None, _urls:list=None, internal_deps:list=None, pass_env:list=None, local:bool=False, output_dirs:list=[], __=None,
+               size:str=None, _urls:list=None, internal_deps:list=None, pass_env:list=None, local:bool=False, output_dirs:list=[],
                exit_on_error:bool=CONFIG.EXIT_ON_ERROR, entry_points:dict={}, env:dict={}, _file_content:str=None):
     pass
 

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -38,7 +38,6 @@ const (
 	buildingDescriptionBuildRuleArgIdx
 	needsTransitiveDepsBuildRuleArgIdx
 	outputIsCompleteBuildRuleArgIdx
-	_
 	sandboxBuildRuleArgIdx
 	testSandboxBuildRuleArgIdx
 	noTestOutputBuildRuleArgIdx
@@ -62,7 +61,6 @@ const (
 	passEnvBuildRuleArgIdx
 	localBuildRuleArgIdx
 	outDirsBuildRuleArgIdx
-	_
 	exitOnErrorArgIdx
 	entryPointsArgIdx
 	envArgIdx


### PR DESCRIPTION
I don't think we have to wait for anything in particular before getting rid of these?