### PR TITLE
Update the lexicon with some missing functions

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -231,9 +231,17 @@
     <li>
       <span>
         <code class="code"
+          ><span class="fn-name">json</span><span class="fn-p">(</span
+          ><span class="fn-arg">x</span><span class="fn-p">)</span></code
+        >
+        - returns a JSON-formatted representation of a plz value.
+      </span>
+    </li>
+    <li>
+      <span>
+        <code class="code"
           ><span class="fn-name">is_semver</span><span class="fn-p">(</span
-          ><span class="fn-arg">s</span>
-          <span class="fn-p">)</span></code
+          ><span class="fn-arg">s</span><span class="fn-p">)</span></code
         >
         - returns true if <code class="code">s</code> is a <a href="https://semver.org/">semantic version</a> (either
         with or without a leading &quot;v&quot;), or false if not.
@@ -624,7 +632,7 @@
           - Indicates that something has gone catastrophically wrong, and causes
           the process to exit immediately and unsuccessfully. Usually you are
           better off using <code class="code">assert</code> or
-          <code class="code">raise</code> to indicate failure, since plz can
+          <code class="code">fail()</code> to indicate failure, since plz can
           handle those and annotate with additional output.
         </span>
       </li>
@@ -1204,6 +1212,7 @@
   {{ template "lexicon_entry.html" .Named "system_library" }}
   {{ template "lexicon_entry.html" .Named "remote_file" }}
   {{ template "lexicon_entry.html" .Named "tarball" }}
+  {{ template "lexicon_entry.html" .Named "text_file" }}
 
   <section class="mt4">
     <h3 class="title-3" id="git_branch">


### PR DESCRIPTION
I noticed json() and text_file() came through, but I didn't see docs reflect. Also, removed another reference to `raise` and fixed a spacing nit with `is_semver`'s display on the webpage.

(disclaimer: I haven't tested this, but I assume this is probably a small enough fix, unless I missed some other file I had to modify, also.)