### PR TITLE
Merge build and test queues

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -35,7 +35,7 @@ type ParseTask struct {
 }
 
 // A TaskType identifies whether a task is a build or test action.
-type TaskType uint16
+type TaskType uint8
 
 const (
 	BuildTask TaskType = 0
@@ -46,7 +46,7 @@ const (
 type Task struct {
 	Label BuildLabel
 	Type  TaskType
-	Run   int32 // Only present for tests (the run of a build is always zero)
+	Run   uint32 // Only present for tests (the run of a build is always zero)
 }
 
 // Debug is the type for debugging a target
@@ -321,7 +321,7 @@ func (state *BuildState) addPendingTest(target *BuildTarget, numRuns int) {
 			ch = state.pendingRemoteActions
 		}
 		for run := 1; run <= numRuns; run++ {
-			ch <- Task{Label: target.Label, Run: int32(run), Type: TestTask}
+			ch <- Task{Label: target.Label, Run: uint32(run), Type: TestTask}
 		}
 	}()
 }

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -34,13 +34,11 @@ type ParseTask struct {
 	ForSubinclude    bool
 }
 
-// BuildTask is the type for the build task queue
-type BuildTask = BuildLabel
-
-// TestTask is the type for the test task queue
-type TestTask struct {
+// A Task is the type for the queue of build/test tasks.
+type Task struct {
 	Label BuildLabel
-	Run   int
+	Test  bool  // True if this task is a test
+	Run   int32 // Only present for tests (the run of a build is always zero)
 }
 
 // Debug is the type for debugging a target
@@ -97,9 +95,8 @@ type TargetHasher interface {
 type BuildState struct {
 	Graph *BuildGraph
 	// Streams of pending tasks
-	pendingParses                      chan ParseTask
-	pendingBuilds, pendingRemoteBuilds chan BuildTask
-	pendingTests, pendingRemoteTests   chan TestTask
+	pendingParses                        chan ParseTask
+	pendingActions, pendingRemoteActions chan Task
 	// Timestamp that the build is considered to start at.
 	StartTime time.Time
 	// Various system statistics. Mostly used during remote communication.
@@ -289,9 +286,9 @@ func (state *BuildState) addPendingBuild(target *BuildTarget) {
 			recover() // Prevent death on 'send on closed channel'
 		}()
 		if state.anyRemote && !target.Local {
-			state.pendingRemoteBuilds <- target.Label
+			state.pendingRemoteActions <- Task{Label: target.Label}
 		} else {
-			state.pendingBuilds <- target.Label
+			state.pendingActions <- Task{Label: target.Label}
 		}
 	}()
 }
@@ -311,19 +308,19 @@ func (state *BuildState) addPendingTest(target *BuildTarget, numRuns int) {
 		defer func() {
 			recover() // Prevent death on 'send on closed channel'
 		}()
-		ch := state.pendingTests
+		ch := state.pendingActions
 		if state.anyRemote && !target.Local {
-			ch = state.pendingRemoteTests
+			ch = state.pendingRemoteActions
 		}
 		for run := 1; run <= numRuns; run++ {
-			ch <- TestTask{Label: target.Label, Run: run}
+			ch <- Task{Label: target.Label, Run: int32(run), Test: true}
 		}
 	}()
 }
 
 // TaskQueues returns a set of channels to listen on for tasks of various types.
-func (state *BuildState) TaskQueues() (parses <-chan ParseTask, builds, remoteBuilds <-chan BuildTask, tests, remoteTests <-chan TestTask) {
-	return state.pendingParses, state.pendingBuilds, state.pendingRemoteBuilds, state.pendingTests, state.pendingRemoteTests
+func (state *BuildState) TaskQueues() (parses <-chan ParseTask, actions, remoteActions <-chan Task) {
+	return state.pendingParses, state.pendingActions, state.pendingRemoteActions
 }
 
 // TaskDone indicates that a single task is finished. Should be called after one is finished with
@@ -345,10 +342,8 @@ func (state *BuildState) taskDone(wasSynthetic bool) {
 func (state *BuildState) Stop() {
 	state.progress.closeOnce.Do(func() {
 		close(state.pendingParses)
-		close(state.pendingBuilds)
-		close(state.pendingRemoteBuilds)
-		close(state.pendingTests)
-		close(state.pendingRemoteTests)
+		close(state.pendingActions)
+		close(state.pendingRemoteActions)
 	})
 }
 
@@ -1132,12 +1127,10 @@ func sandboxTool(config *Configuration) string {
 func NewBuildState(config *Configuration) *BuildState {
 	graph := NewGraph()
 	state := &BuildState{
-		Graph:               graph,
-		pendingParses:       make(chan ParseTask, 10000),
-		pendingBuilds:       make(chan BuildTask, 1000),
-		pendingRemoteBuilds: make(chan BuildTask, 1000),
-		pendingTests:        make(chan TestTask, 1000),
-		pendingRemoteTests:  make(chan TestTask, 1000),
+		Graph:                graph,
+		pendingParses:        make(chan ParseTask, 10000),
+		pendingActions:       make(chan Task, 1000),
+		pendingRemoteActions: make(chan Task, 1000),
 		hashers: map[string]*fs.PathHasher{
 			// For compatibility reasons the sha1 hasher has no suffix.
 			"sha1":   fs.NewPathHasher(RepoRoot, config.Build.Xattrs, sha1.New, "sha1"),

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -109,20 +109,20 @@ func TestAddTargetFilegroupPackageOutputs(t *testing.T) {
 
 func TestAddDepsToTarget(t *testing.T) {
 	state := NewDefaultBuildState()
-	_, builds, _, _, _ := state.TaskQueues() //nolint:dogsled
+	_, builds, _ := state.TaskQueues() //nolint:dogsled
 	pkg := NewPackage("src/core")
 	target1 := addTargetDeps(state, pkg, "//src/core:target1", "//src/core:target2")
 	target2 := addTargetDeps(state, pkg, "//src/core:target2")
 	state.Graph.AddPackage(pkg)
 	state.QueueTarget(target1.Label, OriginalTarget, false)
 	task := <-builds
-	assert.Equal(t, target2.Label, task)
+	assert.Equal(t, Task{Label: target2.Label}, task)
 	// Now simulate target2 being built and adding a new dep to target1 in its post-build function.
 	target3 := addTargetDeps(state, pkg, "//src/core:target3")
 	target1.AddDependency(target3.Label)
 	target2.FinishBuild()
 	task = <-builds
-	assert.Equal(t, target3.Label, task)
+	assert.Equal(t, Task{Label: target3.Label}, task)
 }
 
 func addTarget(state *BuildState, name string, labels ...string) {

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -109,7 +109,7 @@ func TestAddTargetFilegroupPackageOutputs(t *testing.T) {
 
 func TestAddDepsToTarget(t *testing.T) {
 	state := NewDefaultBuildState()
-	_, builds, _ := state.TaskQueues() //nolint:dogsled
+	_, builds, _ := state.TaskQueues()
 	pkg := NewPackage("src/core")
 	target1 := addTargetDeps(state, pkg, "//src/core:target1", "//src/core:target2")
 	target2 := addTargetDeps(state, pkg, "//src/core:target2")

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -132,10 +132,10 @@ func assertPendingBuilds(t *testing.T, state *core.BuildState, targets ...string
 }
 
 func getAllPending(state *core.BuildState) ([]string, []string) {
-	parses, builds, _, tests, _ := state.TaskQueues()
+	parses, builds, _ := state.TaskQueues()
 	state.Stop()
 	var pendingParses, pendingBuilds []string
-	for parses != nil || builds != nil || tests != nil {
+	for parses != nil || builds != nil {
 		select {
 		case p, ok := <-parses:
 			if !ok {
@@ -143,17 +143,12 @@ func getAllPending(state *core.BuildState) ([]string, []string) {
 				break
 			}
 			pendingParses = append(pendingParses, p.Label.String())
-		case l, ok := <-builds:
+		case t, ok := <-builds:
 			if !ok {
 				builds = nil
 				break
 			}
-			pendingBuilds = append(pendingBuilds, l.String())
-		case _, ok := <-tests:
-			if !ok {
-				tests = nil
-				break
-			}
+			pendingBuilds = append(pendingBuilds, t.Label.String())
 		}
 	}
 	return pendingParses, pendingBuilds

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -87,9 +87,10 @@ func RunHost(targets []core.BuildLabel, state *core.BuildState) {
 
 func doTasks(tid int, state *core.BuildState, actions <-chan core.Task, remote bool) {
 	for task := range actions {
-		if task.Test {
+		switch task.Type {
+		case core.TestTask:
 			test.Test(tid, state, task.Label, remote, int(task.Run))
-		} else {
+		case core.BuildTask:
 			build.Build(tid, state, task.Label, remote)
 		}
 		state.TaskDone()

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -38,7 +38,7 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, config *
 	// Start looking for the initial targets to kick the build off
 	go findOriginalTasks(state, preTargets, targets, arch)
 
-	parses, builds, remoteBuilds, tests, remoteTests := state.TaskQueues()
+	parses, actions, remoteActions := state.TaskQueues()
 
 	// Start up all the build workers
 	var wg sync.WaitGroup
@@ -56,13 +56,13 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, config *
 	}()
 	for i := 0; i < config.Please.NumThreads; i++ {
 		go func(tid int) {
-			doTasks(tid, state, builds, tests, false)
+			doTasks(tid, state, actions, false)
 			wg.Done()
 		}(i)
 	}
 	for i := 0; i < config.NumRemoteExecutors(); i++ {
 		go func(tid int) {
-			doTasks(tid, state, remoteBuilds, remoteTests, true)
+			doTasks(tid, state, remoteActions, true)
 			wg.Done()
 		}(config.Please.NumThreads + i)
 	}
@@ -85,24 +85,14 @@ func RunHost(targets []core.BuildLabel, state *core.BuildState) {
 	Run(targets, nil, state, state.Config, cli.HostArch())
 }
 
-func doTasks(tid int, state *core.BuildState, builds <-chan core.BuildTask, tests <-chan core.TestTask, remote bool) {
-	for builds != nil || tests != nil {
-		select {
-		case l, ok := <-builds:
-			if !ok {
-				builds = nil
-				break
-			}
-			build.Build(tid, state, l, remote)
-			state.TaskDone()
-		case testTask, ok := <-tests:
-			if !ok {
-				tests = nil
-				break
-			}
-			test.Test(tid, state, testTask.Label, remote, testTask.Run)
-			state.TaskDone()
+func doTasks(tid int, state *core.BuildState, actions <-chan core.Task, remote bool) {
+	for task := range actions {
+		if task.Test {
+			test.Test(tid, state, task.Label, remote, int(task.Run))
+		} else {
+			build.Build(tid, state, task.Label, remote)
 		}
+		state.TaskDone()
 	}
 }
 


### PR DESCRIPTION
Dreaming a bit about being able to unify more of the behaviour (at least in terms of incrementalism) between the build & test tasks.

Think this is nicer in itself though (particularly the `plz.go` part where it can now just range a single channel).