### PR TITLE
Fix subrepo package names in query graph

### DIFF
--- a/src/query/graph.go
+++ b/src/query/graph.go
@@ -120,7 +120,11 @@ func makeJSONPackage(state *core.BuildState, pkg *core.Package) JSONPackage {
 	for _, target := range pkg.AllTargets() {
 		targets[target.Label.Name] = makeJSONTarget(state, target)
 	}
-	return JSONPackage{name: pkg.Name, Targets: targets}
+	name := pkg.Name
+	if pkg.SubrepoName != "" {
+		name = "///" + pkg.SubrepoName + "//" + pkg.Name
+	}
+	return JSONPackage{name: name, Targets: targets}
 }
 
 func makeJSONTarget(state *core.BuildState, target *core.BuildTarget) JSONTarget {

--- a/src/query/graph.go
+++ b/src/query/graph.go
@@ -43,19 +43,19 @@ type JSONPackage struct {
 
 // JSONTarget is an alternate representation of a build target
 type JSONTarget struct {
-	Inputs   []string `json:"inputs,omitempty" note:"declared inputs of target"`
-	Outputs  []string `json:"outs,omitempty" note:"corresponds to outs in rule declaration"`
+	Inputs   []string    `json:"inputs,omitempty" note:"declared inputs of target"`
+	Outputs  []string    `json:"outs,omitempty" note:"corresponds to outs in rule declaration"`
 	Sources  interface{} `json:"srcs,omitempty" note:"corresponds to srcs in rule declaration"`
 	Tools    interface{} `json:"tools,omitempty" note:"corresponds to tools in rule declaration"`
-	Deps     []string `json:"deps,omitempty" note:"corresponds to deps in rule declaration"`
-	Data     []string `json:"data,omitempty" note:"corresponds to data in rule declaration"`
-	Labels   []string `json:"labels,omitempty" note:"corresponds to labels in rule declaration"`
-	Requires []string `json:"requires,omitempty" note:"corresponds to requires in rule declaration"`
-	Command  string   `json:"command,omitempty" note:"the currently active command of the target. not present on filegroup or remote_file actions"`
-	Hash     string   `json:"hash" note:"partial hash of target, does not include source hash"`
-	Test     bool     `json:"test,omitempty" note:"true if target is a test"`
-	Binary   bool     `json:"binary,omitempty" note:"true if target is a binary"`
-	TestOnly bool     `json:"test_only,omitempty" note:"true if target should be restricted to test code"`
+	Deps     []string    `json:"deps,omitempty" note:"corresponds to deps in rule declaration"`
+	Data     []string    `json:"data,omitempty" note:"corresponds to data in rule declaration"`
+	Labels   []string    `json:"labels,omitempty" note:"corresponds to labels in rule declaration"`
+	Requires []string    `json:"requires,omitempty" note:"corresponds to requires in rule declaration"`
+	Command  string      `json:"command,omitempty" note:"the currently active command of the target. not present on filegroup or remote_file actions"`
+	Hash     string      `json:"hash" note:"partial hash of target, does not include source hash"`
+	Test     bool        `json:"test,omitempty" note:"true if target is a test"`
+	Binary   bool        `json:"binary,omitempty" note:"true if target is a binary"`
+	TestOnly bool        `json:"test_only,omitempty" note:"true if target should be restricted to test code"`
 }
 
 func makeJSONGraph(state *core.BuildState, targets []core.BuildLabel) *JSONGraph {

--- a/src/query/graph.go
+++ b/src/query/graph.go
@@ -50,6 +50,7 @@ type JSONTarget struct {
 	Data     []string `json:"data,omitempty" note:"corresponds to data in rule declaration"`
 	Labels   []string `json:"labels,omitempty" note:"corresponds to labels in rule declaration"`
 	Requires []string `json:"requires,omitempty" note:"corresponds to requires in rule declaration"`
+	Command  string   `json:"command,omitempty" note:"the currently active command of the target. not present on filegroup or remote_file actions"`
 	Hash     string   `json:"hash" note:"partial hash of target, does not include source hash"`
 	Test     bool     `json:"test,omitempty" note:"true if target is a test"`
 	Binary   bool     `json:"binary,omitempty" note:"true if target is a binary"`
@@ -163,6 +164,9 @@ func makeJSONTarget(state *core.BuildState, target *core.BuildTarget) JSONTarget
 	}
 	t.Labels = target.Labels
 	t.Requires = target.Requires
+	if !target.IsFilegroup && !target.IsRemoteFile {
+		t.Command = target.GetCommand(state)
+	}
 	rawHash := append(build.RuleHash(state, target, true, false), state.Hashes.Config...)
 	t.Hash = base64.RawStdEncoding.EncodeToString(rawHash)
 	t.Test = target.IsTest()


### PR DESCRIPTION
They don't have the subrepo name in them, so will overwrite other ones in the output if they have the same name within the repo. This puts them into a separate subfield called `subrepos`.

Also adds `command` and `tools` fields in case the queryer wants to read those.