### PR TITLE
Small improvements to bultins

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -124,9 +124,9 @@ def config_get(self:config, key:str, default=None) -> config:
     pass
 
 
-def get_base_path() -> str:
+def get_base_path(label:str=None) -> str:
     pass
-def package_name() -> str:
+def package_name(label:str=None) -> str:
     pass
 def subrepo_name() -> str:
     pass
@@ -222,7 +222,7 @@ ValueError = _deprecated_exception
 
 
 # Post-build callback functions.
-def get_labels(name:str, prefix:str, all:bool=False) -> list:
+def get_labels(name:str, prefix:str, all:bool=False, transitive=True) -> list:
     pass
 def has_label(name:str, prefix:str, all:bool=False) -> bool:
     return len(get_labels(name, prefix, all)) > 0

--- a/rules/proto_rules.build_defs
+++ b/rules/proto_rules.build_defs
@@ -104,6 +104,7 @@ def proto_library(name:str, srcs:list, deps:list=[], visibility:list=None, label
     # This is the final rule that directs dependencies to the appropriate language.
     return filegroup(
         name = name,
+        srcs = srcs,
         deps = provides.values(),
         provides = provides,
         visibility = visibility,

--- a/src/parse/asp/BUILD
+++ b/src/parse/asp/BUILD
@@ -22,6 +22,15 @@ go_library(
 )
 
 go_test(
+    name = "builtins_test",
+    srcs = ["builtins_test.go"],
+    deps = [
+        ":asp",
+        "//third_party/go:testify",
+    ],
+)
+
+go_test(
     name = "parser_test",
     srcs = ["parser_test.go"],
     data = ["test_data"],

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -628,13 +628,11 @@ func packageName(s *scope, args []pyObject) pyObject {
 	pkg := ""
 	if s.pkg != nil {
 		pkg = s.pkg.Name
-	}
-	if s.subincludeLabel != nil {
+	} else if s.subincludeLabel != nil {
 		pkg = s.subincludeLabel.PackageName
-	}
-
-	if pkg == "" {
+	} else {
 		s.Error("you cannot call package_name() from this context")
+		return nil
 	}
 
 	if label, ok := args[0].(pyString); ok && label != "" {

--- a/src/parse/asp/builtins_test.go
+++ b/src/parse/asp/builtins_test.go
@@ -1,0 +1,48 @@
+package asp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/thought-machine/please/src/core"
+)
+
+func TestPackageName(t *testing.T) {
+	s := &scope{pkg: &core.Package{Name: "test/package"}}
+	assert.Equal(t, "test/package", packageName(s, []pyObject{pyNone{}}).String())
+	assert.Equal(t, "test/package", packageName(s, []pyObject{pyString(":test")}).String())
+	assert.Equal(t, "foo/bar", packageName(s, []pyObject{pyString("//foo/bar:test")}).String())
+
+	s = &scope{subincludeLabel: &core.BuildLabel{PackageName: "test/package"}}
+	assert.Equal(t, "test/package", packageName(s, []pyObject{pyNone{}}).String())
+	assert.Equal(t, "test/package", packageName(s, []pyObject{pyString(":test")}).String())
+	assert.Equal(t, "foo/bar", packageName(s, []pyObject{pyString("//foo/bar:test")}).String())
+}
+
+func TestGetLabels(t *testing.T) {
+	state := core.NewBuildState(core.DefaultConfiguration())
+	foo := core.NewBuildTarget(core.NewBuildLabel("pkg", "foo"))
+	foo.AddLabel("cc:ld:-ldl")
+	foo.SetState(core.Built)
+
+	bar := core.NewBuildTarget(core.NewBuildLabel("pkg", "bar"))
+	bar.AddDependency(foo.Label)
+	bar.AddLabel("cc:ld:-pthread")
+	bar.SetState(core.Built)
+
+	state.Graph.AddTarget(foo)
+	state.Graph.AddTarget(bar)
+
+	err := bar.ResolveDependencies(state.Graph)
+	require.NoError(t, err)
+
+	s := &scope{state: state, pkg: core.NewPackage("pkg")}
+	ls := getLabels(s, []pyObject{pyString(":bar"), pyString("cc:ld:"), False, True}).(pyList)
+	assert.Len(t, ls, 2)
+
+	ls = getLabels(s, []pyObject{pyString(":bar"), pyString("cc:ld:"), False, False}).(pyList)
+	assert.Len(t, ls, 1)
+	assert.Equal(t, pyString("-pthread"), ls[0])
+}


### PR DESCRIPTION
1) Add transitive label to `get_labels()` to allow opting out of fetching all the transitive labels that match
2) Allow `package_name()` to take a build label. In which case it will return the package name of that build label instead.
3) Add the `.proto` files as srcs to the namesake filegroup returned by the proto rules. This is just more useful that returning nothing.  