### PR TITLE
Fixes named fields not showing up when using 'plz query print --field=srcs'

### DIFF
--- a/src/query/print.go
+++ b/src/query/print.go
@@ -192,10 +192,10 @@ func (p *printer) findField(field string) reflect.StructField {
 		resIndex := -1
 		for i := 0; i < v.NumField(); i++ {
 			if f := t.Field(i); p.fieldName(f) == fieldName {
-				if resIndex == -1 {
-					resIndex = i
-				} else if v.Field(resIndex).IsZero() && !v.Field(i).IsZero() {
+				if !v.Field(i).IsZero() {
 					return t.Field(i), true
+				} else if resIndex == -1 {
+					resIndex = i
 				}
 			}
 		}

--- a/src/query/print.go
+++ b/src/query/print.go
@@ -182,20 +182,37 @@ func (p *printer) PrintFields(fields []string) bool {
 // This isn't as simple as using reflect.Value.FieldByName since the print names
 // are different to the actual struct names.
 func (p *printer) findField(field string) reflect.StructField {
-	t := reflect.ValueOf(p.target).Elem().Type()
-	for i := 0; i < t.NumField(); i++ {
-		if f := t.Field(i); p.fieldName(f) == field {
+	// There isn't a 1-1 mapping between the field and its structure. Internally, we use
+	// things like named vs unnamed structures which reflect the same field from the user
+	// perspective. The function below takes that into consideration.
+	findFieldStruct := func(value interface{}, fieldName string) (reflect.StructField, bool) {
+		v := reflect.ValueOf(value).Elem()
+		t := v.Type()
+
+		resIndex := -1
+		for i := 0; i < v.NumField(); i++ {
+			if f := t.Field(i); p.fieldName(f) == fieldName {
+				if resIndex == -1 {
+					resIndex = i
+				} else if v.Field(resIndex).IsZero() && !v.Field(i).IsZero() {
+					return t.Field(i), true
+				}
+			}
+		}
+		if resIndex >= 0 {
+			return t.Field(resIndex), true
+		}
+		return reflect.StructField{}, false
+	}
+
+	if f, ok := findFieldStruct(p.target, field); ok {
+		return f
+	} else if p.target.IsTest() {
+		if f, ok := findFieldStruct(p.target.Test, field); ok {
 			return f
 		}
 	}
-	if p.target.IsTest() {
-		testFields := reflect.ValueOf(p.target.Test).Elem().Type()
-		for i := 0; i < testFields.NumField(); i++ {
-			if f := testFields.Field(i); p.fieldName(f) == field {
-				return f
-			}
-		}
-	}
+
 	log.Fatalf("Unknown field %s", field)
 	return reflect.StructField{}
 }

--- a/src/query/print_test.go
+++ b/src/query/print_test.go
@@ -132,6 +132,22 @@ func TestPrintFields(t *testing.T) {
 	assert.Equal(t, "go\ntest\n", s)
 }
 
+func TestPrintSourcesField(t *testing.T) {
+	target := core.NewBuildTarget(core.ParseBuildLabel("//src/query:test_print_fields", ""))
+	target.AddSource(core.FileLabel{File: "file1", Package: "src/query"})
+
+	s := testPrintFields(target, []string{"srcs"})
+	assert.Equal(t, "file1\n", s)
+}
+
+func TestPrintNamedSourcesField(t *testing.T) {
+	target := core.NewBuildTarget(core.ParseBuildLabel("//src/query:test_print_fields", ""))
+	target.AddNamedSource("foo", core.FileLabel{File: "file1", Package: "src/query"})
+
+	s := testPrintFields(target, []string{"srcs"})
+	assert.Equal(t, "foo: file1\n", s)
+}
+
 func testPrint(target *core.BuildTarget) string {
 	var buf bytes.Buffer
 	newPrinter(&buf, target, 2, order).PrintTarget()


### PR DESCRIPTION
This was happening because only the first field (ie. unnamed sources) was being considered.