### PR TITLE
Plz lint

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -60,9 +60,9 @@ subcommand = test
 subcommand = build
 positionallabels = true
 
-[alias "lint"]
-desc = Runs the linters for this repo
-cmd = run //tools/misc:lint -p --
+[linter "gofmt"]
+cmd = gofmt -s
+include = .*.go$
 
 [alias "go-get"]
 desc = Runs the go deps tool to install new dependencies into the repo

--- a/.plzconfig
+++ b/.plzconfig
@@ -61,8 +61,9 @@ subcommand = build
 positionallabels = true
 
 [linter "gofmt"]
-cmd = gofmt -s
+cmd = gofmt -s $SRCS
 include = .*.go$
+reformat = true
 
 [alias "go-get"]
 desc = Runs the go deps tool to install new dependencies into the repo

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -372,13 +372,19 @@ func (target *BuildTarget) String() string {
 	return target.Label.String()
 }
 
-// TmpDir returns the temporary working directory for this target, eg.
+// TmpDir returns the temporary working directory for this target, e.g.
 // //mickey/donald:goofy -> plz-out/tmp/mickey/donald/goofy._build
 // Note the extra subdirectory to keep rules separate from one another, and the .build suffix
 // to attempt to keep rules from duplicating the names of sub-packages; obviously that is not
 // 100% reliable but we don't have a better solution right now.
 func (target *BuildTarget) TmpDir() string {
 	return path.Join(TmpDir, target.Label.Subrepo, target.Label.PackageName, target.Label.Name+buildDirSuffix)
+}
+
+// LintDir returns the temporary lint directory for this target, e.g.
+// gofmt //mickey/donald:goofy -> plz-out/tmp/mickey/donald/goofy._gofmt
+func (target *BuildTarget) LintDir(linter string) string {
+	return path.Join(TmpDir, target.Label.Subrepo, target.Label.PackageName, target.Label.Name+"._"+linter)
 }
 
 // BuildLockFile returns the lock filename for the target's build stage.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -98,6 +98,11 @@ type DebugFields struct {
 	namedTools map[string][]BuildInput `name:"debug_tools"`
 }
 
+type LintFields struct {
+	// Results from any linters run
+	Results []LintResult `print:"false"`
+}
+
 // A BuildTarget is a representation of a build target and all information about it;
 // its name, dependencies, build commands, etc.
 type BuildTarget struct {
@@ -140,6 +145,8 @@ type BuildTarget struct {
 	Test *TestFields `name:"test"`
 	// Debug related fields.
 	Debug *DebugFields
+	// Lint related fields
+	Lint *LintFields
 	// If ShowProgress is true, this is used to store the current progress of the target.
 	Progress float32 `print:"false"`
 	// Description displayed while the command is building.
@@ -456,6 +463,17 @@ func (target *BuildTarget) AddTestResults(results TestSuite) {
 		target.Test.Results.Cached = target.Test.Results.Cached && results.Cached
 	}
 	target.Test.Results.Collapse(results)
+}
+
+// AddLintResults adds linter results to the target
+func (target *BuildTarget) AddLintResults(results []LintResult) {
+	target.mutex.Lock()
+	defer target.mutex.Unlock()
+	if target.Lint == nil {
+		target.Lint = &LintFields{Results: results}
+	} else {
+		target.Lint.Results = append(target.Lint.Results, results...)
+	}
 }
 
 // StartTestSuite sets the initial properties on the result test suite

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -31,6 +31,16 @@ func TestTmpDirSubrepo(t *testing.T) {
 	assert.Equal(t, "plz-out/tmp/test_x86/mickey/donald/goofy._build", target.TmpDir())
 }
 
+func TestLintDir(t *testing.T) {
+	target := makeTarget1("//mickey/donald:goofy", "")
+	assert.Equal(t, "plz-out/tmp/mickey/donald/goofy._gofmt", target.LintDir("gofmt"))
+}
+
+func TestLintDirSubrepo(t *testing.T) {
+	target := makeTarget1("@test_x86//mickey/donald:goofy", "")
+	assert.Equal(t, "plz-out/tmp/test_x86/mickey/donald/goofy._gofmt", target.LintDir("gofmt"))
+}
+
 func TestOutDirSubrepo(t *testing.T) {
 	target := makeTarget1("@test_x86//mickey/donald:goofy", "")
 	assert.Equal(t, "plz-out/gen/test_x86/mickey/donald", target.OutDir())

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -990,8 +990,9 @@ func (profile ConfigProfile) Complete(match string) (completions []flags.Complet
 
 // A Linter is a subsection of the config dealing with a specific linter.
 type Linter struct {
-	Include []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter applies to."`
-	Exclude []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter does not apply to. Takes priority over include."`
-	Target  BuildLabel                    `help:"Build target to invoke for this linter"`
-	Cmd     string                        `help:"Command line for this linter. If 'target' is given then this becomes additional flags to it, otherwise it's the full command run."`
+	Include  []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter applies to."`
+	Exclude  []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter does not apply to. Takes priority over include."`
+	Target   BuildLabel                    `help:"Build target to invoke for this linter"`
+	Cmd      string                        `help:"Command line for this linter. If 'target' is given then this becomes additional flags to it, otherwise it's the full command run."`
+	Reformat bool                          `help:"True if this linter's output reformats files"`
 }

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -990,10 +990,11 @@ func (profile ConfigProfile) Complete(match string) (completions []flags.Complet
 
 // A Linter is a subsection of the config dealing with a specific linter.
 type Linter struct {
-	Include      []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter applies to."`
-	Exclude      []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter does not apply to. Takes priority over include."`
-	OutputFormat deferredregex.DeferredRegex   `help:"Regex to parse the output format of the linter. Is applied line-by-line on stdout of the linter."`
-	Target       BuildLabel                    `help:"Build target to invoke for this linter"`
-	Cmd          string                        `help:"Command line for this linter. If 'target' is given then this becomes additional flags to it, otherwise it's the full command run."`
-	Reformat     bool                          `help:"True if this linter's output reformats files"`
+	Include          []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter applies to."`
+	Exclude          []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter does not apply to. Takes priority over include."`
+	OutputFormat     deferredregex.DeferredRegex   `help:"Regex to parse the output format of the linter. Is applied line-by-line on stdout of the linter."`
+	Target           BuildLabel                    `help:"Build target to invoke for this linter"`
+	Cmd              string                        `help:"Command line for this linter. If 'target' is given then this becomes additional flags to it, otherwise it's the full command run."`
+	Reformat         bool                          `help:"True if this linter's output reformats files"`
+	TransitiveInputs bool                          `help:"True if this linter requires all transitive inputs to the target to be available"`
 }

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -993,5 +993,5 @@ type Linter struct {
 	Include []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter applies to."`
 	Exclude []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter does not apply to. Takes priority over include."`
 	Target  BuildLabel                    `help:"Build target to invoke for this linter"`
-	Command string                        `help:"Command line for this linter. If 'target' is given then this becomes additional flags to it, otherwise it's the full command run."`
+	Cmd     string                        `help:"Command line for this linter. If 'target' is given then this becomes additional flags to it, otherwise it's the full command run."`
 }

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -990,9 +990,10 @@ func (profile ConfigProfile) Complete(match string) (completions []flags.Complet
 
 // A Linter is a subsection of the config dealing with a specific linter.
 type Linter struct {
-	Include  []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter applies to."`
-	Exclude  []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter does not apply to. Takes priority over include."`
-	Target   BuildLabel                    `help:"Build target to invoke for this linter"`
-	Cmd      string                        `help:"Command line for this linter. If 'target' is given then this becomes additional flags to it, otherwise it's the full command run."`
-	Reformat bool                          `help:"True if this linter's output reformats files"`
+	Include      []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter applies to."`
+	Exclude      []deferredregex.DeferredRegex `help:"Regexes defining source files that this linter does not apply to. Takes priority over include."`
+	OutputFormat deferredregex.DeferredRegex   `help:"Regex to parse the output format of the linter. Is applied line-by-line on stdout of the linter."`
+	Target       BuildLabel                    `help:"Build target to invoke for this linter"`
+	Cmd          string                        `help:"Command line for this linter. If 'target' is given then this becomes additional flags to it, otherwise it's the full command run."`
+	Reformat     bool                          `help:"True if this linter's output reformats files"`
 }

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -997,4 +997,5 @@ type Linter struct {
 	Cmd              string                        `help:"Command line for this linter. If 'target' is given then this becomes additional flags to it, otherwise it's the full command run."`
 	Reformat         bool                          `help:"True if this linter's output reformats files"`
 	TransitiveInputs bool                          `help:"True if this linter requires all transitive inputs to the target to be available"`
+	CreateInitPy     bool                          `help:"True to create __init__.py files in all directories"`
 }

--- a/src/core/lint.go
+++ b/src/core/lint.go
@@ -1,0 +1,24 @@
+package core
+
+// A LintResult represents a result from a linter run.
+type LintResult struct {
+	// The name of the linter (as configured in .plzconfig, but can be overridden by the linter)
+	Linter string `json:"linter"`
+	// The file this occurred in
+	File string `json:"file"`
+	// The line it occurred on (1-indexed)
+	Line int `json:"line"`
+	// The column it occurred on (if present, 1-indexed)
+	Col int `json:"col,omitempty"`
+	// The severity (currently a passthrough from the linter)
+	Severity string `json:"severity"`
+	// A code that the linter attaches to this message. May not be present if
+	// it doesn't do that (e.g. gofmt has no such concept)
+	Code string `json:"code,omitempty"`
+	// Autofix patch, in unified diff format
+	Patch string `json:"patch,omitempty"`
+	// The message of what's going wrong
+	Message string `json:"message"`
+
+	y bool
+}

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -996,7 +996,7 @@ func (state *BuildState) queueTargetAsync(target *BuildTarget, forceBuild, build
 				if building {
 					state.addPendingTask(target, Task{Label: target.Label, Type: BuildTask})
 				}
-				if linting {
+				if linting && state.IsOriginalTarget(target) {
 					state.addPendingTask(target, Task{Label: target.Label, Type: LintTask})
 				}
 			}

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -797,6 +797,7 @@ func (state *BuildState) WaitForBuiltTarget(l, dependent BuildLabel) *BuildTarge
 			return t
 		}
 	}
+	dependent.Name = "all" // Every target in this package depends on this one.
 	// okay, we need to register and wait for this guy.
 	var ch chan struct{}
 	state.progress.pendingTargets.Update(l, func(old interface{}) interface{} {
@@ -877,7 +878,6 @@ func (state *BuildState) EnsureDownloaded(target *BuildTarget) error {
 
 // WaitForTargetAndEnsureDownload waits for the target to be built and then downloads it if executing remotely
 func (state *BuildState) WaitForTargetAndEnsureDownload(l, dependent BuildLabel) *BuildTarget {
-	dependent.Name = "all" // Every target in this package depends on this one.
 	target := state.WaitForBuiltTarget(l, dependent)
 	if err := state.EnsureDownloaded(target); err != nil {
 		panic(fmt.Errorf("failed to download target outputs: %w", err))

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -152,6 +152,8 @@ type BuildState struct {
 	BuildFailed bool
 	// True if >= 1 target has failed test cases
 	TestFailed bool
+	// True if >= 1 target has open lint warnings
+	LintFailed bool
 	// True if tests should calculate coverage metrics
 	NeedCoverage bool
 	// True if we intend to build targets. False if we're just parsing
@@ -193,6 +195,8 @@ type BuildState struct {
 	DebugFailingTests bool
 	// True if we think the underlying filesystem supports xattrs (which affects how we write some metadata).
 	XattrsSupported bool
+	// True if we would rewrite any autoformat suggestions from linters.
+	WriteLinterSuggestions bool
 	// True if we have any remote executors configured.
 	anyRemote bool
 	// Number of times to run each test target. 1 == once each, plus flakes if necessary.

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1251,6 +1251,7 @@ const (
 	TargetLinting
 	TargetLinted
 	TargetLintFailed
+	TargetLintStopped
 )
 
 // Category returns the broad area that this event represents in the tasks we perform for a target.

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1001,6 +1001,8 @@ func (state *BuildState) queueTargetAsync(target *BuildTarget, forceBuild, build
 					state.addPendingTask(target, Task{Label: target.Label, Type: BuildTask})
 				}
 				if linting && state.IsOriginalTarget(target) {
+					// This is a bit ugly but pairs with additional work done in the lint package.
+					atomic.AddInt64(&state.progress.numPending, 1)
 					state.addPendingTask(target, Task{Label: target.Label, Type: LintTask})
 				}
 			}

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -123,7 +123,7 @@ type SourcePair struct{ Src, Tmp string }
 // Yielded values are pairs of the original source location and its temporary location for this rule.
 // If includeTools is true it yields the target's tools as well.
 func IterSources(state *BuildState, graph *BuildGraph, target *BuildTarget, includeTools bool) <-chan SourcePair {
-	return IterSources2(state, graph, target, includeTools, false, target.TmpDir())
+	return IterSources2(state, graph, target, includeTools, target.NeedsTransitiveDependencies, target.TmpDir())
 }
 
 // IterSources2 is like IterSources but allows specifying the tmp dir.

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -123,9 +123,14 @@ type SourcePair struct{ Src, Tmp string }
 // Yielded values are pairs of the original source location and its temporary location for this rule.
 // If includeTools is true it yields the target's tools as well.
 func IterSources(state *BuildState, graph *BuildGraph, target *BuildTarget, includeTools bool) <-chan SourcePair {
+	return IterSources2(state, graph, target, includeTools, target.TmpDir())
+}
+
+// IterSources2 is like IterSources but allows specifying the tmp dir.
+// TODO(peterebden): Get rid of this and force everything to pass it.
+func IterSources2(state *BuildState, graph *BuildGraph, target *BuildTarget, includeTools bool, tmpDir string) <-chan SourcePair {
 	ch := make(chan SourcePair)
 	done := map[string]bool{}
-	tmpDir := target.TmpDir()
 	go func() {
 		for input := range IterInputs(state, graph, target, includeTools, false) {
 			fullPaths := input.FullPaths(graph)

--- a/src/lint/BUILD
+++ b/src/lint/BUILD
@@ -1,0 +1,9 @@
+go_library(
+    name = "lint",
+    srcs = glob(["*.go"], exclude=["*_test.go"]),
+    deps = [
+        "//src/core",
+        "//third_party/go:logging",
+    ],
+    visibility = ["//src/..."],
+)

--- a/src/lint/BUILD
+++ b/src/lint/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//src/..."],
     deps = [
         "//src/core",
+        "//src/fs",
         "//third_party/go:deferred_regex",
         "//third_party/go:logging",
     ],

--- a/src/lint/BUILD
+++ b/src/lint/BUILD
@@ -1,9 +1,13 @@
 go_library(
     name = "lint",
-    srcs = glob(["*.go"], exclude=["*_test.go"]),
+    srcs = glob(
+        ["*.go"],
+        exclude = ["*_test.go"],
+    ),
+    visibility = ["//src/..."],
     deps = [
         "//src/core",
+        "//third_party/go:deferred_regex",
         "//third_party/go:logging",
     ],
-    visibility = ["//src/..."],
 )

--- a/src/lint/BUILD
+++ b/src/lint/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//src/core",
         "//src/fs",
+        "//src/process",
         "//third_party/go:deferred_regex",
         "//third_party/go:logging",
     ],

--- a/src/lint/BUILD
+++ b/src/lint/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//src/fs",
         "//src/process",
         "//third_party/go:deferred_regex",
+        "//third_party/go:gotextdiff",
         "//third_party/go:logging",
     ],
 )
@@ -17,6 +18,7 @@ go_library(
 go_test(
     name = "lint_test",
     srcs = glob(["*_test.go"]),
+    data = ["test_data"],
     deps = [
         ":lint",
         "//src/core",

--- a/src/lint/BUILD
+++ b/src/lint/BUILD
@@ -13,3 +13,14 @@ go_library(
         "//third_party/go:logging",
     ],
 )
+
+go_test(
+    name = "lint_test",
+    srcs = glob(["*_test.go"]),
+    deps = [
+        ":lint",
+        "//src/core",
+        "//third_party/go:deferred_regex",
+        "//third_party/go:testify",
+    ],
+)

--- a/src/lint/lint.go
+++ b/src/lint/lint.go
@@ -50,7 +50,7 @@ func dispatchLintTasks(state *core.BuildState, target *core.BuildTarget) {
 				defer wg.Done()
 				if !linter.Target.IsEmpty() {
 					// Need to wait for this thing to be ready.
-					state.WaitForBuiltTarget(linter.Target, target.Label)
+					state.WaitForTargetAndEnsureDownload(linter.Target, target.Label)
 				}
 				state.AddPendingLint(target, name)
 			}(name, linter, target)
@@ -100,6 +100,10 @@ func matchOne(regexes []deferredregex.DeferredRegex, src core.BuildInput) bool {
 // lint performs the logic of linting a single target.
 func lint(tid int, state *core.BuildState, target *core.BuildTarget, remote bool, linterName string) error {
 	// TODO(peterebden): Remote execution support.
+	if err := state.EnsureDownloaded(target); err != nil {
+		return err
+	}
+
 	linter := state.Config.Linter[linterName]
 	state.LogBuildResult(tid, target, core.TargetLinting, fmt.Sprintf("Preparing to run %s...", linterName))
 

--- a/src/lint/lint.go
+++ b/src/lint/lint.go
@@ -1,0 +1,11 @@
+// Package lint implements the `plz lint` command which invokes linters on build targets.
+package lint
+
+import (
+	"github.com/thought-machine/please/src/core"
+)
+
+// Lint implements the core logic for linting a single target.
+func Lint(tid int, state *core.BuildState, label core.BuildLabel, remote bool) {
+
+}

--- a/src/lint/lint.go
+++ b/src/lint/lint.go
@@ -2,6 +2,7 @@
 package lint
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path"
@@ -164,6 +165,8 @@ func runLintOnce(state *core.BuildState, target *core.BuildTarget, tmpDir, linte
 	existing, err := os.ReadFile(srcs[0])
 	if err != nil {
 		return err
+	} else if bytes.Equal(existing, out) {
+		return nil
 	}
 	target.AddLintResults(computeDiffs(linterName, srcs[0], string(existing), string(out)))
 	state.LintFailed = true

--- a/src/lint/lint.go
+++ b/src/lint/lint.go
@@ -111,7 +111,7 @@ func lint(tid int, state *core.BuildState, target *core.BuildTarget, remote bool
 	if err := prepareDirectory(state, tmpDir); err != nil {
 		return err
 	}
-	if err := prepareSources(state, state.Graph, target, tmpDir); err != nil {
+	if err := prepareSources(state, state.Graph, target, tmpDir, linter.TransitiveInputs); err != nil {
 		return err
 	}
 	if !linter.Target.IsEmpty() {

--- a/src/lint/lint.go
+++ b/src/lint/lint.go
@@ -119,6 +119,11 @@ func lint(tid int, state *core.BuildState, target *core.BuildTarget, remote bool
 			return err
 		}
 	}
+	if state.PrepareOnly {
+		target.SetState(core.Stopped)
+		state.LogBuildResult(tid, target, core.TargetLintStopped, "Lint stopped")
+		return nil
+	}
 
 	state.LogBuildResult(tid, target, core.TargetLinting, fmt.Sprintf("Running %s...", linterName))
 	if err := runLint(state, target, tmpDir, linterName, linter); err != nil {

--- a/src/lint/lint.go
+++ b/src/lint/lint.go
@@ -2,10 +2,107 @@
 package lint
 
 import (
+	"fmt"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/peterebden/go-deferred-regex"
+	"gopkg.in/op/go-logging.v1"
+
 	"github.com/thought-machine/please/src/core"
 )
 
-// Lint implements the core logic for linting a single target.
-func Lint(tid int, state *core.BuildState, label core.BuildLabel, remote bool) {
+var log = logging.MustGetLogger("lint")
 
+// Lint implements the core logic for linting a single target.
+func Lint(tid int, state *core.BuildState, label core.BuildLabel, remote bool, linter string) {
+	target := state.Graph.TargetOrDie(label)
+	// This is a little weird; the first time we get called with no linter set. This package
+	// then decides what linters it is going to run for the relevant target and submits zero
+	// or more additional tasks for them.
+	if linter == "" {
+		dispatchLintTasks(state, target)
+		return
+	}
+	defer state.TaskDone()
+	if err := lint(tid, state, target, remote, linter); err != nil {
+		state.LogBuildError(tid, label, core.TargetLintFailed, err, "Lint failed: %s", err)
+	}
+}
+
+// dispatchLintTasks determines what linters to run for this target and dispatches tasks for them.
+func dispatchLintTasks(state *core.BuildState, target *core.BuildTarget) {
+	// The deferred regexes can panic if the expressions are invalid, so handle that _slightly_
+	// more gracefully here.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Fatalf("%s", r)
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for name, linter := range state.Config.Linter {
+		if shouldInclude(linter, target) {
+			wg.Add(1)
+			go func(name string, linter *core.Linter, target *core.BuildTarget) {
+				defer wg.Done()
+				if !linter.Target.IsEmpty() {
+					// Need to wait for this thing to be ready.
+					state.WaitForBuiltTarget(linter.Target, target.Label)
+				}
+				state.AddPendingLint(target, name)
+			}(name, linter, target)
+		}
+	}
+	// Don't actually wait for this to complete (we need to release the worker to do other things)
+	// but don't mark the task as done until all the goroutines have cleaned up. This ensures the
+	// build doesn't terminate while they're still pending.
+	go func() {
+		wg.Wait()
+		state.TaskDone()
+	}()
+}
+
+// shouldInclude returns true if this linter should include any inputs of this target.
+func shouldInclude(linter *core.Linter, target *core.BuildTarget) bool {
+	// This would be slightly nicer if we had a more unified way of iterating these things.
+	for _, src := range target.Sources {
+		if matchOne(linter.Include, src) && !matchOne(linter.Exclude, src) {
+			return true
+		}
+	}
+	for _, srcs := range target.NamedSources {
+		for _, src := range srcs {
+			if matchOne(linter.Include, src) && !matchOne(linter.Exclude, src) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// matchOne returns true if any one of these regexes matches the given path.
+func matchOne(regexes []deferredregex.DeferredRegex, src core.BuildInput) bool {
+	// The explicit cast is a bit dodgy but we only want to deal with inputs within the source tree.
+	if fl, ok := src.(core.FileLabel); ok {
+		filename := path.Join(fl.Package, fl.File)
+		for _, re := range regexes {
+			if re.MatchString(filename) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// lint performs the logic of linting a single target.
+func lint(tid int, state *core.BuildState, target *core.BuildTarget, remote bool, linterName string) error {
+	linter := state.Config.Linter[linterName]
+	linterTarget := state.Graph.TargetOrDie(linter.Target)
+	log.Debug("target %s", linterTarget)
+	state.LogBuildResult(tid, target, core.TargetLinting, fmt.Sprintf("Running %s...", linterName))
+	time.Sleep(10 * time.Second)
+	state.LogBuildResult(tid, target, core.TargetLinted, fmt.Sprintf("Finished %s", linterName))
+	return nil
 }

--- a/src/lint/lint.go
+++ b/src/lint/lint.go
@@ -27,7 +27,6 @@ func Lint(tid int, state *core.BuildState, label core.BuildLabel, remote bool, l
 		dispatchLintTasks(state, target)
 		return
 	}
-	defer state.TaskDone()
 	if err := lint(tid, state, target, remote, linter); err != nil {
 		state.LogBuildError(tid, label, core.TargetLintFailed, err, "Lint failed: %s", err)
 	}
@@ -149,6 +148,7 @@ func runLintOnce(state *core.BuildState, target *core.BuildTarget, tmpDir, linte
 	env := core.LintEnvironment(state, target, tmpDir, srcs)
 	log.Debug("Linting target %s\nENVIRONMENT:\n%s\n%s", target, env, cmd)
 	out, combined, err := state.ProcessExecutor.ExecWithTimeoutShell(target, tmpDir, env, target.BuildTimeout, state.ShowAllOutput, false, process.NewSandboxConfig(target.Sandbox, target.Sandbox), cmd)
+	log.Debug("Linter output for %s / %s: %s", target, linterName, combined)
 	if trimmed := bytes.TrimSpace(out); err == nil && len(trimmed) == 0 {
 		return nil // assume everything is successful
 	} else if err != nil && len(trimmed) == 0 {

--- a/src/lint/parse.go
+++ b/src/lint/parse.go
@@ -56,9 +56,6 @@ func parseLintLine(linter *core.Linter, linterName, line string) core.LintResult
 }
 
 func computeDiffs(linterName, filename, before, after string) []core.LintResult {
-	if before == after {
-		return nil
-	}
 	edits := myers.ComputeEdits(span.URIFromPath(filename), before, after)
 	unified := gotextdiff.ToUnified(filename, filename, before, edits)
 	results := make([]core.LintResult, len(unified.Hunks))

--- a/src/lint/parse.go
+++ b/src/lint/parse.go
@@ -70,6 +70,7 @@ func computeDiffs(linterName, filename, before, after string) []core.LintResult 
 			File:     filename,
 			Line:     hunk.FromLine,
 			Patch:    fmt.Sprintf("%s", u),
+			Message:  "Not in expected format",
 		}
 	}
 	return results

--- a/src/lint/parse.go
+++ b/src/lint/parse.go
@@ -1,0 +1,52 @@
+package lint
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/thought-machine/please/src/core"
+)
+
+func parseLintLines(linter *core.Linter, linterName, out string) []core.LintResult {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	results := make([]core.LintResult, len(lines))
+	for i, line := range lines {
+		results[i] = parseLintLine(linter, linterName, line)
+	}
+	return results
+}
+
+func parseLintLine(linter *core.Linter, linterName, line string) core.LintResult {
+	matches := linter.OutputFormat.FindStringSubmatch(line)
+	if matches == nil {
+		// Failed to match, turn this into a linter error itself.
+		return core.LintResult{
+			Linter:  linterName,
+			Message: "Failed to parse line: " + line,
+		}
+	}
+	result := core.LintResult{Linter: linterName}
+	v := reflect.ValueOf(&result)
+	subfields := linter.OutputFormat.SubexpNames()
+	// Recall that the first entry is the complete match, hence all the off-by-one stuff.
+	for i, match := range matches[1:] {
+		name := subfields[i+1]
+		field := v.Elem().FieldByName(strings.ToUpper(name[:1]) + name[1:])
+		switch field.Kind() {
+		case reflect.Invalid:
+			panic(fmt.Sprintf("Invalid field %s in linter %s", name, linterName))
+		case reflect.String:
+			field.SetString(match)
+		case reflect.Int:
+			i, err := strconv.ParseInt(match, 10, 64)
+			if err != nil {
+				result.Message = fmt.Sprintf("Invalid value for int field %s: %s", name, match)
+				return result
+			}
+			field.SetInt(i)
+		}
+	}
+	return result
+}

--- a/src/lint/parse_test.go
+++ b/src/lint/parse_test.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"os"
 	"testing"
 
 	"github.com/peterebden/go-deferred-regex"
@@ -23,4 +24,26 @@ func TestParseLintLine(t *testing.T) {
 		Col:     2,
 		Message: "`y` is unused",
 	}}, parseLintLines(linter, "golangci-lint", in))
+}
+
+func TestParseRewrites(t *testing.T) {
+	mustReadFile := func(filename string) string {
+		b, err := os.ReadFile(filename)
+		assert.NoError(t, err)
+		return string(b)
+	}
+
+	before := mustReadFile("src/lint/test_data/test.go")
+	after := mustReadFile("src/lint/test_data/rewritten.go")
+	patch := mustReadFile("src/lint/test_data/patch.diff")
+
+	assert.Equal(t, []core.LintResult{
+		{
+			Linter:   "gofmt",
+			File:     "src/lint/test_data/test.go",
+			Line:     2,
+			Patch:    patch,
+			Severity: "autoformat",
+		},
+	}, computeDiffs("gofmt", "src/lint/test_data/test.go", before, after))
 }

--- a/src/lint/parse_test.go
+++ b/src/lint/parse_test.go
@@ -1,0 +1,26 @@
+package lint
+
+import (
+	"testing"
+
+	"github.com/peterebden/go-deferred-regex"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/thought-machine/please/src/core"
+)
+
+func TestParseLintLine(t *testing.T) {
+	const in = "src/core/lint.go:21:2  structcheck  `y` is unused\n"
+	linter := &core.Linter{
+		OutputFormat: deferredregex.DeferredRegex{
+			Re: "(?P<file>[^:]+):(?P<line>[0-9]+):(?P<col>[0-9]+) +(?P<linter>[a-z]+) +(?P<message>.*)$",
+		},
+	}
+	assert.Equal(t, []core.LintResult{{
+		Linter:  "structcheck", // This should override 'golangci-lint' that we passed in
+		File:    "src/core/lint.go",
+		Line:    21,
+		Col:     2,
+		Message: "`y` is unused",
+	}}, parseLintLines(linter, "golangci-lint", in))
+}

--- a/src/lint/prepare.go
+++ b/src/lint/prepare.go
@@ -3,6 +3,7 @@ package lint
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
@@ -19,10 +20,21 @@ func prepareDirectory(state *core.BuildState, directory string) error {
 	return os.MkdirAll(directory, core.DirPermissions)
 }
 
-// Symlinks the source files of this rule into its temp directory.
+// Links the source files of this rule into its temp directory.
 func prepareSources(state *core.BuildState, graph *core.BuildGraph, target *core.BuildTarget, tmpDir string) error {
 	for source := range core.IterSources2(state, graph, target, false, tmpDir) {
 		if err := core.PrepareSourcePair(source); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Links the output files of this rule into a temp directory.
+func prepareOutputs(state *core.BuildState, target *core.BuildTarget, tmpDir string) error {
+	outDir := target.OutDir()
+	for _, out := range target.Outputs() {
+		if err := core.PrepareSourcePair(core.SourcePair{Src: path.Join(outDir, out), Tmp: path.Join(tmpDir, out)}); err != nil {
 			return err
 		}
 	}

--- a/src/lint/prepare.go
+++ b/src/lint/prepare.go
@@ -43,13 +43,12 @@ func prepareOutputs(state *core.BuildState, target *core.BuildTarget, tmpDir str
 
 // command returns the command we'd run for a linter.
 func command(graph *core.BuildGraph, linter *core.Linter) (string, error) {
-	cmd := linter.Cmd + " $SRCS"
 	if linter.Target.IsEmpty() {
-		return cmd, nil
+		return linter.Cmd, nil
 	}
 	outs := graph.TargetOrDie(linter.Target).Outputs()
 	if len(outs) == 0 {
 		return "", fmt.Errorf("Target %s cannot be used as a linter, it has no outputs", linter.Target)
 	}
-	return outs[0] + " " + cmd, nil
+	return outs[0] + " " + linter.Cmd, nil
 }

--- a/src/lint/prepare.go
+++ b/src/lint/prepare.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/thought-machine/please/src/core"
@@ -26,4 +27,17 @@ func prepareSources(state *core.BuildState, graph *core.BuildGraph, target *core
 		}
 	}
 	return nil
+}
+
+// command returns the command we'd run for a linter.
+func command(graph *core.BuildGraph, linter *core.Linter) (string, error) {
+	cmd := linter.Cmd + " $SRCS"
+	if linter.Target.IsEmpty() {
+		return cmd, nil
+	}
+	outs := graph.TargetOrDie(linter.Target).Outputs()
+	if len(outs) == 0 {
+		return "", fmt.Errorf("Target %s cannot be used as a linter, it has no outputs", linter.Target)
+	}
+	return outs[0] + " " + cmd, nil
 }

--- a/src/lint/prepare.go
+++ b/src/lint/prepare.go
@@ -38,6 +38,14 @@ func prepareOutputs(state *core.BuildState, target *core.BuildTarget, tmpDir str
 			return err
 		}
 	}
+	for _, data := range target.AllData() {
+		fullPaths := data.FullPaths(state.Graph)
+		for i, dataPath := range data.Paths(state.Graph) {
+			if err := core.PrepareSourcePair(core.SourcePair{Src: fullPaths[i], Tmp: path.Join(tmpDir, dataPath)}); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 

--- a/src/lint/prepare.go
+++ b/src/lint/prepare.go
@@ -1,0 +1,29 @@
+package lint
+
+import (
+	"os"
+
+	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/fs"
+)
+
+// TODO(peterebden): Somehow unify a bunch of this stuff between build/test/lint
+
+func prepareDirectory(state *core.BuildState, directory string) error {
+	if core.PathExists(directory) {
+		if err := fs.ForceRemove(state.ProcessExecutor, directory); err != nil {
+			return err
+		}
+	}
+	return os.MkdirAll(directory, core.DirPermissions)
+}
+
+// Symlinks the source files of this rule into its temp directory.
+func prepareSources(state *core.BuildState, graph *core.BuildGraph, target *core.BuildTarget, tmpDir string) error {
+	for source := range core.IterSources2(state, graph, target, false, tmpDir) {
+		if err := core.PrepareSourcePair(source); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/src/lint/prepare.go
+++ b/src/lint/prepare.go
@@ -21,8 +21,8 @@ func prepareDirectory(state *core.BuildState, directory string) error {
 }
 
 // Links the source files of this rule into its temp directory.
-func prepareSources(state *core.BuildState, graph *core.BuildGraph, target *core.BuildTarget, tmpDir string) error {
-	for source := range core.IterSources2(state, graph, target, false, tmpDir) {
+func prepareSources(state *core.BuildState, graph *core.BuildGraph, target *core.BuildTarget, tmpDir string, transitive bool) error {
+	for source := range core.IterSources2(state, graph, target, false, transitive, tmpDir) {
 		if err := core.PrepareSourcePair(source); err != nil {
 			return err
 		}

--- a/src/lint/prepare.go
+++ b/src/lint/prepare.go
@@ -34,7 +34,7 @@ func prepareSources(state *core.BuildState, graph *core.BuildGraph, target *core
 func prepareOutputs(state *core.BuildState, target *core.BuildTarget, tmpDir string) error {
 	outDir := target.OutDir()
 	for _, out := range target.Outputs() {
-		if err := core.PrepareSourcePair(core.SourcePair{Src: path.Join(outDir, out), Tmp: path.Join(tmpDir, out)}); err != nil {
+		if err := core.PrepareSourcePair(core.SourcePair{Src: path.Join(outDir, out), Tmp: path.Join(tmpDir, target.Label.PackageName, out)}); err != nil {
 			return err
 		}
 	}
@@ -50,5 +50,5 @@ func command(graph *core.BuildGraph, linter *core.Linter) (string, error) {
 	if len(outs) == 0 {
 		return "", fmt.Errorf("Target %s cannot be used as a linter, it has no outputs", linter.Target)
 	}
-	return outs[0] + " " + linter.Cmd, nil
+	return path.Join(linter.Target.PackageName, outs[0]) + " " + linter.Cmd, nil
 }

--- a/src/lint/test_data/patch.diff
+++ b/src/lint/test_data/patch.diff
@@ -1,0 +1,17 @@
+--- src/lint/test_data/test.go
++++ src/lint/test_data/test.go
+@@ -2,12 +2,12 @@
+ 
+ // A LintResult represents a result from a linter run.
+ type LintResult struct {
+-	Linter string `json:"linter"`
++	Linter   string `json:"linter"`
+ 	File     string `json:"file"`
+ 	Line     int    `json:"line"`
+ 	Col      int    `json:"col,omitempty"`
+ 	Severity string `json:"severity"`
+ 	Code     string `json:"code,omitempty"`
+-	Patch string `json:"patch,omitempty"`
++	Patch    string `json:"patch,omitempty"`
+ 	Message  string `json:"message"`
+ }

--- a/src/lint/test_data/rewritten.go
+++ b/src/lint/test_data/rewritten.go
@@ -1,0 +1,13 @@
+package core
+
+// A LintResult represents a result from a linter run.
+type LintResult struct {
+	Linter   string `json:"linter"`
+	File     string `json:"file"`
+	Line     int    `json:"line"`
+	Col      int    `json:"col,omitempty"`
+	Severity string `json:"severity"`
+	Code     string `json:"code,omitempty"`
+	Patch    string `json:"patch,omitempty"`
+	Message  string `json:"message"`
+}

--- a/src/lint/test_data/test.go
+++ b/src/lint/test_data/test.go
@@ -1,0 +1,13 @@
+package core
+
+// A LintResult represents a result from a linter run.
+type LintResult struct {
+	Linter string `json:"linter"`
+	File     string `json:"file"`
+	Line     int    `json:"line"`
+	Col      int    `json:"col,omitempty"`
+	Severity string `json:"severity"`
+	Code     string `json:"code,omitempty"`
+	Patch string `json:"patch,omitempty"`
+	Message  string `json:"message"`
+}

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -398,7 +398,7 @@ func PrintLintResults(state *core.BuildState, inJSON bool) {
 		return
 	}
 	printf("${BOLD_WHITE}Linter run complete, errors reported:${RESET}\n")
-	for _, label := range state.ExpandVisibleOriginalTargets() {
+	for _, label := range state.ExpandOriginalLabels() {
 		if target := state.Graph.TargetOrDie(label); target.Lint != nil {
 			sort.Slice(target.Lint.Results, func(i, j int) bool { return target.Lint.Results[i].Line < target.Lint.Results[j].Line })
 			for _, r := range target.Lint.Results {

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -479,6 +479,11 @@ func printTempDirs(state *core.BuildState, duration time.Duration, shell, shellR
 			if len(state.TestArgs) > 0 {
 				env = append(env, "TESTS="+strings.Join(state.TestArgs, " "))
 			}
+		} else if state.NeedLint {
+			// TODO(peterebden): This is really not working well. We don't know most of what we need here.
+			cmd = ""
+			dir = path.Join(core.RepoRoot, target.LintDir("lint"))
+			env = core.LintEnvironment(state, target, dir, target.AllSourcePaths(state.Graph))
 		}
 		cmd, _ = core.ReplaceSequences(state, target, cmd)
 		env = append(env, "CMD="+cmd)

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -393,6 +393,11 @@ func printBuildResults(state *core.BuildState, duration time.Duration) {
 
 // PrintLintResults prints all known lint results, either in JSON or human-readable.
 func PrintLintResults(state *core.BuildState, inJSON bool) {
+	if !state.LintFailed {
+		log.Notice("No lint errors to report!")
+		return
+	}
+	printf("${BOLD_WHITE}Linter run complete, errors reported:${RESET}\n")
 	for _, label := range state.ExpandVisibleOriginalTargets() {
 		if target := state.Graph.TargetOrDie(label); target.Lint != nil {
 			sort.Slice(target.Lint.Results, func(i, j int) bool { return target.Lint.Results[i].Line < target.Lint.Results[j].Line })

--- a/src/please.go
+++ b/src/please.go
@@ -453,6 +453,10 @@ var buildFunctions = map[string]func() int{
 		}
 		return toExitCode(success, state)
 	},
+	"lint": func() int {
+		success, state := runBuild(opts.Lint.Args.Targets, true, false, false)
+		return toExitCode(success, state)
+	},
 	"test": func() int {
 		targets := testTargets(opts.Test.Args.Target, opts.Test.Args.Args, opts.Test.Failed, opts.Test.TestResultsFile)
 		success, state := doTest(targets, opts.Test.SurefireDir, opts.Test.TestResultsFile)

--- a/src/please.go
+++ b/src/please.go
@@ -141,6 +141,12 @@ var opts struct {
 		} `positional-args:"true"`
 	} `command:"test" description:"Builds and tests one or more targets"`
 
+	Lint struct {
+		Args struct {
+			Files []string `positional-arg-name:"files" description:"Files to lint"`
+		} `positional-args:"true"`
+	}
+
 	Cover struct {
 		active              bool          `no-flag:"true"`
 		FailingTestsOk      bool          `long:"failing_tests_ok" hidden:"true" description:"Exit with status 0 even if tests fail (nonzero only if catastrophe happens)"`

--- a/src/please.go
+++ b/src/please.go
@@ -142,8 +142,9 @@ var opts struct {
 	} `command:"test" description:"Builds and tests one or more targets"`
 
 	Lint struct {
-		JSON  bool `short:"j" long:"json" description:"Output lint results as JSON lines (default is human-readable)"`
-		Write bool `short:"w" long:"write" description:"Automatically rewrite files in-place from linter suggestions"`
+		JSON  bool   `short:"j" long:"json" description:"Output lint results as JSON lines (default is human-readable)"`
+		Write bool   `short:"w" long:"write" description:"Automatically rewrite files in-place from linter suggestions"`
+		Shell string `long:"shell" choice:"shell" choice:"run" optional:"true" optional-value:"shell" description:"Opens a shell in the lint directory with the appropriate environment variables."`
 		Args  struct {
 			Targets []core.BuildLabel `positional-arg-name:"target" required:"true" description:"Targets to lint"`
 		} `positional-args:"true"`
@@ -1037,7 +1038,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	if opts.Build.Prepare {
 		log.Warningf("--prepare has been deprecated in favour of --shell and will be removed in v17.")
 	}
-	state.PrepareOnly = opts.Build.Prepare || opts.Build.Shell != "" || opts.Test.Shell != "" || opts.Cover.Shell != ""
+	state.PrepareOnly = opts.Build.Prepare || opts.Build.Shell != "" || opts.Test.Shell != "" || opts.Cover.Shell != "" || opts.Lint.Shell != ""
 	state.Watch = len(opts.Watch.Args.Targets) > 0
 	state.CleanWorkdirs = !opts.FeatureFlags.KeepWorkdirs
 	state.ForceRebuild = opts.Build.Rebuild || opts.Run.Rebuild
@@ -1094,8 +1095,8 @@ func runPlease(state *core.BuildState, targets []core.BuildLabel) {
 		(len(targets) == 1 && !targets[0].IsAllTargets() &&
 			!targets[0].IsAllSubpackages() && targets[0] != core.BuildLabelStdin))
 	streamTests := opts.Test.StreamResults || opts.Cover.StreamResults
-	shell := opts.Build.Shell != "" || opts.Test.Shell != "" || opts.Cover.Shell != ""
-	shellRun := opts.Build.Shell == "run" || opts.Test.Shell == "run" || opts.Cover.Shell == "run"
+	shell := opts.Build.Shell != "" || opts.Test.Shell != "" || opts.Cover.Shell != "" || opts.Lint.Shell != ""
+	shellRun := opts.Build.Shell == "run" || opts.Test.Shell == "run" || opts.Cover.Shell == "run" || opts.Lint.Shell == "run"
 	pretty := prettyOutput(opts.OutputFlags.InteractiveOutput, opts.OutputFlags.PlainOutput, opts.OutputFlags.Verbosity) && state.NeedBuild && !streamTests
 	state.Cache = cache.NewCache(state)
 

--- a/src/please.go
+++ b/src/please.go
@@ -143,9 +143,9 @@ var opts struct {
 
 	Lint struct {
 		Args struct {
-			Files []string `positional-arg-name:"files" description:"Files to lint"`
+			Targets []core.BuildLabel `positional-arg-name:"target" required:"true" description:"Targets to lint"`
 		} `positional-args:"true"`
-	}
+	} `command:"lint" description:"Runs linters against one or more targets"`
 
 	Cover struct {
 		active              bool          `no-flag:"true"`
@@ -1023,6 +1023,8 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	state.NeedCoverage = opts.Cover.active
 	state.NeedBuild = shouldBuild
 	state.NeedTests = shouldTest
+	// TODO(peterebden): This should get passed through like shouldBuild and shouldTest
+	state.NeedLint = len(opts.Lint.Args.Targets) > 0
 	state.NeedRun = !opts.Run.Args.Target.IsEmpty() || len(opts.Run.Parallel.PositionalArgs.Targets) > 0 || len(opts.Run.Sequential.PositionalArgs.Targets) > 0 || !opts.Exec.Args.Target.IsEmpty() || opts.Tool.Args.Tool != "" || debug
 	state.NeedHashesOnly = len(opts.Hash.Args.Targets) > 0
 	if opts.Build.Prepare {

--- a/src/plz/BUILD
+++ b/src/plz/BUILD
@@ -7,6 +7,7 @@ go_library(
         "//src/cli",
         "//src/core",
         "//src/fs",
+        "//src/lint",
         "//src/metrics",
         "//src/parse",
         "//src/remote",

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -12,6 +12,7 @@ import (
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
+	"github.com/thought-machine/please/src/lint"
 	"github.com/thought-machine/please/src/metrics"
 	"github.com/thought-machine/please/src/parse"
 	"github.com/thought-machine/please/src/remote"
@@ -92,6 +93,8 @@ func doTasks(tid int, state *core.BuildState, actions <-chan core.Task, remote b
 			test.Test(tid, state, task.Label, remote, int(task.Run))
 		case core.BuildTask:
 			build.Build(tid, state, task.Label, remote)
+		case core.LintTask:
+			lint.Lint(tid, state, task.Label, remote)
 		}
 		state.TaskDone()
 	}

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -91,12 +91,14 @@ func doTasks(tid int, state *core.BuildState, actions <-chan core.Task, remote b
 		switch task.Type {
 		case core.TestTask:
 			test.Test(tid, state, task.Label, remote, int(task.Run))
+			state.TaskDone()
 		case core.BuildTask:
 			build.Build(tid, state, task.Label, remote)
+			state.TaskDone()
 		case core.LintTask:
-			lint.Lint(tid, state, task.Label, remote)
+			lint.Lint(tid, state, task.Label, remote, task.Linter)
+			// Slightly awkwardly, lint handles TaskDone itself to avoid races.
 		}
-		state.TaskDone()
 	}
 }
 

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -91,14 +91,12 @@ func doTasks(tid int, state *core.BuildState, actions <-chan core.Task, remote b
 		switch task.Type {
 		case core.TestTask:
 			test.Test(tid, state, task.Label, remote, int(task.Run))
-			state.TaskDone()
 		case core.BuildTask:
 			build.Build(tid, state, task.Label, remote)
-			state.TaskDone()
 		case core.LintTask:
 			lint.Lint(tid, state, task.Label, remote, task.Linter)
-			// Slightly awkwardly, lint handles TaskDone itself to avoid races.
 		}
+		state.TaskDone()
 	}
 }
 

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -1081,3 +1081,15 @@ go_module(
     version = "v0.5.0",
     visibility = ["PUBLIC"],
 )
+
+go_module(
+    name = "gotextdiff",
+    install = [
+        ".",
+        "myers",
+        "span",
+    ],
+    module = "github.com/hexops/gotextdiff",
+    version = "v1.0.3",
+    visibility = ["PUBLIC"],
+)

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -1063,7 +1063,7 @@ go_module(
     name = "deferred_regex",
     licences = ["Apache-2.0"],
     module = "github.com/peterebden/go-deferred-regex",
-    version = "v1.0.0",
+    version = "v1.1.0",
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
This is mostly me exploring how `plz lint` might work. This implementation adds an additional task type for lint which can be triggered for each action. 

Basic linters (that work at a single file level) work OK (although working dir generation is a little inefficient), as does file rewriting / autoformatters. Linters that require transitive deps (e.g. golangci-lint) work as long as most things are in the right place already (which does make it a bit pointless since the whole point was to try to solve that). A bit more hacking here to generate things in locations corresponding to output labels might fix it.
Have tried out mypy which is being foiled by require/provide shenanigans (i.e. I _don't_ want the python actions to get the precompressed pex files).

All in all I am thinking of a v2 that works by generating actual additional build actions, which I think might be more elegant than trying to do it this way. Hence not really expecting to merge this but am putting it up for people's interest.