### PR TITLE
`cc_static_library`: expose `hdrs` to dependent targets

### DIFF
--- a/rules/cc_rules.build_defs
+++ b/rules/cc_rules.build_defs
@@ -318,9 +318,9 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
       pkg_config_cflags (list): Libraries to declare a dependency on using `pkg-config --cflags`
     """
     provides = None
-    if srcs:
+    if srcs or hdrs:
         lib_rule = cc_library(
-            name = f'_{name}#lib',
+            name = f'_{name}#lib' if srcs else f'_{name}#lib_hdrs',
             srcs = srcs,
             hdrs = hdrs,
             compiler_flags = compiler_flags,
@@ -331,7 +331,7 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
             pkg_config_cflags = pkg_config_cflags,
             _c=_c,
         )
-        deps += [lib_rule, f':_{name}#lib_hdrs']
+        deps += [lib_rule, f':_{name}#lib_hdrs'] if srcs else [lib_rule]
         provides = {
             'cc_hdrs': f':_{name}#lib_hdrs',
             'cc': ':' + name,


### PR DESCRIPTION
Targets that depend on archives collected by a `cc_static_library` typically need access to the headers that were used to build those libraries, but they currently aren't exported to dependent targets when `cc_static_library` is used purely as a collector for other archives. Export these headers when `hdrs` is defined but `srcs` isn't.