### PR TITLE
asp: preserve original quotes in multiline strings

### DIFF
--- a/src/parse/asp/lexer.go
+++ b/src/parse/asp/lexer.go
@@ -318,8 +318,8 @@ func (l *lex) consumeString(quote byte, pos Position, multiline, raw, fString bo
 		}
 		switch c {
 		case quote:
-			s = append(s, '"')
 			if !multiline || (l.b[l.i] == quote && l.b[l.i+1] == quote) {
+				s = append(s, '"')
 				if multiline {
 					l.i += 2
 					l.col += 2
@@ -330,6 +330,7 @@ func (l *lex) consumeString(quote byte, pos Position, multiline, raw, fString bo
 				}
 				return token
 			}
+			s = append(s, c)
 		case '\n':
 			if multiline {
 				l.line++

--- a/src/parse/asp/parser_test.go
+++ b/src/parse/asp/parser_test.go
@@ -481,20 +481,47 @@ func TestOptimise(t *testing.T) {
 }
 
 func TestMultilineStringQuotes(t *testing.T) {
-	statements, err := newParser().parse("src/parse/asp/test_data/multiline_string_quotes.build")
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(statements))
-	assert.NotNil(t, statements[0].Ident)
-	assert.NotNil(t, statements[0].Ident.Action)
-	assert.NotNil(t, statements[0].Ident.Action.Assign)
-	expected := `"
-#include "UnitTest++/UnitTest++.h"
-"`
-	assert.Equal(t, expected, statements[0].Ident.Action.Assign.Val.String)
+	for _, test := range []struct {
+		Path     string
+		Expected string
+	}{
+		{
+			Path:     "src/parse/asp/test_data/multiline_string_single_in_single.build",
+			Expected: `"
+multiline string containing 'single quotes'
+"`,
+		},
+		{
+			Path:     "src/parse/asp/test_data/multiline_string_double_in_single.build",
+			Expected: `"
+multiline string containing "double quotes"
+"`,
+		},
+		{
+			Path:     "src/parse/asp/test_data/multiline_string_single_in_double.build",
+			Expected: `"
+multiline string containing 'single quotes'
+"`,
+		},
+		{
+			Path:     "src/parse/asp/test_data/multiline_string_double_in_double.build",
+			Expected: `"
+multiline string containing "double quotes"
+"`,
+		},
+	} {
+		statements, err := newParser().parse(test.Path)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(statements))
+		assert.NotNil(t, statements[0].Ident)
+		assert.NotNil(t, statements[0].Ident.Action)
+		assert.NotNil(t, statements[0].Ident.Action.Assign)
+		assert.Equal(t, test.Expected, statements[0].Ident.Action.Assign.Val.String)
 
-	// TODO(BNM): It would be nice if we can get the actual EndPos for the multiline
-	// assert.Equal(t, 4, statements[0].EndPos.Column)
-	// assert.Equal(t, 3, statements[0].EndPos.Line)
+		// TODO(BNM): It would be nice if we can get the actual EndPos for the multiline
+		// assert.Equal(t, 4, statements[0].EndPos.Column)
+		// assert.Equal(t, 3, statements[0].EndPos.Line)
+	}
 }
 
 func TestExample0(t *testing.T) {

--- a/src/parse/asp/parser_test.go
+++ b/src/parse/asp/parser_test.go
@@ -486,25 +486,25 @@ func TestMultilineStringQuotes(t *testing.T) {
 		Expected string
 	}{
 		{
-			Path:     "src/parse/asp/test_data/multiline_string_single_in_single.build",
+			Path: "src/parse/asp/test_data/multiline_string_single_in_single.build",
 			Expected: `"
 multiline string containing 'single quotes'
 "`,
 		},
 		{
-			Path:     "src/parse/asp/test_data/multiline_string_double_in_single.build",
+			Path: "src/parse/asp/test_data/multiline_string_double_in_single.build",
 			Expected: `"
 multiline string containing "double quotes"
 "`,
 		},
 		{
-			Path:     "src/parse/asp/test_data/multiline_string_single_in_double.build",
+			Path: "src/parse/asp/test_data/multiline_string_single_in_double.build",
 			Expected: `"
 multiline string containing 'single quotes'
 "`,
 		},
 		{
-			Path:     "src/parse/asp/test_data/multiline_string_double_in_double.build",
+			Path: "src/parse/asp/test_data/multiline_string_double_in_double.build",
 			Expected: `"
 multiline string containing "double quotes"
 "`,

--- a/src/parse/asp/test_data/multiline_string_double_in_double.build
+++ b/src/parse/asp/test_data/multiline_string_double_in_double.build
@@ -1,0 +1,3 @@
+s = """
+multiline string containing "double quotes"
+"""

--- a/src/parse/asp/test_data/multiline_string_double_in_single.build
+++ b/src/parse/asp/test_data/multiline_string_double_in_single.build
@@ -1,0 +1,3 @@
+s = '''
+multiline string containing "double quotes"
+'''

--- a/src/parse/asp/test_data/multiline_string_quotes.build
+++ b/src/parse/asp/test_data/multiline_string_quotes.build
@@ -1,3 +1,0 @@
-CC_MAIN = """
-#include "UnitTest++/UnitTest++.h"
-"""

--- a/src/parse/asp/test_data/multiline_string_single_in_double.build
+++ b/src/parse/asp/test_data/multiline_string_single_in_double.build
@@ -1,0 +1,3 @@
+s = """
+multiline string containing 'single quotes'
+"""

--- a/src/parse/asp/test_data/multiline_string_single_in_single.build
+++ b/src/parse/asp/test_data/multiline_string_single_in_single.build
@@ -1,0 +1,3 @@
+s = '''
+multiline string containing 'single quotes'
+'''


### PR DESCRIPTION
Don't replace occurrences of single quotes with double quotes when tokenising multiline strings.

Fixes #2182.