### PR TITLE
Proof of concept: exports

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -3,9 +3,9 @@
 
 # Do not change the order of arguments to this function without updating the iota in targets.go to match it.
 def build_rule(name:str, cmd:str|dict='', test_cmd:str|dict='', debug_cmd:str='', srcs:list|dict=None, data:list|dict=None,
-               debug_data:list|dict=None, outs:list|dict=None, deps:list=None, exported_deps:list=None, secrets:list|dict=None,
-               tools:str|list|dict=None, test_tools:str|list|dict=None, debug_tools:str|list|dict=None, labels:list=None,
-               visibility:list=CONFIG.DEFAULT_VISIBILITY, hashes:list=None, binary:bool=False, test:bool=False,
+               debug_data:list|dict=None, outs:list|dict=None, deps:list=None, exported_deps:list=None, exports:list=None,
+               secrets:list|dict=None,tools:str|list|dict=None, test_tools:str|list|dict=None, debug_tools:str|list|dict=None,
+               labels:list=None, visibility:list=CONFIG.DEFAULT_VISIBILITY, hashes:list=None, binary:bool=False, test:bool=False,
                test_only:bool=CONFIG.DEFAULT_TESTONLY, building_description:str=None, needs_transitive_deps:bool=False,
                output_is_complete:bool=False, sandbox:bool=CONFIG.BUILD_SANDBOX, test_sandbox:bool=CONFIG.TEST_SANDBOX,
                no_test_output:bool=False, flaky:bool|int=0, build_timeout:int|str=0, test_timeout:int|str=0, pre_build:function=None,

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -25,6 +25,7 @@ const (
 	outsBuildRuleArgIdx
 	depsBuildRuleArgIdx
 	exportedDepsBuildRuleArgIdx
+	exportsBuildRuleArgsIdx
 	secretsBuildRuleArgIdx
 	toolsBuildRuleArgIdx
 	testToolsBuildRuleArgIdx
@@ -228,6 +229,9 @@ func populateTarget(s *scope, t *core.BuildTarget, args []pyObject) {
 	addDependencies(s, "deps", args[depsBuildRuleArgIdx], t, false, false)
 	addDependencies(s, "exported_deps", args[exportedDepsBuildRuleArgIdx], t, true, false)
 	addDependencies(s, "internal_deps", args[internalDepsBuildRuleArgIdx], t, false, true)
+	addStrings(s, "exports", args[exportsBuildRuleArgsIdx], func(export string) {
+		t.AddExport(core.ParseBuildLabelContext(export, s.pkg))
+	})
 	addStrings(s, "labels", args[labelsBuildRuleArgIdx], t.AddLabel)
 	addStrings(s, "hashes", args[hashesBuildRuleArgIdx], t.AddHash)
 	addStrings(s, "licences", args[licencesBuildRuleArgIdx], t.AddLicence)

--- a/test/exports/BUILD
+++ b/test/exports/BUILD
@@ -1,0 +1,20 @@
+build_rule(
+    name = "foo",
+    outs = ["foo"],
+    cmd = "touch $OUT",
+    exports = [":bar"],
+)
+
+build_rule(
+    name = "bar",
+    outs = ["bar"],
+    cmd = "touch $OUT",
+    deps = [":foo"]
+)
+
+build_rule(
+    name = "baz",
+    outs = ["baz"],
+    cmd = "touch $OUT",
+    deps = [":foo"],
+)


### PR DESCRIPTION
This PR adds in a proof of concept for `exports`. Exports are a list of build targets that a rule will export to any dependees it has. This can be useful where you want to be able to later collect up all the transitive dependencies of a target, but the target doesn't actually need these dependencies to build itself. 

A good example of this is `python_wheel()`. The `python_wheel()` rules doesn't need its dependencies to build, however any `python_binary()` rule that depends on a `python_wheel()` need these transitive deps. In this case, the `python_wheel()` rules could export each other, and any `python_binary()` would then end up depending on all those wheels. This would allow cyclic dependencies between wheels without causing a problem for Please. 
