### PR TITLE
Fix test fields not being displayed correctly when running 'plz query…

### DIFF
--- a/src/query/print_test.go
+++ b/src/query/print_test.go
@@ -128,8 +128,9 @@ func TestPrintFields(t *testing.T) {
 	target := core.NewBuildTarget(core.ParseBuildLabel("//src/query:test_print_fields", ""))
 	target.AddLabel("go")
 	target.AddLabel("test")
-	s := testPrintFields(target, []string{"labels"})
-	assert.Equal(t, "go\ntest\n", s)
+	target.Test = &core.TestFields{Sandbox: true}
+	s := testPrintFields(target, []string{"labels", "test_sandbox"})
+	assert.Equal(t, "go\ntest\nTrue\n", s)
 }
 
 func TestPrintSourcesField(t *testing.T) {


### PR DESCRIPTION
… print --field'

Test fields now live in a separate data structure, but the index found was still being applied to the main build target data structure.