### PR TITLE
Set Prometheus pusher to use text format

### DIFF
--- a/src/metrics/prometheus.go
+++ b/src/metrics/prometheus.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
+	"github.com/prometheus/common/expfmt"
 	"gopkg.in/op/go-logging.v1"
 
 	"github.com/thought-machine/please/src/core"
@@ -19,9 +20,8 @@ func Push(config *core.Configuration) {
 	if config.Metrics.PrometheusGatewayURL == "" {
 		return
 	}
-	if err := push.New(config.Metrics.PrometheusGatewayURL, "please").Gatherer(prometheus.DefaultGatherer).Push(); err != nil {
-		// TODO(jpoole): diagnose why we're seeing this and promote this to error again
-		log.Debugf("Error pushing Prometheus metrics: %s", err)
+	if err := push.New(config.Metrics.PrometheusGatewayURL, "please").Gatherer(prometheus.DefaultGatherer).Format(expfmt.FmtText).Push(); err != nil {
+		log.Warning("Error pushing Prometheus metrics: %s", err)
 	}
 }
 


### PR DESCRIPTION
As of Prometheus version 2.0, all processes that expose metrics to Prometheus need to use a text-based format. However the go client defaults to a proto buffer format. This PR sets the pusher to push metrics in a test based format, fixing the Error pushing Prometheus metrics issue.