### PR TITLE
Add tag() builtin that can be used to tag a target name

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -1112,6 +1112,34 @@
   </section>
 
   <section class="mt4">
+    <h3 class="title-3" id="tag">
+      tag
+    </h3>
+
+    <code class="code-signature">tag(name, tag)</code>
+
+    <p>Tags a build label name with a given tag. This can be useful to keep following the intermediate build target
+      naming convention when a build definition doesn't expose the <code class="code">tag</code> parameter.</p>
+
+    <p>For example:</p>
+
+    <ul class="bulleted-list">
+      <li>
+        <span
+        ><code class="code">tag("name", "foo")</code> -&gt;
+          <code class="code">"_name#foo"</code>
+        </span>
+      </li>
+      <li>
+        <span
+        ><code class="code">tag("_name#foo", "bar")</code> -&gt;
+          <code class="code">"_name#foo_bar"</code>
+        </span>
+      </li>
+    </ul>
+  </section>
+
+  <section class="mt4">
     <h3 class="title-3" id="fail">
       fail
     </h3>

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -16,7 +16,6 @@ def build_rule(name:str, cmd:str|dict='', test_cmd:str|dict='', debug_cmd:str=''
                _subrepo:bool=False):
     pass
 
-
 def len(obj:list|dict|str) -> int:
     pass
 def enumerate(seq:list):
@@ -138,6 +137,15 @@ def canonicalise(label:str) -> str:
       //package:target -> //package:target
       //package -> //package:package
       :target -> //current_package:target
+    """
+    pass
+
+def tag(name:str, tag:str):
+    """Applies a tag to a build target name, similar to the `tag` param on build_rule().
+
+    For example:
+        tag("name", "foo") -> "_name#foo"
+        tag("_name#foo", "bar") -> "_name#foo_bar"
     """
     pass
 

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -30,6 +30,7 @@ func registerBuiltins(s *scope) {
 	const varargs = true
 	const kwargs = true
 	setNativeCode(s, "build_rule", buildRule)
+	setNativeCode(s, "tag", tag)
 	setNativeCode(s, "subrepo", subrepo)
 	setNativeCode(s, "fail", builtinFail)
 	setNativeCode(s, "subinclude", subinclude, varargs)
@@ -234,6 +235,13 @@ func pkg(s *scope, args []pyObject) pyObject {
 		s.config.IndexAssign(pyString(k), v)
 	}
 	return None
+}
+
+func tag(s *scope, args []pyObject) pyObject {
+	name := args[0].String()
+	tag := args[1].String()
+
+	return pyString(tagName(name, tag))
 }
 
 // tagName applies the given tag to a target name.

--- a/src/parse/asp/builtins_test.go
+++ b/src/parse/asp/builtins_test.go
@@ -46,3 +46,11 @@ func TestGetLabels(t *testing.T) {
 	assert.Len(t, ls, 1)
 	assert.Equal(t, pyString("-pthread"), ls[0])
 }
+
+func TestTag(t *testing.T) {
+	res := tag(nil, []pyObject{pyString("name"), pyString("foo")})
+	assert.Equal(t, res.String(), "_name#foo")
+
+	res = tag(nil, []pyObject{res, pyString("bar")})
+	assert.Equal(t, res.String(), "_name#foo_bar")
+}


### PR DESCRIPTION
I think this can really help with keeping the naming convention of intermediate targets going. We have a lot of `name = f"_{name}#{tag}" stuff that results in `__{name}#tag#tag2` which isn't great. 

This is especially true for the proto language rules which require that you tag rules accordingly. 