### PR TITLE
Make C/C++ library output filenames customisable

### DIFF
--- a/rules/c_rules.build_defs
+++ b/rules/c_rules.build_defs
@@ -8,7 +8,7 @@ you must pay attention to interoperability when needed (e.g. 'extern "C"' and so
 """
 
 
-def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:list=[],
+def c_library(name:str, srcs:list=[], out:str='', hdrs:list=[], private_hdrs:list=[], deps:list=[],
               visibility:list=None, test_only:bool&testonly=False, compiler_flags:list&cflags&copts=[],
               linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[], pkg_config_cflags:list=[],
               includes:list=[], defines:list|dict=[], alwayslink:bool=False):
@@ -17,6 +17,8 @@ def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:l
     Args:
       name (str): Name of the rule
       srcs (list): C source files to compile.
+      out (str): Name of the output library. Defaults to lib<name>.a (or just <name>.a if name already
+                 begins with 'lib').
       hdrs (list): Header files. These will be made available to dependent rules, so the distinction
                    between srcs and hdrs is important.
       private_hdrs (list): Header files that are available only to this rule and not exported to
@@ -41,6 +43,7 @@ def c_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:l
     return cc_library(
         name = name,
         srcs = srcs,
+        out = out,
         hdrs = hdrs,
         private_hdrs = private_hdrs,
         deps = deps,
@@ -112,8 +115,9 @@ def c_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=None
     )
 
 
-def c_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[], linker_flags:list&ldflags&linkopts=[],
-                     deps:list=[], visibility:list=None, test_only:bool&testonly=False, pkg_config_libs:list=[], pkg_config_cflags:list=[]):
+def c_static_library(name:str, srcs:list=[], out:str='', hdrs:list=[], compiler_flags:list&cflags&copts=[],
+                     linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None,
+                     test_only:bool&testonly=False, pkg_config_libs:list=[], pkg_config_cflags:list=[]):
     """Generates a C static library (.a).
 
     This is essentially just a collection of other c_library rules into a single archive.
@@ -123,6 +127,8 @@ def c_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&c
     Args:
       name (str): Name of the rule
       srcs (list): C or C++ source files to compile.
+      out (str): Name of the output library. Defaults to lib<name>.a (or just <name>.a if name already
+                 begins with 'lib').
       hdrs (list): Header files.
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker.
@@ -136,6 +142,7 @@ def c_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&c
     return cc_static_library(
         name = name,
         srcs = srcs,
+        out = out,
         hdrs = hdrs,
         deps = deps,
         visibility = visibility,

--- a/rules/cc_rules.build_defs
+++ b/rules/cc_rules.build_defs
@@ -15,7 +15,7 @@ _WHOLE_ARCHIVE = '-all_load' if CONFIG.OS == 'darwin' else '--whole-archive'
 _NO_WHOLE_ARCHIVE = '-noall_load' if CONFIG.OS == 'darwin' else '--no-whole-archive'
 
 
-def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:list=[],
+def cc_library(name:str, srcs:list=[], out:str='', hdrs:list=[], private_hdrs:list=[], deps:list=[],
                visibility:list=None, test_only:bool&testonly=False, compiler_flags:list&cflags&copts=[],
                linker_flags:list&ldflags&linkopts=[], pkg_config_libs:list=[], pkg_config_cflags:list=[], includes:list=[],
                defines:list|dict=[], alwayslink:bool=False, linkstatic:bool=False, _c=False,
@@ -25,6 +25,8 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
     Args:
       name (str): Name of the rule
       srcs (list): C++ source files to compile.
+      out (str): Name of the output library. Defaults to lib<name>.a (or just <name>.a if name already
+                 begins with 'lib').
       hdrs (list): Header files. These will be made available to dependent rules, so the distinction
                    between srcs and hdrs is important.
       private_hdrs (list): Header files that are available only to this rule and not exported to
@@ -129,6 +131,8 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
         all_deps = deps
 
     cmds, tools = _library_cmds(_c, compiler_flags, pkg_config_libs, pkg_config_cflags)
+    if not out:
+        out = f'{name}.a' if name.startswith('lib') else f'lib{name}.a'
     if len(srcs) > 1:
         # Compile all the sources separately, this is much faster for large numbers of files
         # than giving them all to gcc in one invocation.
@@ -158,7 +162,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
             name = name,
             tag = 'a',
             srcs = {'srcs': a_rules},
-            outs = [name + '.a'],
+            outs = [out],
             cmd = '"$TOOLS_JARCAT" ar --combine && "$TOOLS_AR" s "$OUT"',
             building_description = 'Archiving...',
             test_only = test_only,
@@ -170,7 +174,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
             },
         )
         if alwayslink:
-            labels += [f'cc:al:{pkg}/{name}.a']
+            labels += [f'cc:al:{pkg}/{out}']
 
         # Filegroup to pick that up with extra deps. This is a little annoying but means that
         # things depending on this get the combined rule and not the individual ones, but do get
@@ -192,7 +196,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
             name=name,
             tag='cc',
             srcs={'srcs': srcs, 'hdrs': hdrs, 'priv': private_hdrs},
-            outs=[name + '.a'],
+            outs=[out],
             optional_outs=['*.gcno'],  # For coverage
             deps=deps if srcs == _interfaces else all_deps,
             cmd=cmds,
@@ -205,7 +209,7 @@ def cc_library(name:str, srcs:list=[], hdrs:list=[], private_hdrs:list=[], deps:
             needs_transitive_deps=True,
         )
         if alwayslink:
-            labels += [f'cc:al:{pkg}/{name}.a']
+            labels += [f'cc:al:{pkg}/{out}']
         # Need another rule to cover require / provide stuff. This is getting a bit complicated...
         lib_rule = filegroup(
             name = name,
@@ -296,7 +300,7 @@ def cc_object(name:str, src:str, hdrs:list=[], private_hdrs:list=[], out:str=Non
     )
 
 
-def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&cflags&copts=[],
+def cc_static_library(name:str, srcs:list=[], out:str='', hdrs:list=[], compiler_flags:list&cflags&copts=[],
                       linker_flags:list&ldflags&linkopts=[], deps:list=[], visibility:list=None,
                       test_only:bool&testonly=False, pkg_config_libs:list=[], pkg_config_cflags:list=[],_c=False):
     """Generates a C++ static library (.a).
@@ -308,6 +312,8 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
     Args:
       name (str): Name of the rule
       srcs (list): C or C++ source files to compile.
+      out (str): Name of the output library. Defaults to lib<name>.a (or just <name>.a if name already
+                 begins with 'lib').
       hdrs (list): Header files.
       compiler_flags (list): Flags to pass to the compiler.
       linker_flags (list): Flags to pass to the linker.
@@ -336,10 +342,12 @@ def cc_static_library(name:str, srcs:list=[], hdrs:list=[], compiler_flags:list&
             'cc_hdrs': f':_{name}#lib_hdrs',
             'cc': ':' + name,
         }
+    if not out:
+        out = f'{name}.a' if name.startswith('lib') else f'lib{name}.a'
     return build_rule(
         name = name,
         deps = deps,
-        outs = [f'lib{name}.a'],
+        outs = [out],
         cmd = '"$TOOLS_JARCAT" ar --find && "$TOOLS_AR" s "$OUT"',
         needs_transitive_deps = True,
         output_is_complete = True,

--- a/src/help/rules_test.go
+++ b/src/help/rules_test.go
@@ -25,7 +25,7 @@ func TestRuleArgs(t *testing.T) {
 	assert.False(t, arg.Deprecated)
 	assert.Equal(t, []string{"str"}, arg.Types)
 	assert.Equal(t, "Name of the rule", arg.Comment)
-	arg = rule.Args[2]
+	arg = rule.Args[3]
 	assert.Equal(t, "hdrs", arg.Name)
 	assert.False(t, arg.Required)
 	assert.False(t, arg.Deprecated)


### PR DESCRIPTION
There are occasions when a C/C++ library needs to be given a specific filename, e.g. when it needs to be automatically detected by an Autoconf-generated configure script, but doing this using the built-in rules requires either a library target whose name matches the desired library name or an additional `genrule` target to do the renaming if this isn't possible.

Add an `out` parameter to the `cc_library` and `cc_static_library` rules (and their C equivalents) to allow the library filename to be customised. Similarly to the existing behaviour for `cc_shared_object`, a sensible default is chosen if no value of `out` is given.