### PR TITLE
Support go 1.18 tests

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -893,7 +893,7 @@ def go_test_main(name:str, srcs:list, test_package:str="", test_only:bool=False,
     cover = cover and (CONFIG.BUILD_CONFIG == "cover")
     test_package = test_package or _get_import_path()
     external_flag = " --external" if external else ""
-    cmd = f'"$TOOLS" testmain --test_package "{test_package}"{external_flag} --import_path "{CONFIG.GO_IMPORT_PATH}" -o $OUT'
+    cmd = f'"$TOOLS_PLZ" testmain --test_package "{test_package}"{external_flag} --import_path "{CONFIG.GO_IMPORT_PATH}" --go_tool "$TOOLS_GO" -o $OUT'
     if benchmark:
         cmd = f'{cmd} --benchmark'
     cmds = {
@@ -914,7 +914,10 @@ def go_test_main(name:str, srcs:list, test_package:str="", test_only:bool=False,
         needs_transitive_deps = cover,  # Need all dependencies to template coverage variables
         requires = ['go', 'go_src'] if cover else ['go'],
         test_only = test_only,
-        tools = [CONFIG.PLEASE_GO_TOOL],
+        tools = {
+            'plz': [CONFIG.PLEASE_GO_TOOL],
+            'go': [CONFIG.GO_TOOL],
+        },
         post_build = _post_build,
         visibility = visibility,
         labels = labels,

--- a/tools/please_go/install/toolchain/BUILD
+++ b/tools/please_go/install/toolchain/BUILD
@@ -3,7 +3,7 @@ go_library(
     srcs = [
         "toolchain.go",
     ],
-    visibility = ["//tools/please_go/install/..."],
+    visibility = ["//tools/please_go/..."],
     deps = [
         "//tools/please_go/install/exec",
     ],

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -33,7 +33,7 @@ var opts = struct {
 		} `positional-args:"true" required:"true"`
 	} `command:"install" alias:"i" description:"Compile a go module similarly to 'go install'"`
 	Test struct {
-		GoTool            string   `short:"g" long:"go_tool" description:"The location of the go binary" default:"go"`
+		GoTool      string   `short:"g" long:"go_tool" description:"The location of the go binary" default:"go"`
 		Dir         string   `short:"d" long:"dir" description:"Directory to search for Go package files for coverage"`
 		Exclude     []string `short:"x" long:"exclude" default:"third_party/go" description:"Directories to exclude from search"`
 		Output      string   `short:"o" long:"output" description:"Output filename" required:"true"`

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -33,6 +33,7 @@ var opts = struct {
 		} `positional-args:"true" required:"true"`
 	} `command:"install" alias:"i" description:"Compile a go module similarly to 'go install'"`
 	Test struct {
+		GoTool            string   `short:"g" long:"go_tool" description:"The location of the go binary" default:"go"`
 		Dir         string   `short:"d" long:"dir" description:"Directory to search for Go package files for coverage"`
 		Exclude     []string `short:"x" long:"exclude" default:"third_party/go" description:"Directories to exclude from search"`
 		Output      string   `short:"o" long:"output" description:"Output filename" required:"true"`
@@ -82,6 +83,7 @@ var subCommands = map[string]func() int{
 	},
 	"testmain": func() int {
 		test.PleaseGoTest(
+			opts.Test.GoTool,
 			opts.Test.Dir,
 			opts.Test.ImportPath,
 			opts.Test.TestPackage,

--- a/tools/please_go/test/BUILD
+++ b/tools/please_go/test/BUILD
@@ -7,6 +7,9 @@ go_library(
         "gotest.go",
         "write_test_main.go",
     ],
+    deps = [
+        "//tools/please_go/install/toolchain",
+    ],
     visibility = ["//tools/please_go/..."],
 )
 

--- a/tools/please_go/test/gotest.go
+++ b/tools/please_go/test/gotest.go
@@ -1,6 +1,10 @@
 package test
 
-import "log"
+import (
+	"log"
+
+	"github.com/thought-machine/please/tools/please_go/install/toolchain"
+)
 
 // PleaseGoTest will generate the test main for the provided sources
 func PleaseGoTest(goTool, dir, importPath, testPackage, output string, sources, exclude []string, isBenchmark, external bool) {
@@ -8,7 +12,12 @@ func PleaseGoTest(goTool, dir, importPath, testPackage, output string, sources, 
 	if err != nil {
 		log.Fatalf("Error scanning for coverage: %s", err)
 	}
-	if err = WriteTestMain(goTool, testPackage, sources, output, dir != "", coverVars, isBenchmark); err != nil {
+	tc := toolchain.Toolchain{GoTool: goTool}
+	minor, err := tc.GoMinorVersion()
+	if err != nil {
+		log.Fatalf("Failed to determine Go version: %s", err)
+	}
+	if err := WriteTestMain(testPackage, sources, output, dir != "", coverVars, isBenchmark, minor >= 18); err != nil {
 		log.Fatalf("Error writing test main: %s", err)
 	}
 }

--- a/tools/please_go/test/gotest.go
+++ b/tools/please_go/test/gotest.go
@@ -3,12 +3,12 @@ package test
 import "log"
 
 // PleaseGoTest will generate the test main for the provided sources
-func PleaseGoTest(dir, importPath, testPackage, output string, sources, exclude []string, isBenchmark, external bool) {
+func PleaseGoTest(goTool, dir, importPath, testPackage, output string, sources, exclude []string, isBenchmark, external bool) {
 	coverVars, err := FindCoverVars(dir, importPath, testPackage, external, exclude, sources)
 	if err != nil {
 		log.Fatalf("Error scanning for coverage: %s", err)
 	}
-	if err = WriteTestMain(testPackage, sources, output, dir != "", coverVars, isBenchmark); err != nil {
+	if err = WriteTestMain(goTool, testPackage, sources, output, dir != "", coverVars, isBenchmark); err != nil {
 		log.Fatalf("Error writing test main: %s", err)
 	}
 }

--- a/tools/please_go/test/write_test_main.go
+++ b/tools/please_go/test/write_test_main.go
@@ -11,8 +11,6 @@ import (
 	"text/template"
 	"unicode"
 	"unicode/utf8"
-
-	"github.com/thought-machine/please/tools/please_go/install/toolchain"
 )
 
 type testDescr struct {
@@ -30,7 +28,7 @@ type testDescr struct {
 
 // WriteTestMain templates a test main file from the given sources to the given output file.
 // This mimics what 'go test' does, although we do not currently support benchmarks or examples.
-func WriteTestMain(goTool, testPackage string, sources []string, output string, coverage bool, coverVars []CoverVar, benchmark bool) error {
+func WriteTestMain(testPackage string, sources []string, output string, coverage bool, coverVars []CoverVar, benchmark, hasFuzz bool) error {
 	testDescr, err := parseTestSources(sources)
 	if err != nil {
 		return err
@@ -43,13 +41,7 @@ func WriteTestMain(goTool, testPackage string, sources []string, output string, 
 	}
 
 	testDescr.Benchmark = benchmark
-
-	tc := toolchain.Toolchain{GoTool: goTool}
-	minor, err := tc.GoMinorVersion()
-	if err != nil {
-		return err
-	}
-	testDescr.HasFuzz = minor >= 18
+	testDescr.HasFuzz = hasFuzz
 
 	f, err := os.Create(output)
 	if err != nil {

--- a/tools/please_go/test/write_test_main_test.go
+++ b/tools/please_go/test/write_test_main_test.go
@@ -47,7 +47,7 @@ func TestParseTestSourcesFailsGracefully(t *testing.T) {
 }
 
 func TestWriteTestMain(t *testing.T) {
-	err := WriteTestMain("test_pkg", []string{"tools/please_go/test/test_data/test/example_test.go"}, "test.go", false, []CoverVar{}, false)
+	err := WriteTestMain("test_pkg", []string{"tools/please_go/test/test_data/test/example_test.go"}, "test.go", false, []CoverVar{}, false, true)
 	assert.NoError(t, err)
 	// It's not really practical to assert the contents of the file in great detail.
 	// We'll do the obvious thing of asserting that it is valid Go source.
@@ -62,7 +62,7 @@ func TestWriteTestMainWithCoverage(t *testing.T) {
 		ImportPath: "core",
 		Var:        "GoCover_lock_go",
 		File:       "tools/please_go/test/test_data/lock.go",
-	}}, false)
+	}}, false, false)
 	assert.NoError(t, err)
 	// It's not really practical to assert the contents of the file in great detail.
 	// We'll do the obvious thing of asserting that it is valid Go source.
@@ -72,7 +72,7 @@ func TestWriteTestMainWithCoverage(t *testing.T) {
 }
 
 func TestWriteTestMainWithBenchmark(t *testing.T) {
-	err := WriteTestMain("test_package", []string{"tools/please_go/test/test_data/bench/example_benchmark_test.go"}, "test.go", true, []CoverVar{}, true)
+	err := WriteTestMain("test_package", []string{"tools/please_go/test/test_data/bench/example_benchmark_test.go"}, "test.go", true, []CoverVar{}, true, true)
 	assert.NoError(t, err)
 	// It's not really practical to assert the contents of the file in great detail.
 	// We'll do the obvious thing of asserting that it is valid Go source.


### PR DESCRIPTION
This doesn't _actually_ add support for fuzzing, but does allow tests to actually compile (because they have changed the signature of `MainStart`)