### PR TITLE
Don't show line-by-line coverage results if things failed

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -483,7 +483,7 @@ var buildFunctions = map[string]func() int{
 		test.WriteCoverageToFileOrDie(state.Coverage, string(opts.Cover.CoverageResultsFile), stats)
 		test.WriteXMLCoverageToFileOrDie(targets, state.Coverage, string(opts.Cover.CoverageXMLReport))
 
-		if opts.Cover.LineCoverageReport {
+		if opts.Cover.LineCoverageReport && success {
 			output.PrintLineCoverageReport(state, opts.Cover.IncludeFile.AsStrings())
 		} else if !opts.Cover.NoCoverageReport && opts.Cover.Shell == "" {
 			output.PrintCoverage(state, opts.Cover.IncludeFile.AsStrings())


### PR DESCRIPTION
This has annoyed me a few times; if your tests fail then `-l` gives you a sea of red, and you have to scroll up past it to find out what went wrong.

Given that coverage is always zero on test failure, there seems to be no downside to this (although you could argue maybe we should be interpreting it anyway, in which case it might provide a little info?).