### PR TITLE
Add xxhash support & allow specifying

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//third_party/go:semver",
         "//third_party/go:shlex",
         "//third_party/go:xattr",
+        "//third_party/go:xxhash",
     ],
 )
 

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -442,7 +442,7 @@ type Configuration struct {
 		PassEnv              []string     `help:"A list of environment variables to pass from the current environment to build rules. For example\n\nPassEnv = HTTP_PROXY\n\nwould copy your HTTP_PROXY environment variable to the build env for any rules."`
 		PassUnsafeEnv        []string     `help:"Similar to PassEnv, a list of environment variables to pass from the current environment to build rules. Unlike PassEnv, the environment variable values are not used when calculating build target hashes."`
 		HTTPProxy            cli.URL      `help:"A URL to use as a proxy server for downloads. Only applies to internal ones - e.g. self-updates or remote_file rules."`
-		HashFunction         string       `help:"The hash function to use internally for build actions." options:"sha1,sha256"`
+		HashFunction         string       `help:"The hash function to use internally for build actions." options:"sha1,sha256,blake3,xxhash,crc32,crc64"`
 		ExitOnError          bool         `help:"True to have build actions automatically fail on error (essentially passing -e to the shell they run in)." var:"EXIT_ON_ERROR"`
 		LinkGeneratedSources string       `help:"If set, supported build definitions will link generated sources back into the source tree. The list of generated files can be generated for the .gitignore through 'plz query print --label gitignore: //...'. The available options are: 'hard' (hardlinks), 'soft' (symlinks), 'true' (symlinks) and 'false' (default)" var:"LINK_GEN_SOURCES"`
 		UpdateGitignore      bool         `help:"Whether to automatically update the nearest gitignore with generated sources"`

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/OneOfOne/cmap"
+	"github.com/cespare/xxhash/v2"
 	"lukechampine.com/blake3"
 
 	"github.com/thought-machine/please/src/cli"
@@ -1117,6 +1118,10 @@ func newBlake3() hash.Hash {
 	return blake3.New(32, nil)
 }
 
+func newXXHash() hash.Hash {
+	return xxhash.New()
+}
+
 func sandboxTool(config *Configuration) string {
 	tool := config.Sandbox.Tool
 	if filepath.IsAbs(tool) {
@@ -1143,6 +1148,7 @@ func NewBuildState(config *Configuration) *BuildState {
 			"crc32":  fs.NewPathHasher(RepoRoot, config.Build.Xattrs, newCRC32, "crc32"),
 			"crc64":  fs.NewPathHasher(RepoRoot, config.Build.Xattrs, newCRC64, "crc64"),
 			"blake3": fs.NewPathHasher(RepoRoot, config.Build.Xattrs, newBlake3, "blake3"),
+			"xxhash": fs.NewPathHasher(RepoRoot, config.Build.Xattrs, newXXHash, "xxhash"),
 		},
 		ProcessExecutor: process.NewSandboxingExecutor(
 			config.Sandbox.Tool == "" && (config.Sandbox.Build || config.Sandbox.Test),


### PR DESCRIPTION
xxhash is fast but rather more modern than crc - we already have it as a dependency so no real overhead to supporting it as a hash function.

Not sure if there was a reason you can't choose non-SHA options in the config? It all seems to work fine.