### PR TITLE
Align the please go tool more with how the toolchain builds things

### DIFF
--- a/tools/please_go/install/test_data/example.com/cgo/foo.go
+++ b/tools/please_go/install/test_data/example.com/cgo/foo.go
@@ -1,0 +1,10 @@
+package cgo
+
+// #include "./include/foo.h"
+import "C"
+import "unsafe"
+
+func bar() {
+	v := struct{ count int }{1}
+	_ = (*C.foo_t)(unsafe.Pointer(&v))
+}

--- a/tools/please_go/install/test_data/example.com/cgo/include/foo.h
+++ b/tools/please_go/install/test_data/example.com/cgo/include/foo.h
@@ -1,0 +1,6 @@
+// This header file is referenced in an upper directory to test that
+// it can include relative header files in different directories.
+
+typedef struct {
+  unsigned int count;
+} foo_t;


### PR DESCRIPTION
This shuffles a few things around. The work dir is now solely used for generated source files and objects. Original source files aren't copied into it anymore. Compiling directly from the original source code location allows for relative imports (such as c header files) to be resolved and not freak out.