### PR TITLE
Parallel hashing of directories

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1143,12 +1143,12 @@ func NewBuildState(config *Configuration) *BuildState {
 		pendingRemoteActions: make(chan Task, 1000),
 		hashers: map[string]*fs.PathHasher{
 			// For compatibility reasons the sha1 hasher has no suffix.
-			"sha1":   fs.NewPathHasher(RepoRoot, config.Build.Xattrs, sha1.New, "sha1"),
-			"sha256": fs.NewPathHasher(RepoRoot, config.Build.Xattrs, sha256.New, "sha256"),
-			"crc32":  fs.NewPathHasher(RepoRoot, config.Build.Xattrs, newCRC32, "crc32"),
-			"crc64":  fs.NewPathHasher(RepoRoot, config.Build.Xattrs, newCRC64, "crc64"),
-			"blake3": fs.NewPathHasher(RepoRoot, config.Build.Xattrs, newBlake3, "blake3"),
-			"xxhash": fs.NewPathHasher(RepoRoot, config.Build.Xattrs, newXXHash, "xxhash"),
+			"sha1":   fs.NewPathHasher(RepoRoot, config.Build.Xattrs, sha1.New, "sha1", config.Please.NumThreads),
+			"sha256": fs.NewPathHasher(RepoRoot, config.Build.Xattrs, sha256.New, "sha256", config.Please.NumThreads),
+			"crc32":  fs.NewPathHasher(RepoRoot, config.Build.Xattrs, newCRC32, "crc32", config.Please.NumThreads),
+			"crc64":  fs.NewPathHasher(RepoRoot, config.Build.Xattrs, newCRC64, "crc64", config.Please.NumThreads),
+			"blake3": fs.NewPathHasher(RepoRoot, config.Build.Xattrs, newBlake3, "blake3", config.Please.NumThreads),
+			"xxhash": fs.NewPathHasher(RepoRoot, config.Build.Xattrs, newXXHash, "xxhash", config.Please.NumThreads),
 		},
 		ProcessExecutor: process.NewSandboxingExecutor(
 			config.Sandbox.Tool == "" && (config.Sandbox.Build || config.Sandbox.Test),

--- a/src/fs/BUILD
+++ b/src/fs/BUILD
@@ -1,3 +1,5 @@
+subinclude("//build_defs:benchmark")
+
 go_library(
     name = "fs",
     srcs = glob(
@@ -18,7 +20,7 @@ go_test(
     name = "fs_test",
     srcs = glob(
         ["*_test.go"],
-        exclude = ["glob_integration_test.go"],
+        exclude = ["glob_integration_test.go", "*_benchmark_test.go"],
     ),
     data = ["test_data"],
     deps = [
@@ -32,4 +34,13 @@ go_test(
     srcs = ["glob_integration_test.go"],
     # This must remain a glob because the tests rely on data being loaded in via globs
     data = glob(["test_data/**"]),
+)
+
+benchmark(
+    name = "hash_benchmark",
+    srcs = ["hash_benchmark_test.go"],
+    data = ["//third_party/go:toolchain"],
+    deps = [
+        ":fs",
+    ],
 )

--- a/src/fs/hash_benchmark_test.go
+++ b/src/fs/hash_benchmark_test.go
@@ -28,7 +28,7 @@ func BenchmarkHashTree(b *testing.B) {
 	NewPathHasher(".", false, sha256.New, "sha256", 1).Hash(data, false, false)
 	b.ResetTimer()
 
-	for _, parallelism := range []int{1, 2, 4, 8} {
+	for _, parallelism := range []int{1, 2, 4, 8, 16, 24} {
 		b.Run(fmt.Sprintf("%dWay", parallelism), func(b *testing.B) {
 			start := time.Now()
 			for i := 0; i < b.N; i++ {
@@ -40,8 +40,10 @@ func BenchmarkHashTree(b *testing.B) {
 					b.Fatalf("Unexpected hash; was %s, expected %s", enc, expected)
 				}
 			}
-			b.ReportMetric(float64(size*b.N)/(1024.0 * 1024.0 * time.Since(start).Seconds()), "MB/s")
-			b.ReportMetric(float64(size)/(1024.0 * 1024.0 * time.Since(start).Seconds()), "MB/s/thread")
+			s := time.Since(start).Seconds()
+			mb := float64(size * b.N) / (1024.0 * 1024.0)
+			b.ReportMetric(mb/s, "MB/s")
+			b.ReportMetric(mb/(s * float64(parallelism)), "MB/s/thread")
 		})
 	}
 }

--- a/src/fs/hash_benchmark_test.go
+++ b/src/fs/hash_benchmark_test.go
@@ -25,7 +25,7 @@ func BenchmarkHashTree(b *testing.B) {
 		b.Fatalf("Failed to calculate size of input tree: %s", err)
 	}
 	// Run one hash initially to ensure any fs caching is warm.
-	NewPathHasher(".", false, sha256.New, "sha256").Hash(data, false, false)
+	NewPathHasher(".", false, sha256.New, "sha256", 1).Hash(data, false, false)
 	b.ResetTimer()
 
 	for _, parallelism := range []int{1, 2, 4, 8} {
@@ -33,7 +33,7 @@ func BenchmarkHashTree(b *testing.B) {
 			start := time.Now()
 			for i := 0; i < b.N; i++ {
 				// N.B. We force off xattrs to avoid it trying to short-circuit anything.
-				hasher := NewPathHasher(".", false, sha256.New, "sha256")
+				hasher := NewPathHasher(".", false, sha256.New, "sha256", parallelism)
 				if hash, err := hasher.Hash(data, false, false); err != nil {
 					b.Fatalf("Failed to hash path %s: %s", data, err)
 				} else if enc := hex.EncodeToString(hash); enc != expected {

--- a/src/fs/hash_benchmark_test.go
+++ b/src/fs/hash_benchmark_test.go
@@ -1,0 +1,46 @@
+package fs
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func BenchmarkHashTree(b *testing.B) {
+	const expected = "0dfc40ae0c5b728b2dd0797b99cf8e7361796fead051bc8f8dcfe21b2a307903"
+	data := os.Getenv("DATA")
+
+	// Calculate size of dir for metrics later
+	size := 0
+	if err := filepath.Walk(data, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() {
+			size += int(info.Size())
+		}
+		return err
+	}); err != nil {
+		b.Fatalf("Failed to calculate size of input tree: %s", err)
+	}
+	// Run one hash initially to ensure any fs caching is warm.
+	NewPathHasher(".", false, sha256.New, "sha256").Hash(data, false, false)
+	b.ResetTimer()
+
+	for _, parallelism := range []int{1, 2, 4, 8} {
+		b.Run(fmt.Sprintf("%dWay", parallelism), func(b *testing.B) {
+			start := time.Now()
+			for i := 0; i < b.N; i++ {
+				// N.B. We force off xattrs to avoid it trying to short-circuit anything.
+				hasher := NewPathHasher(".", false, sha256.New, "sha256")
+				if hash, err := hasher.Hash(data, false, false); err != nil {
+					b.Fatalf("Failed to hash path %s: %s", data, err)
+				} else if enc := hex.EncodeToString(hash); enc != expected {
+					b.Fatalf("Unexpected hash; was %s, expected %s", enc, expected)
+				}
+			}
+			b.ReportMetric(float64(size*b.N)/(1024.0 * 1024.0 * time.Since(start).Seconds()), "MB/s")
+		})
+	}
+}

--- a/src/fs/hash_benchmark_test.go
+++ b/src/fs/hash_benchmark_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func BenchmarkHashTree(b *testing.B) {
-	const expected = "0dfc40ae0c5b728b2dd0797b99cf8e7361796fead051bc8f8dcfe21b2a307903"
+	const expected = "9f944e70c49c8e0ab10993ec2dd0caabebcb9dfd0b9e6fd309b9fc8c56d12346"
 	data := os.Getenv("DATA")
 
 	// Calculate size of dir for metrics later
@@ -41,6 +41,7 @@ func BenchmarkHashTree(b *testing.B) {
 				}
 			}
 			b.ReportMetric(float64(size*b.N)/(1024.0 * 1024.0 * time.Since(start).Seconds()), "MB/s")
+			b.ReportMetric(float64(size)/(1024.0 * 1024.0 * time.Since(start).Seconds()), "MB/s/thread")
 		})
 	}
 }

--- a/src/fs/hash_test.go
+++ b/src/fs/hash_test.go
@@ -14,7 +14,7 @@ import (
 func TestHash(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	h := NewPathHasher(wd, true, sha1.New, "")
+	h := NewPathHasher(wd, true, sha1.New, "", 1)
 	b1, err1 := h.Hash("src/fs/test_data/test_subfolder1/a.txt", false, false)
 	b2, err2 := h.Hash("src/fs/test_data/test_subfolder1/a.txt", false, false)
 	assert.NoError(t, err1)
@@ -25,7 +25,7 @@ func TestHash(t *testing.T) {
 func TestMoveHash(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	h := NewPathHasher(wd, true, sha1.New, "")
+	h := NewPathHasher(wd, true, sha1.New, "", 1)
 	b1, err1 := h.Hash("src/fs/test_data/test_subfolder1/a.txt", false, false)
 	h.MoveHash("src/fs/test_data/test_subfolder1/a.txt", "doesnt_exist.txt", true)
 	b2, err2 := h.Hash("doesnt_exist.txt", false, false)
@@ -37,7 +37,7 @@ func TestMoveHash(t *testing.T) {
 func TestSetHash(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	h := NewPathHasher(wd, true, sha1.New, "")
+	h := NewPathHasher(wd, true, sha1.New, "", 1)
 	b1, err1 := h.Hash("src/fs/test_data/test_subfolder1/a.txt", false, false)
 	h.SetHash("doesnt_exist.txt", b1)
 	b2, err2 := h.Hash("doesnt_exist.txt", false, false)
@@ -49,7 +49,7 @@ func TestSetHash(t *testing.T) {
 func TestHashConstructorSHA1(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	h := NewPathHasher(wd, true, sha1.New, "")
+	h := NewPathHasher(wd, true, sha1.New, "", 1)
 	b, err := h.Hash("src/fs/test_data/test_subfolder1/a.txt", false, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "da39a3ee5e6b4b0d3255bfef95601890afd80709", hex.EncodeToString(b))
@@ -57,7 +57,7 @@ func TestHashConstructorSHA1(t *testing.T) {
 func TestHashConstructorSHA256(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	h := NewPathHasher(wd, true, sha256.New, "_256")
+	h := NewPathHasher(wd, true, sha256.New, "_256", 1)
 	b, err := h.Hash("src/fs/test_data/test_subfolder1/a.txt", false, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hex.EncodeToString(b))


### PR DESCRIPTION
This is really a proof-of-concept to show how we can hash big directory trees faster by hashing the files in them in parallel. 

```
goos: linux
goarch: amd64
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
BenchmarkHashTree
BenchmarkHashTree/1Way
BenchmarkHashTree/1Way-12                      1        1048907728 ns/op         296.96 MB/s           297.0 MB/s/thread
BenchmarkHashTree/2Way
BenchmarkHashTree/2Way-12                      2         558632038 ns/op         557.58 MB/s           278.8 MB/s/thread
BenchmarkHashTree/4Way
BenchmarkHashTree/4Way-12                      4         310531512 ns/op        1003.07 MB/s           250.8 MB/s/thread
BenchmarkHashTree/8Way
BenchmarkHashTree/8Way-12                      5         231179949 ns/op        1347.36 MB/s           269.5 MB/s/thread
PASS
```

(The numbers can be surprisingly wonky, will try to redo this on a machine without corporate nonsense)

Unfortunately it is a complete change to our hash strategy for directories; the previous one writes the contents of all files into a single hash, the new one hashes them all separately them combines them together at the top. The previous one simply cannot be parallelised as is.

Still a bit to do; the parallelism limit should apply to all hashes, not just directories, and some of the other stuff could be simplified (e.g. maybe we could use `x/sync/singleflight` rather than the current mechanism).