### PR TITLE
Couple of smol tweaks to benchmark scripts

### DIFF
--- a/tools/performance/gen_parse_tree.py
+++ b/tools/performance/gen_parse_tree.py
@@ -102,7 +102,7 @@ def main(argv):
         pass
     if FLAGS.format:
         # Format them all up (in chunks to avoid 'argument too long')
-        n = 100
+        n = 1000
         for i in progress('Formatting files', range(0, len(filenames), n)):
             subprocess.check_call([FLAGS.plz, 'fmt', '-w'] + filenames[i: i + n])
 

--- a/tools/performance/parse_perf_test.py
+++ b/tools/performance/parse_perf_test.py
@@ -78,7 +78,7 @@ def main(argv):
     log.info('Complete, median time: %0.2fs, median mem: %0.2f KB', median_time, median_mem)
     log.info('Running again to generate profiling info')
     profile_file = os.path.join(os.getcwd(), 'plz.prof')
-    subprocess.check_call(plz() + ['--profile_file', profile_file], stdout=subprocess.DEVNULL)
+    subprocess.check_call(plz() + ['--profile_file', profile_file], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     log.info('Reading CPU info')
     cpu_model, num_cpus = read_cpu_info()
     log.info('Generating results')


### PR DESCRIPTION
These are pretty silly but:
 - Increasing batch size is measurably faster for me (looks like 100 files isn't really enough to overcome startup overhead)
 - Profile command writes some numbers to stderr which look a little out of place.