### PR TITLE
Improve Go detection from #2225

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -894,7 +894,7 @@ def go_test_main(name:str, srcs:list, test_package:str="", test_only:bool=False,
     test_package = test_package or _get_import_path()
     external_flag = " --external" if external else ""
 
-    cmd = f'"$TOOLS_PLZ" testmain --test_package "{test_package}"{external_flag} --import_path "{CONFIG.GO_IMPORT_PATH}" --go_tool "$TOOLS_GO" -o $OUT'
+    cmd = f'"$TOOLS_PLZ" testmain --test_package "{test_package}"{external_flag} --import_path "{CONFIG.GO_IMPORT_PATH}" -o $OUT'
     # TODO(jpoole): remove this in v17
     if CONFIG.FF_GO_DONT_COLLAPSE_IMPORT_PATHS:
         cmd = f"FF_GO_DONT_COLLAPSE_IMPORT_PATHS=true {cmd}"

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -33,7 +33,7 @@ var opts = struct {
 		} `positional-args:"true" required:"true"`
 	} `command:"install" alias:"i" description:"Compile a go module similarly to 'go install'"`
 	Test struct {
-		GoTool      string   `short:"g" long:"go_tool" description:"The location of the go binary" default:"go"`
+		GoTool      string   `short:"g" long:"go_tool" description:"The location of the go binary" env:"TOOLS_GO" default:"go"`
 		Dir         string   `short:"d" long:"dir" description:"Directory to search for Go package files for coverage"`
 		Exclude     []string `short:"x" long:"exclude" default:"third_party/go" description:"Directories to exclude from search"`
 		Output      string   `short:"o" long:"output" description:"Output filename" required:"true"`


### PR DESCRIPTION
I've run across a few cases post #2225 where things tend to go wrong; when run in another repo it downloads the latest released version of the tool which then fails because it doesn't accept the flag.

This makes the compatibility a bit nicer in that it passes the flag by an env var rather than a flag so it won't break. It's still gonna be pretty hard to use for 1.18 until we tag a new version but should make things a little nicer otherwise.

Think this would all be better if it were a plugin (then the rules would version alongside the tool)