### PR TITLE
fix: allow a token to access private github repos

### DIFF
--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -370,7 +370,7 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
                 labels:list=[], deps:list=None, exported_deps:list=None,
                 extract:bool=False, strip_prefix:str='', _tag:str='',exported_files=[],
                 entry_points:dict={}, username:str=None, password_file:str=None,
-                headers:dict={}, secret_headers:dict={}):
+                headers:dict={}, secret_headers:dict={}, pass_env:list=[]):
     """Defines a rule to fetch a file over HTTP(S).
 
     Args:
@@ -394,6 +394,7 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
       password_file (str): A file on disk that contains a password or access token.
       headers (dict): Headers to pass to curl.
       secret_headers (dict): Headers contained in files to pass to curl.
+      pass_env (list): Any environment variables referenced by headers that should be passed in from the host.
     """
     if extract:
         if out:
@@ -457,17 +458,17 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
 
     auth = username and password_file
     curl = auth or headers or secret_headers
-    header_flag = []
+    header_flag = ""
     cmd = ''
 
     if curl:
-        for header in headers.items():
-            header_flag += [f' --header "{header}: {headers[header]}"']
-        for header in secret_headers.items():
-            header_flag += [f' --header "{header}: $(cat {headers[header]})"']
+        for header, value in headers.items():
+            header_flag = f'{header_flag} --header "{header}: {value}"'
+        for header, value in secret_headers.items():
+            header_flag = f'{header_flag} --header "{header}: $(cat {value})"'
 
         # Authentication info
-        user_info = f'--user {username}:$(cat {password_file})' if auth else None
+        user_info = f'--user {username}:$(cat {password_file})' if auth else ""
 
         # Check http response
         check_url = f'curl -s -o /dev/null -I {header_flag} {user_info} -w %{{http_code}}'
@@ -497,6 +498,7 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
         labels = labels,
         sandbox = False,
         entry_points = entry_points,
+        pass_env = pass_env,
     )
 
 def text_file(name:str, content:str, hashes:list=None, data:list|dict=[], out:str=None,

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -193,6 +193,12 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
 
     prefix = f'{repo}-{prefix}'
 
+    headers = {}
+    if access_token:
+        headers = {
+            'Authorization': f'token {access_token}'
+        }
+
     return new_http_archive(
         name = name,
         urls = [f'https://github.com/{org}/{repo}/archive/{revision}.zip'],
@@ -201,9 +207,7 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
         build_file = build_file,
         hashes = hashes,
         config = config,
-        headers = {
-            'Authorization': f'token {access_token}'
-        },
+        headers = headers,
         bazel_compat = bazel_compat,
     )
 

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -202,7 +202,7 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
         hashes = hashes,
         config = config,
         headers = {
-            'Authorization': f"token {access_token}"
+            'Authorization': f'token {access_token}'
         },
         bazel_compat = bazel_compat,
     )

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -59,7 +59,7 @@ def http_archive(name:str, urls:list, strip_prefix:str=None, hashes:str|list&sha
 def new_http_archive(name:str, urls:list, build_file:str=None, build_file_content:str=None,
                      strip_prefix:str=None, strip_build:bool=False, hashes:str|list&sha256=None,
                      username:str=None, password_file:str=None, headers:dict={}, secret_headers:dict={},
-                     config:str=None, bazel_compat:bool=False, visibility:list=None):
+                     config:str=None, bazel_compat:bool=False, visibility:list=None, pass_env:list=[]):
     """Fetches a remote file over HTTP and expands its contents, combined with a BUILD file.
 
     The archive should be either a zipfile or a tarball. Which one to use will be autodetected
@@ -89,6 +89,7 @@ def new_http_archive(name:str, urls:list, build_file:str=None, build_file_conten
                     specifying a config file with `compatibility = true` in the `[bazel]`
                     section.
       visibility: Deprecated, has no effect.
+      pass_env: Any environment variables referenced by headers that should be passed in from the host.
     """
     if isinstance(hashes, str):
         hashes = [hashes]
@@ -101,7 +102,8 @@ def new_http_archive(name:str, urls:list, build_file:str=None, build_file_conten
         username = username,
         password_file = password_file,
         headers = headers,
-        secret_headers = secret_headers
+        secret_headers = secret_headers,
+        pass_env = pass_env,
     )
     if strip_prefix:
         cmd = '$TOOL x $SRCS_REMOTE -o "$OUT" -s ' + strip_prefix
@@ -124,6 +126,7 @@ def new_http_archive(name:str, urls:list, build_file:str=None, build_file_conten
         outs = [name],
         cmd = cmd,
         _subrepo = True,
+        visibility = visibility,
     )
     return subrepo(
         name = name,
@@ -160,8 +163,7 @@ def new_local_repository(name:str, path:str):
 
 def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:str|list=None,
                 strip_prefix:str=None, strip_build:bool=False, config:str=None,
-                access_token:str=None,
-                bazel_compat:bool=False):
+                access_token:str=None, bazel_compat:bool=False):
     """Defines a new subrepo corresponding to a Github project.
 
     This is a convenience alias to the more general new_http_archive. It knows how to
@@ -175,7 +177,8 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
       hashes: List of hashes to verify the rule with.
       strip_prefix: Prefix to strip from the contents of the zip. Is usually autodetected for you.
       strip_build: True to strip any BUILD files from the archive after download.
-      access_token: Your github personal access token.
+      access_token: An environment variable containing a github personal access token. This can be used to access
+                    private repos.
       config: Configuration file to apply to this subrepo.
       bazel_compat: Shorthand to turn on Bazel compatibility. This is equivalent to
                     specifying a config file with `compatibility = true` in the `[bazel]`
@@ -194,10 +197,12 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
     prefix = f'{repo}-{prefix}'
 
     headers = {}
+    pass_env = []
     if access_token:
         headers = {
-            'Authorization': f'token {access_token}'
+            'Authorization': 'token \$%s' % access_token,
         }
+        pass_env = [access_token]
 
     return new_http_archive(
         name = name,
@@ -209,6 +214,7 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
         config = config,
         headers = headers,
         bazel_compat = bazel_compat,
+        pass_env = pass_env,
     )
 
 

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -58,6 +58,7 @@ def http_archive(name:str, urls:list, strip_prefix:str=None, hashes:str|list&sha
 
 def new_http_archive(name:str, urls:list, build_file:str=None, build_file_content:str=None,
                      strip_prefix:str=None, strip_build:bool=False, hashes:str|list&sha256=None,
+                     username:str=None, password_file:str=None, headers:dict=None, secret_headers:dict=None,
                      config:str=None, bazel_compat:bool=False, visibility:list=None):
     """Fetches a remote file over HTTP and expands its contents, combined with a BUILD file.
 
@@ -79,6 +80,10 @@ def new_http_archive(name:str, urls:list, build_file:str=None, build_file_conten
       strip_prefix: Prefix to strip from the expanded archive.
       strip_build: True to strip any BUILD files from the archive after download.
       hashes: List of hashes to verify the rule with.
+      username: Username for accessing a private file or repo.
+      password_file: A file on disk that contains a password or access token.
+      headers: Headers to pass to curl.
+      secret_headers: Headers contained in files to pass to curl.
       config: Configuration file to apply to this subrepo.
       bazel_compat: Shorthand to turn on Bazel compatibility. This is equivalent to
                     specifying a config file with `compatibility = true` in the `[bazel]`
@@ -93,6 +98,10 @@ def new_http_archive(name:str, urls:list, build_file:str=None, build_file_conten
         url = urls,
         out = name + '_' + basename(urls[0]),
         hashes = hashes,
+        username = username,
+        password_file = password_file,
+        headers = headers,
+        secret_headers = secret_headers
     )
     if strip_prefix:
         cmd = '$TOOL x $SRCS_REMOTE -o "$OUT" -s ' + strip_prefix
@@ -151,6 +160,7 @@ def new_local_repository(name:str, path:str):
 
 def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:str|list=None,
                 strip_prefix:str=None, strip_build:bool=False, config:str=None,
+                access_token:str=None,
                 bazel_compat:bool=False):
     """Defines a new subrepo corresponding to a Github project.
 
@@ -165,6 +175,7 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
       hashes: List of hashes to verify the rule with.
       strip_prefix: Prefix to strip from the contents of the zip. Is usually autodetected for you.
       strip_build: True to strip any BUILD files from the archive after download.
+      access_token: Your github personal access token.
       config: Configuration file to apply to this subrepo.
       bazel_compat: Shorthand to turn on Bazel compatibility. This is equivalent to
                     specifying a config file with `compatibility = true` in the `[bazel]`
@@ -190,6 +201,9 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
         build_file = build_file,
         hashes = hashes,
         config = config,
+        headers = {
+            'Authorization': f"token {access_token}"
+        },
         bazel_compat = bazel_compat,
     )
 

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -58,7 +58,7 @@ def http_archive(name:str, urls:list, strip_prefix:str=None, hashes:str|list&sha
 
 def new_http_archive(name:str, urls:list, build_file:str=None, build_file_content:str=None,
                      strip_prefix:str=None, strip_build:bool=False, hashes:str|list&sha256=None,
-                     username:str=None, password_file:str=None, headers:dict=None, secret_headers:dict=None,
+                     username:str=None, password_file:str=None, headers:dict={}, secret_headers:dict={},
                      config:str=None, bazel_compat:bool=False, visibility:list=None):
     """Fetches a remote file over HTTP and expands its contents, combined with a BUILD file.
 


### PR DESCRIPTION
Hi. I want to start using build defs in private repos. I made this change to the subrepos, but I think I need help testing it. I have my project that uses a few public repos for build_defs already. Is there a page showing me how to get a custom build and test this out?

Thanks... 