### PR TITLE
Fix syntax typo in named outputs documentation

### DIFF
--- a/docs/build_rules.html
+++ b/docs/build_rules.html
@@ -194,7 +194,7 @@
     genrule(
         ...
         srcs = [":my_rule|srcs"],
-        deps = ["my_rule|libs"],
+        deps = [":my_rule|libs"],
         ...
     )
       </code>


### PR DESCRIPTION
`my_rule|libs` -> `:my_rule|libs`.