### PR TITLE
Show the download rate of files in interactive display

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -1097,10 +1097,11 @@ func fetchOneRemoteFile(state *core.BuildState, target *core.BuildTarget, url st
 	var r io.Reader = resp.Body
 	if length := resp.Header.Get("Content-Length"); length != "" {
 		if i, err := strconv.Atoi(length); err == nil {
-			r = &progressReader{Reader: resp.Body, Target: target, Total: float32(i)}
+			target.FileSize = float32(i)
+			r = &progressReader{Reader: resp.Body, Target: target, Total: target.FileSize}
+			target.ShowProgress = true // Required for it to actually display
 		}
 	}
-	target.ShowProgress = true // Required for it to actually display
 	h := state.PathHasher.NewHash()
 	if _, err := io.Copy(io.MultiWriter(f, h), r); err != nil {
 		return err

--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -100,6 +100,7 @@ var KnownFields = map[string]bool{
 	"BuildingDescription":    true,
 	"ShowProgress":           true,
 	"Progress":               true,
+	"FileSize":               true,
 	"PassUnsafeEnv":          true,
 	"NeededForSubinclude":    true,
 	"mutex":                  true,

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -142,6 +142,8 @@ type BuildTarget struct {
 	Debug *DebugFields
 	// If ShowProgress is true, this is used to store the current progress of the target.
 	Progress float32 `print:"false"`
+	// For remote_files, this is the total size of the download (if known)
+	FileSize float32 `print:"false"`
 	// Description displayed while the command is building.
 	// Default is just "Building" but it can be customised.
 	BuildingDescription string `name:"building_description"`

--- a/src/output/targets.go
+++ b/src/output/targets.go
@@ -16,10 +16,11 @@ type buildingTarget struct {
 	Colour       string
 	Target       *core.BuildTarget
 	Eta          time.Duration
+	LastProgress float32
+	BPS          float32
 	Active       bool
 	Failed       bool
 	Cached       bool
-	LastProgress float32
 }
 
 // Collects all the currently building targets.


### PR DESCRIPTION
This displays like:
```
=> [ 5.1s] //test/java_rules/java_toolchain/src/main/java/net/thoughtmachine:java11 Fetching... (3.8%, 1.4 MB/s, est 2m9s remaining)
```
Thought it was kind of nice to see (although the calculation is a bit crap, it should really be a rolling average over the last few seconds).

Bonus: does not add any size to BuildTarget because it slotted into an existing 32 bytes of padding.