### PR TITLE
updating action digest so data can always be downloaded

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -594,7 +594,9 @@ func (c *Client) execute(tid int, target *core.BuildTarget, command *pb.Command,
 		}
 	}
 	// We didn't actually upload the inputs before, so we must do so now.
-	command, digest, err := c.uploadAction(target, isTest, false)
+	command, newDigest, err := c.uploadAction(target, isTest, false)
+	// Update the original digest to ensure it matches the uploaded action.
+	*digest = *newDigest
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to upload build action: %s", err)
 	}


### PR DESCRIPTION
I had an issue with data dependencies failing to be downloaded when remote execution is enabled with the following error:
`Failed to retrieve action result for <data-dep-tgt>`
It appears that please was looking at the wrong digest to get the data because the digest added to `unstampedBuildActionDigests` is incorrect. It seems that at least some of the time the uploaded action digest doesn't match the original build action digest, and so we need to update the original digest before storing it in `unstampedBuildActionDigests`.

After this change I have not seen the above error again. 