### PR TITLE
Only exit plz fmt with exit code 1 on error or if in quiet mode

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -637,8 +637,8 @@ var buildFunctions = map[string]func() int{
 	"format": func() int {
 		if changed, err := format.Format(config, opts.Format.Args.Files.AsStrings(), opts.Format.Write, opts.Format.Quiet); err != nil {
 			log.Fatalf("Failed to reformat files: %s", err)
-		} else if changed && !opts.Format.Write {
-			return 0
+		} else if changed && opts.Format.Quiet {
+			return 1
 		}
 		return 0
 	},

--- a/src/please.go
+++ b/src/please.go
@@ -638,7 +638,7 @@ var buildFunctions = map[string]func() int{
 		if changed, err := format.Format(config, opts.Format.Args.Files.AsStrings(), opts.Format.Write, opts.Format.Quiet); err != nil {
 			log.Fatalf("Failed to reformat files: %s", err)
 		} else if changed && !opts.Format.Write {
-			return 1
+			return 0
 		}
 		return 0
 	},

--- a/src/please.go
+++ b/src/please.go
@@ -637,7 +637,7 @@ var buildFunctions = map[string]func() int{
 	"format": func() int {
 		if changed, err := format.Format(config, opts.Format.Args.Files.AsStrings(), opts.Format.Write, opts.Format.Quiet); err != nil {
 			log.Fatalf("Failed to reformat files: %s", err)
-		} else if changed && !opts.Format.Write && opts.Format.Quiet {
+		} else if changed && !opts.Format.Write {
 			return 1
 		}
 		return 0

--- a/src/please.go
+++ b/src/please.go
@@ -635,6 +635,9 @@ var buildFunctions = map[string]func() int{
 		return toExitCode(success, state)
 	},
 	"format": func() int {
+		if opts.Format.Quiet && opts.Format.Write {
+			log.Fatal("Can't use both --quiet and --write at the same time")
+		}
 		if changed, err := format.Format(config, opts.Format.Args.Files.AsStrings(), opts.Format.Write, opts.Format.Quiet); err != nil {
 			log.Fatalf("Failed to reformat files: %s", err)
 		} else if changed && opts.Format.Quiet {

--- a/src/please.go
+++ b/src/please.go
@@ -637,7 +637,7 @@ var buildFunctions = map[string]func() int{
 	"format": func() int {
 		if changed, err := format.Format(config, opts.Format.Args.Files.AsStrings(), opts.Format.Write, opts.Format.Quiet); err != nil {
 			log.Fatalf("Failed to reformat files: %s", err)
-		} else if changed && !opts.Format.Write {
+		} else if changed && !opts.Format.Write && opts.Format.Quiet {
 			return 1
 		}
 		return 0

--- a/test/plz_format/BUILD
+++ b/test/plz_format/BUILD
@@ -37,3 +37,10 @@ please_repo_e2e_test(
     },
     repo = "test_repo",
 )
+
+please_repo_e2e_test(
+    name = "fails_when_quiet_and_write_mode_given",
+    plz_command = "plz format --write --quiet src/FORMATTED_BUILD_FILE",
+    expected_failure = True,
+    repo = "test_repo",
+)

--- a/test/plz_format/BUILD
+++ b/test/plz_format/BUILD
@@ -40,7 +40,10 @@ please_repo_e2e_test(
 
 please_repo_e2e_test(
     name = "fails_when_quiet_and_write_mode_given",
-    plz_command = "plz format --write --quiet src/FORMATTED_BUILD_FILE",
+    plz_command = "plz format --write --quiet src/FORMATTED_BUILD_FILE 2> output",
+    expect_output_contains = {
+        "output": "Can't use both --quiet and --write at the same time",
+    },
     expected_failure = True,
     repo = "test_repo",
 )

--- a/test/plz_format/BUILD
+++ b/test/plz_format/BUILD
@@ -1,5 +1,12 @@
 subinclude("//test/build_defs")
 
+BUILD_FILE = """
+python_binary(
+name = "foo",
+main = "main.py"
+)
+""".strip()
+
 FORMATTED_BUILD_FILE = """
 python_binary(
     name = "foo",
@@ -10,6 +17,7 @@ python_binary(
 please_repo_e2e_test(
     name = "outputs_formatted_build_file_to_stdout",
     expected_output = {
+        "src/BUILD_FILE": BUILD_FILE,
         "output": FORMATTED_BUILD_FILE,
     },
     plz_command = "plz format src/BUILD_FILE > output",
@@ -19,6 +27,9 @@ please_repo_e2e_test(
 please_repo_e2e_test(
     name = "fails_when_file_needs_formatting_in_quiet_mode",
     plz_command = "plz format --quiet src/BUILD_FILE",
+    expected_output = {
+        "src/BUILD_FILE": BUILD_FILE,
+    },
     expected_failure = True,
     repo = "test_repo",
 )
@@ -26,6 +37,9 @@ please_repo_e2e_test(
 please_repo_e2e_test(
     name = "succeeds_when_file_doesnt_need_formatting_in_quiet_mode",
     plz_command = "plz format --quiet src/FORMATTED_BUILD_FILE",
+    expected_output = {
+        "src/BUILD_FILE": BUILD_FILE,
+    },
     repo = "test_repo",
 )
 
@@ -41,6 +55,9 @@ please_repo_e2e_test(
 please_repo_e2e_test(
     name = "fails_when_quiet_and_write_mode_given",
     plz_command = "plz format --write --quiet src/FORMATTED_BUILD_FILE 2> output",
+    expected_output = {
+        "src/BUILD_FILE": BUILD_FILE,
+    },
     expect_output_contains = {
         "output": "Can't use both --quiet and --write at the same time",
     },

--- a/test/plz_format/BUILD
+++ b/test/plz_format/BUILD
@@ -28,3 +28,12 @@ please_repo_e2e_test(
     plz_command = "plz format --quiet src/FORMATTED_BUILD_FILE",
     repo = "test_repo",
 )
+
+please_repo_e2e_test(
+    name = "writes_formatted_file_back_in_write_mode",
+    plz_command = "plz format --write src/BUILD_FILE",
+    expected_output = {
+        "src/BUILD_FILE": FORMATTED_BUILD_FILE,
+    },
+    repo = "test_repo",
+)

--- a/test/plz_format/BUILD
+++ b/test/plz_format/BUILD
@@ -15,3 +15,10 @@ please_repo_e2e_test(
     plz_command = "plz format src/BUILD_FILE > output",
     repo = "test_repo",
 )
+
+please_repo_e2e_test(
+    name = "fails_when_file_needs_formatting_in_quiet_mode",
+    plz_command = "plz format --quiet src/BUILD_FILE",
+    expected_failure = True,
+    repo = "test_repo",
+)

--- a/test/plz_format/BUILD
+++ b/test/plz_format/BUILD
@@ -22,3 +22,9 @@ please_repo_e2e_test(
     expected_failure = True,
     repo = "test_repo",
 )
+
+please_repo_e2e_test(
+    name = "succeeds_when_file_doesnt_need_formatting_in_quiet_mode",
+    plz_command = "plz format --quiet src/FORMATTED_BUILD_FILE",
+    repo = "test_repo",
+)

--- a/test/plz_format/BUILD
+++ b/test/plz_format/BUILD
@@ -26,41 +26,41 @@ please_repo_e2e_test(
 
 please_repo_e2e_test(
     name = "fails_when_file_needs_formatting_in_quiet_mode",
-    plz_command = "plz format --quiet src/BUILD_FILE",
+    expected_failure = True,
     expected_output = {
         "src/BUILD_FILE": BUILD_FILE,
     },
-    expected_failure = True,
+    plz_command = "plz format --quiet src/BUILD_FILE",
     repo = "test_repo",
 )
 
 please_repo_e2e_test(
     name = "succeeds_when_file_doesnt_need_formatting_in_quiet_mode",
-    plz_command = "plz format --quiet src/FORMATTED_BUILD_FILE",
     expected_output = {
         "src/BUILD_FILE": BUILD_FILE,
     },
+    plz_command = "plz format --quiet src/FORMATTED_BUILD_FILE",
     repo = "test_repo",
 )
 
 please_repo_e2e_test(
     name = "writes_formatted_file_back_in_write_mode",
-    plz_command = "plz format --write src/BUILD_FILE",
     expected_output = {
         "src/BUILD_FILE": FORMATTED_BUILD_FILE,
     },
+    plz_command = "plz format --write src/BUILD_FILE",
     repo = "test_repo",
 )
 
 please_repo_e2e_test(
     name = "fails_when_quiet_and_write_mode_given",
-    plz_command = "plz format --write --quiet src/FORMATTED_BUILD_FILE 2> output",
-    expected_output = {
-        "src/BUILD_FILE": BUILD_FILE,
-    },
     expect_output_contains = {
         "output": "Can't use both --quiet and --write at the same time",
     },
     expected_failure = True,
+    expected_output = {
+        "src/BUILD_FILE": BUILD_FILE,
+    },
+    plz_command = "plz format --write --quiet src/FORMATTED_BUILD_FILE 2> output",
     repo = "test_repo",
 )

--- a/test/plz_format/BUILD
+++ b/test/plz_format/BUILD
@@ -1,0 +1,17 @@
+subinclude("//test/build_defs")
+
+FORMATTED_BUILD_FILE = """
+python_binary(
+    name = "foo",
+    main = "main.py",
+)
+""".strip()
+
+please_repo_e2e_test(
+    name = "outputs_formatted_build_file_to_stdout",
+    expected_output = {
+        "output": FORMATTED_BUILD_FILE,
+    },
+    plz_command = "plz format src/BUILD_FILE > output",
+    repo = "test_repo",
+)

--- a/test/plz_format/test_repo/.plzconfig
+++ b/test/plz_format/test_repo/.plzconfig
@@ -1,0 +1,2 @@
+[Parse]
+BuildFileName = BUILD_FILE

--- a/test/plz_format/test_repo/src/BUILD_FILE
+++ b/test/plz_format/test_repo/src/BUILD_FILE
@@ -1,0 +1,4 @@
+python_binary(
+name = "foo",
+main = "main.py"
+)


### PR DESCRIPTION
This PR changes the exit code of `plz fmt` to only be 1 if either
- there was an error during formatting
- `--quiet` is given and `--write` is not 

This differs from the existing behaviour where running `plz fmt` with no options would exit with a 1 even if the file was successfully formatted and output to stdout. The rationale for the `--quiet` and not `--write` combination comes from the description of the `--quiet` flag:
> Don't print corrections to stdout, simply exit with a code indicating success / failure (for linting etc).

Having both successful formatting and error cases exit with 1 messes with tools (like https://github.com/sbdchd/neoformat) which check the error code before doing something (in this case writing the formatters stdout to the current buffer).