### PR TITLE
Support Go 1.18 fuzzing for real

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -129,7 +129,10 @@ go_test(
 
 go_test(
     name = "build_label_test",
-    srcs = ["build_label_test.go"],
+    srcs = [
+        "build_label_test.go",
+        "build_label_fuzz_test.go",
+    ],
     deps = [
         ":core",
         "//third_party/go:testify",

--- a/src/core/build_label_fuzz_test.go
+++ b/src/core/build_label_fuzz_test.go
@@ -1,0 +1,28 @@
+//go:build go1.18
+// +build go1.18
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func FuzzParseBuildLabel(f *testing.F) {
+	f.Add("//src/core:core")
+	f.Add("//src/core:build_label")
+	f.Add("//test/fuzz")
+	f.Add(":please")
+	f.Add("///third_party/cc/googletest//testing:test_main")
+	f.Add("///third_party/cc/googletest//:googletest")
+	f.Fuzz(func(t *testing.T, in string) {
+		label, err := TryParseBuildLabel(in, "src/core", "")
+		if err != nil {
+			t.Skip("Fuzzer gave us an unparseable input")
+		}
+		label2, err := TryParseBuildLabel(label.String(), "src/core", "")
+		assert.NoError(t, err, "Failed to re-parse the build label")
+		assert.Equal(t, label, label2, "Re-parsed label not equal to original")
+	})
+}


### PR DESCRIPTION
#2225 made it not fail to compile any more, this actually detects & runs fuzz tests. Should have done it in the same PR, for some reason I had it in my head that this might be in some way hard.

With a temp change to upgrade the toolchain locally:
```
$ plz test //src/core:build_label_test 
//src/core:build_label_test 23 tests run in 11ms; 23 passed
    TestLabelString                      PASS  0s
    TestShortString                      PASS  0s
    TestIncludes                         PASS  0s
    TestIncludesRoot                     PASS  0s
    TestIncludesSubstring                PASS  0s
    TestIncludesSubpackages              PASS  0s
    TestLabelParent                      PASS  0s
    TestUnmarshalFlag                    PASS  0s
    TestUnmarshalText                    PASS  0s
    TestPackageDir                       PASS  0s
    TestLooksLikeABuildLabel             PASS  0s
    TestComplete                         PASS  0s
    TestCompleteError                    PASS  0s
    TestSubrepoLabel                     PASS  0s
    TestParseBuildLabelParts             PASS  0s
    TestParseSubrepoLabelWithExtraColon  PASS  0s
    FuzzParseBuildLabel                  PASS  0s
    FuzzParseBuildLabel/seed#0           PASS  0s
    FuzzParseBuildLabel/seed#1           PASS  0s
    FuzzParseBuildLabel/seed#2           PASS  0s
    FuzzParseBuildLabel/seed#3           PASS  0s
    FuzzParseBuildLabel/seed#4           PASS  0s
    FuzzParseBuildLabel/seed#5           PASS  0s
1 test target and 23 tests run; 23 passed.
Total time: 1.15s real, 10ms compute.
```
