### PR TITLE
Fix resolving of special @self keyword

### DIFF
--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -89,9 +89,9 @@ func resolveSelf(values []string, subrepo string) []string {
 	ret := make([]string, len(values))
 	for i, v := range values {
 		if core.LooksLikeABuildLabel(v) {
-			l := core.ParseBuildLabel(v, "")
-			if l.Subrepo == "self" {
-				l.Subrepo = subrepo
+			l, err := core.TryParseBuildLabel(v, "", subrepo)
+			if err != nil {
+				panic(err)
 			}
 			// Force the full build label including empty subrepo so this is portable
 			v = fmt.Sprintf("///%v//%v:%v", l.Subrepo, l.PackageName, l.Name)


### PR DESCRIPTION
While working on the `python proto` plugin which relies both on https://github.com/please-build/proto-rules and https://github.com/please-build/python-rules as plugins, I kept getting the following error:

```
Build stopped after 29.72s. 1 target failed:
    //tools/wheel_resolver:wheel_resolver                                                                                                                                                                                    
//third_party/python:_grpc#download depends on //tools/wheel_resolver:wheel_resolver, but the directory tools/wheel_resolver doesn't exist: tools/wheel_resolver
```

The `//tools/wheel_resolver:wheel_resolver` is part of the `python` plugin and it is set as the default wheel tool in https://github.com/please-build/python-rules/blob/master/.plzconfig#L74 which uses the special`@self` keyword. `//third_party/python:_grpc#download` is part of the host `python proto` plugin.

The `@self` keyword was being resolved to nothing instead of the the subrepo where it was defined.

TODO: Add test to cover for `@self`.