### PR TITLE
fix: safely add follow redirects feature to remote_file

### DIFF
--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -452,7 +452,7 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
     urls = [url] if isinstance(url, str) else url
     url = urls[0]
 
-    urls_str = ' '.join(url) if isinstance(url, list) else url
+    urls_str = ' '.join(urls)
 
     if bool(username) != bool(password_file):
         fail(f"Both or neither of username and password_file should be specified")
@@ -477,11 +477,11 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
         user_info = f'--user {username}:$(cat {password_file})' if auth else ""
 
         # Check http response
-        check_url = f'curl -s -o /dev/null -I {header_flag} {user_info} -w %{{http_code}}'
+        check_url = f'curl -s -o /dev/null {extra_flags} -I {header_flag} {user_info} -w %{{http_code}}'
 
         # Download file
         fetch_url = f'curl {extra_flags} --anyauth {user_info} {header_flag} -o $OUTS --url'
-
+     
         # Download first url that succeeds
         cmd = f'for URL in {urls_str}; do '
         cmd += f'STATUS=$({check_url} $URL);'

--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -370,7 +370,7 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
                 labels:list=[], deps:list=None, exported_deps:list=None,
                 extract:bool=False, strip_prefix:str='', _tag:str='',exported_files=[],
                 entry_points:dict={}, username:str=None, password_file:str=None,
-                headers:dict={}, secret_headers:dict={}, pass_env:list=[]):
+                headers:dict={}, secret_headers:dict={}, pass_env:list=[], follow_redirects:bool=False):
     """Defines a rule to fetch a file over HTTP(S).
 
     Args:
@@ -395,6 +395,7 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
       headers (dict): Headers to pass to curl.
       secret_headers (dict): Headers contained in files to pass to curl.
       pass_env (list): Any environment variables referenced by headers that should be passed in from the host.
+      follow_redirects (bool): If true, use curl -L to follow 3XX http redirect headers
     """
     if extract:
         if out:
@@ -467,6 +468,11 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
         for header, value in secret_headers.items():
             header_flag = f'{header_flag} --header "{header}: $(cat {value})"'
 
+        # Extra flags, e.g. follow redirect
+        extra_flags = ''
+        if follow_redirects:
+            extra_flags = '-L'
+
         # Authentication info
         user_info = f'--user {username}:$(cat {password_file})' if auth else ""
 
@@ -474,7 +480,7 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
         check_url = f'curl -s -o /dev/null -I {header_flag} {user_info} -w %{{http_code}}'
 
         # Download file
-        fetch_url = f'curl --anyauth {user_info} {header_flag} -o $OUTS --url'
+        fetch_url = f'curl {extra_flags} --anyauth {user_info} {header_flag} -o $OUTS --url'
 
         # Download first url that succeeds
         cmd = f'for URL in {urls_str}; do '

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -198,7 +198,9 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
 
     prefix = f'{repo}-{prefix}'
 
-    headers = {}
+    headers = {
+        'Accept': 'application/vnd.github.v3+json'
+    }
     pass_env = []
     if access_token:
         headers = {
@@ -208,7 +210,10 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
 
     return new_http_archive(
         name = name,
-        urls = [f'https://github.com/{org}/{repo}/archive/{revision}.zip'],
+        urls = [
+            #f'https://github.com/{org}/{repo}/archive/{revision}.zip',
+            f'https://api.github.com/repos/{org}/{repo}/zipball/{revision}'
+        ],
         strip_prefix = strip_prefix or prefix,
         strip_build = strip_build,
         build_file = build_file,

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -211,7 +211,7 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
     return new_http_archive(
         name = name,
         urls = [
-            #f'https://github.com/{org}/{repo}/archive/{revision}.zip',
+            f'https://github.com/{org}/{repo}/archive/{revision}.zip',
             f'https://api.github.com/repos/{org}/{repo}/zipball/{revision}'
         ],
         strip_prefix = strip_prefix or prefix,

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -215,7 +215,7 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
         hashes = hashes,
         config = config,
         headers = headers,
-        follow_redirects = follow_redirects,
+        follow_redirects = True,
         bazel_compat = bazel_compat,
         pass_env = pass_env,
     )

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -59,7 +59,7 @@ def http_archive(name:str, urls:list, strip_prefix:str=None, hashes:str|list&sha
 def new_http_archive(name:str, urls:list, build_file:str=None, build_file_content:str=None,
                      strip_prefix:str=None, strip_build:bool=False, plugin:bool=False,
                      hashes:str|list&sha256=None,username:str=None, password_file:str=None, headers:dict={}, secret_headers:dict={},
-                     config:str=None, bazel_compat:bool=False, visibility:list=None, pass_env:list=[]):
+                     follow_redirects:bool=False, config:str=None, bazel_compat:bool=False, visibility:list=None, pass_env:list=[]):
     """Fetches a remote file over HTTP and expands its contents, combined with a BUILD file.
 
     The archive should be either a zipfile or a tarball. Which one to use will be autodetected
@@ -84,6 +84,7 @@ def new_http_archive(name:str, urls:list, build_file:str=None, build_file_conten
       password_file: A file on disk that contains a password or access token.
       headers: Headers to pass to curl.
       secret_headers: Headers contained in files to pass to curl.
+      follow_redirects (bool): If true, use curl -L to follow 3XX http redirect headers
       config: Configuration file to apply to this subrepo.
       bazel_compat: Shorthand to turn on Bazel compatibility. This is equivalent to
                     specifying a config file with `compatibility = true` in the `[bazel]`
@@ -104,6 +105,7 @@ def new_http_archive(name:str, urls:list, build_file:str=None, build_file_conten
         headers = headers,
         secret_headers = secret_headers,
         pass_env = pass_env,
+        follow_redirects = follow_redirects
     )
     if strip_prefix:
         cmd = '$TOOL x $SRCS_REMOTE -o "$OUT" -s ' + strip_prefix
@@ -213,6 +215,7 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
         hashes = hashes,
         config = config,
         headers = headers,
+        follow_redirects = follow_redirects,
         bazel_compat = bazel_compat,
         pass_env = pass_env,
     )


### PR DESCRIPTION
disabled by default, only active for github_subrepo

I think we need this to fix #2249.