### PR TITLE
Set the architefcture for a subrepo to the architecture of the repo it's defined in

### DIFF
--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1035,6 +1035,9 @@ func subrepo(s *scope, args []pyObject) pyObject {
 
 	isCrossCompile := s.pkg.Subrepo != nil && s.pkg.Subrepo.IsCrossCompile
 	arch := cli.HostArch()
+	if s.pkg.Subrepo != nil {
+		arch = s.pkg.Subrepo.Arch
+	}
 	if args[ArchArgIdx] != None { // arg 5 is arch-string, for arch-subrepos.
 		givenArch := string(args[ArchArgIdx].(pyString))
 		if err := arch.UnmarshalFlag(givenArch); err != nil {

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -100,7 +100,7 @@ func checkSubrepo(tid int, state *core.BuildState, label, dependent core.BuildLa
 	}
 	if !localSubinclude {
 		// Fix for #577; fallback like above, it might be defined within the subrepo.
-		if handled, err := parseSubrepoPackage(tid, state, sl.PackageName, dependent.Subrepo, label); handled && err == nil {
+		if handled, err := parseSubrepoPackage(tid, state, sl.PackageName, label.Subrepo, label); handled && err == nil {
 			return state.Graph.Subrepo(label.Subrepo), nil
 		}
 		return nil, fmt.Errorf("Subrepo %s is not defined (referenced by %s)", label.Subrepo, dependent)

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -100,7 +100,7 @@ func checkSubrepo(tid int, state *core.BuildState, label, dependent core.BuildLa
 	}
 	if !localSubinclude {
 		// Fix for #577; fallback like above, it might be defined within the subrepo.
-		if handled, err := parseSubrepoPackage(tid, state, sl.PackageName, label.Subrepo, label); handled && err == nil {
+		if handled, err := parseSubrepoPackage(tid, state, sl.PackageName, dependent.Subrepo, label); handled && err == nil {
 			return state.Graph.Subrepo(label.Subrepo), nil
 		}
 		return nil, fmt.Errorf("Subrepo %s is not defined (referenced by %s)", label.Subrepo, dependent)


### PR DESCRIPTION
Otherwise we end up with different architectures when calculating the subrepo arch name, and the actual architecture on the subrepo.