### PR TITLE
Make proto plugin use the same go version as the host repo

### DIFF
--- a/test/proto_plugin/BUILD
+++ b/test/proto_plugin/BUILD
@@ -2,8 +2,11 @@ subinclude("//test/build_defs:build_defs")
 
 please_repo_e2e_test(
     name = "proto_rules_test",
-    plz_command = "plz test",
+    plz_command = "plz -o go.gotool:$TOOLS_GO test",
     repo = "test_repo",
+    tools = {
+        "go": [CONFIG.GO_TOOL],
+    },
     # the protoc releases page doesn't support these platforms
     labels = ["no_cirrus", "no-musl"],
 )


### PR DESCRIPTION
This is a workaround as the go config is not a plugin yet so we can't configure it to inherit from the host repo. I probably need a config option on the plugin so we can inherit, or make the non-plugin options always inherit. 