### PR TITLE
pleasew: download binary for correct arch

### DIFF
--- a/pleasew
+++ b/pleasew
@@ -9,7 +9,15 @@ RESET="\x1B[0m"
 DEFAULT_URL_BASE="https://get.please.build"
 
 OS="$(uname)"
-ARCH="$(uname -m)"
+
+if [[ $OS == "Darwin" ]]; then
+    # switch between mac amd64/arm64 
+    ARCH="$(uname -m)"
+else
+    # default to amd64 on other operating systems
+    # because we only build intel binaries
+    ARCH="amd64"
+fi
 
 # Check PLZ_CONFIG_PROFILE or fall back to arguments for a profile.
 PROFILE="${PLZ_CONFIG_PROFILE:-$(sed -E 's/.*--profile[= ]([^ ]+).*/\1/g' <<< "$*")}"

--- a/pleasew
+++ b/pleasew
@@ -9,8 +9,7 @@ RESET="\x1B[0m"
 DEFAULT_URL_BASE="https://get.please.build"
 
 OS="$(uname)"
-# Don't have any builds other than amd64 at the moment.
-ARCH="amd64"
+ARCH="$(uname -m)"
 
 # Check PLZ_CONFIG_PROFILE or fall back to arguments for a profile.
 PROFILE="${PLZ_CONFIG_PROFILE:-$(sed -E 's/.*--profile[= ]([^ ]+).*/\1/g' <<< "$*")}"


### PR DESCRIPTION
I found that pleasew downloads the wrong binary when running on apple silicon / m1. Subsequent problem is that some build files are also looking at the wrong HOSTARCH etc.

I'm not sure if the proposed solution is valid for all supported operating system and arch combinations. We can, of course, replace it with a more distinct "if darwin" case.