### PR TITLE
Download targets that are linkable

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1773,6 +1773,20 @@ func (target *BuildTarget) GetFileContent(state *BuildState) (string, error) {
 	return ReplaceSequences(state, target, target.FileContent)
 }
 
+// HasLinks returns true if the outputs are meant to be linked somewhere (i.e. via symlinks).
+// This check is useful in deciding whether this target should be downloaded during remote execution or not.
+func (target *BuildTarget) HasLinks(state *BuildState) bool {
+	for _, prefix := range []string{"link:", "hlink:", "dlink:", "dhlink:"} {
+		if labels := target.PrefixedLabels(prefix); len(labels) > 0 {
+			return true
+		}
+	}
+	if state.Config.ShouldLinkGeneratedSources() && target.HasLabel("codegen") {
+		return true
+	}
+	return false
+}
+
 // BuildTargets makes a slice of build targets sortable by their labels.
 type BuildTargets []*BuildTarget
 

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -887,7 +887,7 @@ func (state *BuildState) ShouldDownload(target *BuildTarget) bool {
 	// Need to download the target if it was originally requested (and the user didn't pass --nodownload).
 	downloadOriginalTarget := state.OutputDownload == OriginalOutputDownload && state.IsOriginalTarget(target)
 	downloadTransitiveTarget := state.OutputDownload == TransitiveOutputDownload
-	return target.NeededForSubinclude || ((downloadOriginalTarget || downloadTransitiveTarget) && !state.NeedTests)
+	return target.NeededForSubinclude || ((downloadOriginalTarget || downloadTransitiveTarget) && !state.NeedTests) || target.HasLinks(state)
 }
 
 // ShouldRebuild returns true if we should force a rebuild of this target (i.e. the user


### PR DESCRIPTION
Download targets in remote execution with links. This guarantees code generation works as expected.