### PR TITLE
Fix textfile not being marked as executable in remote execution

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -907,8 +907,9 @@ func (c *Client) buildTextFile(state *core.BuildState, target *core.BuildTarget,
 		entry := uploadinfo.EntryFromBlob([]byte(content))
 		ch <- entry
 		ar.OutputFiles = append(ar.OutputFiles, &pb.OutputFile{
-			Path:   command.OutputPaths[0],
-			Digest: entry.Digest.ToProto(),
+			Path:         command.OutputPaths[0],
+			Digest:       entry.Digest.ToProto(),
+			IsExecutable: target.IsBinary,
 		})
 		return nil
 	}); err != nil {


### PR DESCRIPTION
This fixes the `text_file` build rule with `binary=True`, not being marked as such in remote execution