### PR TITLE
reorder CONFIGS priority in pleasew

### DIFF
--- a/pleasew
+++ b/pleasew
@@ -25,8 +25,8 @@ PROFILE="${PLZ_CONFIG_PROFILE:-$(sed -E 's/.*--profile[= ]([^ ]+).*/\1/g' <<< "$
 # Config files on order of precedence high to low.
 CONFIGS=(
   ".plzconfig.local"
-  ".plzconfig_${OS}_${ARCH}"
   "${PROFILE:+.plzconfig.$PROFILE}"
+  ".plzconfig_${OS}_${ARCH}"
   ".plzconfig"
   "$HOME/.config/please/plzconfig"
   "/etc/please/plzconfig"


### PR DESCRIPTION
This raises the priority of the `.plzconfig.<profile>` above the `.plzconfig_<arch>`, as indicated in the docs: https://please.build/config.html

Tested with 16.19.0.

Show that it's currently not behaving as the docs indicate:
```
echo "[buildconfig]\ntoolchain-version = 3.7.3" > .plzconfig.testprofile
cat .plzconfig_linux_amd64
...
[buildconfig]
toolchain-version = 3.5.0
...
```
```
PLZ_CONFIG_PROFILE=testprofile
plz query config buildconfig.toolchain-version
3.5.0
```