### PR TITLE
Check that the go_library srcs list is not empty

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -125,6 +125,7 @@ def go_library(name:str, srcs:list, resources:list=None, asm_srcs:list=None, hdr
       package (str): The package as it would appear at the top of the go source files. Defaults
                      to name.
     """
+    assert srcs, "Cannot provide an empty srcs list to go_library"
     cover = cover and CONFIG.BUILD_CONFIG == "cover"
     package = package or name
     out = package + '.a'


### PR DESCRIPTION
Seems that this fails if you pass an empty list:
```
/opt/tm/toolchains/3.7.0/usr/bin/bash: SRCS_GO: unbound variable
```
The argument is required, but this can still happen (if e.g. you have a `glob` that finds nothing, or explicitly passed it for some reason).

Since this came up internally today, let's try to help users out by making the failure clearer.