### PR TITLE
Make pkg_sources correctly aware of subrepos

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -88,7 +88,7 @@ def _pkg_sources(name: str, deps: list, test_only:bool):
     Without this, we'd have to transitively pull in all third party sources for the rule which is very expensive,
     especially for remote execution.
     """
-    package_prefix = "//" + package_name() + ":"
+    package_prefix = canonicalise(":all").removesuffix("all")
     return filegroup(
        name = name,
        tag = "pkg_srcs",


### PR DESCRIPTION
At some point we have changed `canonicalise` to produce more correct output that includes the subrepo name. However now this disagrees with the home-grown label building here.

Now using `canonicalise` for both so they should stay in sync better (and it's quite a bit fiddlier to handle the subrepo correctly).