### PR TITLE
Pick up correct file when loading java plugin config

### DIFF
--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -323,7 +323,7 @@ def plugin_repo(name:str, revision:str,  plugin:str="", owner:str="please-build"
         outs = [name],
         cmd = " && ".join([
           "$TOOL x $SRCS -o _tmp",
-          "mv $(dirname $(find . -name .plzconfig | sort | head -n 1)) $OUT",
+          "mv $(dirname $(find . -name .plzconfig | sort -r | head -n 1)) $OUT",
         ]),
         _subrepo = True,
     )


### PR DESCRIPTION
```
plugin_repo(              
  name = "java",          
  revision = "v0.1.0",    
  plugin = "java-rules",  
  owner = "please-build", 
)                         
```

```
Temp directories prepared, total time 60ms:                                                              
  //plugins:java: plz-out/tmp/plugins/java._build                                                        
    Command: $TOOL x $SRCS -o _tmp && mv $(dirname $(find . -name .plzconfig | sort | head -n 1)) $OUT   
                                                                                                         
bash-4.4$ $TOOL x $SRCS -o _tmp                                                                          
bash-4.4$ ls                                                                                             
plugins  _tmp                                                                                            
bash-4.4$ find . -name .plzconfig                                                                        
./_tmp/java-rules-0.1.0/.plzconfig                                                                       
./_tmp/java-rules-0.1.0/example/.plzconfig                                                               
bash-4.4$ find . -name .plzconfig | sort                                                                 
./_tmp/java-rules-0.1.0/example/.plzconfig                                                               
./_tmp/java-rules-0.1.0/.plzconfig                                                                       
bash-4.4$                                                                                                
```
The `plugin_repo` rule does this sort to find the plugin's root. But in the case of the java plugin we were pulling in `example/.plzconfig` which is not what we want. Seems like we want to just reverse sort these to get the highest level config:

```
bash-4.4$ find . -name .plzconfig | sort -r 
./_tmp/java-rules-0.1.0/.plzconfig          
./_tmp/java-rules-0.1.0/example/.plzconfig  
```