### PR TITLE
Allow adding of arbitrary labels to third-party build rules

### DIFF
--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -357,16 +357,17 @@ def java_test(name:str, srcs:list, resources:list=None, resources_root:str=None,
     )
 
 
-def maven_jar(name:str, id:str, repository:str|list=None, hash:str=None, hashes:list=None, source_hashes:list|str=None,
-              deps:list=None, visibility:list=None, filename:str=None, sources:bool=True, licences:list=None,
-              native:bool=False, artifact_type:str=None, test_only:bool&testonly=False,
-              binary:bool=False, classifier:str='', classifier_sources_override:str=''):
+def maven_jar(name:str, id:str, repository:str|list=None, labels:list=[], hash:str=None, hashes:list=None,
+              source_hashes:list|str=None, deps:list=None, visibility:list=None, filename:str=None,
+              sources:bool=True, licences:list=None, native:bool=False, artifact_type:str=None,
+              test_only:bool&testonly=False, binary:bool=False, classifier:str='', classifier_sources_override:str=''):
     """Fetches a single Java dependency from Maven.
 
     Args:
       name (str): Name of the output rule.
       id (str): Maven id of the artifact (eg. org.junit:junit:4.1.0)
       repository (str | list): Maven repositories to fetch deps from.
+      labels (list): Additional labels to apply to this rule.
       hash (str): Hash for produced rule.
       hashes (list): List of hashes downloaded classes jar.
       source_hashes (list): List of hashes for the downloaded sources jar.
@@ -474,7 +475,7 @@ def maven_jar(name:str, id:str, repository:str|list=None, hash:str=None, hashes:
         provides = provides,
         exported_deps=deps,  # easiest to assume these are always exported.
         deps = local_deps,  # ensure the classes_rule gets built correctly if there is one.
-        labels = ['mvn:' + id, 'rule:maven_jar'],
+        labels = labels + ['mvn:' + id, 'rule:maven_jar'],
         visibility = visibility,
         licences = licences,
         test_only=test_only,

--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -346,7 +346,7 @@ def python_test(name:str, srcs:list, data:list|dict=[], resources:list=[], deps:
     )
 
 
-def pip_library(name:str, version:str, hashes:list=None, package_name:str=None,
+def pip_library(name:str, version:str, labels:list=[], hashes:list=None, package_name:str=None,
                 test_only:bool&testonly=False, deps:list=[], post_install_commands:list=None,
                 install_subdirectory:str=None, repo:str=None, use_pypi:bool=None, patch:str|list=None,
                 visibility:list=None, zip_safe:bool=True, licences:list=None, pip_flags:str=None,
@@ -356,6 +356,7 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None,
     Args:
       name (str): Name of the build rule.
       version (str): Specific version of the package to install.
+      labels (list): Additional labels to apply to this rule.
       hashes (list): List of acceptable hashes for this target.
       package_name (str): Name of the pip package to install. Defaults to the same as 'name'.
       outs (list): List of output files / directories. Defaults to [name]. If subdirectory is used outs[0] is used as the prefix.
@@ -469,12 +470,12 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None,
             'jarcat': [CONFIG.JARCAT_TOOL],
         },
         post_build = None if licences else _add_licences,
-        labels = ['py', 'pip:' + package_name] + (['py:zip-unsafe'] if not zip_safe else []),
+        labels = labels + ['py', 'pip:' + package_name] + (['py:zip-unsafe'] if not zip_safe else []),
         visibility = visibility,
     )
 
-def python_wheel(name:str, version:str, hashes:list=None, package_name:str=None, outs:list=None,
-                 post_install_commands:list=None, patch:str|list=None, licences:list=None,
+def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, package_name:str=None,
+                 outs:list=None, post_install_commands:list=None, patch:str|list=None, licences:list=None,
                  test_only:bool&testonly=False, repo:str=None, zip_safe:bool=True, visibility:list=None,
                  deps:list=[], name_scheme:str=None, strip:list=['*.pyc', 'tests']):
     """Downloads a Python wheel and extracts it.
@@ -492,6 +493,7 @@ def python_wheel(name:str, version:str, hashes:list=None, package_name:str=None,
       name (str): Name of the rule. Also doubles as the name of the package if package_name
             is not set.
       version (str): Version of the package to install.
+      labels (list): Additional labels to apply to this rule.
       hashes (list): List of hashes to verify the package against.
       package_name (str): If given, overrides `name` for the name of the package to look for.
       outs (list): List of output files. Defaults to a directory named the same as `name`.
@@ -599,7 +601,7 @@ def python_wheel(name:str, version:str, hashes:list=None, package_name:str=None,
         visibility = visibility,
         licences = licences,
         test_only = test_only,
-        labels = [label] + ["link:plz-out/python/venv"],
+        labels = labels + [label] + ["link:plz-out/python/venv"],
         provides = {'py': wheel_rule},
     )
 

--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -24,8 +24,8 @@ def workspace(name:str):
     )
 
 
-def http_archive(name:str, urls:list, strip_prefix:str=None, hashes:str|list&sha256=None,
-                 config:str=None, bazel_compat:bool=False,
+def http_archive(name:str, urls:list, strip_prefix:str=None, labels:list=[],
+                 hashes:str|list&sha256=None, config:str=None, bazel_compat:bool=False,
                  visibility:list=None):
     """Fetches a remote file over HTTP and expands its contents.
 
@@ -39,6 +39,7 @@ def http_archive(name:str, urls:list, strip_prefix:str=None, hashes:str|list&sha
       urls: List of URLs to fetch from. These are assumed to be mirrors and will be
             tried in sequence.
       strip_prefix: Prefix to strip from the expanded archive.
+      labels: Labels to apply to this rule.
       hashes: List of hashes to verify the rule with.
       config: Configuration file to apply to this subrepo.
       bazel_compat: Shorthand to turn on Bazel compatibility. This is equivalent to
@@ -50,6 +51,7 @@ def http_archive(name:str, urls:list, strip_prefix:str=None, hashes:str|list&sha
         name = name,
         urls = urls,
         strip_prefix = strip_prefix,
+        labels = labels,
         hashes = hashes,
         config = config,
         bazel_compat = bazel_compat,
@@ -57,7 +59,7 @@ def http_archive(name:str, urls:list, strip_prefix:str=None, hashes:str|list&sha
 
 
 def new_http_archive(name:str, urls:list, build_file:str=None, build_file_content:str=None,
-                     strip_prefix:str=None, strip_build:bool=False, plugin:bool=False,
+                     strip_prefix:str=None, strip_build:bool=False, plugin:bool=False, labels:list=[],
                      hashes:str|list&sha256=None,username:str=None, password_file:str=None, headers:dict={}, secret_headers:dict={},
                      config:str=None, bazel_compat:bool=False, visibility:list=None, pass_env:list=[]):
     """Fetches a remote file over HTTP and expands its contents, combined with a BUILD file.
@@ -79,6 +81,7 @@ def new_http_archive(name:str, urls:list, build_file:str=None, build_file_conten
                           We suggest using build_file instead, but this is provided for Bazel compatibility.
       strip_prefix: Prefix to strip from the expanded archive.
       strip_build: True to strip any BUILD files from the archive after download.
+      labels: Labels to apply to this rule.
       hashes: List of hashes to verify the rule with.
       username: Username for accessing a private file or repo.
       password_file: A file on disk that contains a password or access token.
@@ -126,6 +129,7 @@ def new_http_archive(name:str, urls:list, build_file:str=None, build_file_conten
         outs = [name],
         cmd = cmd,
         _subrepo = True,
+        labels = labels,
         visibility = visibility,
     )
     return subrepo(
@@ -161,8 +165,8 @@ def new_local_repository(name:str, path:str):
     )
 
 
-def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:str|list=None,
-                strip_prefix:str=None, strip_build:bool=False, config:str=None,
+def github_repo(name:str, repo:str, revision:str, build_file:str=None, labels:list=[],
+                hashes:str|list=None, strip_prefix:str=None, strip_build:bool=False, config:str=None,
                 access_token:str=None, bazel_compat:bool=False):
     """Defines a new subrepo corresponding to a Github project.
 
@@ -174,6 +178,7 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
       repo: Github repo to fetch from (e.g. "thought-machine/please").
       revision: Revision to download. This can be either a release version, commit or branch.
       build_file: The file to use as a BUILD file for this subrepository.
+      labels: Labels to apply to this rule.
       hashes: List of hashes to verify the rule with.
       strip_prefix: Prefix to strip from the contents of the zip. Is usually autodetected for you.
       strip_build: True to strip any BUILD files from the archive after download.
@@ -210,6 +215,7 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
         strip_prefix = strip_prefix or prefix,
         strip_build = strip_build,
         build_file = build_file,
+        labels = labels,
         hashes = hashes,
         config = config,
         headers = headers,
@@ -219,8 +225,8 @@ def github_repo(name:str, repo:str, revision:str, build_file:str=None, hashes:st
 
 
 def gitlab_repo(name:str, repo:str, revision:str, instance:str="gitlab.com", build_file:str=None,
-                hashes:str|list=None, strip_prefix:str=None, strip_build:bool=False, config:str=None,
-                bazel_compat:bool=False):
+                labels:list=[], hashes:str|list=None, strip_prefix:str=None, strip_build:bool=False,
+                config:str=None, bazel_compat:bool=False):
     """Defines a new subrepo corresponding to a GitLab project.
 
     Like github_repo, this is a convenience alias to new_http_archive.
@@ -233,6 +239,7 @@ def gitlab_repo(name:str, repo:str, revision:str, instance:str="gitlab.com", bui
                 GNOME GitLab instance at https://gitlab.gnome.org). Defaults to "gitlab.com", the
                 official public GitLab instance.
       build_file: The file to use as a BUILD file for this subrepository.
+      labels: Labels to apply to this rule.
       hashes: List of hashes to verify the rule with.
       strip_prefix: Prefix to strip from the contents of the zip. This is usually automatically
                     detected.
@@ -253,6 +260,7 @@ def gitlab_repo(name:str, repo:str, revision:str, instance:str="gitlab.com", bui
         strip_prefix = strip_prefix or prefix,
         strip_build = strip_build,
         build_file = build_file,
+        labels = labels,
         hashes = hashes,
         config = config,
         bazel_compat = bazel_compat,


### PR DESCRIPTION
Some rules that download and/or build third-party code, e.g. `go_mod_download`, already accept a `labels` parameter whose value is passed through to the underlying `build_rule`. Do the same for the remaining third-party build rules that don't already allow this:

* `maven_jar`
* `pip_library`
* `python_wheel`
* `http_archive`
* `new_http_archive`
* `github_repo`
* `gitlab_repo`