### PR TITLE
Update to Go 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,16 @@ jobs:
    build-alpine:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_alpine:20210817
+       - image: thoughtmachine/please_alpine:20220316
      resource_class: large
      environment:
        PLZ_ARGS: "-p --profile ci --profile alpine --exclude no-musl"
      steps:
        - checkout
        - restore_cache:
-           key: go-mod-alpine-v5-{{ checksum "go.mod" }}
+           key: go-mod-alpine-v6-{{ checksum "go.mod" }}
        - restore_cache:
-           key: go-alpine-main-v5-{{ checksum "third_party/go/BUILD" }}
+           key: go-alpine-main-v6-{{ checksum "third_party/go/BUILD" }}
        - restore_cache:
            key: python-alpine-main-v2-{{ checksum "third_party/python/BUILD" }}
        - restore_cache:
@@ -32,11 +32,11 @@ jobs:
        - store_artifacts:
            path: plz-out/log
        - save_cache:
-           key: go-mod-alpine-v5-{{ checksum "go.mod" }}
+           key: go-mod-alpine-v6-{{ checksum "go.mod" }}
            paths:
              - "~/go/pkg/mod"
        - save_cache:
-           key: go-alpine-main-v5-{{ checksum "third_party/go/BUILD" }}
+           key: go-alpine-main-v6-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
        - save_cache:
            key: python-alpine-main-v2-{{ checksum "third_party/python/BUILD" }}
@@ -55,9 +55,9 @@ jobs:
      steps:
        - checkout
        - restore_cache:
-           key: go-mod-linux-v5-{{ checksum "go.mod" }}
+           key: go-mod-linux-v6-{{ checksum "go.mod" }}
        - restore_cache:
-           key: go-linux-main-v5-{{ checksum "third_party/go/BUILD" }}
+           key: go-linux-main-v6-{{ checksum "third_party/go/BUILD" }}
        - restore_cache:
            key: python-linux-main-v2-{{ checksum "third_party/python/BUILD" }}
        - restore_cache:
@@ -82,11 +82,11 @@ jobs:
        - store_artifacts:
            path: plz-out/log
        - save_cache:
-           key: go-mod-linux-v5-{{ checksum "go.mod" }}
+           key: go-mod-linux-v6-{{ checksum "go.mod" }}
            paths:
              - "~/go/pkg/mod"
        - save_cache:
-           key: go-linux-main-v5-{{ checksum "third_party/go/BUILD" }}
+           key: go-linux-main-v6-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
        - save_cache:
            key: python-linux-main-v2-{{ checksum "third_party/python/BUILD" }}
@@ -106,9 +106,9 @@ jobs:
      steps:
        - checkout
        - restore_cache:
-           key: go-mod-linux-alt-v4-{{ checksum "go.mod" }}
+           key: go-mod-linux-alt-v5-{{ checksum "go.mod" }}
        - restore_cache:
-           key: go-linux-alt-v4-{{ checksum "third_party/go/BUILD" }}
+           key: go-linux-alt-v5-{{ checksum "third_party/go/BUILD" }}
        - restore_cache:
            key: python-linux-alt-v2-{{ checksum "third_party/python/BUILD" }}
        - restore_cache:
@@ -121,11 +121,11 @@ jobs:
        - store_artifacts:
            path: plz-out/log
        - save_cache:
-           key: go-mod-linux-alt-v4-{{ checksum "go.mod" }}
+           key: go-mod-linux-alt-v5-{{ checksum "go.mod" }}
            paths:
              - "~/go/pkg/mod"
        - save_cache:
-           key: go-linux-alt-v4-{{ checksum "third_party/go/BUILD" }}
+           key: go-linux-alt-v5-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
        - save_cache:
            key: java-toolchain-linux-alt-v1-{{ checksum "test/java_rules/java_toolchain/src/main/java/net/thoughtmachine/BUILD" }}-{{ checksum "test/java_rules/java_toolchain/src/main/java/net/thoughtmachine/bazel_compat/BUILD" }}
@@ -142,7 +142,7 @@ jobs:
        - attach_workspace:
            at: /tmp/workspace
        - restore_cache:
-           key: go-darwin-arm64-v2-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-arm64-v3-{{ checksum "third_party/go/BUILD" }}
        - run:
            name: Extract plz
            command: tar -xzf /tmp/workspace/darwin_amd64/please_*.tar.gz
@@ -156,7 +156,7 @@ jobs:
        - store_artifacts:
            path: plz-out/log
        - save_cache:
-           key: go-darwin-arm64-v1-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-arm64-v3-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
 
    build-freebsd:
@@ -194,9 +194,9 @@ jobs:
       steps:
        - checkout
        - restore_cache:
-           key: go-mod-darwin-v4-{{ checksum "bootstrap.sh" }}
+           key: go-mod-darwin-v5-{{ checksum "bootstrap.sh" }}
        - restore_cache:
-           key: go-darwin-go115-v1-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-go118-v1-{{ checksum "third_party/go/BUILD" }}
        - restore_cache:
            key: python-darwin-py372-{{ checksum "third_party/python/BUILD" }}
        - restore_cache:
@@ -221,11 +221,11 @@ jobs:
        - store_artifacts:
            path: /tmp/artifacts
        - save_cache:
-           key: go-mod-darwin-v4-{{ checksum "go.mod" }}
+           key: go-mod-darwin-v5-{{ checksum "go.mod" }}
            paths:
              - "~/go/pkg/mod"
        - save_cache:
-           key: go-darwin-go115-v1-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-go118-v1-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
        - save_cache:
            key: python-darwin-py372-{{ checksum "third_party/python/BUILD" }}

--- a/.circleci/setup_osx.sh
+++ b/.circleci/setup_osx.sh
@@ -4,7 +4,7 @@ set -eu
 
 # /usr/local/go might get cached.
 if [ ! -d "/usr/local/go" ]; then
-    curl -fsSL https://dl.google.com/go/go1.16.2.darwin-amd64.tar.gz | sudo tar -xz -C /usr/local
+    curl -fsSL https://dl.google.com/go/go1.18.darwin-amd64.tar.gz | sudo tar -xz -C /usr/local
 fi
 sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
 

--- a/test/proto_plugin/test_repo/third_party/go/BUILD_FILE
+++ b/test/proto_plugin/test_repo/third_party/go/BUILD_FILE
@@ -207,7 +207,7 @@ go_module(
     name = "sys",
     install = ["unix"],
     module = "golang.org/x/sys",
-    version = "v0.0.0-20200323222414-85ca7c5b95cd",
+    version = "v0.0.0-20220315194320-039c03cc5b86",
     visibility = ["PUBLIC"],
 )
 

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -3,13 +3,13 @@ package(default_visibility = ["PUBLIC"])
 go_toolchain(
     name = "toolchain",
     hashes = [
-        "da4e3e3c194bf9eed081de8842a157120ef44a7a8d7c820201adae7b0e28b20b",  # darwin_arm64
-        "355bd544ce08d7d484d9d7de05a71b5c6f5bc10aa4b316688c2192aeb3dacfd1",  # darwin_amd64
-        "6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d",  # linux_amd64
-        "15c184c83d99441d719da201b26256455eee85a808747c404b4183e9aa6c64b4",  # freebsd_amd64
+        "70bb4a066997535e346c8bfa3e0dfe250d61100b17ccc5676274642447834969",  # darwin_amd64
+        "9cab6123af9ffade905525d79fc9ee76651e716c85f1f215872b5f2976782480",  # darwin_arm64
+        "01cd67bbc12e659ff236ecebde1806f76452f7ca145c172d5ecdbf4f4803daae",  # freebsd_amd64
+        "e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f",  # linux_amd64
     ],
     strip_srcs = CONFIG.BUILD_CONFIG != "dbg",
-    version = "1.17",
+    version = "1.18",
 )
 
 go_module(

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -544,7 +544,7 @@ go_module(
     name = "xsys",
     install = ["..."],
     module = "golang.org/x/sys",
-    version = "v0.0.0-20210823070655-63515b42dcdf",
+    version = "v0.0.0-20220315194320-039c03cc5b86",
 )
 
 go_module(

--- a/tools/images/alpine/Dockerfile
+++ b/tools/images/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine
+FROM golang:1.18-alpine
 MAINTAINER peter.ebden@gmail.com
 
 RUN apk update && apk add --no-cache git patch gcc g++ libc-dev bash libgcc xz protoc protobuf-dev perl-utils

--- a/tools/images/ubuntu/Dockerfile
+++ b/tools/images/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 MAINTAINER peter.ebden@gmail.com
 
 
@@ -14,11 +14,9 @@ RUN truncate -s0 /tmp/preseed.cfg; \
     curl unzip git locales pkg-config zlib1g-dev psmisc awscli && \
     apt-get clean
 
-# Go - we want 1.17 here but the latest package available is 1.10.
-RUN curl -fsSL https://dl.google.com/go/go1.17.linux-amd64.tar.gz | tar -xzC /usr/local
+# Go - we want a specific package version here.
+RUN curl -fsSL https://dl.google.com/go/go1.18.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
-# Golint
-RUN go get golang.org/x/lint/golint && mv ~/go/bin/golint /usr/local/bin && rm -rf ~/go
 
 # Locale
 RUN locale-gen en_GB.UTF-8

--- a/tools/images/ubuntu_alt/Dockerfile
+++ b/tools/images/ubuntu_alt/Dockerfile
@@ -1,5 +1,7 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 MAINTAINER peter.ebden@gmail.com
+
+ENV DEBIAN_FRONTEND noninteractive
 
 # Most dependencies; Python, Java, Clang
 RUN apt-get update && \
@@ -7,8 +9,8 @@ RUN apt-get update && \
     curl unzip git locales pkg-config zlib1g-dev clang && \
     apt-get clean
 
-# Go - we require 1.16 here to check we're compatible but the latest package available is 1.10.
-RUN curl -fsSL https://dl.google.com/go/go1.16.7.linux-amd64.tar.gz | tar -xzC /usr/local
+# Go - we require 1.17 here to check we're compatible
+RUN curl -fsSL https://dl.google.com/go/go1.17.8.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Locale

--- a/tools/please_go/BUILD
+++ b/tools/please_go/BUILD
@@ -11,7 +11,7 @@ go_module(
     name = "xsys",
     install = ["..."],
     module = "golang.org/x/sys",
-    version = "765f4ea38db36397e827c4153018aa272eed7835",
+    version = "039c03cc5b867cd7b06a19ff375be5c945c80b10",
 )
 
 go_module(

--- a/tools/please_go/install/install_test.go
+++ b/tools/please_go/install/install_test.go
@@ -20,9 +20,10 @@ func TestMissingImport(t *testing.T) {
 	err := install.Install([]string{"missing_import"})
 	require.Error(t, err)
 	assert.Contains(t, []string{
-		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: could not import github.com/doesnt-exist (open : no such file or directory)\n"),    // go 1.18
-		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: could not import \"github.com/doesnt-exist\": open : no such file or directory\n"), // go 1.17
-		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: can't find import: \"github.com/doesnt-exist\"\n"),                                 // go 1.16
+		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:8: could not import github.com/doesnt-exist (open : no such file or directory)\n"),    // go 1.18
+		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: could not import github.com/doesnt-exist (open : no such file or directory)\n"),    // go 1.18 (sometimes the column is different?)
+		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:8: could not import \"github.com/doesnt-exist\": open : no such file or directory\n"), // go 1.17
+		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:8: can't find import: \"github.com/doesnt-exist\"\n"),                                 // go 1.16
 	}, stdOut.String())
 }
 

--- a/tools/please_go/install/install_test.go
+++ b/tools/please_go/install/install_test.go
@@ -20,8 +20,9 @@ func TestMissingImport(t *testing.T) {
 	err := install.Install([]string{"missing_import"})
 	require.Error(t, err)
 	assert.Contains(t, []string{
-		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:8: could not import \"github.com/doesnt-exist\": open : no such file or directory\n"), // go 1.17
-		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:8: can't find import: \"github.com/doesnt-exist\"\n"),                                 // go 1.16
+		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: could not import github.com/doesnt-exist (open : no such file or directory)\n"), // go 1.18
+		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: could not import \"github.com/doesnt-exist\": open : no such file or directory\n"), // go 1.17
+		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: can't find import: \"github.com/doesnt-exist\"\n"),                                 // go 1.16
 	}, stdOut.String())
 }
 

--- a/tools/please_go/install/install_test.go
+++ b/tools/please_go/install/install_test.go
@@ -20,7 +20,7 @@ func TestMissingImport(t *testing.T) {
 	err := install.Install([]string{"missing_import"})
 	require.Error(t, err)
 	assert.Contains(t, []string{
-		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: could not import github.com/doesnt-exist (open : no such file or directory)\n"), // go 1.18
+		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: could not import github.com/doesnt-exist (open : no such file or directory)\n"),    // go 1.18
 		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: could not import \"github.com/doesnt-exist\": open : no such file or directory\n"), // go 1.17
 		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: can't find import: \"github.com/doesnt-exist\"\n"),                                 // go 1.16
 	}, stdOut.String())

--- a/tools/please_go/install/install_test.go
+++ b/tools/please_go/install/install_test.go
@@ -21,7 +21,7 @@ func TestMissingImport(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, []string{
 		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:8: could not import github.com/doesnt-exist (open : no such file or directory)\n"),    // go 1.18
-		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: could not import github.com/doesnt-exist (open : no such file or directory)\n"),    // go 1.18 (sometimes the column is different?)
+		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:16: could not import github.com/doesnt-exist (open : no such file or directory)\n"),   // go 1.18 (sometimes the column is different?)
 		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:8: could not import \"github.com/doesnt-exist\": open : no such file or directory\n"), // go 1.17
 		filepath.Join(os.Getenv("TMP_DIR"), "tools/please_go/install/test_data/example.com/missing_import/missing_import.go:3:8: can't find import: \"github.com/doesnt-exist\"\n"),                                 // go 1.16
 	}, stdOut.String())

--- a/tools/please_go/install/test_data/example.com/missing_import/missing_import.go
+++ b/tools/please_go/install/test_data/example.com/missing_import/missing_import.go
@@ -1,3 +1,5 @@
 package foo
 
-import "github.com/doesnt-exist"
+import noexist "github.com/doesnt-exist"
+
+var _ = noexist.Constant

--- a/tools/please_go/install/toolchain/toolchain_test.go
+++ b/tools/please_go/install/toolchain/toolchain_test.go
@@ -12,5 +12,5 @@ func TestGetVersion(t *testing.T) {
 
 	ver, err := tc.GoMinorVersion()
 	require.NoError(t, err)
-	require.Equal(t, 17, ver)
+	require.Equal(t, 18, ver)
 }


### PR DESCRIPTION
We still build on 1.17 as well so this (sadly) doesn't mean we can start using generics right away - we probably want to think when that is (I don't think we need to wait until 1.19 but we shouldn't require everyone to upgrade on day 1 either).