### PR TITLE
Add test to make sure plugins inherit config correctly

### DIFF
--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -170,9 +170,6 @@ func pluginConfig(pluginState *core.BuildState, pkgState *core.BuildState) pyDic
 			}
 			ret[key] = toPyObject(fullConfigKey, val, definition.Type)
 		}
-		if key == "COMPILE_FLAGS" {
-			log.Warningf("set compile flags to %v from %v", ret[key], pkgState.CurrentSubrepo)
-		}
 	}
 	return ret
 }

--- a/test/plugins/BUILD
+++ b/test/plugins/BUILD
@@ -67,3 +67,13 @@ please_repo_e2e_test(
     plz_command = "cp .plzconfig .foo; mv .foo .plzconfig; plz init plugin cc; plz init plugin cc; lines=$(cat plugins/BUILD | wc -l); if [ $lines -gt 6 ]; then exit 1; else exit 0; fi",
     repo = "init_plugin_test",
 )
+
+please_repo_e2e_test(
+    name = "inherit_default_test",
+    expected_output = {
+        "plz-out/gen/foo/test/bar_inherit_test": "bar",
+        "plugins/foo_plugin/plz-out/gen/test/bar_inherit_test": "overridden",
+    },
+    plz_command = "plz build -o foo.modulepath:something ///foo//test:bar_inherit_test && (cd plugins/foo_plugin && plz build  -o foo.modulepath:something //test:bar_inherit_test)",
+    repo = "test_repo",
+)

--- a/test/plugins/test_repo/plugins/foo_plugin/.plzconfig
+++ b/test/plugins/test_repo/plugins/foo_plugin/.plzconfig
@@ -7,11 +7,17 @@ name = foo
 [Plugin "foo"]
 ModulePath = foolang
 CompileFlag = -sha1
+BarTool = overridden
 
 [PluginConfig "fooc_tool"]
 ConfigKey = FoocTool
 Inherit = true
 DefaultValue = fooc
+
+[PluginConfig "bar_tool"]
+ConfigKey = BarTool
+Inherit = true
+DefaultValue = bar
 
 [PluginConfig "module_path"]
 ConfigKey = ModulePath

--- a/test/plugins/test_repo/plugins/foo_plugin/test/BUILD.plugin
+++ b/test/plugins/test_repo/plugins/foo_plugin/test/BUILD.plugin
@@ -4,3 +4,10 @@ foolang_library(
     name = "foo_lib",
     src = "test.foo",
 )
+
+bar = CONFIG.FOO.BAR_TOOL
+genrule(
+    name = "bar_inherit_test",
+    cmd = f"echo {bar} > $OUT",
+    outs = ["bar_inherit_test"],
+)


### PR DESCRIPTION
This test makes sure that the default value is used for inherited configuration values when 1) building from the host repo, and 2) the host repo doesn't specify a value, and 3) the plugin repo defines that value. 

This also makes sure that the correct value is used when building the target in the plugin directly. 