### PR TITLE
Preload subincludes for the architecture subrepos too

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1044,6 +1044,8 @@ func (state *BuildState) ForArch(arch cli.Arch) *BuildState {
 	// in fact take priority over this, but that's a lot more fiddly to get right.
 	s := state.forConfig(".plzconfig_" + arch.String())
 	s.Arch = arch
+
+	s.Parser.NewParser(s)
 	return s
 }
 


### PR DESCRIPTION
We were re-using the same parser for the architecture subrepo which isn't the correct thing to do. This was manifesting in the form of missing the plugin config but could cause other issues too if they rely on the architecture in the top level of these subincludes.

The bug was as follows:
1) We create and cache the `pyConfig{}` for the host state
2) We initialise the parser for this state and load the plugin config into this base state. 
3) We create a new architecture state
4) We then have a cache miss as this state is different to the state the above config was created for. 
5) We create a new `pyConfig{}` for the architecture state however we never preload into this as we re-use the same parser

We could just preload into the architecture state's `pyConfig{}`, however if the pre-loaded subincludes ever use `CONFIG.OS` etc. in the top level, this will cause other issues. This PR just creates a new parser for the architecture subrepo just like we do for normal subrepos. This triggers the preloading which loads the plugin config into the architecture's `pyConfig{}` correctly. 