### PR TITLE
Remove JCenter as a default Maven repo

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -401,7 +401,7 @@ func DefaultConfiguration() *Configuration {
 	config.Java.SourceLevel = "8"
 	config.Java.TargetLevel = "8"
 	config.Java.ReleaseLevel = ""
-	config.Java.DefaultMavenRepo = []cli.URL{"https://repo1.maven.org/maven2", "https://jcenter.bintray.com/"}
+	config.Java.DefaultMavenRepo = []cli.URL{"https://repo1.maven.org/maven2", "https://repo.maven.apache.org/maven2"}
 	config.Java.JavacFlags = "-Werror -Xlint:-options" // bootstrap class path warnings are pervasive without this.
 	config.Java.JlinkTool = "jlink"
 	config.Java.JavaHome = ""


### PR DESCRIPTION
JFrog announced the sunsetting of JCenter, which Please uses as one of its default Maven repos, in February 2021 [1]. Although they later U-turned and committed to indefinitely maintaining a frozen mirror in April 2021, it seems that JCenter is indeed dead (e.g. [2]).

Sonatype [3] says that the canonical URLs for Maven Central are now https://repo1.maven.org/maven2 and https://repo.maven.apache.org/maven2 (both are hosted by Sonatype's CDN), so replace the JCenter URL with the
Apache URL in `DefaultMavenRepo`.

[1] https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
[2] https://jcenter.bintray.com/org/apache/commons/commons-io/maven-metadata.xml
[3] https://central.sonatype.org/consume/