### PR TITLE
Adding histogram for tracking build times

### DIFF
--- a/src/build/BUILD
+++ b/src/build/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//src/generate",
         "//src/process",
         "//src/worker",
+        "//src/metrics",
         "//third_party/go:go-multierror",
         "//third_party/go:logging",
         "//third_party/go:protobuf",

--- a/src/metrics/prometheus.go
+++ b/src/metrics/prometheus.go
@@ -42,3 +42,20 @@ func NewCounter(subsystem, name, help string) prometheus.Counter {
 	MustRegister(counter)
 	return counter
 }
+
+// NewHistogram creates & registers a new histogram.
+func NewHistogram(subsystem, name, help string, buckets []float64) prometheus.Histogram {
+	histogram := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "plz",
+		Subsystem: subsystem,
+		Name:      name,
+		Buckets:   buckets,
+		Help:      help,
+	})
+	MustRegister(histogram)
+	return histogram
+}
+
+func ExponentialBuckets(start, factor float64, numBuckets int) []float64 {
+	return prometheus.ExponentialBuckets(start, factor, numBuckets)
+}


### PR DESCRIPTION
This tracks the time taken to build individual targets, locally and remotely, and records it in histogram buckets pushed to the pushgateway. I've tested this by running local & remote builds and the times are pushed successfully to our TM gateway.