### PR TITLE
stop using find to find the repo root for plugin_repo()

### DIFF
--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -331,7 +331,7 @@ def plugin_repo(name:str, revision:str,  plugin:str="", owner:str="please-build"
         outs = [name],
         cmd = " && ".join([
           "$TOOL x $SRCS -o _tmp",
-          "mv $(dirname $(find . -name .plzconfig | sort -r | head -n 1)) $OUT",
+          "mv $(dirname $(ls _tmp/*/.plzconfig)) $OUT",
         ]),
         _subrepo = True,
     )


### PR DESCRIPTION
This was sometimes picking up the wrong .plzconfig file which causes errors. This approach assumes more about the repo structure but ultimately works for github. 