### PR TITLE
REX: Acquire the target lock when downloading target outputs

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -438,6 +438,10 @@ func (c *Client) download(target *core.BuildTarget, f func() error) error {
 
 func (c *Client) reallyDownload(target *core.BuildTarget, digest *pb.Digest, ar *pb.ActionResult) error {
 	log.Debug("Downloading outputs for %s", target)
+
+	file := core.AcquireExclusiveFileLock(target.BuildLockFile())
+	defer core.ReleaseFileLock(file)
+
 	if err := removeOutputs(target); err != nil {
 		return err
 	}


### PR DESCRIPTION
I don't think this should deadlock as we only download when we build the target remotely, in which case, we haven't acquired the target lock in `build_step.go`.