### PR TITLE
add freebsd recognition

### DIFF
--- a/pleasew
+++ b/pleasew
@@ -75,6 +75,8 @@ if [ "$OS" = "Linux" ]; then
     GOOS="linux"
 elif [ "$OS" = "Darwin" ]; then
     GOOS="darwin"
+elif [ "$OS" = "FreeBSD" ]; then
+    GOOS="freebsd"
 else
     echo -e >&2 "${RED}Unknown operating system $OS${RESET}"
     exit 1

--- a/tools/misc/get_plz.sh
+++ b/tools/misc/get_plz.sh
@@ -11,6 +11,8 @@ if [ "$OS" = "Linux" ]; then
     GOOS="linux"
 elif [ "$OS" = "Darwin" ]; then
     GOOS="darwin"
+elif [ "$OS" = "FreeBSD" ]; then
+    GOOS="freebsd"
 else
     echo "Unknown operating system $OS"
     exit 1


### PR DESCRIPTION
Added an if branch to cater for FreeBSD. Tested with FreeBSD 11. There doesn't seem to be any automated tests associated with this script.