### PR TITLE
Set repeatable to true when migrating with plz init

### DIFF
--- a/src/plzinit/plugins.go
+++ b/src/plzinit/plugins.go
@@ -165,7 +165,7 @@ func writeFieldsToConfig(plugin string, file ast.File, configMap map[string]stri
 			foundSection = true
 			for _, field := range s.Fields {
 				if plugVal, ok := configMap[strings.ToLower(field.Name)]; ok {
-					file = ast.InjectField(file, plugVal, field.Value, section, plugin, false)
+					file = ast.InjectField(file, plugVal, field.Value, section, plugin, true)
 				}
 			}
 		}


### PR DESCRIPTION
This was a mistake in plz init - when we're migrating fields from [section] to [plugin "section"], if we pick up repeated values we should inject all of them into the new section, which this wasn't doing before.