### PR TITLE
Fix duplicate resource in python pex

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -129,6 +129,8 @@ def package_name(label:str=None, subinclude_context:bool=None) -> str:
     pass
 def subrepo_name(label:str=None, subinclude_context:bool=None) -> str:
     pass
+def looks_like_build_label(label:str) -> bool:
+    pass
 
 def canonicalise(label:str, subinclude_context:bool=None) -> str:
     """Converts the given build label to its full form.

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -407,7 +407,7 @@ def cgo_library(name:str, srcs:list=[], resources:list=None, go_srcs:list=[], c_
             test_only = test_only,
         )
 
-    file_srcs = [src for src in srcs if not src.startswith('/') and not src.startswith(':')]
+    file_srcs = [src for src in srcs if not looks_like_build_label(src)]
     post_build = lambda rule, output: [add_out(rule, 'c' if line.endswith('.c') else 'go', line) for line in output]
     subdir2 = (subdir + '/') if subdir and not subdir.endswith('/') else subdir
 
@@ -1490,7 +1490,7 @@ def _go_get_download(name:str, tag:str, get:str, repo:str='', patch:list=[], has
     revision = revision or 'master'
 
     # if the repo is a build rule, just return that assuming it outputs in the correct format
-    if repo.startswith("//") or repo.startswith(":"):
+    if looks_like_build_label(repo):
         return repo, getroot
 
     # Allow overriding with locally cloned repos

--- a/rules/proto_rules.build_defs
+++ b/rules/proto_rules.build_defs
@@ -47,7 +47,7 @@ def proto_library(name:str, srcs:list, deps:list=[], visibility:list=None, label
         if CONFIG.GO_IMPORT_PATH:
             base_path = join_path(CONFIG.GO_IMPORT_PATH, base_path)
         labels += [f'proto:go-map: {base_path}/{src}={base_path}/{name}' for src in srcs
-                   if not src.startswith(':') and not src.startswith('/') and
+                   if not looks_like_build_label(src) and
                    (src != (name + '.proto') or len(srcs) > 1 or diff_pkg)]
 
     # Plugins can declare their own pre-build functions. If there are any, we need to apply them all in sequence.
@@ -57,7 +57,7 @@ def proto_library(name:str, srcs:list, deps:list=[], visibility:list=None, label
 
     # If the protoc tool is a build rule, depend on it as it's probably a protoc_binary() which provides the well known
     # types
-    if CONFIG.PROTOC_TOOL.startswith("//") or CONFIG.PROTOC_TOOL.startswith(":"):
+    if looks_like_build_label(CONFIG.PROTOC_TOOL):
         # Extract the wkt into another rule as we already depend on the main rule as a tool.
         deps += [filegroup(
             name = name,

--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -80,10 +80,12 @@ def python_library(name:str, srcs:list=[], resources:list=[], deps:list=[], visi
     elif strip:
         fail("Can't pass strip=True to a python_library with no srcs")
 
+    src_resources = [r for r in resources if not looks_like_build_label(r)]
+    dep_resources = [r for r in resources if looks_like_build_label(r)]
     return filegroup(
         name=name,
-        srcs=resources if strip else (srcs + resources),
-        deps=deps,
+        srcs=src_resources if strip else (srcs + src_resources),
+        deps=deps + dep_resources,
         visibility=visibility,
         output_is_complete=False,
         requires=['py'],

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -66,6 +66,7 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "breakpoint", breakpoint)
 	setNativeCode(s, "is_semver", isSemver)
 	setNativeCode(s, "semver_check", semverCheck)
+	setNativeCode(s, "looks_like_build_label", looksLikeBuildLabel)
 	stringMethods = map[string]*pyFunc{
 		"join":         setNativeCode(s, "join", strJoin),
 		"split":        setNativeCode(s, "split", strSplit),
@@ -630,6 +631,10 @@ func joinPath(s *scope, args []pyObject) pyObject {
 		l[i] = string(arg.(pyString))
 	}
 	return pyString(path.Join(l...))
+}
+
+func looksLikeBuildLabel(s *scope, args []pyObject) pyObject {
+	return pyBool(core.LooksLikeABuildLabel(args[0].String()))
 }
 
 // scopeOrSubincludePackage is like (*scope).contextPackage() package but allows the option to force the use the


### PR DESCRIPTION
@samwestmoreland we'll need to duplicate this on the plugin too

This really seemed like it could use require/provide so the `python_binary()` only ever gets the `.pex.zip` output but that might have some regressions. Perhaps this is the way we can do it for the plugin. 

Fixes #2304