### PR TITLE
Fix some data races

### DIFF
--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -102,7 +102,7 @@ var KnownFields = map[string]bool{
 	"Progress":               true,
 	"FileSize":               true,
 	"PassUnsafeEnv":          true,
-	"NeededForSubinclude":    true,
+	"neededForSubinclude":    true,
 	"mutex":                  true,
 	"dependenciesRegistered": true,
 	"finishedBuilding":       true,

--- a/src/core/atomic_bool.go
+++ b/src/core/atomic_bool.go
@@ -16,3 +16,9 @@ func (b *atomicBool) Set() {
 func (b *atomicBool) IsSet() bool {
 	return atomic.LoadInt32(&b.b) == 1
 }
+
+func (b *atomicBool) Or(set bool) {
+	if set {
+		b.Set()
+	}
+}

--- a/src/core/atomic_bool.go
+++ b/src/core/atomic_bool.go
@@ -1,0 +1,18 @@
+package core
+
+import (
+	"sync/atomic"
+)
+
+// An atomicBool is a type we use as an opaque boolean that doesn't trigger the race detector.
+type atomicBool struct {
+	b int32
+}
+
+func (b *atomicBool) Set() {
+	atomic.StoreInt32(&b.b, 1)
+}
+
+func (b *atomicBool) IsSet() bool {
+	return atomic.LoadInt32(&b.b) == 1
+}

--- a/src/core/atomic_bool.go
+++ b/src/core/atomic_bool.go
@@ -16,9 +16,3 @@ func (b *atomicBool) Set() {
 func (b *atomicBool) IsSet() bool {
 	return atomic.LoadInt32(&b.b) == 1
 }
-
-func (b *atomicBool) Or(set bool) {
-	if set {
-		b.Set()
-	}
-}

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -200,6 +200,9 @@ type BuildTarget struct {
 	FileContent string `name:"content"`
 	// Represents the state of this build target (see below)
 	state int32 `print:"false"`
+	// If true, the target is needed for a subinclude and therefore we will have to make sure its
+	// outputs are available locally when built.
+	neededForSubinclude atomicBool `print:"false"`
 	// The number of completed runs
 	completedRuns uint16 `print:"false"`
 	// True if this target is a binary (ie. runnable, will appear in plz-out/bin)
@@ -228,9 +231,6 @@ type BuildTarget struct {
 	// If true, the executed commands will exit whenever an error is encountered (i.e. shells
 	// are executed with -e).
 	ExitOnError bool
-	// If true, the target is needed for a subinclude and therefore we will have to make sure its
-	// outputs are available locally when built.
-	NeededForSubinclude bool `print:"false"`
 	// Marks the target as a filegroup.
 	IsFilegroup bool `print:"false"`
 	// Marks the target as a remote_file.

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -867,7 +867,7 @@ func (state *BuildState) ShouldDownload(target *BuildTarget) bool {
 	downloadOriginalTarget := state.OutputDownload == OriginalOutputDownload && state.IsOriginalTarget(target)
 	downloadTransitiveTarget := state.OutputDownload == TransitiveOutputDownload
 	downloadLinkableTarget := state.Config.Build.DownloadLinkable && target.HasLinks(state)
-	return target.NeededForSubinclude || ((downloadOriginalTarget || downloadTransitiveTarget) && !state.NeedTests) || downloadLinkableTarget
+	return target.neededForSubinclude.IsSet() || ((downloadOriginalTarget || downloadTransitiveTarget) && !state.NeedTests) || downloadLinkableTarget
 }
 
 // ShouldRebuild returns true if we should force a rebuild of this target (i.e. the user
@@ -951,7 +951,7 @@ func (state *BuildState) queueTestTarget(target *BuildTarget) {
 
 // queueResolvedTarget is like queueTarget but once we have a resolved target.
 func (state *BuildState) queueResolvedTarget(target *BuildTarget, forceBuild, neededForSubinclude bool) error {
-	target.NeededForSubinclude = target.NeededForSubinclude || neededForSubinclude
+	target.neededForSubinclude.Or(neededForSubinclude)
 	if target.State() >= Active && !forceBuild {
 		return nil // Target is already tagged to be built and likely on the queue.
 	}

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -995,9 +995,9 @@ func (state *BuildState) queueTargetAsync(target *BuildTarget, forceBuild, build
 		}
 	}
 	for {
-		called := false
+		var called atomicBool
 		if err := target.resolveDependencies(state.Graph, func(t *BuildTarget) error {
-			called = true
+			called.Set()
 			return state.queueResolvedTarget(t, forceBuild, false)
 		}); err != nil {
 			state.asyncError(target.Label, err)
@@ -1009,7 +1009,7 @@ func (state *BuildState) queueTargetAsync(target *BuildTarget, forceBuild, build
 				t.WaitForBuild()
 			}
 		}
-		if !called {
+		if !called.IsSet() {
 			// We are now ready to go, we have nothing to wait for.
 			if building && target.SyncUpdateState(Active, Pending) {
 				state.addPendingBuild(target)

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -951,7 +951,9 @@ func (state *BuildState) queueTestTarget(target *BuildTarget) {
 
 // queueResolvedTarget is like queueTarget but once we have a resolved target.
 func (state *BuildState) queueResolvedTarget(target *BuildTarget, forceBuild, neededForSubinclude bool) error {
-	target.neededForSubinclude.Or(neededForSubinclude)
+	if neededForSubinclude {
+		target.neededForSubinclude.Set()
+	}
 	if target.State() >= Active && !forceBuild {
 		return nil // Target is already tagged to be built and likely on the queue.
 	}

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -23,6 +23,9 @@ import (
 // A few sneaky globals for when we don't have a scope handy
 var stringMethods, dictMethods, configMethods map[string]*pyFunc
 
+// Protects setting the above
+var builtinsOnce sync.Once
+
 // A nativeFunc is a function that implements a builtin function natively.
 type nativeFunc func(*scope, []pyObject) pyObject
 
@@ -67,39 +70,41 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "is_semver", isSemver)
 	setNativeCode(s, "semver_check", semverCheck)
 	setNativeCode(s, "looks_like_build_label", looksLikeBuildLabel)
-	stringMethods = map[string]*pyFunc{
-		"join":         setNativeCode(s, "join", strJoin),
-		"split":        setNativeCode(s, "split", strSplit),
-		"replace":      setNativeCode(s, "replace", strReplace),
-		"partition":    setNativeCode(s, "partition", strPartition),
-		"rpartition":   setNativeCode(s, "rpartition", strRPartition),
-		"startswith":   setNativeCode(s, "startswith", strStartsWith),
-		"endswith":     setNativeCode(s, "endswith", strEndsWith),
-		"lstrip":       setNativeCode(s, "lstrip", strLStrip),
-		"rstrip":       setNativeCode(s, "rstrip", strRStrip),
-		"removeprefix": setNativeCode(s, "removeprefix", strRemovePrefix),
-		"removesuffix": setNativeCode(s, "removesuffix", strRemoveSuffix),
-		"strip":        setNativeCode(s, "strip", strStrip),
-		"find":         setNativeCode(s, "find", strFind),
-		"rfind":        setNativeCode(s, "find", strRFind),
-		"format":       setNativeCode(s, "format", strFormat),
-		"count":        setNativeCode(s, "count", strCount),
-		"upper":        setNativeCode(s, "upper", strUpper),
-		"lower":        setNativeCode(s, "lower", strLower),
-	}
-	stringMethods["format"].kwargs = true
-	dictMethods = map[string]*pyFunc{
-		"get":        setNativeCode(s, "get", dictGet),
-		"setdefault": s.Lookup("setdefault").(*pyFunc),
-		"keys":       setNativeCode(s, "keys", dictKeys),
-		"items":      setNativeCode(s, "items", dictItems),
-		"values":     setNativeCode(s, "values", dictValues),
-		"copy":       setNativeCode(s, "copy", dictCopy),
-	}
-	configMethods = map[string]*pyFunc{
-		"get":        setNativeCode(s, "config_get", configGet),
-		"setdefault": s.Lookup("setdefault").(*pyFunc),
-	}
+	builtinsOnce.Do(func() {
+		stringMethods = map[string]*pyFunc{
+			"join":         setNativeCode(s, "join", strJoin),
+			"split":        setNativeCode(s, "split", strSplit),
+			"replace":      setNativeCode(s, "replace", strReplace),
+			"partition":    setNativeCode(s, "partition", strPartition),
+			"rpartition":   setNativeCode(s, "rpartition", strRPartition),
+			"startswith":   setNativeCode(s, "startswith", strStartsWith),
+			"endswith":     setNativeCode(s, "endswith", strEndsWith),
+			"lstrip":       setNativeCode(s, "lstrip", strLStrip),
+			"rstrip":       setNativeCode(s, "rstrip", strRStrip),
+			"removeprefix": setNativeCode(s, "removeprefix", strRemovePrefix),
+			"removesuffix": setNativeCode(s, "removesuffix", strRemoveSuffix),
+			"strip":        setNativeCode(s, "strip", strStrip),
+			"find":         setNativeCode(s, "find", strFind),
+			"rfind":        setNativeCode(s, "find", strRFind),
+			"format":       setNativeCode(s, "format", strFormat),
+			"count":        setNativeCode(s, "count", strCount),
+			"upper":        setNativeCode(s, "upper", strUpper),
+			"lower":        setNativeCode(s, "lower", strLower),
+		}
+		stringMethods["format"].kwargs = true
+		dictMethods = map[string]*pyFunc{
+			"get":        setNativeCode(s, "get", dictGet),
+			"setdefault": s.Lookup("setdefault").(*pyFunc),
+			"keys":       setNativeCode(s, "keys", dictKeys),
+			"items":      setNativeCode(s, "items", dictItems),
+			"values":     setNativeCode(s, "values", dictValues),
+			"copy":       setNativeCode(s, "copy", dictCopy),
+		}
+		configMethods = map[string]*pyFunc{
+			"get":        setNativeCode(s, "config_get", configGet),
+			"setdefault": s.Lookup("setdefault").(*pyFunc),
+		}
+	})
 	if s.state.Config.Parse.GitFunctions {
 		setNativeCode(s, "git_branch", execGitBranch)
 		setNativeCode(s, "git_commit", execGitCommit)


### PR DESCRIPTION
The core ones are benign but it's nice not to see them (admittedly at a minor cost of 3 unused bytes in BuildTarget).

The asp one should also be benign but it might still trigger Go's map race detector. Seems like no real cost there (in fact the sync.Once is probably faster then re-setting all those map entries)

Was testing this by temporarily adding `-race` into the bootstrap script. This fixes nearly all of it (there was also some weird stuff in asp but I think it's confused, it was complaining about not being able to restore stacks) but there is still something occasional in the logger. That deserves a separate PR though.