### PR TITLE
Fix data race in the system stats code

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -119,7 +119,7 @@ type BuildState struct {
 	// Timestamp that the build is considered to start at.
 	StartTime time.Time
 	// Various system statistics. Mostly used during remote communication.
-	Stats *SystemStats
+	stats *lockedStats
 	// Configuration options
 	Config *Configuration
 	// The .plzconfig file for this repo. Unlike Config, no default values are applied. This will represent the
@@ -289,6 +289,12 @@ type SystemStats struct {
 	// N.B. These are background workers as started by $(worker) commands, not the internal worker
 	//      threads tracked in the state object.
 	NumWorkerProcesses int
+}
+
+// lockedStats is just SystemStats with a mutex to protect it.
+type lockedStats struct {
+	sync.Mutex
+	Stats SystemStats
 }
 
 // addActiveTargets increments the counter for a number of newly active build targets.
@@ -1215,7 +1221,7 @@ func NewBuildState(config *Configuration) *BuildState {
 		Coverage:        TestCoverage{Files: map[string][]LineCoverage{}},
 		TargetArch:      config.Build.Arch,
 		Arch:            cli.HostArch(),
-		Stats:           &SystemStats{},
+		stats:           &lockedStats{},
 		progress: &stateProgress{
 			numActive:       1, // One for the initial target adding on the main thread.
 			numPending:      1,

--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -118,11 +118,12 @@ func (d *interactiveDisplay) printLines(local, remote []buildingTarget) {
 	d.printf("Building [%d/%d, %3.1fs]:\n", d.state.NumDone(), d.state.NumActive(), time.Since(d.state.StartTime).Seconds())
 	d.lines++
 	if d.stats {
-		d.printStat("CPU use", d.state.Stats.CPU.Used, d.state.Stats.CPU.Count)
-		d.printStat("I/O", d.state.Stats.CPU.IOWait, d.state.Stats.CPU.Count)
-		d.printStat("Mem use", d.state.Stats.Memory.UsedPercent, 1)
-		if d.state.Stats.NumWorkerProcesses > 0 {
-			d.printf("  ${BOLD_WHITE}Worker processes: %d${RESET}", d.state.Stats.NumWorkerProcesses)
+		stats := d.state.SystemStats()
+		d.printStat("CPU use", stats.CPU.Used, stats.CPU.Count)
+		d.printStat("I/O", stats.CPU.IOWait, stats.CPU.Count)
+		d.printStat("Mem use", stats.Memory.UsedPercent, 1)
+		if stats.NumWorkerProcesses > 0 {
+			d.printf("  ${BOLD_WHITE}Worker processes: %d${RESET}", stats.NumWorkerProcesses)
 		}
 		if d.state.RemoteClient != nil {
 			in, out, _, _ := d.state.RemoteClient.DataRate()

--- a/src/worker/worker.go
+++ b/src/worker/worker.go
@@ -120,7 +120,7 @@ func getOrStartWorker(state *core.BuildState, worker string) (*workerServer, err
 	go w.sendRequests(stdin)
 	go w.readResponses(stdout)
 	go w.wait()
-	state.Stats.NumWorkerProcesses = len(workerMap)
+	state.SetNumWorkerStat(len(workerMap))
 	return w, nil
 }
 


### PR DESCRIPTION
This is also getting accessed concurrently. Protect stuff with a mutex.