### PR TITLE
Fix data races in logging

### DIFF
--- a/src/BUILD.plz
+++ b/src/BUILD.plz
@@ -13,6 +13,7 @@ go_binary(
         "//src/cache",
         "//src/clean",
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/debug",
         "//src/exec",
@@ -38,7 +39,6 @@ go_binary(
         "//src/worker",
         "//third_party/go:automaxprocs",
         "//third_party/go:go-flags",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/build/BUILD
+++ b/src/build/BUILD
@@ -35,6 +35,7 @@ go_test(
         ":build",
         "//src/core",
         "//src/fs",
+        "//third_party/go:logging",
         "//third_party/go:testify",
     ],
 )

--- a/src/build/BUILD
+++ b/src/build/BUILD
@@ -6,14 +6,14 @@ go_library(
     ),
     visibility = ["PUBLIC"],
     deps = [
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/generate",
+        "//src/metrics",
         "//src/process",
         "//src/worker",
-        "//src/metrics",
         "//third_party/go:go-multierror",
-        "//third_party/go:logging",
         "//third_party/go:protobuf",
         "//third_party/go:shlex",
     ],
@@ -45,10 +45,10 @@ go_test(
     external = True,
     deps = [
         ":build",
+        "//src/cli/logging",
         "//src/core",
         "//src/output",
         "//src/plz",
-        "//third_party/go:logging",
         "//third_party/go:testify",
     ],
 )

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -31,7 +31,7 @@ import (
 	"github.com/thought-machine/please/src/worker"
 )
 
-var log = logging.MustGetLogger("build")
+var log = logging.Log
 
 // Type that indicates that we're stopping the build of a target in a nonfatal way.
 var errStop = fmt.Errorf("stopping build")

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/shlex"
 	"github.com/hashicorp/go-multierror"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"

--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/thought-machine/please/src/plz"
 )
 
-var log = logging.MustGetLogger("build_test")
+var log = logging.Log
 
 const size = 1000
 

--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/plz"

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/thought-machine/please/src/cli/logging"
+	"gopkg.in/op/go-logging.v1"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"

--- a/src/cache/BUILD
+++ b/src/cache/BUILD
@@ -10,13 +10,13 @@ go_library(
     deps = [
         "//src/clean",
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/process",
         "//third_party/go:atime",
         "//third_party/go:go-retryablehttp",
         "//third_party/go:humanize",
-        "//third_party/go:logging",
     ],
 )
 
@@ -32,7 +32,7 @@ go_test(
     data = [":test_data"],
     deps = [
         ":cache",
-        "//third_party/go:logging",
+        "//src/cli/logging",
         "//third_party/go:testify",
     ],
 )

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -10,7 +10,7 @@ import (
 	"github.com/thought-machine/please/src/core"
 )
 
-var log = logging.MustGetLogger("cache")
+var log = logging.Log
 
 // NewCache is the factory function for creating a cache setup from the given config.
 func NewCache(state *core.BuildState) core.Cache {

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -5,7 +5,7 @@ package cache
 import (
 	"sync"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 )

--- a/src/clean/BUILD
+++ b/src/clean/BUILD
@@ -4,10 +4,10 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//src/build",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/test",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/clean/clean.go
+++ b/src/clean/clean.go
@@ -11,7 +11,7 @@ import (
 	"path"
 	"syscall"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/build"
 	"github.com/thought-machine/please/src/core"

--- a/src/clean/clean.go
+++ b/src/clean/clean.go
@@ -19,7 +19,7 @@ import (
 	"github.com/thought-machine/please/src/test"
 )
 
-var log = logging.MustGetLogger("clean")
+var log = logging.Log
 
 // Clean cleans the entire output directory and optionally the cache as well.
 func Clean(config *core.Configuration, cache core.Cache, background bool) {

--- a/src/cli/BUILD
+++ b/src/cli/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//third_party/go:go-flags",
         "//third_party/go:humanize",
         "//third_party/go:levenshtein",
-        "//third_party/go:logging",
         "//third_party/go:promptui",
         "//third_party/go:semver",
         "//third_party/go:xcrypto",

--- a/src/cli/BUILD
+++ b/src/cli/BUILD
@@ -6,6 +6,7 @@ go_library(
     ),
     visibility = ["PUBLIC"],
     deps = [
+        "//src/cli/logging",
         "//third_party/go:cli-init",
         "//third_party/go:deferred_regex",
         "//third_party/go:go-flags",

--- a/src/cli/BUILD
+++ b/src/cli/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//third_party/go:go-flags",
         "//third_party/go:humanize",
         "//third_party/go:levenshtein",
+        "//third_party/go:logging",
         "//third_party/go:promptui",
         "//third_party/go:semver",
         "//third_party/go:xcrypto",

--- a/src/cli/logging.go
+++ b/src/cli/logging.go
@@ -86,12 +86,19 @@ func logFormatter(coloured bool) logging.Formatter {
 func setLogBackend(backend logging.Backend) {
 	backend = logging.NewBackendFormatter(backend, logFormatter(StdErrIsATerminal))
 	if fileBackend == nil {
-		logging.SetBackend(newLogBackend(backend))
+		log.SetBackend(newLogBackend(backend))
 	} else {
 		fileBackendLeveled := logging.AddModuleLevel(fileBackend)
 		fileBackendLeveled.SetLevel(fileLogLevel, "")
-		logging.SetBackend(newLogBackend(backend), fileBackendLeveled)
+		log.SetBackend(logging.AddModuleLevel(multiBackend(newLogBackend(backend), fileBackendLeveled)))
 	}
+}
+
+func multiBackend(backends ...logging.Backend) logging.Backend {
+	if len(backends) == 1 {
+		return backends[0]
+	}
+	return logging.MultiLogger(backends...)
 }
 
 type logBackendFacade struct {

--- a/src/cli/logging.go
+++ b/src/cli/logging.go
@@ -16,11 +16,13 @@ import (
 	"github.com/peterebden/go-deferred-regex"
 	"golang.org/x/crypto/ssh/terminal"
 	"gopkg.in/op/go-logging.v1"
+
+	logger "github.com/thought-machine/please/src/cli/logging"
 )
 
 const messageHistoryMaxSize = 100
 
-var log = logging.MustGetLogger("cli")
+var log = logger.Log
 
 // StdErrIsATerminal is true if the process' stderr is an interactive TTY.
 var StdErrIsATerminal = terminal.IsTerminal(int(os.Stderr.Fd()))

--- a/src/cli/logging/BUILD
+++ b/src/cli/logging/BUILD
@@ -1,0 +1,8 @@
+go_library(
+    name = "logging",
+    srcs = ["logging.go"],
+    visibility = ["PUBLIC"],
+    deps = [
+        "//third_party/go:logging",
+    ],
+)

--- a/src/cli/logging/BUILD
+++ b/src/cli/logging/BUILD
@@ -3,6 +3,6 @@ go_library(
     srcs = ["logging.go"],
     visibility = ["PUBLIC"],
     deps = [
-        "//third_party/go:logging",
+        "//src/cli/logging",
     ],
 )

--- a/src/cli/logging/BUILD
+++ b/src/cli/logging/BUILD
@@ -3,6 +3,6 @@ go_library(
     srcs = ["logging.go"],
     visibility = ["PUBLIC"],
     deps = [
-        "//src/cli/logging",
+        "//third_party/go:logging",
     ],
 )

--- a/src/cli/logging/logging.go
+++ b/src/cli/logging/logging.go
@@ -13,3 +13,13 @@ var Log = logging.MustGetLogger("plz")
 
 // Level is a re-export of the library type.
 type Level = logging.Level
+
+// Re-exports of various log levels.
+const (
+	CRITICAL = logging.CRITICAL
+	ERROR    = logging.ERROR
+	WARNING  = logging.WARNING
+	NOTICE   = logging.NOTICE
+	INFO     = logging.INFO
+	DEBUG    = logging.DEBUG
+)

--- a/src/cli/logging/logging.go
+++ b/src/cli/logging/logging.go
@@ -6,4 +6,10 @@ import (
 	"gopkg.in/op/go-logging.v1"
 )
 
+// Log is the singleton logger instance.
+// We never alter individual levels and don't log the module name, so there
+// is no need to have more than one, and it helps avoid race conditions.
 var Log = logging.MustGetLogger("plz")
+
+// Level is a re-export of the library type.
+type Level = logging.Level

--- a/src/cli/logging/logging.go
+++ b/src/cli/logging/logging.go
@@ -1,0 +1,9 @@
+// Package logging contains the singleton logger that we use globally.
+// It deliberately has little else since it's a dependency everywhere.
+package logging
+
+import (
+	"gopkg.in/op/go-logging.v1"
+)
+
+var Log = logging.MustGetLogger("plz")

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -12,6 +12,7 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",
+        "//src/cli/logging",
         "//src/fs",
         "//src/process",
         "//src/scm",
@@ -22,7 +23,6 @@ go_library(
         "//third_party/go:gcfg",
         "//third_party/go:go-flags",
         "//third_party/go:godirwalk",
-        "//third_party/go:logging",
         "//third_party/go:psutil",
         "//third_party/go:semver",
         "//third_party/go:shlex",

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -14,7 +14,7 @@ import (
 	"github.com/thought-machine/please/src/process"
 )
 
-var log = logging.MustGetLogger("core")
+var log = logging.Log
 
 // A BuildLabel is a representation of an identifier of a build target, e.g. //spam/eggs:ham
 // corresponds to BuildLabel{PackageName: spam/eggs name: ham}

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/thought-machine/go-flags"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/process"
 )

--- a/src/core/lock.go
+++ b/src/core/lock.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 
 	"github.com/thought-machine/please/src/fs"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 )
 
 const repoLockFilePath = "plz-out/.lock"

--- a/src/core/lock.go
+++ b/src/core/lock.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 
 	"github.com/thought-machine/please/src/fs"
-	"github.com/thought-machine/please/src/cli/logging"
 )
 
 const repoLockFilePath = "plz-out/.lock"
@@ -45,7 +44,7 @@ func acquireRepoLock(how int) error {
 		return err
 	}
 
-	return acquireFileLock(repoLockFile, how, (*logging.Logger).Warning)
+	return acquireFileLock(repoLockFile, how, log.Warning)
 }
 
 // This acts like a singleton allowing the same file descriptor to used to override a previously set lock
@@ -80,7 +79,7 @@ func acquireOpenFileLock(filePath string, how int) (*os.File, error) {
 		return nil, err
 	}
 
-	if err = acquireFileLock(lockFile, how, (*logging.Logger).Debug); err != nil {
+	if err = acquireFileLock(lockFile, how, log.Debug); err != nil {
 		return nil, err
 	}
 
@@ -102,7 +101,7 @@ func ReleaseFileLock(file *os.File) {
 	}
 }
 
-type logFunc func(logger *logging.Logger, format string, args ...interface{})
+type logFunc func(format string, args ...interface{})
 
 func acquireFileLock(file *os.File, how int, levelLog logFunc) error {
 	// Try a non-blocking acquire first so we can warn the user if we're waiting.
@@ -111,9 +110,9 @@ func acquireFileLock(file *os.File, how int, levelLog logFunc) error {
 	if err != nil {
 		pid, err := ioutil.ReadFile(file.Name())
 		if err == nil && len(pid) > 0 {
-			levelLog(log, "Looks like process with PID %s has already acquired the lock for %s. Waiting for it to finish...", string(pid), file.Name())
+			levelLog("Looks like process with PID %s has already acquired the lock for %s. Waiting for it to finish...", string(pid), file.Name())
 		} else {
-			levelLog(log, "Looks like another process has already acquired the lock for %s. Waiting for it to finish...", file.Name())
+			levelLog("Looks like another process has already acquired the lock for %s. Waiting for it to finish...", file.Name())
 		}
 
 		if err := syscall.Flock(int(file.Fd()), how); err != nil {

--- a/src/debug/BUILD
+++ b/src/debug/BUILD
@@ -6,9 +6,9 @@ go_library(
     ),
     visibility = ["PUBLIC"],
     deps = [
+        "//src/cli/logging",
         "//src/core",
         "//src/exec",
         "//src/process",
-        "//third_party/go:logging",
     ],
 )

--- a/src/debug/debug.go
+++ b/src/debug/debug.go
@@ -11,7 +11,7 @@ import (
 	"github.com/thought-machine/please/src/process"
 )
 
-var log = logging.MustGetLogger("debug")
+var log = logging.Log
 
 func Debug(state *core.BuildState, label core.BuildLabel, args []string) int {
 	target := state.Graph.TargetOrDie(label)

--- a/src/debug/debug.go
+++ b/src/debug/debug.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/exec"

--- a/src/exec/BUILD
+++ b/src/exec/BUILD
@@ -6,9 +6,9 @@ go_library(
     ),
     visibility = ["PUBLIC"],
     deps = [
+        "//src/cli/logging",
         "//src/core",
         "//src/process",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/exec/exec.go
+++ b/src/exec/exec.go
@@ -14,7 +14,7 @@ import (
 	"github.com/thought-machine/please/src/process"
 )
 
-var log = logging.MustGetLogger("exec")
+var log = logging.Log
 
 // Exec allows the execution of a target or override command in a sandboxed environment that can also be configured to have some namespaces shared.
 func Exec(state *core.BuildState, label core.AnnotatedOutputLabel, dir string, env, overrideCmdArgs []string, foreground bool, sandbox process.SandboxConfig) int {

--- a/src/exec/exec.go
+++ b/src/exec/exec.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/process"

--- a/src/export/BUILD
+++ b/src/export/BUILD
@@ -3,10 +3,10 @@ go_library(
     srcs = ["export.go"],
     visibility = ["PUBLIC"],
     deps = [
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/gc",
         "//src/parse",
-        "//third_party/go:logging",
     ],
 )

--- a/src/export/export.go
+++ b/src/export/export.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"strings"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"

--- a/src/export/export.go
+++ b/src/export/export.go
@@ -16,7 +16,7 @@ import (
 	"github.com/thought-machine/please/src/parse"
 )
 
-var log = logging.MustGetLogger("export")
+var log = logging.Log
 
 // ToDir exports a set of targets to the given directory.
 // It dies on any errors.

--- a/src/format/BUILD
+++ b/src/format/BUILD
@@ -3,12 +3,12 @@ go_library(
     srcs = ["fmt.go"],
     visibility = ["//src/..."],
     deps = [
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/plz",
         "//third_party/go:buildtools",
         "//third_party/go:errgroup",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/format/fmt.go
+++ b/src/format/fmt.go
@@ -19,7 +19,7 @@ import (
 	"github.com/thought-machine/please/src/plz"
 )
 
-var log = logging.MustGetLogger("format")
+var log = logging.Log
 
 // Format reformats the given BUILD files to their canonical version.
 // It either prints the reformatted versions to stdout or rewrites the files in-place.

--- a/src/format/fmt.go
+++ b/src/format/fmt.go
@@ -11,8 +11,8 @@ import (
 	"sync/atomic"
 
 	"github.com/bazelbuild/buildtools/build"
-	"golang.org/x/sync/errgroup"
 	"github.com/thought-machine/please/src/cli/logging"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"

--- a/src/format/fmt.go
+++ b/src/format/fmt.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/bazelbuild/buildtools/build"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"

--- a/src/fs/BUILD
+++ b/src/fs/BUILD
@@ -6,10 +6,10 @@ go_library(
     ),
     visibility = ["PUBLIC"],
     deps = [
+        "//src/cli/logging",
         "//src/process",
         "//third_party/go:deferred_regex",
         "//third_party/go:godirwalk",
-        "//third_party/go:logging",
         "//third_party/go:xattr",
     ],
 )

--- a/src/fs/fs.go
+++ b/src/fs/fs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/thought-machine/please/src/cli/logging"
 )
 
-var log = logging.MustGetLogger("fs")
+var log = logging.Log
 
 // DirPermissions are the default permission bits we apply to directories.
 const DirPermissions = os.ModeDir | 0775

--- a/src/fs/fs.go
+++ b/src/fs/fs.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/thought-machine/please/src/process"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 )
 
 var log = logging.MustGetLogger("fs")

--- a/src/gc/BUILD
+++ b/src/gc/BUILD
@@ -4,11 +4,11 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/parse/asp",
         "//src/scm",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/gc/gc.go
+++ b/src/gc/gc.go
@@ -21,7 +21,7 @@ import (
 	"github.com/thought-machine/please/src/scm"
 )
 
-var log = logging.MustGetLogger("gc")
+var log = logging.Log
 
 type targetMap map[*core.BuildTarget]bool
 

--- a/src/gc/gc.go
+++ b/src/gc/gc.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"

--- a/src/generate/BUILD
+++ b/src/generate/BUILD
@@ -3,9 +3,9 @@ go_library(
     srcs = ["generate.go"],
     visibility = ["//src/..."],
     deps = [
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/scm",
-        "//third_party/go:logging",
     ],
 )

--- a/src/generate/generate.go
+++ b/src/generate/generate.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"

--- a/src/generate/generate.go
+++ b/src/generate/generate.go
@@ -13,7 +13,7 @@ import (
 	"github.com/thought-machine/please/src/scm"
 )
 
-var log = logging.MustGetLogger("generate")
+var log = logging.Log
 
 // UpdateGitignore will regenerate the .gitignore adding the outputs of the targets to it. If the gitignore is not the
 // root gitignore, only targets that sit under that part of the repo will be added.

--- a/src/hashes/BUILD
+++ b/src/hashes/BUILD
@@ -3,9 +3,9 @@ go_library(
     srcs = ["rewrite_hashes.go"],
     visibility = ["PUBLIC"],
     deps = [
+        "//src/cli/logging",
         "//src/core",
         "//src/parse/asp",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/hashes/rewrite_hashes.go
+++ b/src/hashes/rewrite_hashes.go
@@ -14,7 +14,7 @@ import (
 	"github.com/thought-machine/please/src/parse/asp"
 )
 
-var log = logging.MustGetLogger("hashes")
+var log = logging.Log
 
 // RewriteHashes rewrites the hashes in a BUILD file.
 func RewriteHashes(state *core.BuildState, labels []core.BuildLabel) {

--- a/src/hashes/rewrite_hashes.go
+++ b/src/hashes/rewrite_hashes.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"strings"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/parse/asp"

--- a/src/help/BUILD
+++ b/src/help/BUILD
@@ -8,12 +8,12 @@ go_library(
     deps = [
         "//rules",
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/parse/asp",
         "//src/plz",
         "//third_party/go:deferred_regex",
         "//third_party/go:go-flags",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/help/rules.go
+++ b/src/help/rules.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/rules"
 	"github.com/thought-machine/please/src/core"

--- a/src/help/rules.go
+++ b/src/help/rules.go
@@ -16,7 +16,7 @@ import (
 	"github.com/thought-machine/please/src/parse/asp"
 )
 
-var log = logging.MustGetLogger("help")
+var log = logging.Log
 
 // PrintRuleArgs prints the arguments of all builtin rules
 func PrintRuleArgs() {

--- a/src/metrics/BUILD
+++ b/src/metrics/BUILD
@@ -3,8 +3,8 @@ go_library(
     srcs = ["prometheus.go"],
     visibility = ["PUBLIC"],
     deps = [
+        "//src/cli/logging",
         "//src/core",
-        "//third_party/go:logging",
         "//third_party/go:prometheus",
         "//third_party/go:prometheus_common",
     ],

--- a/src/metrics/prometheus.go
+++ b/src/metrics/prometheus.go
@@ -9,7 +9,7 @@ import (
 	"github.com/thought-machine/please/src/core"
 )
 
-var log = logging.MustGetLogger("metrics")
+var log = logging.Log
 
 var registerer = prometheus.WrapRegistererWith(prometheus.Labels{
 	"version": core.PleaseVersion,

--- a/src/metrics/prometheus.go
+++ b/src/metrics/prometheus.go
@@ -4,7 +4,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/prometheus/common/expfmt"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 )

--- a/src/output/BUILD
+++ b/src/output/BUILD
@@ -7,13 +7,13 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/process",
         "//src/test",
         "//third_party/go:deferred_regex",
         "//third_party/go:go-flags",
         "//third_party/go:humanize",
-        "//third_party/go:logging",
         "//third_party/go:xcrypto",
     ],
 )

--- a/src/output/trace.go
+++ b/src/output/trace.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 )

--- a/src/output/trace.go
+++ b/src/output/trace.go
@@ -14,7 +14,7 @@ import (
 	"github.com/thought-machine/please/src/core"
 )
 
-var log = logging.MustGetLogger("output")
+var log = logging.Log
 
 // A traceWriter is responsible for writing the JSON trace info.
 type traceWriter struct {

--- a/src/parse/BUILD
+++ b/src/parse/BUILD
@@ -12,11 +12,11 @@ go_library(
         "//rules",
         "//rules/bazel",
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/parse/asp",
         "//src/worker",
-        "//third_party/go:logging",
         "//third_party/go:semver",
     ],
 )

--- a/src/parse/asp/BUILD
+++ b/src/parse/asp/BUILD
@@ -13,9 +13,9 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
-        "//third_party/go:logging",
         "//third_party/go:promptui",
         "//third_party/go:semver2",
     ],

--- a/src/parse/asp/BUILD
+++ b/src/parse/asp/BUILD
@@ -29,6 +29,7 @@ go_test(
         ":asp",
         "//rules",
         "//src/core",
+        "//third_party/go:logging",
         "//third_party/go:testify",
     ],
 )

--- a/src/parse/asp/main/BUILD
+++ b/src/parse/asp/main/BUILD
@@ -4,9 +4,9 @@ go_binary(
     deps = [
         "//rules",
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/parse/asp",
-        "//third_party/go:logging",
         "//third_party/go:spew",
     ],
 )

--- a/src/parse/asp/main/main.go
+++ b/src/parse/asp/main/main.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/rules"
 	"github.com/thought-machine/please/src/cli"

--- a/src/parse/asp/main/main.go
+++ b/src/parse/asp/main/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/thought-machine/please/src/parse/asp"
 )
 
-var log = logging.MustGetLogger("parser")
+var log = logging.Log
 
 var opts = struct {
 	Usage        string

--- a/src/parse/asp/parser.go
+++ b/src/parse/asp/parser.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 )

--- a/src/parse/asp/parser.go
+++ b/src/parse/asp/parser.go
@@ -14,7 +14,7 @@ import (
 	"github.com/thought-machine/please/src/core"
 )
 
-var log = logging.MustGetLogger("asp")
+var log = logging.Log
 
 // A semaphore implements the standard synchronisation mechanism based on a buffered channel.
 type semaphore chan struct{}

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -10,7 +10,7 @@ import (
 	"path"
 	"strings"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -17,7 +17,7 @@ import (
 	"github.com/thought-machine/please/src/fs"
 )
 
-var log = logging.MustGetLogger("parse")
+var log = logging.Log
 
 // Parse parses the package corresponding to a single build label. The label can be :all to add all targets in a package.
 // It is not an error if the package has already been parsed.

--- a/src/please.go
+++ b/src/please.go
@@ -49,7 +49,7 @@ import (
 	"github.com/thought-machine/please/src/worker"
 )
 
-var log = logging.MustGetLogger("plz")
+var log = logging.Log
 
 var config *core.Configuration
 

--- a/src/please.go
+++ b/src/please.go
@@ -17,13 +17,13 @@ import (
 
 	"github.com/thought-machine/go-flags"
 	"go.uber.org/automaxprocs/maxprocs"
-	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/assets"
 	"github.com/thought-machine/please/src/build"
 	"github.com/thought-machine/please/src/cache"
 	"github.com/thought-machine/please/src/clean"
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/debug"
 	"github.com/thought-machine/please/src/exec"

--- a/src/please.go
+++ b/src/please.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/thought-machine/go-flags"
 	"go.uber.org/automaxprocs/maxprocs"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/assets"
 	"github.com/thought-machine/please/src/build"

--- a/src/plz/BUILD
+++ b/src/plz/BUILD
@@ -5,6 +5,7 @@ go_library(
     deps = [
         "//src/build",
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/metrics",
@@ -12,6 +13,5 @@ go_library(
         "//src/remote",
         "//src/test",
         "//third_party/go:cli-init",
-        "//third_party/go:logging",
     ],
 )

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/peterebden/go-cli-init/v5/flags"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/build"
 	"github.com/thought-machine/please/src/cli"

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -19,7 +19,7 @@ import (
 	"github.com/thought-machine/please/src/test"
 )
 
-var log = logging.MustGetLogger("plz")
+var log = logging.Log
 
 // Run runs a build to completion.
 // The given state object controls most of the parameters to it and can be interrogated

--- a/src/plzinit/BUILD
+++ b/src/plzinit/BUILD
@@ -8,13 +8,13 @@ go_library(
     deps = [
         "//src/assets",
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
-        "//src/plz",
         "//src/fs",
+        "//src/plz",
         "//src/scm",
-        "//third_party/go:levenshtein",
-        "//third_party/go:logging",
         "//third_party/go:gcfg",
+        "//third_party/go:levenshtein",
     ],
 )
 

--- a/src/plzinit/init.go
+++ b/src/plzinit/init.go
@@ -42,7 +42,7 @@ github_repo(
 )
 `
 
-var log = logging.MustGetLogger("init")
+var log = logging.Log
 
 // InitConfig initialises a .plzconfig template in the given directory.
 func InitConfig(dir string, bazelCompatibility bool, noPrompt bool) {

--- a/src/plzinit/init.go
+++ b/src/plzinit/init.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/assets"
 	"github.com/thought-machine/please/src/cli"

--- a/src/process/BUILD
+++ b/src/process/BUILD
@@ -7,8 +7,8 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",
+        "//src/cli/logging",
         "//third_party/go:deferred_regex",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/process/process.go
+++ b/src/process/process.go
@@ -17,7 +17,7 @@ import (
 	"github.com/thought-machine/please/src/cli"
 )
 
-var log = logging.MustGetLogger("progress")
+var log = logging.Log
 
 type NamespacingPolicy string
 

--- a/src/process/process.go
+++ b/src/process/process.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"time"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/cli"
 )

--- a/src/query/BUILD
+++ b/src/query/BUILD
@@ -8,12 +8,12 @@ go_library(
     deps = [
         "//src/build",
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/parse",
         "//src/scm",
         "//third_party/go:gcfg",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/query/query_step.go
+++ b/src/query/query_step.go
@@ -23,6 +23,6 @@
 //            that other programs can interpret for their own uses.
 package query
 
-import "gopkg.in/op/go-logging.v1"
+import "github.com/thought-machine/please/src/cli/logging"
 
 var log = logging.MustGetLogger("query")

--- a/src/query/query_step.go
+++ b/src/query/query_step.go
@@ -25,4 +25,4 @@ package query
 
 import "github.com/thought-machine/please/src/cli/logging"
 
-var log = logging.MustGetLogger("query")
+var log = logging.Log

--- a/src/remote/BUILD
+++ b/src/remote/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//src/build",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/metrics",
@@ -16,7 +17,6 @@ go_library(
         "//third_party/go:genproto_rpc",
         "//third_party/go:grpc",
         "//third_party/go:grpc-middleware",
-        "//third_party/go:logging",
         "//third_party/go:protobuf-go",
         "//third_party/go:remote-apis",
         "//third_party/go:remote-apis-sdks",

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -39,7 +39,7 @@ import (
 	"github.com/thought-machine/please/src/metrics"
 )
 
-var log = logging.MustGetLogger("remote")
+var log = logging.Log
 
 // The API version we support.
 var apiVersion = semver.SemVer{Major: 2}

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -24,6 +24,7 @@ import (
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/bazelbuild/remote-apis/build/bazel/semver"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"github.com/thought-machine/please/src/cli/logging"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/genproto/googleapis/longrunning"
 	"google.golang.org/grpc"
@@ -32,7 +33,6 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
-	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"

--- a/src/run/BUILD
+++ b/src/run/BUILD
@@ -4,12 +4,12 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/output",
         "//src/process",
         "//third_party/go:errgroup",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -23,7 +23,7 @@ import (
 	"github.com/thought-machine/please/src/process"
 )
 
-var log = logging.MustGetLogger("run")
+var log = logging.Log
 
 type ProcessOutput string
 

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -13,8 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/sync/errgroup"
 	"github.com/thought-machine/please/src/cli/logging"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"

--- a/src/scm/BUILD
+++ b/src/scm/BUILD
@@ -6,9 +6,9 @@ go_library(
     ),
     visibility = ["PUBLIC"],
     deps = [
+        "//src/cli/logging",
         "//src/fs",
         "//third_party/go:diff",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -10,7 +10,7 @@ import (
 	"github.com/thought-machine/please/src/fs"
 )
 
-var log = logging.MustGetLogger("scm")
+var log = logging.Log
 
 // An SCM represents an SCM implementation that we can ask for various things.
 type SCM interface {

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -5,7 +5,7 @@ package scm
 import (
 	"path"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/fs"
 )

--- a/src/test/BUILD
+++ b/src/test/BUILD
@@ -10,13 +10,13 @@ go_library(
     deps = [
         "//src/build",
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/process",
         "//src/worker",
         "//third_party/go:cover",
         "//third_party/go:deferred_regex",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/build"
 	"github.com/thought-machine/please/src/core"

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -21,7 +21,7 @@ import (
 	"github.com/thought-machine/please/src/worker"
 )
 
-var log = logging.MustGetLogger("test")
+var log = logging.Log
 
 const dummyOutput = "=== RUN DummyTest\n--- PASS: DummyTest (0.00s)\nPASS\n"
 const dummyCoverage = "<?xml version=\"1.0\" ?><coverage></coverage>"

--- a/src/tool/BUILD
+++ b/src/tool/BUILD
@@ -3,10 +3,10 @@ go_library(
     srcs = ["tool.go"],
     visibility = ["PUBLIC"],
     deps = [
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//third_party/go:go-flags",
-        "//third_party/go:logging",
     ],
 )
 

--- a/src/tool/tool.go
+++ b/src/tool/tool.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 
 	"github.com/thought-machine/go-flags"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"

--- a/src/tool/tool.go
+++ b/src/tool/tool.go
@@ -18,7 +18,7 @@ import (
 	"github.com/thought-machine/please/src/fs"
 )
 
-var log = logging.MustGetLogger("tool")
+var log = logging.Log
 
 // A Tool is one of Please's tools; this only exists for facilitating tab-completion for flags.
 type Tool string

--- a/src/update/BUILD
+++ b/src/update/BUILD
@@ -10,12 +10,12 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/process",
         "//third_party/go:go-crypto",
         "//third_party/go:go-retryablehttp",
-        "//third_party/go:logging",
         "//third_party/go:semver",
         "//third_party/go:xz",
     ],
@@ -37,8 +37,8 @@ go_test(
     deps = [
         ":update",
         "//src/cli",
+        "//src/cli/logging",
         "//third_party/go:go-retryablehttp",
-        "//third_party/go:logging",
         "//third_party/go:testify",
     ],
 )

--- a/src/update/BUILD
+++ b/src/update/BUILD
@@ -38,6 +38,7 @@ go_test(
         ":update",
         "//src/cli",
         "//src/cli/logging",
+        "//third_party/go:logging",
         "//third_party/go:go-retryablehttp",
         "//third_party/go:testify",
     ],

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -34,7 +34,7 @@ import (
 	"github.com/thought-machine/please/src/process"
 )
 
-var log = logging.MustGetLogger("update")
+var log = logging.Log
 
 // minSignedVersion is the earliest version of Please that has a signature.
 var minSignedVersion = semver.Version{Major: 9, Minor: 2}

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/ulikunitz/xz"
 	"github.com/thought-machine/please/src/cli/logging"
+	"github.com/ulikunitz/xz"
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -26,7 +26,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/ulikunitz/xz"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"

--- a/src/update/update_test.go
+++ b/src/update/update_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
-	"github.com/thought-machine/please/src/cli/logging"
+	"gopkg.in/op/go-logging.v1"
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"

--- a/src/update/update_test.go
+++ b/src/update/update_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"

--- a/src/watch/BUILD
+++ b/src/watch/BUILD
@@ -4,10 +4,10 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/run",
         "//third_party/go:fsnotify",
-        "//third_party/go:logging",
     ],
 )

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -17,7 +17,7 @@ import (
 	"github.com/thought-machine/please/src/run"
 )
 
-var log = logging.MustGetLogger("watch")
+var log = logging.Log
 
 const debounceInterval = 100 * time.Millisecond
 

--- a/src/worker/BUILD
+++ b/src/worker/BUILD
@@ -6,8 +6,8 @@ go_library(
     ],
     visibility = ["//src/..."],
     deps = [
+        "//src/cli/logging",
         "//src/core",
         "//src/process",
-        "//third_party/go:logging",
     ],
 )

--- a/src/worker/worker.go
+++ b/src/worker/worker.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"gopkg.in/op/go-logging.v1"
+	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/process"

--- a/src/worker/worker.go
+++ b/src/worker/worker.go
@@ -16,7 +16,7 @@ import (
 	"github.com/thought-machine/please/src/process"
 )
 
-var log = logging.MustGetLogger("worker")
+var log = logging.Log
 
 // A workerServer is the structure we use to maintain information about a remote work server.
 type workerServer struct {

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -18,7 +18,10 @@ go_module(
     module = "gopkg.in/op/go-logging.v1",
     version = "v1.0.0-20160211212156-b2cb9fa56473",
     visibility = [
+        "//src/build:build_step_test",
         "//src/cli/...",
+        "//src/parse/asp:asp_test",
+        "//src/update:update_test",
         "//test/...",
         "//tools/...",
     ],

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -17,7 +17,11 @@ go_module(
     licences = ["BSD-3-Clause"],
     module = "gopkg.in/op/go-logging.v1",
     version = "v1.0.0-20160211212156-b2cb9fa56473",
-    visibility = ["PUBLIC"],
+    visibility = [
+        "//src/cli/...",
+        "//test/...",
+        "//tools/...",
+    ],
 )
 
 go_module(


### PR DESCRIPTION
...I think.

When we call `logging.SetBackend` it resets the global backend which is read by loggers constantly to determine if they should log statements.

This attempts to fix by having one singleton logger which we set the backend on. I'd been thinking about this for a while since there is really no benefit to having multiple loggers (we never log the module name and never alter individual logger levels).