### PR TITLE
Don't automatically close stale issues, but still keep the notification

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,12 +1,9 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 90
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
-# Issues with these labels will never be considered stale
-exemptLabels:
-  - not-stale
+daysUntilClose: -1
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
Mark inactive issues as stale, if there was not activity for 90 days, but don't automatically close them. A `stale` label has been added. This prevents issues from being closed which are still relevant.