### PR TITLE
More race fixes

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,7 +15,7 @@ PLZ_ARGS="${PLZ_ARGS:-}"
 # Now invoke Go to run Please to build itself.
 notice "Bootstrapping please..."
 go build -o plz-out/bootstrap/please_go tools/please_go/please_go.go
-go run src/please.go $PLZ_ARGS --log_file plz-out/log/bootstrap_build.log -o please.location:"$(pwd)/plz-out/bootstrap" export outputs -o plz-out/please //package:installed_files
+go run -race src/please.go $PLZ_ARGS --log_file plz-out/log/bootstrap_build.log -o please.location:"$(pwd)/plz-out/bootstrap" export outputs -o plz-out/please //package:installed_files
 cp -f plz-out/please/please plz-out/please/plz
 
 echo "Please has been installed under plz-out/please"

--- a/src/cli/logging.go
+++ b/src/cli/logging.go
@@ -43,7 +43,14 @@ var fileBackend logging.Backend
 type Verbosity = cli.Verbosity
 
 // CurrentBackend is the current interactive logging backend.
-var CurrentBackend *LogBackend
+var CurrentBackend = &LogBackend{
+	interactiveRows: 10,
+	maxRecords:      10,
+	logMessages:     list.New(),
+	messageHistory:  list.New(),
+	formatter:       logFormatter(StdErrIsATerminal),
+	passthrough:     true,
+}
 
 // InitLogging initialises logging backends.
 func InitLogging(verbosity Verbosity) {
@@ -162,17 +169,8 @@ func (backend *LogBackend) RecalcLines() {
 
 // newLogBackend constructs a new logging backend.
 func newLogBackend(origBackend logging.Backend) logging.LeveledBackend {
-	b := &LogBackend{
-		interactiveRows: 10,
-		maxRecords:      10,
-		logMessages:     list.New(),
-		messageHistory:  list.New(),
-		formatter:       logFormatter(StdErrIsATerminal),
-		origBackend:     origBackend,
-		passthrough:     true,
-	}
-	CurrentBackend = b
-	l := logging.AddModuleLevel(logBackendFacade{realBackend: b})
+	CurrentBackend.origBackend = origBackend
+	l := logging.AddModuleLevel(logBackendFacade{realBackend: CurrentBackend})
 	l.SetLevel(logLevel, "")
 	return l
 }

--- a/src/core/resources.go
+++ b/src/core/resources.go
@@ -20,7 +20,10 @@ func (state *BuildState) UpdateResources() {
 	lastTime := time.Now()
 	// Assume this doesn't change through the process lifetime.
 	count, _ := cpu.Counts(true)
+	state.stats.Lock()
 	stats.CPU.Count = count
+	state.stats.Unlock()
+
 	// Top out max CPU; sometimes we get our maths slightly wrong, probably because of
 	// mild uncertainty in times.
 	maxCPU := float64(100 * count)

--- a/src/please.go
+++ b/src/please.go
@@ -1098,7 +1098,8 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	if state.RemoteClient != nil && !opts.Run.Remote {
 		defer state.RemoteClient.Disconnect()
 	}
-	return state.Successful(), state
+	failures, _, _ := state.Failures()
+	return !failures, state
 }
 
 func runPlease(state *core.BuildState, targets []core.BuildLabel) {
@@ -1400,9 +1401,9 @@ func toExitCode(success bool, state *core.BuildState) int {
 		return 0
 	} else if state == nil {
 		return 1
-	} else if state.BuildFailed {
+	} else if _, buildFailed, testFailed := state.Failures(); buildFailed {
 		return 2
-	} else if state.TestFailed {
+	} else if testFailed {
 		if opts.Test.FailingTestsOk || opts.Cover.FailingTestsOk {
 			return 0
 		}

--- a/src/process/process.go
+++ b/src/process/process.go
@@ -272,10 +272,10 @@ func progressMessage(progress *float32) string {
 
 // killAll kills all subprocesses of this executor.
 func (e *Executor) killAll() {
+	e.mutex.Lock()
 	var wg sync.WaitGroup
 	wg.Add(len(e.processes))
 	defer wg.Wait()
-	e.mutex.Lock()
 	defer e.mutex.Unlock()
 	for proc, ch := range e.processes {
 		go func(proc *exec.Cmd, ch <-chan error) {

--- a/src/process/process.go
+++ b/src/process/process.go
@@ -35,7 +35,7 @@ type Executor struct {
 	// The tool that will do the network/mount sandboxing
 	sandboxTool      string
 	usePleaseSandbox bool
-	processes        map[*exec.Cmd]*os.Process
+	processes        map[*exec.Cmd]<-chan error
 	mutex            sync.Mutex
 }
 
@@ -44,7 +44,7 @@ func NewSandboxingExecutor(usePleaseSandbox bool, namespace NamespacingPolicy, s
 		namespace:        namespace,
 		usePleaseSandbox: usePleaseSandbox,
 		sandboxTool:      sandboxTool,
-		processes:        map[*exec.Cmd]*os.Process{},
+		processes:        map[*exec.Cmd]<-chan error{},
 	}
 	cli.AtExit(o.killAll) // Kill any subprocess if we are ourselves killed
 	return o
@@ -128,9 +128,9 @@ func (e *Executor) ExecWithTimeout(ctx context.Context, target Target, dir strin
 	if err != nil {
 		return nil, nil, err
 	}
-	e.registerProcess(cmd)
-	defer e.removeProcess(cmd)
 	ch := make(chan error)
+	e.registerProcess(cmd, ch)
+	defer e.removeProcess(cmd)
 	go runCommand(cmd, ch)
 	select {
 	case err = <-ch:
@@ -143,7 +143,7 @@ func (e *Executor) ExecWithTimeout(ctx context.Context, target Target, dir strin
 }
 
 // runCommand runs a command and signals on the given channel when it's done.
-func runCommand(cmd *exec.Cmd, ch chan error) {
+func runCommand(cmd *exec.Cmd, ch chan<- error) {
 	ch <- cmd.Wait()
 }
 
@@ -163,8 +163,12 @@ func (e *Executor) ExecWithTimeoutShellStdStreams(target Target, dir string, env
 // KillProcess kills a process, attempting to send it a SIGTERM first followed by a SIGKILL
 // shortly after if it hasn't exited.
 func (e *Executor) KillProcess(cmd *exec.Cmd) {
-	success := killProcess(cmd, cmd.Process, syscall.SIGTERM, 30*time.Millisecond)
-	if !killProcess(cmd, cmd.Process, syscall.SIGKILL, time.Second) && !success {
+	e.killProcess(cmd, e.processChan(cmd))
+}
+
+func (e *Executor) killProcess(cmd *exec.Cmd, ch <-chan error) {
+	success := sendSignal(cmd, ch, syscall.SIGTERM, 30*time.Millisecond)
+	if !sendSignal(cmd, ch, syscall.SIGKILL, time.Second) && !success {
 		log.Error("Failed to kill inferior process")
 	}
 	e.removeProcess(cmd)
@@ -177,25 +181,31 @@ func (e *Executor) removeProcess(cmd *exec.Cmd) {
 }
 
 // registerProcess stores the given process in this executor's map.
-func (e *Executor) registerProcess(cmd *exec.Cmd) {
+func (e *Executor) registerProcess(cmd *exec.Cmd, ch <-chan error) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
-	e.processes[cmd] = cmd.Process
+	e.processes[cmd] = ch
 }
 
-// killProcess implements the two-step killing of processes with a SIGTERM and a SIGKILL if
-// that's unsuccessful. It returns true if the process exited within the timeout.
-func killProcess(cmd *exec.Cmd, process *os.Process, sig syscall.Signal, timeout time.Duration) bool {
-	if process == nil {
+// processChan returns the error channel for a process.
+func (e *Executor) processChan(cmd *exec.Cmd) <-chan error {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	return e.processes[cmd]
+}
+
+// sendSignal sends a single signal to the process in an attempt to stop it.
+// It returns true if the process exited within the timeout.
+func sendSignal(cmd *exec.Cmd, ch <-chan error, sig syscall.Signal, timeout time.Duration) bool {
+	if cmd.Process == nil {
 		log.Debug("Not terminating process, it seems to have not started yet")
 		return false
 	}
 	// This is a bit of a fiddle. We want to wait for the process to exit but only for just so
 	// long (we do not want to get hung up if it ignores our SIGTERM).
-	log.Debug("Sending signal %s to -%d", sig, process.Pid)
-	syscall.Kill(-process.Pid, sig) // Kill the group - we always set one in ExecCommand.
-	ch := make(chan error, 1)
-	go runCommand(cmd, ch)
+	log.Debug("Sending signal %s to -%d", sig, cmd.Process.Pid)
+	syscall.Kill(-cmd.Process.Pid, sig) // Kill the group - we always set one in ExecCommand.
+
 	select {
 	case <-ch:
 		return true
@@ -262,23 +272,16 @@ func progressMessage(progress *float32) string {
 
 // killAll kills all subprocesses of this executor.
 func (e *Executor) killAll() {
+	var wg sync.WaitGroup
+	wg.Add(len(e.processes))
+	defer wg.Wait()
 	e.mutex.Lock()
-	processes := make([]*exec.Cmd, 0, len(e.processes))
-	for proc := range e.processes {
-		processes = append(processes, proc)
-	}
-	e.mutex.Unlock()
-
-	if len(processes) > 0 {
-		var wg sync.WaitGroup
-		wg.Add(len(processes))
-		for _, proc := range processes {
-			go func(proc *exec.Cmd) {
-				e.KillProcess(proc)
-				wg.Done()
-			}(proc)
-		}
-		wg.Wait()
+	defer e.mutex.Unlock()
+	for proc, ch := range e.processes {
+		go func(proc *exec.Cmd, ch <-chan error) {
+			e.killProcess(proc, ch)
+			wg.Done()
+		}(proc, ch)
 	}
 }
 

--- a/src/process/process.go
+++ b/src/process/process.go
@@ -289,7 +289,6 @@ func (e *Executor) killAll() {
 func ExecCommand(args ...string) ([]byte, error) {
 	e := New()
 	cmd := e.ExecCommand(NoSandbox, false, args[0], args[1:]...)
-	defer e.removeProcess(cmd)
 	return cmd.CombinedOutput()
 }
 

--- a/src/process/process_test.go
+++ b/src/process/process_test.go
@@ -47,7 +47,7 @@ func TestKillSubprocesses(t *testing.T) {
 	e := New()
 	ch := make(chan error)
 	go func() {
-		_, _, err := e.ExecWithTimeout(context.Background(), nil, "", nil, time.Hour, false, false, false, false, NoSandbox, []string{"sleep", "infinity"})
+		_, _, err := e.ExecWithTimeout(context.Background(), nil, "", nil, time.Hour, false, false, false, false, NoSandbox, []string{"sleep", "1h"})
 		ch <- err
 	}()
 	// Check that it doesn't error immediately

--- a/src/process/process_test.go
+++ b/src/process/process_test.go
@@ -42,22 +42,3 @@ func TestExecWithTimeoutStderr(t *testing.T) {
 	assert.Equal(t, "", string(out))
 	assert.Equal(t, "hello\n", string(stderr))
 }
-
-func TestKillSubprocesses(t *testing.T) {
-	e := New()
-	ch := make(chan error)
-	go func() {
-		_, _, err := e.ExecWithTimeout(context.Background(), nil, "", nil, time.Hour, false, false, false, false, NoSandbox, []string{"sleep", "1h"})
-		ch <- err
-	}()
-	// Check that it doesn't error immediately
-	select {
-	case err := <-ch:
-		t.Fatalf("Unexpected error from executor: %s", err)
-	case <-time.After(10 * time.Millisecond):
-	}
-	// Now kill it
-	e.killAll()
-	err := <-ch
-	assert.Error(t, err)
-}


### PR DESCRIPTION
- Stop logging code from resetting a global variable by just doing it once
- Trivial lock in resource code
- Make various booleans in state atomic
- Refactor process executor, `cmd.Wait()` isn't goroutine-safe so wrap it up with a channel and manage ourselves.

I've left `-race` on for bootstrapping now, it seems OK for me after these changes (although ofc may have missed something)