### PR TITLE
Turn on gci in lint to enforce import orders

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,7 @@ linters:
     - dogsled
     - dupl
     - exportloopref
+    - gci
     - gocritic
     - gofmt
     - misspell
@@ -64,3 +65,8 @@ linters-settings:
       - shadow # Probably not useful enough to clean everything up
       # TODO(peterebden): Should clean up these warnings & enable (although they are pretty finicky)
       - fieldalignment
+  gci:
+    sections:
+      - standard # Captures all standard packages if they do not match another section.
+      - default # Contains all imports that could not be matched to another section type.
+      - prefix(github.com/thought-machine/please)

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/google/shlex"
 	"github.com/hashicorp/go-multierror"
-	"github.com/thought-machine/please/src/cli/logging"
 
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/generate"

--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/thought-machine/please/src/cli/logging"
 
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/plz"
 )

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/core"
 )
 

--- a/src/cache/cmd_cache_test.go
+++ b/src/cache/cmd_cache_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/thought-machine/please/src/core"
 )
 

--- a/src/clean/clean.go
+++ b/src/clean/clean.go
@@ -11,9 +11,8 @@ import (
 	"path"
 	"syscall"
 
-	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/build"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/test"

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/thought-machine/go-flags"
-	"github.com/thought-machine/please/src/cli/logging"
 
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/process"
 )
 

--- a/src/core/command_replacements_test.go
+++ b/src/core/command_replacements_test.go
@@ -4,13 +4,13 @@ package core
 
 import (
 	"encoding/base64"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var wd string

--- a/src/core/config_flags.go
+++ b/src/core/config_flags.go
@@ -1,9 +1,9 @@
 package core
 
 import (
-	"github.com/thought-machine/go-flags"
-
 	"strings"
+
+	"github.com/thought-machine/go-flags"
 )
 
 // AttachAliasFlags attaches the alias flags to the given flag parser.

--- a/src/core/previous_op.go
+++ b/src/core/previous_op.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/pkg/xattr"
+
 	"github.com/thought-machine/please/src/fs"
 )
 

--- a/src/debug/debug.go
+++ b/src/debug/debug.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/exec"
 	"github.com/thought-machine/please/src/process"

--- a/src/exec/exec.go
+++ b/src/exec/exec.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/process"
 )

--- a/src/export/export.go
+++ b/src/export/export.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/gc"

--- a/src/format/fmt.go
+++ b/src/format/fmt.go
@@ -11,9 +11,9 @@ import (
 	"sync/atomic"
 
 	"github.com/bazelbuild/buildtools/build"
-	"github.com/thought-machine/please/src/cli/logging"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/plz"

--- a/src/fs/fs.go
+++ b/src/fs/fs.go
@@ -8,9 +8,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/thought-machine/please/src/process"
-
 	"github.com/thought-machine/please/src/cli/logging"
+	"github.com/thought-machine/please/src/process"
 )
 
 var log = logging.Log

--- a/src/gc/gc.go
+++ b/src/gc/gc.go
@@ -13,9 +13,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/parse/asp"
 	"github.com/thought-machine/please/src/scm"

--- a/src/generate/generate.go
+++ b/src/generate/generate.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/scm"

--- a/src/hashes/rewrite_hashes.go
+++ b/src/hashes/rewrite_hashes.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/parse/asp"
 )

--- a/src/help/rules.go
+++ b/src/help/rules.go
@@ -9,9 +9,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/rules"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/parse/asp"
 )

--- a/src/metrics/prometheus.go
+++ b/src/metrics/prometheus.go
@@ -4,8 +4,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/prometheus/common/expfmt"
-	"github.com/thought-machine/please/src/cli/logging"
 
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 )
 

--- a/src/output/trace.go
+++ b/src/output/trace.go
@@ -10,7 +10,6 @@ import (
 	"os"
 
 	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/core"
 )
 

--- a/src/parse/asp/main/main.go
+++ b/src/parse/asp/main/main.go
@@ -15,10 +15,10 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/rules"
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/parse/asp"
 )

--- a/src/parse/asp/parser.go
+++ b/src/parse/asp/parser.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/core"
 )
 

--- a/src/parse/asp/targets_test.go
+++ b/src/parse/asp/targets_test.go
@@ -1,9 +1,11 @@
 package asp
 
 import (
-	"github.com/stretchr/testify/require"
-	"github.com/thought-machine/please/src/core"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/thought-machine/please/src/core"
 )
 
 func TestValidateTargetNoSandbox(t *testing.T) {

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -10,9 +10,8 @@ import (
 	"path"
 	"strings"
 
-	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 )

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -3,10 +3,12 @@
 package parse
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/thought-machine/please/src/core"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/thought-machine/please/src/core"
 )
 
 func TestAddDepSimple(t *testing.T) {

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 
 	"github.com/peterebden/go-cli-init/v5/flags"
-	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/build"
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/metrics"

--- a/src/plzinit/go.go
+++ b/src/plzinit/go.go
@@ -3,18 +3,18 @@ package plzinit
 import (
 	"bufio"
 	"fmt"
-	"github.com/thought-machine/please/src/core"
 	"os"
 	"path"
 	"strings"
 
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/core"
 )
 
 const goConfig = `
 [go]
 ;gotool = ...
-;goroot - ... 
+;goroot - ...
 `
 
 // golangConfig prompts the user and returns the go config to add to the .plzconfig

--- a/src/plzinit/init.go
+++ b/src/plzinit/init.go
@@ -8,10 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/assets"
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/scm"

--- a/src/plzinit/init_test.go
+++ b/src/plzinit/init_test.go
@@ -1,11 +1,13 @@
 package plzinit
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/thought-machine/please/src/fs"
 	"io/ioutil"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/thought-machine/please/src/fs"
 )
 
 const expectedRule = `

--- a/src/plzinit/plugins.go
+++ b/src/plzinit/plugins.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/please-build/gcfg/ast"
+
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/plz"

--- a/src/process/process.go
+++ b/src/process/process.go
@@ -12,9 +12,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/cli/logging"
 )
 
 var log = logging.Log

--- a/src/query/completions.go
+++ b/src/query/completions.go
@@ -2,13 +2,13 @@ package query
 
 import (
 	"fmt"
-	"github.com/thought-machine/please/src/fs"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/fs"
 )
 
 type CompletionPackages struct {

--- a/src/query/config.go
+++ b/src/query/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/please-build/gcfg"
+
 	"github.com/thought-machine/please/src/core"
 )
 

--- a/src/query/deps.go
+++ b/src/query/deps.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+
 	"github.com/thought-machine/please/src/core"
 )
 

--- a/src/query/print_test.go
+++ b/src/query/print_test.go
@@ -3,15 +3,15 @@ package query
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/stretchr/testify/require"
-	"github.com/thought-machine/please/src/parse"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/parse"
 )
 
 var order = parse.InitParser(core.NewDefaultBuildState()).Parser.BuildRuleArgOrder()

--- a/src/query/roots.go
+++ b/src/query/roots.go
@@ -2,9 +2,10 @@ package query
 
 import (
 	"fmt"
-	"github.com/thought-machine/please/src/core"
 	"sort"
 	"strings"
+
+	"github.com/thought-machine/please/src/core"
 )
 
 // Roots returns build labels with no dependents from the given list.

--- a/src/remote/build_metadata_store.go
+++ b/src/remote/build_metadata_store.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
-	"github.com/thought-machine/please/src/core"
-	"github.com/thought-machine/please/src/fs"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/fs"
 )
 
 const pleaseCacheDirName = "please"

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -24,7 +24,6 @@ import (
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/bazelbuild/remote-apis/build/bazel/semver"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
-	"github.com/thought-machine/please/src/cli/logging"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/genproto/googleapis/longrunning"
 	"google.golang.org/grpc"
@@ -34,6 +33,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/metrics"

--- a/src/remote/remote_test.go
+++ b/src/remote/remote_test.go
@@ -13,10 +13,10 @@ import (
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/thought-machine/please/src/fs"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/fs"
 )
 
 func TestInit(t *testing.T) {

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -13,10 +13,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/thought-machine/please/src/cli/logging"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/output"

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -6,7 +6,6 @@ import (
 	"path"
 
 	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/fs"
 )
 

--- a/src/test/coverage.go
+++ b/src/test/coverage.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/thought-machine/please/src/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/fs"
 )
 
 // Parses test coverage for a single target from its output file.

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -12,9 +12,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/build"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/process"

--- a/src/test/xml_results.go
+++ b/src/test/xml_results.go
@@ -7,14 +7,13 @@ import (
 	"compress/gzip"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
 	"strconv"
 	"time"
-
-	"io"
 
 	"github.com/thought-machine/please/src/core"
 )

--- a/src/tool/tool.go
+++ b/src/tool/tool.go
@@ -12,8 +12,8 @@ import (
 	"syscall"
 
 	"github.com/thought-machine/go-flags"
-	"github.com/thought-machine/please/src/cli/logging"
 
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 )

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/ulikunitz/xz"
 
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/process"

--- a/src/update/verify.go
+++ b/src/update/verify.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
+
 	"github.com/thought-machine/please/src/cli"
 )
 

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/thought-machine/please/src/cli/logging"
 
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/run"

--- a/src/worker/worker.go
+++ b/src/worker/worker.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/thought-machine/please/src/cli/logging"
-
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/process"
 )

--- a/tools/http_cache/cache/cache.go
+++ b/tools/http_cache/cache/cache.go
@@ -2,12 +2,14 @@ package cache
 
 import (
 	"fmt"
-	"github.com/thought-machine/please/src/fs"
-	"gopkg.in/op/go-logging.v1"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/op/go-logging.v1"
+
+	"github.com/thought-machine/please/src/fs"
 )
 
 var log = logging.MustGetLogger("httpcache")

--- a/tools/http_cache/main.go
+++ b/tools/http_cache/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/thought-machine/please/src/cli"
-	"github.com/thought-machine/please/tools/http_cache/cache"
-	"gopkg.in/op/go-logging.v1"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/op/go-logging.v1"
+
+	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/tools/http_cache/cache"
 )
 
 var log = logging.MustGetLogger("httpcache")
@@ -20,8 +22,8 @@ var opts = struct {
 }{
 	Usage: `
 HTTP cache implements a resource based http server that please can use as a cache. The cache supports storing files
-via PUT requests and retrieving them again through GET requests. Really any http server (e.g. nginx) can be used as a 
-cache for please however this is a lightweight and easy to configure option. 
+via PUT requests and retrieving them again through GET requests. Really any http server (e.g. nginx) can be used as a
+cache for please however this is a lightweight and easy to configure option.
 `,
 }
 

--- a/tools/please_go/install/toolchain/toolchain_test.go
+++ b/tools/please_go/install/toolchain/toolchain_test.go
@@ -1,10 +1,11 @@
 package toolchain
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetVersion(t *testing.T) {


### PR DESCRIPTION
Quite a few of these were caused by #2387 but also quite a few were just hanging around.