### PR TITLE
Fix initial capacity of slice

### DIFF
--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -291,7 +291,7 @@ func ruleHash(state *core.BuildState, target *core.BuildTarget, runtime bool) []
 }
 
 func hashMap(writer hash.Hash, eps map[string]string) {
-	keys := make([]string, len(eps))
+	keys := make([]string, 0, len(eps))
 	for ep := range eps {
 		keys = append(keys, ep)
 	}


### PR DESCRIPTION
Found this while mucking around with linters (`makezero` in this case). I'm breaking it out from any other changes because this is a functional change and shouldn't get lost in noise.

It seems clear that this wasn't the intention here. However this change will force incrementality re-calculation for anything with `env` or `entry_points` specified. I think those two are not _that_ common so it makes sense to just make this change, but we _could_ also roll it into v17 if we wanted to be especially careful.