### PR TITLE
Fix output download for plz debug

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -879,7 +879,7 @@ func (state *BuildState) ShouldDownload(target *BuildTarget) bool {
 	downloadOriginalTarget := state.OutputDownload == OriginalOutputDownload && state.IsOriginalTarget(target)
 	downloadTransitiveTarget := state.OutputDownload == TransitiveOutputDownload
 	downloadLinkableTarget := state.Config.Build.DownloadLinkable && target.HasLinks(state)
-	return target.neededForSubinclude.IsSet() || ((downloadOriginalTarget || downloadTransitiveTarget) && !state.NeedTests) || downloadLinkableTarget
+	return target.neededForSubinclude.IsSet() || (downloadOriginalTarget && !state.NeedTests) || downloadTransitiveTarget || downloadLinkableTarget
 }
 
 // ShouldRebuild returns true if we should force a rebuild of this target (i.e. the user

--- a/src/please.go
+++ b/src/please.go
@@ -1070,12 +1070,14 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	state.DebugFailingTests = debugFailingTests
 	state.ShowAllOutput = opts.OutputFlags.ShowAllOutput
 	state.ParsePackageOnly = opts.ParsePackageOnly
-	downloadOriginalOutputs := (!opts.Build.NoDownload && !opts.Run.Remote && len(targets) > 0 && (!targets[0].IsAllSubpackages() || len(opts.BuildFlags.Include) > 0)) || opts.Build.Download
-	if downloadOriginalOutputs {
-		state.OutputDownload = core.OriginalOutputDownload
-	} else if debug {
+
+	// What outputs get downloaded in remote execution.
+	if debug {
 		state.OutputDownload = core.TransitiveOutputDownload
+	} else if (!opts.Build.NoDownload && !opts.Run.Remote && len(targets) > 0 && (!targets[0].IsAllSubpackages() || len(opts.BuildFlags.Include) > 0)) || opts.Build.Download {
+		state.OutputDownload = core.OriginalOutputDownload
 	}
+
 	state.SetIncludeAndExclude(opts.BuildFlags.Include, opts.BuildFlags.Exclude)
 	if opts.BuildFlags.Arch.OS != "" {
 		state.TargetArch = opts.BuildFlags.Arch


### PR DESCRIPTION
I'm almost positive this was working before to some extent but it's not anymore. This guarantees that `plz debug` ensures that transitive targets get download as expected.