### PR TITLE
Sanitise environment variable values when executing remote actions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/OneOfOne/cmap v0.0.0-20170825200327-ccaef7657ab8
 	github.com/ProtonMail/go-crypto v0.0.0-20210920135941-2c5829bbf927
+	github.com/alessio/shellescape v1.4.1
 	github.com/bazelbuild/buildtools v0.0.0-20210920153738-d6daef01a1a2
 	github.com/bazelbuild/remote-apis v0.0.0-20210718193713-0ecef08215cf
 	github.com/bazelbuild/remote-apis-sdks v0.0.0-20210909182119-af1232ee0d79

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/bazelbuild/buildtools v0.0.0-20210920153738-d6daef01a1a2 h1:hWvEw/36XcpZzKZB2LBYhKSGt72ETiIhudjxd637+4w=
 github.com/bazelbuild/buildtools v0.0.0-20210920153738-d6daef01a1a2/go.mod h1:689QdV3hBP7Vo9dJMmzhoYIyo/9iMhEmHkJcnaPRCbo=

--- a/src/remote/BUILD
+++ b/src/remote/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//third_party/go:protobuf-go",
         "//third_party/go:remote-apis",
         "//third_party/go:remote-apis-sdks",
+        "//third_party/go:shellescape",
         "//third_party/go:uuid",
     ],
 )

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alessio/shellescape"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/command"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/digest"
 	"github.com/bazelbuild/remote-apis-sdks/go/pkg/filemetadata"
@@ -97,7 +98,7 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			commandPrefix += fmt.Sprintf("export %s=\"%s\" && ", k, target.Env[k])
+			commandPrefix += fmt.Sprintf("export %s=%s && ", k, shellescape.Quote(target.Env[k]))
 		}
 	}
 

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -1085,3 +1085,11 @@ go_module(
     version = "v0.5.0",
     visibility = ["PUBLIC"],
 )
+
+go_module(
+    name = "shellescape",
+    licences = ["MIT"],
+    module = "github.com/alessio/shellescape",
+    version = "v1.4.1",
+    visibility = ["PUBLIC"],
+)


### PR DESCRIPTION
When executing remote actions to build targets that have a custom environment, Please sets up the environment in the remote shell by executing an `export` command for each environment variable before executing the build command. The environment variable values aren't sanitised, so shell constructs such as `$(...)` will be interpreted (which isn't the case when building locally, since the environment is set up by `os/exec` instead), and any value containing a double-quote
causes the action to fail altogether.

When constructing the `export` commands, sanitise environment variable values using [shellescape](https://github.com/alessio/shellescape). This ensures not only that double-quotes in the value don't cause failures when building the target remotely, but also that the environment when building the target remotely is identical to that when building it locally.

Closes #2407.