### PR TITLE
Stop trying to preload the subrepo's preloads

### DIFF
--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -72,10 +72,6 @@ func (p *aspParser) WaitForInit() {
 
 func (p *aspParser) preloadSubincludes(state *core.BuildState) {
 	includes := state.Config.Parse.PreloadSubincludes
-	if state.RepoConfig != nil {
-		// TODO(jpoole): is this the right thing to do?
-		includes = append(includes, state.RepoConfig.Parse.PreloadSubincludes...)
-	}
 	wg := sync.WaitGroup{}
 	for _, inc := range includes {
 		if inc.IsPseudoTarget() {


### PR DESCRIPTION
This is a data-race that came out on the go plugin PR (nice one @pebers) 

The RepoConfig field is populated when we build the subrepo target but we kick off the Parser preloading before that. This means that this might or might not be populated by the time we hit this code. 

We should probably kick off preloading the subincludes for the subrepo state when we have built its target and loaded its config. 

see: #2413