### PR TITLE
Update linter

### DIFF
--- a/src/update/BUILD
+++ b/src/update/BUILD
@@ -38,8 +38,8 @@ go_test(
         ":update",
         "//src/cli",
         "//src/cli/logging",
-        "//third_party/go:logging",
         "//third_party/go:go-retryablehttp",
+        "//third_party/go:logging",
         "//third_party/go:testify",
     ],
 )

--- a/test/please_shim/BUILD
+++ b/test/please_shim/BUILD
@@ -2,76 +2,76 @@ subinclude("//test/build_defs:build_defs")
 
 please_repo_e2e_test(
     name = "install",
+    expect_output_contains = {
+        # Version installed must match the one in the .plzconfig file.
+        "plz_version.txt": "Please version 16.18.0",
+    },
     plz_command = " && ".join([
         # Install Please since it won't find it. Please location
         # has been set to `./please` relative to the repo root.
         "$TOOLS_PLEASE_SHIM --version > plz_version.txt",
         # Guarantee it was installed in the right place.
-        "[ -e $($TOOLS_PLEASE_SHIM query config please.location) ]"
+        "[ -e $($TOOLS_PLEASE_SHIM query config please.location) ]",
     ]),
-    expect_output_contains = {
-        # Version installed must match the one in the .plzconfig file.
-        "plz_version.txt": "Please version 16.18.0",
-    },
     repo = "test_repo",
     tools = {
-        "please_shim": "//tools/please_shim"
-    }
+        "please_shim": "//tools/please_shim",
+    },
 )
 
 please_repo_e2e_test(
     name = "no_binary_no_completion",
-    plz_command = " && ".join([
-        # Try argument completion for non-existant binary.
-        "GO_FLAGS_COMPLETION=1 $TOOLS_PLEASE_SHIM 2>&1 > completions.txt",
-        # Guarantee that it didn't install Please.
-        "! [ -e please/please ]"
-    ]),
     expected_output = {
         # No completions.
         "completions.txt": "",
     },
+    plz_command = " && ".join([
+        # Try argument completion for non-existant binary.
+        "GO_FLAGS_COMPLETION=1 $TOOLS_PLEASE_SHIM 2>&1 > completions.txt",
+        # Guarantee that it didn't install Please.
+        "! [ -e please/please ]",
+    ]),
     repo = "test_repo",
     tools = {
-        "please_shim": "//tools/please_shim"
-    }
+        "please_shim": "//tools/please_shim",
+    },
 )
 
 please_repo_e2e_test(
     name = "update",
-    plz_command = " && ".join([
-        # Install binary first.
-        "$TOOLS_PLEASE_SHIM --version > install_version.txt",
-        # Update version.
-        "$TOOLS_PLEASE_SHIM --profile=update_version --version > update_version.txt",
-    ]),
     expect_output_contains = {
         # Version installed must match the one in the .plzconfig file.
         "install_version.txt": "Please version 16.18.0",
         # Update version.
         "update_version.txt": "Please version 16.17.0",
     },
+    plz_command = " && ".join([
+        # Install binary first.
+        "$TOOLS_PLEASE_SHIM --version > install_version.txt",
+        # Update version.
+        "$TOOLS_PLEASE_SHIM --profile=update_version --version > update_version.txt",
+    ]),
     repo = "test_repo",
     tools = {
-        "please_shim": "//tools/please_shim"
-    }
+        "please_shim": "//tools/please_shim",
+    },
 )
 
 please_repo_e2e_test(
     name = "completion",
+    expect_output_contains = {
+        "completions.txt": "build",
+        "completions.txt": "test",
+        "completions.txt": "cover",
+    },
     plz_command = " && ".join([
         # Install binary first.
         "$TOOLS_PLEASE_SHIM --version",
         # Trigger completion.
         "GO_FLAGS_COMPLETION=1 $TOOLS_PLEASE_SHIM > completions.txt",
     ]),
-    expect_output_contains = {
-        "completions.txt": "build",
-        "completions.txt": "test",
-        "completions.txt": "cover",
-    },
     repo = "test_repo",
     tools = {
-        "please_shim": "//tools/please_shim"
-    }
+        "please_shim": "//tools/please_shim",
+    },
 )

--- a/test/plugins/BUILD
+++ b/test/plugins/BUILD
@@ -42,7 +42,7 @@ please_repo_e2e_test(
 please_repo_e2e_test(
     name = "init_plugin_test",
     expect_output_contains = {
-        ".plzconfig" : "[Plugin \"python\"]*Target = //plugins:python"
+        ".plzconfig": "[Plugin \"python\"]*Target = //plugins:python",
     },
     # Need to break hard link here so init_plugin_test's actual .plzconfig doesn't get updated.
     plz_command = "cp .plzconfig .foo; mv .foo .plzconfig; plz init plugin python",
@@ -53,7 +53,7 @@ please_repo_e2e_test(
 please_repo_e2e_test(
     name = "init_create_target_test",
     expect_output_contains = {
-        "plugins/BUILD" : "plugin_repo*name = \\\"cc\\\"*plugin = \\\"cc-rules\\\"",
+        "plugins/BUILD": "plugin_repo*name = \\\"cc\\\"*plugin = \\\"cc-rules\\\"",
     },
     # Need to break hard link here so init_plugin_test's actual .plzconfig doesn't get updated.
     plz_command = "cp .plzconfig .foo; mv .foo .plzconfig; plz init plugin cc",

--- a/test/proto_plugin/BUILD
+++ b/test/proto_plugin/BUILD
@@ -2,14 +2,14 @@ subinclude("//test/build_defs:build_defs")
 
 please_repo_e2e_test(
     name = "proto_rules_test",
-    plz_command = "plz -o plugin.go.gotool:$TOOLS_GO test",
-    repo = "test_repo",
-    tools = {
-        "go": [CONFIG.GO_TOOL],
-    },
     # the protoc releases page doesn't support these platforms
     labels = [
         "no_cirrus",
         "no-musl",
     ],
+    plz_command = "plz -o plugin.go.gotool:$TOOLS_GO test",
+    repo = "test_repo",
+    tools = {
+        "go": [CONFIG.GO_TOOL],
+    },
 )

--- a/test/revdeps/hidden_test/BUILD
+++ b/test/revdeps/hidden_test/BUILD
@@ -1,7 +1,7 @@
 subinclude("//test/build_defs")
 
 # creates a filegroup with two hidden intermediate rules
-def two_intermediate(name:str, deps:list):
+def two_intermediate(name, deps):
     one = filegroup(
         name = name,
         tag = "one",

--- a/test/revdeps/require_provide/BUILD
+++ b/test/revdeps/require_provide/BUILD
@@ -1,13 +1,13 @@
 subinclude("//test/build_defs")
 
-def provider(name, deps=[]):
+def provider(name, deps = []):
     # This is the rule that actually gets depended on after resolving the require/provide setup
     go = build_rule(
         name = name,
-        tag = "go",
         outs = [name],
         cmd = "touch $OUT",
         requires = ["go"],
+        tag = "go",
         deps = deps,
     )
 
@@ -16,7 +16,7 @@ def provider(name, deps=[]):
         provides = {
             "go": go,
         },
-        deps=[go],
+        deps = [go],
     )
 
 provider(

--- a/test/revdeps/require_provide/BUILD
+++ b/test/revdeps/require_provide/BUILD
@@ -1,6 +1,6 @@
 subinclude("//test/build_defs")
 
-def provider(name:str, deps:list=[]):
+def provider(name, deps=[]):
     # This is the rule that actually gets depended on after resolving the require/provide setup
     go = build_rule(
         name = name,

--- a/third_party/binary/BUILD
+++ b/third_party/binary/BUILD
@@ -1,4 +1,4 @@
-GO_CI_LINT_VERSION = "1.38.0"
+GO_CI_LINT_VERSION = "1.45.2"
 
 remote_file(
     name = "golangci-lint",
@@ -6,10 +6,11 @@ remote_file(
     exported_files = ["golangci-lint-%s-${OS}-${ARCH}/golangci-lint" % GO_CI_LINT_VERSION],
     extract = True,
     hashes = [
-        "sha256: 9748c2697a65d2962106e74db6db6e3acc9066ec5ff0b81f47d803479e7b4994",  # darwin_arm64
-        "sha256: a9b5eb572ce55ae900a3935640fa5e199729e784a6f058e8077a9a2126e00857",  # darwin_amd64
-        "sha256: 97be8342ac9870bee003904bd8de25c0f3169c6b6238a013d6d6862efa5af992",  # linux_amd64
-        "sha256: a05d18756522b2803ab53d49f5da074c298b69546691338809dbd16c7a4840fd",  # freebsd_amd64
+        "995e509e895ca6a64ffc7395ac884d5961bdec98423cb896b17f345a9b4a19cf",  # darwin-amd64
+        "c2b9669decc1b638cf2ee9060571af4e255f6dfcbb225c293e3a7ee4bb2c7217",  # darwin-arm64
+        "726cb045559b7518bafdd3459de70a0647c087eb1b4634627a4b2e95b1258580",  # freebsd-amd64
+        "595ad6c6dade4c064351bc309f411703e457f8ffbb7a1806b3d8ee713333427f",  # linux-amd64
+        "1463049b744871168095e3e8f687247d6040eeb895955b869889ea151e0603ab",  # linux-arm64
     ],
     url = "https://github.com/golangci/golangci-lint/releases/download/v%s/golangci-lint-%s-%s-%s.tar.gz" % (
         GO_CI_LINT_VERSION,

--- a/third_party/cc/BUILD
+++ b/third_party/cc/BUILD
@@ -1,7 +1,7 @@
 github_repo(
     name = "gtest",
+    build_file = "gtest.build",
     repo = "google/googletest",
     revision = "release-1.11.0",
     strip_build = True,
-    build_file = "gtest.build",
 )

--- a/tools/please_go/test/BUILD
+++ b/tools/please_go/test/BUILD
@@ -7,10 +7,10 @@ go_library(
         "gotest.go",
         "write_test_main.go",
     ],
+    visibility = ["//tools/please_go/..."],
     deps = [
         "//tools/please_go/install/toolchain",
     ],
-    visibility = ["//tools/please_go/..."],
 )
 
 go_test(

--- a/tools/please_shim/BUILD
+++ b/tools/please_shim/BUILD
@@ -6,6 +6,10 @@ go_binary(
         # an empty please version config.
         "github.com/thought-machine/please/src/core.PleaseVersion": "0.0.1",
     },
+    visibility = [
+        "//package:all",
+        "//test/please_shim/...",
+    ],
     deps = [
         "//src/cli",
         "//src/core",
@@ -14,5 +18,4 @@ go_binary(
         "//third_party/go:go-flags",
         "//third_party/go:logging",
     ],
-    visibility = ["//test/please_shim/...", "//package:all"]
 )


### PR DESCRIPTION
Puts golangci-lint on latest (1.45.2). Also autoformats all BUILD files so `plz lint` completes cleanly.