### PR TITLE
Tweaking metric bucket sizes

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -46,14 +46,14 @@ var successfulRemoteTargetBuildDuration = metrics.NewHistogram(
 	"remote",
 	"target_build_duration",
 	"Time taken to successfully build a target, in milliseconds",
-	metrics.ExponentialBuckets(10, 2, 16), // 16 buckets, starting at 10ms and doubling in width.
+	metrics.ExponentialBuckets(0.5, 2, 16), // 16 buckets, starting at 0.5ms and doubling in width.
 )
 
 var successfulLocalTargetBuildDuration = metrics.NewHistogram(
 	"local",
 	"target_build_duration",
 	"Time taken to successfully build a target, in milliseconds",
-	metrics.ExponentialBuckets(10, 2, 16), // 16 buckets, starting at 10ms and doubling in width.
+	metrics.ExponentialBuckets(0.5, 2, 16), // 16 buckets, starting at 0.5ms and doubling in width.
 )
 
 // Build implements the core logic for building a single target.

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -48,7 +48,7 @@ var remoteCacheReadDuration = metrics.NewHistogram(
 	"remote",
 	"cache_read_duration",
 	"Time taken to read the remote cache, in milliseconds",
-	metrics.ExponentialBuckets(1, 2, 10), // 10 buckets, starting at 1ms and doubling in width.
+	metrics.ExponentialBuckets(0.1, 2, 12), // 12 buckets, starting at 0.1ms and doubling in width.
 )
 
 // A Client is the interface to the remote API.


### PR DESCRIPTION
For more granularity in the cache read times & overall target build times metrics.