### PR TITLE
Stay on Git branch when using `--since` with `query changes`

### DIFF
--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -320,7 +320,7 @@ func initStampEnv() {
 	var revision, commitDate, describe string
 	wg.Add(2)
 	go func() {
-		revision = repoScm.CurrentRevIdentifier()
+		revision = repoScm.CurrentRevIdentifier(true)
 		describe = repoScm.DescribeIdentifier(revision)
 		wg.Done()
 	}()

--- a/src/please.go
+++ b/src/please.go
@@ -856,7 +856,7 @@ var buildFunctions = map[string]func() int{
 		} else if opts.Query.Changes.Inexact {
 			return runInexact(scm.ChangedFiles(opts.Query.Changes.Since, true, ""))
 		}
-		original := scm.CurrentRevIdentifier()
+		original := scm.CurrentRevIdentifier(false)
 		files := scm.ChangedFiles(opts.Query.Changes.Since, true, "")
 		log.Debugf("Number of changed files: %d", len(files))
 		if err := scm.Checkout(opts.Query.Changes.Since); err != nil {

--- a/src/scm/git.go
+++ b/src/scm/git.go
@@ -43,7 +43,19 @@ func (g *git) DescribeIdentifier(revision string) string {
 }
 
 // CurrentRevIdentifier returns the string that specifies what the current revision is.
-func (g *git) CurrentRevIdentifier() string {
+//
+// If "permanent" is true, CurrentRevIdentifier returns the current revision's commit hash; this
+// should be used to uniquely and permanently identify the revision. If "permanent" is false,
+// CurrentRevIdentifier returns the name of a branch if the revision is the HEAD of that branch,
+// and the current revision's commit hash otherwise; this will not permanently identify the current
+// revision, as the HEAD of the branch may change in future.
+func (g *git) CurrentRevIdentifier(permanent bool) string {
+	if !permanent {
+		out, err := exec.Command("git", "symbolic-ref", "-q", "--short", "HEAD").CombinedOutput()
+		if err == nil {
+			return strings.TrimSpace(string(out))
+		}
+	}
 	out, err := exec.Command("git", "rev-parse", "HEAD").CombinedOutput()
 	if err != nil {
 		log.Fatalf("Failed to read HEAD: %s\nOutput:\n%s", err, string(out))

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -15,8 +15,10 @@ var log = logging.Log
 type SCM interface {
 	// DescribeIdentifier returns the string that is a "human-readable" identifier of the given revision.
 	DescribeIdentifier(revision string) string
-	// CurrentRevIdentifier returns the string that specifies what the current revision is.
-	CurrentRevIdentifier() string
+	// CurrentRevIdentifier returns a string that specifies what the current revision is. If
+	// "permanent" is true, this string will permanently identify the revision; otherwise, the string
+	// may only be a transient identifier.
+	CurrentRevIdentifier(permanent bool) string
 	// ChangesIn returns a list of modified files in the given diffSpec.
 	ChangesIn(diffSpec string, relativeTo string) []string
 	// ChangedFiles returns a list of modified files since the given commit, optionally including untracked files.

--- a/src/scm/stub.go
+++ b/src/scm/stub.go
@@ -12,7 +12,7 @@ func (s *stub) DescribeIdentifier(sha string) string {
 	return "<unknown>"
 }
 
-func (s *stub) CurrentRevIdentifier() string {
+func (s *stub) CurrentRevIdentifier(permanent bool) string {
 	return "<unknown>"
 }
 


### PR DESCRIPTION
When used on a Git repository, `plz query changes --since <S>` gets the commit hash of the current HEAD `C`, checks out the revision `S`, then checks out `C`. If the repository was on a branch before the command was run, Please restores the working tree to `C` rather than the branch for which `C` is the HEAD, leaving the repository in detached HEAD state.

Before checking out `S`, run `git symbolic-ref -q --short HEAD` to determine the name of the current branch (if any), falling back to `git rev-parse HEAD` if this fails (which indicates that the working tree is not on a branch), and use this as the value of `C`. This ensures the repository is always restored to the state it was in before `plz query changes` was executed.

Closes #2423.