### PR TITLE
Fix plugin_repo erroring out on top level BUILD

### DIFF
--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -91,7 +91,7 @@ func checkSubrepo(tid int, state *core.BuildState, label, dependent core.BuildLa
 	sl := label.SubrepoLabel(state, dependent.Subrepo)
 
 	// Local subincludes are when we subinclude from a subrepo defined in the current package
-	localSubinclude := sl.PackageName == dependent.PackageName && forSubinclude
+	localSubinclude := label.Subrepo == dependent.Subrepo && label.PackageName == dependent.PackageName && forSubinclude
 
 	// If we're including from the same package, we don't want to parse the subrepo package
 	if !localSubinclude {


### PR DESCRIPTION
This fixes https://github.com/thought-machine/please-issues/issues/67.

What was happening was that:
  `label == BuildLabel{PackageName:"build_defs", Name: "cc", Subrepo:"cc"}`
  `dependent == BuildLabel{PackageName:"", Name: ":all", Subrepo:""}`

and once `sl := label.SubrepoLabel(state, dependent.Subrepo)` is called:
  `sl == BuildLabel{PackageName:"", Name: "cc", Subrepo:""}`

therefore `localSubinclude := sl.PackageName == dependent.PackageName && forSubinclude` would always be true for the `preloadsubincludes = ///cc//build_defs:cc` on `.plzconfig`.

My understanding of the `localSubinclude` logic is that it should be true if the subrepo and package are the same between `label` and `dependent`.