### PR TITLE
Fix deadlock when applying architectures

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1082,7 +1082,7 @@ func (state *BuildState) ForArch(arch cli.Arch) *BuildState {
 	s.Arch = arch
 
 	s.Parser.NewParser(s)
-	s.Parser.Init(s)
+	go s.Parser.Init(s)
 	state.progress.allStates = append(state.progress.allStates, s)
 
 	return s


### PR DESCRIPTION
This would hold open the progress lock while we preload the subincludes. This needs to happen in the background. 