### PR TITLE
Document meaning of PUBLIC in visibility specifications

### DIFF
--- a/docs/basics.html
+++ b/docs/basics.html
@@ -360,6 +360,8 @@
   <p>
     Build targets can't use these as dependencies; these are primarily for using
     on the command line or in the visibility specification for a target.
+    The special pseudo-label <code class="code">PUBLIC</code> is equivalent to
+    <code class="code">//...</code> in visibility specifications.
   </p>
 </section>
 


### PR DESCRIPTION
Prior, PUBLIC was only documented in the Go and Python tutorials.
But I don’t use Go nor Python, so never encountered its explanation.