### PR TITLE
Only log errors for the Please shim

### DIFF
--- a/tools/please_shim/main.go
+++ b/tools/please_shim/main.go
@@ -28,7 +28,7 @@ var opts struct {
 	} `group:"Options controlling what to build & how to build it"`
 
 	OutputFlags struct {
-		Verbosity cli.Verbosity `short:"v" long:"verbosity" description:"Verbosity of output (error, warning, notice, info, debug)" default:"error"`
+		ShimDebugVerbosity bool `long:"shim_debug_verbosity" description:"Shim debug verbosity of output"`
 	} `group:"Options controlling output & logging"`
 
 	FeatureFlags struct {
@@ -69,6 +69,27 @@ func parseFlags() (*flags.Parser, error) {
 	}
 
 	return parser, nil
+}
+
+func setLogging() {
+	verbosity := cli.MinVerbosity
+	if opts.OutputFlags.ShimDebugVerbosity {
+		verbosity = cli.MaxVerbosity
+		os.Args = filterArgsFlag(os.Args, "--shim_debug_verbosity")
+	}
+
+	cli.InitLogging(verbosity)
+
+}
+
+func filterArgsFlag(args []string, flag string) []string {
+	var filteredArgs []string
+	for _, arg := range os.Args {
+		if arg != flag {
+			filteredArgs = append(filteredArgs, arg)
+		}
+	}
+	return filteredArgs
 }
 
 // Tries to find the repo root and read the respective config files.
@@ -178,7 +199,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	cli.InitLogging(opts.OutputFlags.Verbosity)
+	setLogging()
 
 	// Finds and sets the root, and reads the respective config files without going through the same
 	// code path as in the main binary that further applies defaults and other resolving. This is required

--- a/tools/please_shim/main.go
+++ b/tools/please_shim/main.go
@@ -27,10 +27,6 @@ var opts struct {
 		Profile  []core.ConfigProfile `long:"profile" env:"PLZ_CONFIG_PROFILE" env-delim:";" description:"Configuration profile to load; e.g. --profile=dev will load .plzconfig.dev if it exists."`
 	} `group:"Options controlling what to build & how to build it"`
 
-	OutputFlags struct {
-		Verbosity cli.Verbosity `short:"v" long:"verbosity" description:"Verbosity of output (error, warning, notice, info, debug)" default:"warning"`
-	} `group:"Options controlling output & logging"`
-
 	FeatureFlags struct {
 		NoUpdate bool `long:"noupdate" description:"Disable Please attempting to auto-update itself."`
 	} `group:"Options that enable / disable certain features"`
@@ -178,7 +174,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	cli.InitLogging(opts.OutputFlags.Verbosity)
+	cli.InitLogging(cli.MinVerbosity)
 
 	// Finds and sets the root, and reads the respective config files without going through the same
 	// code path as in the main binary that further applies defaults and other resolving. This is required

--- a/tools/please_shim/main.go
+++ b/tools/please_shim/main.go
@@ -79,7 +79,6 @@ func setLogging() {
 	}
 
 	cli.InitLogging(verbosity)
-
 }
 
 func filterArgsFlag(args []string, flag string) []string {

--- a/tools/please_shim/main.go
+++ b/tools/please_shim/main.go
@@ -27,6 +27,10 @@ var opts struct {
 		Profile  []core.ConfigProfile `long:"profile" env:"PLZ_CONFIG_PROFILE" env-delim:";" description:"Configuration profile to load; e.g. --profile=dev will load .plzconfig.dev if it exists."`
 	} `group:"Options controlling what to build & how to build it"`
 
+	OutputFlags struct {
+		Verbosity cli.Verbosity `short:"v" long:"verbosity" description:"Verbosity of output (error, warning, notice, info, debug)" default:"error"`
+	} `group:"Options controlling output & logging"`
+
 	FeatureFlags struct {
 		NoUpdate bool `long:"noupdate" description:"Disable Please attempting to auto-update itself."`
 	} `group:"Options that enable / disable certain features"`
@@ -104,6 +108,7 @@ func resolvePleaseLocation(config *core.Configuration) {
 	if config.Please.Location == "" {
 		config.Please.Location = core.DefaultPleaseLocation
 	}
+
 	config.Please.Location = fs.ExpandHomePath(config.Please.Location)
 
 	if !filepath.IsAbs(config.Please.Location) {
@@ -174,7 +179,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	cli.InitLogging(cli.MinVerbosity)
+	cli.InitLogging(opts.OutputFlags.Verbosity)
 
 	// Finds and sets the root, and reads the respective config files without going through the same
 	// code path as in the main binary that further applies defaults and other resolving. This is required

--- a/tools/please_shim/main.go
+++ b/tools/please_shim/main.go
@@ -108,7 +108,6 @@ func resolvePleaseLocation(config *core.Configuration) {
 	if config.Please.Location == "" {
 		config.Please.Location = core.DefaultPleaseLocation
 	}
-
 	config.Please.Location = fs.ExpandHomePath(config.Please.Location)
 
 	if !filepath.IsAbs(config.Please.Location) {


### PR DESCRIPTION
This will prevent warnings for unknown fields (as seen below) if the Please shim version differs from the Please binary installed.

```
17:14:13.022 WARNING: Error in config file: warning:
can't store data at section "featureflags", variable "ExcludeShellRules"
```