### PR TITLE
Bring plz exec process to the foreground

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -519,7 +519,7 @@ var buildFunctions = map[string]func() int{
 
 		shouldSandbox := state.Graph.TargetOrDie(opts.Exec.Args.Target.BuildLabel).Sandbox
 		dir := filepath.Join(core.OutDir, "exec", opts.Exec.Args.Target.Subrepo, opts.Exec.Args.Target.PackageName)
-		if code := exec.Exec(state, opts.Exec.Args.Target, dir, nil, opts.Exec.Args.OverrideCommandArgs, false, process.NewSandboxConfig(shouldSandbox && !opts.Exec.Share.Network, shouldSandbox && !opts.Exec.Share.Mount)); code != 0 {
+		if code := exec.Exec(state, opts.Exec.Args.Target, dir, nil, opts.Exec.Args.OverrideCommandArgs, true, process.NewSandboxConfig(shouldSandbox && !opts.Exec.Share.Network, shouldSandbox && !opts.Exec.Share.Mount)); code != 0 {
 			return code
 		}
 


### PR DESCRIPTION
This brings the process group created by `plz exec` to the foreground by default, making it behave like `plz run`. This should be fine as far as Please is concern, since it is already listening to when the spawn process terminates.