### PR TITLE
Add an initial config for build/test using Github Actions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -9,7 +9,7 @@ jobs:
       image: thoughtmachine/please_alpine:20220422
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -32,7 +32,7 @@ jobs:
       image: thoughtmachine/please_ubuntu:20220426
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -60,7 +60,7 @@ jobs:
       image: thoughtmachine/please_ubuntu_alt:20220422
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -80,7 +80,7 @@ jobs:
     needs: [ubuntu, ubuntu_alt, alpine]  # Doesn't really need them but no point doing the expensive macos run if the linux ones fail
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -10,12 +10,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Cache
+      - name: Cache third_party
         uses: actions/cache@v3
         with:
           path: plz-out/gen/third_party/go
           key: go-alpine-${{ hashFiles('third_party/go/BUILD', 'tools/images/alpine/Dockerfile') }}
           restore-keys: go-alpine-
+      - name: Cache go.mod
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-alpine-${{ hashFiles('go.mod') }}
+          restore-keys: go-mod-alpine-
       - name: Mark Git directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Bootstrap & Build
@@ -35,12 +41,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Cache
+      - name: Cache third_party
         uses: actions/cache@v3
         with:
           path: plz-out/gen/third_party/go
           key: go-ubuntu-${{ hashFiles('third_party/go/BUILD', 'tools/images/ubuntu/Dockerfile') }}
           restore-keys: go-ubuntu-
+      - name: Cache go.mod
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-ubuntu-${{ hashFiles('go.mod') }}
+          restore-keys: go-mod-ubuntu-
       - name: Bootstrap & Build
         run: ./bootstrap.sh
       - name: No plugins
@@ -63,12 +75,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Cache
+      - name: Cache third_party
         uses: actions/cache@v3
         with:
           path: plz-out/gen/third_party/go
           key: go-ubuntu-alt-${{ hashFiles('third_party/go/BUILD', 'tools/images/ubuntu_alt/Dockerfile') }}
           restore-keys: go-ubuntu-alt-
+      - name: Cache go.mod
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-ubuntu-alt-${{ hashFiles('go.mod') }}
+          restore-keys: go-mod-ubuntu-alt-
       - name: Bootstrap & Build
         run: ./bootstrap.sh
       - name: Archive logs
@@ -83,12 +101,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Cache
+      - name: Cache third_party
         uses: actions/cache@v3
         with:
           path: plz-out/gen/third_party/go
           key: go-darwin-${{ hashFiles('third_party/go/BUILD') }}
           restore-keys: go-darwin-
+      - name: Cache go.mod
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-darwin-${{ hashFiles('go.mod') }}
+          restore-keys: go-mod-darwin-
       - name: Bootstrap & Build
         run: ./bootstrap.sh
       - name: Package

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,133 @@
+name: Build & Test
+on: [push, pull_request]
+env:
+  PLZ_ARGS: "-p --profile ci"
+jobs:
+  alpine:
+    runs-on: ubuntu-latest
+    container:
+      image: thoughtmachine/please_alpine:20220422
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: plz-out/gen/third_party/go
+          key: ${{ runner.os }}-go-alpine-${{ hashFiles('third_party/go/BUILD', 'tools/images/alpine/Dockerfile') }}
+          restore-keys: ${{ runner.os }}-go-alpine-
+      - name: Bootstrap & Build
+        run: ./bootstrap.sh --test_results_file plz-out/results/please/test_results.xml
+        env:
+          PLZ_ARGS: "-p --profile ci --profile alpine --exclude no-musl"
+      - name: Archive logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: plz-out/log
+  ubuntu:
+    runs-on: ubuntu-latest
+    container:
+      image: thoughtmachine/please_ubuntu:20220426
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: plz-out/gen/third_party/go
+          key: ${{ runner.os }}-go-ubuntu-${{ hashFiles('third_party/go/BUILD', 'tools/images/ubuntu/Dockerfile') }}
+          restore-keys: ${{ runner.os }}-go-ubuntu-
+      - name: Bootstrap & Build
+        run: ./bootstrap.sh
+      - name: No plugins
+        run: plz-out/bin/src/please build //package:installed_files && ./test.sh --profile noplugins --test_results_file plz-out/results/please/no_plugin.xml
+      - name: Package
+        run: plz-out/bin/src/please build //package:signer //tools/misc:gen_release //docs:tarball //docs:deep-tarball //tools/performance:all -p
+      - name: FreeBSD cross-compile
+        run: plz-out/bin/src/please build --arch freebsd_amd64 //package:release_files
+      # TODO(peterebden): Persist artifacts to be retrieved later for release
+      - name: Archive logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: plz-out/log
+  ubuntu_alt:
+    runs-on: ubuntu-latest
+    container:
+      image: thoughtmachine/please_ubuntu_alt:20220422
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: plz-out/gen/third_party/go
+          key: ${{ runner.os }}-go-ubuntu-alt-${{ hashFiles('third_party/go/BUILD', 'tools/images/ubuntu_alt/Dockerfile') }}
+          restore-keys: ${{ runner.os }}-go-ubuntu-alt-
+      - name: Bootstrap & Build
+        run: ./bootstrap.sh
+      - name: Archive logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: plz-out/log
+  darwin:
+    runs-on: macos-latest
+    needs: [ubuntu, ubuntu_alt, alpine]  # Doesn't really need them but no point doing the expensive macos run if the linux ones fail
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: plz-out/gen/third_party/go
+          key: ${{ runner.os }}-go-darwin-${{ hashFiles('third_party/go/BUILD') }}
+          restore-keys: ${{ runner.os }}-go-darwin-
+      - name: Bootstrap & Build
+        run: ./bootstrap.sh
+      - name: Package
+        run: plz-out/bin/src/please build //package:release_files
+      - name: Cross-compile arm64
+        run: plz-out/bin/src/please build  --arch darwin_arm64 -o go.cgoenabled:1 -o go.cgocctool:clang -o "go.cflags:-target arm64-apple-macos11" //package:release_files
+      - name: Archive logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: plz-out/log
+  test_rex:
+    runs-on: ubuntu-latest
+    needs: [ubuntu]
+    container:
+      image: thoughtmachine/please_ubuntu:20220426
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Test Remote Execution
+        run: ./circleci/rex_test.sh
+      - name: Archive logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: plz-out/log
+  test_http_cache:
+    runs-on: ubuntu-latest
+    needs: [ubuntu]
+    container:
+      image: thoughtmachine/please_ubuntu:20220426
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Test Remote Execution
+        run: ./circleci/http_cache_test.sh
+      - name: Archive logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: plz-out/log

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,6 +16,8 @@ jobs:
           path: plz-out/gen/third_party/go
           key: go-alpine-${{ hashFiles('third_party/go/BUILD', 'tools/images/alpine/Dockerfile') }}
           restore-keys: go-alpine-
+      - name: Mark Git directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Bootstrap & Build
         run: ./bootstrap.sh --test_results_file plz-out/results/please/test_results.xml
         env:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -14,8 +14,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: plz-out/gen/third_party/go
-          key: ${{ runner.os }}-go-alpine-${{ hashFiles('third_party/go/BUILD', 'tools/images/alpine/Dockerfile') }}
-          restore-keys: ${{ runner.os }}-go-alpine-
+          key: go-alpine-${{ hashFiles('third_party/go/BUILD', 'tools/images/alpine/Dockerfile') }}
+          restore-keys: go-alpine-
       - name: Bootstrap & Build
         run: ./bootstrap.sh --test_results_file plz-out/results/please/test_results.xml
         env:
@@ -37,8 +37,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: plz-out/gen/third_party/go
-          key: ${{ runner.os }}-go-ubuntu-${{ hashFiles('third_party/go/BUILD', 'tools/images/ubuntu/Dockerfile') }}
-          restore-keys: ${{ runner.os }}-go-ubuntu-
+          key: go-ubuntu-${{ hashFiles('third_party/go/BUILD', 'tools/images/ubuntu/Dockerfile') }}
+          restore-keys: go-ubuntu-
       - name: Bootstrap & Build
         run: ./bootstrap.sh
       - name: No plugins
@@ -65,8 +65,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: plz-out/gen/third_party/go
-          key: ${{ runner.os }}-go-ubuntu-alt-${{ hashFiles('third_party/go/BUILD', 'tools/images/ubuntu_alt/Dockerfile') }}
-          restore-keys: ${{ runner.os }}-go-ubuntu-alt-
+          key: go-ubuntu-alt-${{ hashFiles('third_party/go/BUILD', 'tools/images/ubuntu_alt/Dockerfile') }}
+          restore-keys: go-ubuntu-alt-
       - name: Bootstrap & Build
         run: ./bootstrap.sh
       - name: Archive logs
@@ -85,46 +85,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: plz-out/gen/third_party/go
-          key: ${{ runner.os }}-go-darwin-${{ hashFiles('third_party/go/BUILD') }}
-          restore-keys: ${{ runner.os }}-go-darwin-
+          key: go-darwin-${{ hashFiles('third_party/go/BUILD') }}
+          restore-keys: go-darwin-
       - name: Bootstrap & Build
         run: ./bootstrap.sh
       - name: Package
         run: plz-out/bin/src/please build //package:release_files
       - name: Cross-compile arm64
         run: plz-out/bin/src/please build  --arch darwin_arm64 -o go.cgoenabled:1 -o go.cgocctool:clang -o "go.cflags:-target arm64-apple-macos11" //package:release_files
-      - name: Archive logs
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: logs
-          path: plz-out/log
-  test_rex:
-    runs-on: ubuntu-latest
-    needs: [ubuntu]
-    container:
-      image: thoughtmachine/please_ubuntu:20220426
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Test Remote Execution
-        run: ./circleci/rex_test.sh
-      - name: Archive logs
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: logs
-          path: plz-out/log
-  test_http_cache:
-    runs-on: ubuntu-latest
-    needs: [ubuntu]
-    container:
-      image: thoughtmachine/please_ubuntu:20220426
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Test Remote Execution
-        run: ./circleci/http_cache_test.sh
       - name: Archive logs
         if: always()
         uses: actions/upload-artifact@v3

--- a/src/parse/asp/exec.go
+++ b/src/parse/asp/exec.go
@@ -12,9 +12,7 @@ import (
 )
 
 type execKey struct {
-	args       string
-	wantStdout bool
-	wantStderr bool
+	args string
 }
 
 type execPromise struct {
@@ -55,11 +53,7 @@ func init() {
 // want to cache the failure).
 //
 // NOTE: Commands that rely on the current working directory must not be cached.
-func doExec(s *scope, cmdIn pyObject, wantStdout bool, wantStderr bool, cacheOutput bool, storeNegative bool) (pyObj pyObject, success bool, err error) {
-	if !wantStdout && !wantStderr {
-		return s.Error("exec() must have at least stdout or stderr set to true, both can not be false"), false, nil
-	}
-
+func doExec(s *scope, cmdIn pyObject, cacheOutput bool, storeNegative bool) (pyObj pyObject, success bool, err error) {
 	var argv []string
 	if isType(cmdIn, "str") {
 		argv = strings.Fields(string(cmdIn.(pyString)))
@@ -72,7 +66,7 @@ func doExec(s *scope, cmdIn pyObject, wantStdout bool, wantStderr bool, cacheOut
 	}
 
 	// The cache key is tightly coupled to the operating parameters
-	key := execMakeKey(argv, wantStdout, wantStderr)
+	key := execMakeKey(argv)
 	if cacheOutput {
 		out, found := execGetCachedOutput(key, argv)
 		if found {
@@ -89,28 +83,15 @@ func doExec(s *scope, cmdIn pyObject, wantStdout bool, wantStderr bool, cacheOut
 	}
 	cmdArgs := argv[1:]
 
-	var out []byte
 	cmd := exec.CommandContext(ctx, cmdPath, cmdArgs...)
-	if wantStdout && wantStderr {
-		out, err = cmd.CombinedOutput()
-	} else {
-		buf := &bytes.Buffer{}
-		switch {
-		case wantStdout:
-			cmd.Stderr = nil
-			cmd.Stdout = buf
-		case wantStderr:
-			cmd.Stderr = buf
-			cmd.Stdout = nil
-		}
-
-		err = cmd.Run()
-		out = buf.Bytes()
-	}
-	out = bytes.TrimSpace(out)
-	outStr := string(out)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	outStr := string(bytes.TrimSpace(stdout.Bytes()))
 
 	if err != nil {
+		err = fmt.Errorf("%w: %s", err, bytes.TrimSpace(stderr.Bytes()))
 		if cacheOutput && storeNegative {
 			// Completed successfully and returned an error.  Store the negative value
 			// since we're also returning an error, which tells the caller to
@@ -206,11 +187,9 @@ func execGitBranch(s *scope, args []pyObject) pyObject {
 	}
 	cmdIn = append(cmdIn, pyString("HEAD"))
 
-	wantStdout := true
-	wantStderr := false
 	cacheOutput := true
 	storeNegative := true
-	gitSymRefResult, success, err := doExec(s, pyList(cmdIn), wantStdout, wantStderr, cacheOutput, storeNegative)
+	gitSymRefResult, success, err := doExec(s, pyList(cmdIn), cacheOutput, storeNegative)
 	switch {
 	case success && err == nil:
 		return gitSymRefResult
@@ -229,7 +208,7 @@ func execGitBranch(s *scope, args []pyObject) pyObject {
 	cmdIn[2] = pyString("-q")
 	cmdIn[3] = pyString("--format=%D")
 	storeNegative = false
-	gitShowResult, success, err := doExec(s, pyList(cmdIn), wantStdout, wantStderr, cacheOutput, storeNegative)
+	gitShowResult, success, err := doExec(s, pyList(cmdIn), cacheOutput, storeNegative)
 	if !success {
 		// doExec returns a formatted error string
 		return s.Error("exec() %q failed: %v", pyList(cmdIn).String(), err)
@@ -254,12 +233,10 @@ func execGitCommit(s *scope, args []pyObject) pyObject {
 		pyString("HEAD"),
 	}
 
-	wantStdout := true
-	wantStderr := false
 	cacheOutput := true
 	storeNegative := false
 	// No error handling required since we don't want to retry
-	pyResult, success, err := doExec(s, pyList(cmdIn), wantStdout, wantStderr, cacheOutput, storeNegative)
+	pyResult, success, err := doExec(s, pyList(cmdIn), cacheOutput, storeNegative)
 	if !success {
 		return s.Error("git_commit() failed: %v", err)
 	}
@@ -309,11 +286,9 @@ func execGitShow(s *scope, args []pyObject) pyObject {
 		pyString(fmt.Sprintf("--format=%s", formatVerb)),
 	}
 
-	wantStdout := true
-	wantStderr := false
 	cacheOutput := true
 	storeNegative := false
-	pyResult, success, err := doExec(s, pyList(cmdIn), wantStdout, wantStderr, cacheOutput, storeNegative)
+	pyResult, success, err := doExec(s, pyList(cmdIn), cacheOutput, storeNegative)
 	if !success {
 		return s.Error("git_show() failed: %v", err)
 	}
@@ -333,11 +308,9 @@ func execGitState(s *scope, args []pyObject) pyObject {
 		pyString("--porcelain"),
 	}
 
-	wantStdout := true
-	wantStderr := false
 	cacheOutput := true
 	storeNegative := false
-	pyResult, success, err := doExec(s, pyList(cmdIn), wantStdout, wantStderr, cacheOutput, storeNegative)
+	pyResult, success, err := doExec(s, pyList(cmdIn), cacheOutput, storeNegative)
 	if !success {
 		return s.Error("git_state() failed: %v", err)
 	}
@@ -353,11 +326,9 @@ func execGitState(s *scope, args []pyObject) pyObject {
 }
 
 // execMakeKey returns an execKey.
-func execMakeKey(args []string, wantStdout bool, wantStderr bool) execKey {
+func execMakeKey(args []string) execKey {
 	return execKey{
-		args:       strings.Join(args, ""),
-		wantStdout: wantStdout,
-		wantStderr: wantStderr,
+		args: strings.Join(args, ""),
 	}
 }
 


### PR DESCRIPTION
Lots to do still:
 - Persist artifacts between jobs
 - Set up the release action
 - Can we reuse steps using composite actions or similar? Repeating the archive_logs & cache steps is tedious.
 - Add rex_test and http_cache_test (needs persisted artifacts)

Main goal here is to see if this works (I'm sure it will need some iteration) and how fast it ends up being. The runners are apparently smaller and I'm not sure we can increase them, which may make a difference for us.