### PR TITLE
unconditionally add remote_file label to remote_files

### DIFF
--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -457,6 +457,7 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
     if bool(username) != bool(password_file):
         fail(f"Both or neither of username and password_file should be specified")
 
+    lables = labels + ["remote_file"]
     labels = labels + [f"remote_file:header:{h}:{v}" for h, v in headers.items()]
     labels = labels + [f"remote_file:secret_header:{h}:{v}" for h, v in secret_headers.items()]
 


### PR DESCRIPTION
So we can query for all remote_files like so: `plz query alltargets --hidden --include=remote_file //...`