### PR TITLE
Experimental static variable analysis for asp

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -1431,8 +1431,6 @@ def go_get(name:str, get:str|list, repo:str='', deps:list=[], exported_deps:list
         fail("must provide get or install!")
     else:
         if not srcs and not binary:
-            # we are going to infer the getroot name from the 1st install dependency
-            getroot = install[0][:-4] if install[0].endswith('/...') else install[0]
             # NOTE: for this case in the install list I'm expecting full package names
             outs += [i[:-4] if i.endswith('/...') else i+".a" for i in install]
             provides = {'go': go_rule} # I can't find the sources


### PR DESCRIPTION
Basically it finds cases where variables are written to but never read from. I'm pretty happy with the extension to WalkAST, it feels pretty elegant to write the logic this way.

Has located one case in go_rules (although admittedly in `go_get` which is deprecated) and would have spotted the one in #2461 too (tried that locally)
Does have some false positives for our builtins where we do things like `cxx_binary = cc_binary`; maybe just needs some kind of whitelisting? If that is sorted it might be nice to use this as a premerge test (although also need to think how this would work for plugins)