### PR TITLE
Update all Docker images and toolchain to go1.18.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
    build-linux:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20220426
+       - image: thoughtmachine/please_ubuntu:20220516
      resource_class: large
      environment:
        PLZ_ARGS: "-p --profile ci"
@@ -101,7 +101,7 @@ jobs:
    build-linux-alt:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu_alt:20220422
+       - image: thoughtmachine/please_ubuntu_alt:20220516
      resource_class: large
      environment:
        PLZ_ARGS: "-p -c cover --profile ci-alt"
@@ -165,7 +165,7 @@ jobs:
    build-freebsd:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_freebsd_builder:20220422
+       - image: thoughtmachine/please_freebsd_builder:20220516
      resource_class: large
      steps:
        - checkout
@@ -191,7 +191,7 @@ jobs:
    build-linux-arm64:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20220317
+       - image: thoughtmachine/please_ubuntu:20220516
      resource_class: large
      steps:
        - checkout
@@ -265,7 +265,7 @@ jobs:
    test-rex:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20210720
+       - image: thoughtmachine/please_ubuntu:20220516
      resource_class: large
      steps:
        - checkout
@@ -282,7 +282,7 @@ jobs:
    test-http-cache:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20210720
+       - image: thoughtmachine/please_ubuntu:20220516
      resource_class: large
      steps:
        - checkout
@@ -298,7 +298,7 @@ jobs:
    # Releases to github and homebrew
    release:
      docker:
-       - image: thoughtmachine/please_docs:20200930
+       - image: thoughtmachine/please_docs:20220516
      steps:
        - attach_workspace:
            at: /tmp/workspace
@@ -310,7 +310,7 @@ jobs:
    # Releases the docs and the binaries to s3 for please.build and get.please.build
    release-s3:
      docker:
-       - image: thoughtmachine/please_docs:20200930
+       - image: thoughtmachine/please_docs:20220516
      steps:
        - checkout
        - attach_workspace:
@@ -320,7 +320,7 @@ jobs:
    # Runs a benchmarking test and records some performance results.
    perf-test:
      docker:
-       - image: thoughtmachine/please_ubuntu:20210720
+       - image: thoughtmachine/please_ubuntu:20220516
      resource_class: xlarge  # Want to run these tests with a significant amount of parallelism
      steps:
        - checkout

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -1,14 +1,15 @@
+
 package(default_visibility = ["PUBLIC"])
 
 go_toolchain(
     name = "toolchain",
     hashes = [
-        "70bb4a066997535e346c8bfa3e0dfe250d61100b17ccc5676274642447834969",  # darwin_amd64
-        "9cab6123af9ffade905525d79fc9ee76651e716c85f1f215872b5f2976782480",  # darwin_arm64
-        "01cd67bbc12e659ff236ecebde1806f76452f7ca145c172d5ecdbf4f4803daae",  # freebsd_amd64
-        "e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f",  # linux_amd64
+        "1f5f539ce0baa8b65f196ee219abf73a7d9cf558ba9128cc0fe4833da18b04f2",  # darwin_amd64
+        "6c7df9a2405f09aa9bab55c93c9c4ce41d3e58127d626bc1825ba5d0a0045d5c",  # darwin_arm64
+        "8e21cb761a02d4e3f31ec031d7ce90a0980e317f61ac023057d9a462e4a00512",  # freebsd_amd64
+        "e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc",  # linux_amd64
     ],
-    version = "1.18",
+    version = "1.18.2",
 )
 
 go_module(

--- a/tools/images/docs/Dockerfile
+++ b/tools/images/docs/Dockerfile
@@ -1,5 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 MAINTAINER peter.ebden@gmail.com
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y openssh-client ca-certificates python3 awscli
-COPY sftp.txt /root/sftp.txt

--- a/tools/images/docs/sftp.txt
+++ b/tools/images/docs/sftp.txt
@@ -1,5 +1,0 @@
-cd vhosts/please.build/htdocs
-put /tmp/site/*.html
-put /tmp/site/*.css
-put /tmp/site/*.js
-bye

--- a/tools/images/freebsd_builder/Dockerfile
+++ b/tools/images/freebsd_builder/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER peter.ebden@gmail.com
 RUN apt-get update && apt-get install -y curl git gcc xz-utils && apt-get clean
 
 # Go
-RUN curl -fsSL https://dl.google.com/go/go1.18.1.linux-amd64.tar.gz | tar -xzC /usr/local
+RUN curl -fsSL https://dl.google.com/go/go1.18.2.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 RUN GOOS=freebsd go install std
 

--- a/tools/images/ubuntu/Dockerfile
+++ b/tools/images/ubuntu/Dockerfile
@@ -15,7 +15,7 @@ RUN truncate -s0 /tmp/preseed.cfg; \
     apt-get clean
 
 # Go - we want a specific package version here.
-RUN curl -fsSL https://dl.google.com/go/go1.18.1.linux-amd64.tar.gz | tar -xzC /usr/local
+RUN curl -fsSL https://dl.google.com/go/go1.18.2.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Locale

--- a/tools/images/ubuntu_alt/Dockerfile
+++ b/tools/images/ubuntu_alt/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && \
     curl unzip git locales pkg-config zlib1g-dev clang && \
     apt-get clean
 
-# Go - we require 1.17 here to check we're compatible
-RUN curl -fsSL https://dl.google.com/go/go1.17.9.linux-amd64.tar.gz | tar -xzC /usr/local
+# Go - we require at least 1.18 now to build the repo
+RUN curl -fsSL https://dl.google.com/go/go1.18.2.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Locale


### PR DESCRIPTION
In preparation for merging #2347, this puts everything on the latest version (and cleans up an old sftp thing for old docs releases)