### PR TITLE
Migrate other maps to src/cmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/thought-machine/please
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/OneOfOne/cmap v0.0.0-20170825200327-ccaef7657ab8
 	github.com/ProtonMail/go-crypto v0.0.0-20210920135941-2c5829bbf927
 	github.com/alessio/shellescape v1.4.1
 	github.com/bazelbuild/buildtools v0.0.0-20210920153738-d6daef01a1a2

--- a/go.sum
+++ b/go.sum
@@ -36,9 +36,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/OneOfOne/cmap v0.0.0-20170825200327-ccaef7657ab8 h1:LvJrjPfvQXehyO8Vs6HK2X1jbL+8cKA5R84gj8+IIi0=
-github.com/OneOfOne/cmap v0.0.0-20170825200327-ccaef7657ab8/go.mod h1:jQmVrGXGFu7sbAteKCQgJWfTJbEHUaxGw4EKV0AQxIU=
-github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20210920135941-2c5829bbf927 h1:OSZDIq6u4iqaEjBZ8BmlEAwM4x8bRLHRWzzOkbv/Jvc=
 github.com/ProtonMail/go-crypto v0.0.0-20210920135941-2c5829bbf927/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//src/process",
         "//src/scm",
         "//third_party/go:blake3",
-        "//third_party/go:cmap",
         "//third_party/go:deferred_regex",
         "//third_party/go:errgroup",
         "//third_party/go:gcfg",

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -457,6 +457,10 @@ func (label BuildLabel) subrepoLabel() BuildLabel {
 	return BuildLabel{Name: label.Subrepo}
 }
 
+func hashBuildLabel(l BuildLabel) uint64 {
+	return cmap.XXHashes(l.Subrepo, l.PackageName, l.Name)
+}
+
 // packageKey returns a key for this build label that only uses the subrepo and package parts.
 func (label BuildLabel) packageKey() packageKey {
 	return packageKey{Name: label.PackageName, Subrepo: label.Subrepo}

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -11,6 +11,7 @@ import (
 	"github.com/thought-machine/go-flags"
 
 	"github.com/thought-machine/please/src/cli/logging"
+	"github.com/thought-machine/please/src/cmap"
 	"github.com/thought-machine/please/src/process"
 )
 
@@ -459,6 +460,10 @@ func (label BuildLabel) subrepoLabel() BuildLabel {
 // packageKey returns a key for this build label that only uses the subrepo and package parts.
 func (label BuildLabel) packageKey() packageKey {
 	return packageKey{Name: label.PackageName, Subrepo: label.Subrepo}
+}
+
+func hashPackageKey(key packageKey) uint64 {
+	return cmap.XXHashes(key.Subrepo, key.Name)
 }
 
 // CanSee returns true if label can see the given dependency, or false if not.

--- a/src/core/graph.go
+++ b/src/core/graph.go
@@ -151,9 +151,7 @@ func NewGraph() *BuildGraph {
 		targets: cmap.New[BuildLabel, *BuildTarget](cmap.DefaultShardCount, func(key BuildLabel) uint64 {
 			return cmap.XXHashes(key.Subrepo, key.PackageName, key.Name)
 		}),
-		packages: cmap.New[packageKey, *Package](cmap.DefaultShardCount, func(key packageKey) uint64 {
-			return cmap.XXHashes(key.Subrepo, key.Name)
-		}),
+		packages: cmap.New[packageKey, *Package](cmap.DefaultShardCount, hashPackageKey),
 		subrepos: cmap.New[string, *Subrepo](cmap.SmallShardCount, cmap.XXHash),
 	}
 	return g

--- a/src/core/graph.go
+++ b/src/core/graph.go
@@ -148,9 +148,7 @@ func (graph *BuildGraph) PackageMap() map[string]*Package {
 // NewGraph constructs and returns a new BuildGraph.
 func NewGraph() *BuildGraph {
 	g := &BuildGraph{
-		targets: cmap.New[BuildLabel, *BuildTarget](cmap.DefaultShardCount, func(key BuildLabel) uint64 {
-			return cmap.XXHashes(key.Subrepo, key.PackageName, key.Name)
-		}),
+		targets:  cmap.New[BuildLabel, *BuildTarget](cmap.DefaultShardCount, hashBuildLabel),
 		packages: cmap.New[packageKey, *Package](cmap.DefaultShardCount, hashPackageKey),
 		subrepos: cmap.New[string, *Subrepo](cmap.SmallShardCount, cmap.XXHash),
 	}

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -14,7 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/OneOfOne/cmap"
+	ocmap "github.com/OneOfOne/cmap"
 	"github.com/cespare/xxhash/v2"
 	"lukechampine.com/blake3"
 
@@ -252,11 +252,11 @@ type stateProgress struct {
 	closeOnce  sync.Once
 	resultOnce sync.Once
 	// Used to track subinclude() calls that block until targets are built. Keyed by their label.
-	pendingTargets *cmap.CMap
+	pendingTargets *ocmap.CMap
 	// Used to track general package parsing requests. Keyed by a packageKey struct.
-	pendingPackages *cmap.CMap
+	pendingPackages *ocmap.CMap
 	// similar to pendingPackages but consumers haven't committed to parsing the package
-	packageWaits *cmap.CMap
+	packageWaits *ocmap.CMap
 	// The set of known states
 	allStates []*BuildState
 	// Targets that we were originally requested to build
@@ -1239,9 +1239,9 @@ func NewBuildState(config *Configuration) *BuildState {
 		progress: &stateProgress{
 			numActive:       1, // One for the initial target adding on the main thread.
 			numPending:      1,
-			pendingPackages: cmap.New(),
-			pendingTargets:  cmap.New(),
-			packageWaits:    cmap.New(),
+			pendingPackages: ocmap.New(),
+			pendingTargets:  ocmap.New(),
+			packageWaits:    ocmap.New(),
 			internalResults: make(chan *BuildResult, 1000),
 			cycleDetector:   cycleDetector{graph: graph},
 		},

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -862,15 +862,6 @@ go_module(
 )
 
 go_module(
-    name = "cmap",
-    install = [
-        "...",
-    ],
-    module = "github.com/OneOfOne/cmap",
-    version = "ccaef7657ab896465978ddf580830288b61f9f6e",
-)
-
-go_module(
     name = "csslex",
     module = "github.com/x1ddos/csslex",
     version = "v0.0.0-20160125172232-7894d8ab8bfe",


### PR DESCRIPTION
Just cleanup really; drops OneOfOne/cmap now we have the new one.