### PR TITLE
Prefix metadata store path with instance name

### DIFF
--- a/src/remote/build_metadata_store.go
+++ b/src/remote/build_metadata_store.go
@@ -21,11 +21,12 @@ type buildMetadataStore interface {
 }
 
 type directoryMetadataStore struct {
+	instance      string
 	directory     string
 	cacheDuration time.Duration
 }
 
-func newDirMDStore(cacheDuration time.Duration) *directoryMetadataStore {
+func newDirMDStore(instance string, cacheDuration time.Duration) *directoryMetadataStore {
 	userCacheDir, err := os.UserCacheDir()
 	if err != nil {
 		log.Fatalf("failed to find user cache dir for metadata store: %v", err)
@@ -36,6 +37,7 @@ func newDirMDStore(cacheDuration time.Duration) *directoryMetadataStore {
 		log.Fatalf("failed to create metadata store directory: %v", err)
 	}
 	store := &directoryMetadataStore{
+		instance:      instance,
 		directory:     dir,
 		cacheDuration: cacheDuration,
 	}
@@ -60,16 +62,12 @@ func (d *directoryMetadataStore) clean() {
 
 func (d *directoryMetadataStore) storeMetadata(key string, md *core.BuildMetadata) error {
 	prefix := key[:2]
-	dir := filepath.Join(d.directory, prefix)
+	dir := filepath.Join(d.directory, d.instance, prefix)
 	if err := os.MkdirAll(dir, fs.DirPermissions); err != nil {
 		return fmt.Errorf("failed to create metadata store directory: %w", err)
 	}
 
 	filename := filepath.Join(dir, key)
-	if err := os.RemoveAll(filename); err != nil {
-		return err
-	}
-
 	var buf bytes.Buffer
 	writer := gob.NewEncoder(&buf)
 	if err := writer.Encode(md); err != nil {
@@ -80,7 +78,7 @@ func (d *directoryMetadataStore) storeMetadata(key string, md *core.BuildMetadat
 
 func (d *directoryMetadataStore) retrieveMetadata(key string) (*core.BuildMetadata, error) {
 	prefix := key[:2]
-	fileName := filepath.Join(d.directory, prefix, key)
+	fileName := filepath.Join(d.directory, d.instance, prefix, key)
 
 	md, err := loadMetadata(fileName)
 	if err != nil {

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -137,7 +137,7 @@ func New(state *core.BuildState) *Client {
 		state:    state,
 		instance: state.Config.Remote.Instance,
 		outputs:  map[core.BuildLabel]*pb.Directory{},
-		mdStore:  newDirMDStore(time.Duration(state.Config.Remote.CacheDuration)),
+		mdStore:  newDirMDStore(state.Config.Remote.Instance, time.Duration(state.Config.Remote.CacheDuration)),
 		existingBlobs: map[string]struct{}{
 			digest.Empty.Hash: {},
 		},


### PR DESCRIPTION
There isn't really anything wrong here per se but it's confusing trying to work out what's going on with the store paths since they are different hashes (because they're convoluted with the instance name). This makes the instance a directory name at the top of the cache which should be easier to reason about.