### PR TITLE
Print build outputs without formatting when stdout is noninteractive

### DIFF
--- a/src/cli/logging.go
+++ b/src/cli/logging.go
@@ -25,7 +25,7 @@ const messageHistoryMaxSize = 100
 var log = logger.Log
 
 // StdErrIsATerminal is true if the process' stderr is an interactive TTY.
-var StdErrIsATerminal = term.IsTerminal(int(os.Stderr.Fd()))
+var StdErrIsATerminal = IsATerminal(os.Stderr)
 
 // ShowColouredOutput tracks whether we are displaying coloured output or not.
 var ShowColouredOutput = StdErrIsATerminal
@@ -307,4 +307,9 @@ func (w *HTTPLogWrapper) Debug(msg string, keysAndValues ...interface{}) {
 // Warn logs at warning level
 func (w *HTTPLogWrapper) Warn(msg string, keysAndValues ...interface{}) {
 	w.Log.Warningf("%v: %v", msg, keysAndValues)
+}
+
+// IsATerminal returns true if the given file is an interactive TTY.
+func IsATerminal(file *os.File) bool {
+	return term.IsTerminal(int(file.Fd()))
 }

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -28,7 +28,7 @@ const testDurationGranularity = time.Millisecond
 
 // MonitorState monitors the build while it's running and prints output until the results
 // channel of state has completed.
-func MonitorState(state *core.BuildState, plainOutput, unformattedBuildOutput, detailedTests, streamTestResults, shell, shellRun bool, traceFile string) {
+func MonitorState(state *core.BuildState, plainOutput, detailedTests, streamTestResults, shell, shellRun bool, traceFile string) {
 	initPrintf(state.Config)
 
 	if len(state.Config.Please.Motd) != 0 {
@@ -93,7 +93,7 @@ loop:
 		} else if state.NeedHashesOnly {
 			printHashes(state, duration)
 		} else if !state.NeedRun { // Must be plz build or similar, report build outputs.
-			if unformattedBuildOutput {
+			if !cli.IsATerminal(os.Stdout) {
 				printUnformattedBuildResults(state)
 			} else {
 				printBuildResults(state, duration)

--- a/src/please.go
+++ b/src/please.go
@@ -103,13 +103,12 @@ var opts struct {
 	Complete         string `long:"complete" hidden:"true" env:"PLZ_COMPLETE" description:"Provide completion options for this build target."`
 
 	Build struct {
-		Prepare     bool   `long:"prepare" description:"Prepare build directory for these targets but don't build them."`
-		Shell       string `long:"shell" choice:"shell" choice:"run" optional:"true" optional-value:"shell" description:"Like --prepare, but opens a shell in the build directory with the appropriate environment variables."`
-		Rebuild     bool   `long:"rebuild" description:"To force the optimisation and rebuild one or more targets."`
-		NoDownload  bool   `long:"nodownload" hidden:"true" description:"Don't download outputs after building. Only applies when using remote build execution."`
-		Download    bool   `long:"download" hidden:"true" description:"Force download of all outputs regardless of original target spec. Only applies when using remote build execution."`
-		Unformatted bool   `long:"unformatted" description:"Print unformatted build outputs only, with no other information"`
-		Args        struct {
+		Prepare    bool   `long:"prepare" description:"Prepare build directory for these targets but don't build them."`
+		Shell      string `long:"shell" choice:"shell" choice:"run" optional:"true" optional-value:"shell" description:"Like --prepare, but opens a shell in the build directory with the appropriate environment variables."`
+		Rebuild    bool   `long:"rebuild" description:"To force the optimisation and rebuild one or more targets."`
+		NoDownload bool   `long:"nodownload" hidden:"true" description:"Don't download outputs after building. Only applies when using remote build execution."`
+		Download   bool   `long:"download" hidden:"true" description:"Force download of all outputs regardless of original target spec. Only applies when using remote build execution."`
+		Args       struct {
 			Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to build"`
 		} `positional-args:"true" required:"true"`
 	} `command:"build" description:"Builds one or more targets"`
@@ -1130,7 +1129,7 @@ func runPlease(state *core.BuildState, targets []core.BuildLabel) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		output.MonitorState(state, !pretty, opts.Build.Unformatted, detailedTests, streamTests, shell, shellRun, string(opts.OutputFlags.TraceFile))
+		output.MonitorState(state, !pretty, detailedTests, streamTests, shell, shellRun, string(opts.OutputFlags.TraceFile))
 		wg.Done()
 	}()
 	plz.Run(targets, opts.BuildFlags.PreTargets, state, config, state.TargetArch)

--- a/src/please.go
+++ b/src/please.go
@@ -103,12 +103,13 @@ var opts struct {
 	Complete         string `long:"complete" hidden:"true" env:"PLZ_COMPLETE" description:"Provide completion options for this build target."`
 
 	Build struct {
-		Prepare    bool   `long:"prepare" description:"Prepare build directory for these targets but don't build them."`
-		Shell      string `long:"shell" choice:"shell" choice:"run" optional:"true" optional-value:"shell" description:"Like --prepare, but opens a shell in the build directory with the appropriate environment variables."`
-		Rebuild    bool   `long:"rebuild" description:"To force the optimisation and rebuild one or more targets."`
-		NoDownload bool   `long:"nodownload" hidden:"true" description:"Don't download outputs after building. Only applies when using remote build execution."`
-		Download   bool   `long:"download" hidden:"true" description:"Force download of all outputs regardless of original target spec. Only applies when using remote build execution."`
-		Args       struct {
+		Prepare     bool   `long:"prepare" description:"Prepare build directory for these targets but don't build them."`
+		Shell       string `long:"shell" choice:"shell" choice:"run" optional:"true" optional-value:"shell" description:"Like --prepare, but opens a shell in the build directory with the appropriate environment variables."`
+		Rebuild     bool   `long:"rebuild" description:"To force the optimisation and rebuild one or more targets."`
+		NoDownload  bool   `long:"nodownload" hidden:"true" description:"Don't download outputs after building. Only applies when using remote build execution."`
+		Download    bool   `long:"download" hidden:"true" description:"Force download of all outputs regardless of original target spec. Only applies when using remote build execution."`
+		Unformatted bool   `long:"unformatted" description:"Print unformatted build outputs only, with no other information"`
+		Args        struct {
 			Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to build"`
 		} `positional-args:"true" required:"true"`
 	} `command:"build" description:"Builds one or more targets"`
@@ -1129,7 +1130,7 @@ func runPlease(state *core.BuildState, targets []core.BuildLabel) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		output.MonitorState(state, !pretty, detailedTests, streamTests, shell, shellRun, string(opts.OutputFlags.TraceFile))
+		output.MonitorState(state, !pretty, opts.Build.Unformatted, detailedTests, streamTests, shell, shellRun, string(opts.OutputFlags.TraceFile))
 		wg.Done()
 	}()
 	plz.Run(targets, opts.BuildFlags.PreTargets, state, config, state.TargetArch)

--- a/test/BUILD
+++ b/test/BUILD
@@ -155,7 +155,7 @@ filegroup(
 plz_e2e_test(
     name = "require_provide_test",
     cmd = "plz build //test/moar:require_provide_check -v 2 -p",
-    expect_output_doesnt_contain = "//test/moar:test_require",
+    expected_output = "require_provide_test.txt",
 )
 
 # Test for running individual tests

--- a/test/build_defs/test.build_defs
+++ b/test/build_defs/test.build_defs
@@ -78,7 +78,7 @@ def plz_e2e_test(name:str, cmd:str, pre_cmd:str=None, expected_output:str=None,
         elif expect_output_contains:
             test_cmd += f'_STR="$(cat output)" _SUBSTR="{expect_output_contains}" && if [ "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi'
         elif expect_output_doesnt_contain:
-            test_cmd += f'_STR="$(cat output)" _SUBSTR="{expect_output_contains}" && if [ -z "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi'
+            test_cmd += f'_STR="$(cat output)" _SUBSTR="{expect_output_doesnt_contain}" && if [ -z "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi'
         elif expect_file_exists:
             test_cmd += 'if [ ! -f %s ]; then cat output; exit 1; fi' % expect_file_exists
         elif expect_file_doesnt_exist:


### PR DESCRIPTION
Resolves #2477 

This is the most obvious way of doing it. Also thought about leaving off the flag and interleaving outputs to stdout/stderr but I think that might be confusing (although nice to not have yet another flag). Thoughts?