### PR TITLE
Fix building initial targets in a subrepo that race with preloaded subincludes

### DIFF
--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -121,7 +121,7 @@ func findOriginalTasks(state *core.BuildState, preTargets, targets []core.BuildL
 		}
 		for _, target := range state.ExpandLabels(preTargets) {
 			log.Debug("Waiting for pre-target %s...", target)
-			state.WaitForTargetAndEnsureDownload(target, targets[0])
+			state.WaitForInitialTargetAndEnsureDownload(target, targets[0])
 			log.Debug("Pre-target %s built, continuing...", target)
 		}
 	}
@@ -146,7 +146,7 @@ func findOriginalTask(state *core.BuildState, target core.BuildLabel, addToList 
 		dir := target.PackageName
 		prefix := ""
 		if target.Subrepo != "" {
-			state.WaitForTargetAndEnsureDownload(target.SubrepoLabel(state, ""), target)
+			state.WaitForInitialTargetAndEnsureDownload(target.SubrepoLabel(state, ""), target)
 			subrepo := state.Graph.SubrepoOrDie(target.Subrepo)
 			dir = subrepo.Dir(dir)
 			prefix = subrepo.Dir(prefix)


### PR DESCRIPTION
I have an internal example of this but difficult to produce a reduced test case.

Basically if you ask for `plz build ///cc/grpc/grpc//...`, it needs to build `//cc/grpc` upfront (in `plz.go`, because it has to download the subrepo to figure out what to do in it). That sets `forSubinclude` which bypasses the checks on the preloaded subincludes completing, and hence will fail if that build file expects one of them to be there.

It feels a bit fiddly having to break all these functions up but I think this is the right answer.