### PR TITLE
Load config and initialise the parser for local subrepos

### DIFF
--- a/src/exec/exec.go
+++ b/src/exec/exec.go
@@ -35,6 +35,7 @@ func Exec(state *core.BuildState, label core.AnnotatedOutputLabel, dir string, e
 	return 0
 }
 
+// exec runs the given command in the given directory, with the given environment and arguments.
 func exec(state *core.BuildState, target *core.BuildTarget, runtimeDir string, env []string, overrideCmdArgs []string, foreground bool, sandbox process.SandboxConfig) error {
 	if !target.IsBinary && len(overrideCmdArgs) == 0 {
 		return fmt.Errorf("Either the target needs to be a binary or an override command must be provided")
@@ -54,6 +55,7 @@ func exec(state *core.BuildState, target *core.BuildTarget, runtimeDir string, e
 	return err
 }
 
+// resolveCmd resolves the command to run for the given target.
 func resolveCmd(state *core.BuildState, target *core.BuildTarget, overrideCmdArgs []string, runtimeDir string, sandbox process.SandboxConfig) (string, error) {
 	// The override command takes precedence if provided
 	if len(overrideCmdArgs) > 0 {

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1098,6 +1098,14 @@ func subrepo(s *scope, args []pyObject) pyObject {
 		IsCrossCompile: isCrossCompile,
 	}
 
+	// Typically this would be deferred until we have built the subrepo target and have its config available. As we
+	// don't have a subrepo target, we can and should load it here.
+	if target == nil {
+		if err := sr.LoadSubrepoConfig(); err != nil {
+			log.Fatalf("Could not load subrepo config for %s: %v", sr.Name, err)
+		}
+	}
+
 	if args[ConfigArgIdx].IsTruthy() {
 		sr.AdditionalConfigFiles = append(sr.AdditionalConfigFiles, string(args[ConfigArgIdx].(pyString)))
 	}


### PR DESCRIPTION
Fixes #2485

In 16.20.0, we defer initialising a subrepo's parser until we've loaded any configuration for that subrepo, so we trigger this once we've build the subrepo's target. For subrepos defined locally, we don't have a subrepo target so we never initialised the parser. 

This PR just checks to see if we have a target to build. If we don't, we can load the config immediately when we define the subrepo. 