### PR TITLE
Fix bug where we wouldn't traverse excluded deps

### DIFF
--- a/build_defs/BUILD
+++ b/build_defs/BUILD
@@ -10,7 +10,6 @@ filegroup(
     visibility = ["PUBLIC"],
 )
 
-
 filegroup(
     name = "go",
     srcs = ["go.build_defs"],

--- a/src/build/BUILD
+++ b/src/build/BUILD
@@ -29,7 +29,10 @@ go_test(
 
 go_test(
     name = "build_step_test",
-    srcs = ["build_step_test.go", "remote_file_test.go"],
+    srcs = [
+        "build_step_test.go",
+        "remote_file_test.go",
+    ],
     data = ["test_data"],
     deps = [
         ":build",

--- a/src/cmap/BUILD
+++ b/src/cmap/BUILD
@@ -1,6 +1,9 @@
 go_library(
     name = "cmap",
-    srcs = ["cmap.go", "hash.go"],
+    srcs = [
+        "cmap.go",
+        "hash.go",
+    ],
     visibility = ["PUBLIC"],
     deps = [
         "//third_party/go:xxhash",

--- a/src/fs/copy_test.go
+++ b/src/fs/copy_test.go
@@ -63,7 +63,6 @@ func TestLink(t *testing.T) {
 
 				assert.Equal(t, string(srcFileContents), string(destFileContents))
 			}
-
 		})
 	}
 }
@@ -121,7 +120,6 @@ func TestSymlink(t *testing.T) {
 
 				assert.Equal(t, string(srcFileContents), string(destFileContents))
 			}
-
 		})
 	}
 }

--- a/src/parse/asp/BUILD
+++ b/src/parse/asp/BUILD
@@ -13,13 +13,13 @@ go_library(
     visibility = ["PUBLIC"],
     deps = [
         "//src/cli",
-        "//src/cmap",
         "//src/cli/logging",
+        "//src/cmap",
         "//src/core",
         "//src/fs",
+        "//third_party/go:gcfg",
         "//third_party/go:promptui",
         "//third_party/go:semver2",
-        "//third_party/go:gcfg",
     ],
 )
 

--- a/src/query/deps.go
+++ b/src/query/deps.go
@@ -2,30 +2,32 @@ package query
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/thought-machine/please/src/core"
 )
 
 // Deps prints all transitive dependencies of a set of targets.
 func Deps(state *core.BuildState, labels []core.BuildLabel, hidden bool, targetLevel int) {
+	deps(os.Stdout, state, labels, hidden, targetLevel)
+}
+
+func deps(out io.Writer, state *core.BuildState, labels []core.BuildLabel, hidden bool, targetLevel int) {
 	done := map[core.BuildLabel]bool{}
 	for _, label := range labels {
-		printTarget(state, state.Graph.TargetOrDie(label), "", done, hidden, 0, targetLevel)
+		printTarget(out, state, state.Graph.TargetOrDie(label), "", done, hidden, 0, targetLevel)
 	}
 }
 
-func printTarget(state *core.BuildState, target *core.BuildTarget, indent string, done map[core.BuildLabel]bool, hidden bool, currentLevel int, targetLevel int) {
-	if !state.ShouldInclude(target) {
-		return
-	}
-
+func printTarget(out io.Writer, state *core.BuildState, target *core.BuildTarget, indent string, done map[core.BuildLabel]bool, hidden bool, currentLevel int, targetLevel int) {
 	levelLimitReached := targetLevel != -1 && currentLevel == targetLevel
 	if done[target.Label] || levelLimitReached {
 		return
 	}
 
-	if hidden || !target.HasParent() {
-		fmt.Printf("%s%s\n", indent, target)
+	if state.ShouldInclude(target) && (hidden || !target.HasParent()) {
+		fmt.Fprintf(out, "%s%s\n", indent, target)
 		done[target.Label] = true
 
 		indent += "  "
@@ -33,6 +35,6 @@ func printTarget(state *core.BuildState, target *core.BuildTarget, indent string
 	}
 
 	for _, dep := range target.Dependencies() {
-		printTarget(state, dep, indent, done, hidden, currentLevel, targetLevel)
+		printTarget(out, state, dep, indent, done, hidden, currentLevel, targetLevel)
 	}
 }

--- a/src/query/deps_test.go
+++ b/src/query/deps_test.go
@@ -1,0 +1,109 @@
+package query
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/thought-machine/please/src/core"
+)
+
+func TestQueryDepsHiddenTarget(t *testing.T) {
+	state := core.NewDefaultBuildState()
+
+	pkg := core.NewPackage("")
+
+	target := core.NewBuildTarget(core.ParseBuildLabel("//:t1", ""))
+	hiddenTarget := core.NewBuildTarget(core.ParseBuildLabel("//:_t2#test", ""))
+
+	target.AddDependency(hiddenTarget.Label)
+
+	state.AddTarget(pkg, hiddenTarget)
+	state.AddTarget(pkg, target)
+
+	target.ResolveDependencies(state.Graph)
+	hiddenTarget.ResolveDependencies(state.Graph)
+
+	var hiddenOut bytes.Buffer
+	deps(&hiddenOut, state, []core.BuildLabel{target.Label}, true, -1)
+
+	var publicOut bytes.Buffer
+	deps(&publicOut, state, []core.BuildLabel{target.Label}, false, -1)
+
+	expectedWithHidden := "//:t1\n  //:_t2#test\n"
+	expectedWithoutHidden := "//:t1\n"
+
+	assert.Equal(t, expectedWithHidden, hiddenOut.String())
+	assert.Equal(t, expectedWithoutHidden, publicOut.String())
+}
+
+func TestQueryDepsInlcudeLabels(t *testing.T) {
+	state := core.NewDefaultBuildState()
+
+	pkg := core.NewPackage("")
+
+	target := core.NewBuildTarget(core.ParseBuildLabel("//:t1", ""))
+	fooTarget := core.NewBuildTarget(core.ParseBuildLabel("//:t2", ""))
+	barTarget := core.NewBuildTarget(core.ParseBuildLabel("//:t3", ""))
+
+	fooTarget.AddLabel("foo")
+
+	target.AddDependency(fooTarget.Label)
+	target.AddDependency(barTarget.Label)
+
+	state.AddTarget(pkg, fooTarget)
+	state.AddTarget(pkg, barTarget)
+	state.AddTarget(pkg, target)
+
+	target.ResolveDependencies(state.Graph)
+	fooTarget.ResolveDependencies(state.Graph)
+	barTarget.ResolveDependencies(state.Graph)
+
+	var out bytes.Buffer
+	deps(&out, state, []core.BuildLabel{target.Label}, false, -1)
+
+	expected := "//:t1\n  //:t2\n  //:t3\n"
+	assert.Equal(t, expected, out.String())
+
+	state.Include = []string{"foo"}
+
+	var out2 bytes.Buffer
+	deps(&out2, state, []core.BuildLabel{target.Label}, false, -1)
+	expected = "//:t2\n"
+	assert.Equal(t, expected, out2.String())
+}
+
+func TestQueryDepsLevel(t *testing.T) {
+	state := core.NewDefaultBuildState()
+
+	pkg := core.NewPackage("")
+
+	target := core.NewBuildTarget(core.ParseBuildLabel("//:t1", ""))
+	fooTarget := core.NewBuildTarget(core.ParseBuildLabel("//:t2", ""))
+	barTarget := core.NewBuildTarget(core.ParseBuildLabel("//:t3", ""))
+
+	fooTarget.AddLabel("foo")
+
+	target.AddDependency(fooTarget.Label)
+	fooTarget.AddDependency(barTarget.Label)
+
+	state.AddTarget(pkg, fooTarget)
+	state.AddTarget(pkg, barTarget)
+	state.AddTarget(pkg, target)
+
+	target.ResolveDependencies(state.Graph)
+	fooTarget.ResolveDependencies(state.Graph)
+	barTarget.ResolveDependencies(state.Graph)
+
+	var out bytes.Buffer
+	deps(&out, state, []core.BuildLabel{target.Label}, false, -1)
+
+	expected := "//:t1\n  //:t2\n    //:t3\n"
+	assert.Equal(t, expected, out.String())
+
+	var out2 bytes.Buffer
+	deps(&out2, state, []core.BuildLabel{target.Label}, false, 1)
+	expected = "//:t1\n  //:t2\n"
+	assert.Equal(t, expected, out2.String())
+}

--- a/test/go_rules/embed/BUILD
+++ b/test/go_rules/embed/BUILD
@@ -1,13 +1,19 @@
 go_library(
     name = "embed",
     srcs = ["embed.go"],
-    resources = ["hello.txt", "test_data"],
+    resources = [
+        "hello.txt",
+        "test_data",
+    ],
 )
 
 go_test(
     name = "embed_test",
     srcs = ["embed_test.go"],
-    resources = ["hello.txt", "test_data"],
+    resources = [
+        "hello.txt",
+        "test_data",
+    ],
     deps = [
         ":embed",
         "//third_party/go:testify",

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -1,4 +1,3 @@
-
 package(default_visibility = ["PUBLIC"])
 
 go_toolchain(


### PR DESCRIPTION
Fixes: #2495 

I wasn't sure how this should behave, but in hindsight I think this makes more sense. 

We used to stop traversing dependencies if that dependency was excluded from the results via a label filter. This instead just skips printing that dependency but still traverses it. 