### PR TITLE
Update gcfg to allow setting empty values in SSM sections

### DIFF
--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -89,7 +89,7 @@ go_module(
         "...",
     ],
     module = "github.com/please-build/gcfg",
-    version = "3ea2edaeaa7487f498b4feeec8c27c7682fc3f35",
+    version = "9b4d14cddd6148920e11c8bb7ee19369473b1019",
     deps = [
         ":warnings",
     ],

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -89,7 +89,7 @@ go_module(
         "...",
     ],
     module = "github.com/please-build/gcfg",
-    version = "10ea9d657afb66f12bbcf5184c9c2e3bffa2ddd3",
+    version = "3ea2edaeaa7487f498b4feeec8c27c7682fc3f35",
     deps = [
         ":warnings",
     ],


### PR DESCRIPTION
Upstream is https://github.com/please-build/gcfg/pull/16

This means one can set e.g.
```
[buildenv]
myvar =
```
and `MYVAR` will be set to the empty string in the environment (previously it would not be which was unintuitive)