### PR TITLE
Fix data race in remote stats code

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -93,8 +93,7 @@ type Client struct {
 	userHome string
 
 	// Stats used to report RPC data rates
-	byteRateIn, byteRateOut, totalBytesIn, totalBytesOut int
-	stats                                                *statsHandler
+	stats *statsHandler
 
 	// Used to store and retrieve action results to reduce RPC calls when re-building targets
 	mdStore buildMetadataStore
@@ -830,7 +829,7 @@ func (c *Client) PrintHashes(target *core.BuildTarget, isTest bool) {
 
 // DataRate returns an estimate of the current in/out RPC data rates in bytes per second.
 func (c *Client) DataRate() (int, int, int, int) {
-	return c.byteRateIn, c.byteRateOut, c.totalBytesIn, c.totalBytesOut
+	return c.stats.DataRate()
 }
 
 // fetchRemoteFile sends a request to fetch a file using the remote asset API.


### PR DESCRIPTION
Found some things like this when bootstrapping with remote execution enabled:
```
WARNING: DATA RACE
Write at 0x00c000550528 by goroutine 51:
  github.com/thought-machine/please/src/remote.(*statsHandler).update()
      /home/pebers/git/please/src/remote/stats.go:70 +0x1b2
  github.com/thought-machine/please/src/remote.newStatsHandler.func1()
      /home/pebers/git/please/src/remote/stats.go:35 +0x39

Previous read at 0x00c000550528 by goroutine 49:
  github.com/thought-machine/please/src/remote.(*Client).DataRate()
      /home/pebers/git/please/src/remote/remote.go:833 +0x90
```
Looks like the previous setup wasn't sufficient. I've simplified it down to one mutex (don't imagine we are going to have a huge issue with contention here)
