### PR TITLE
Update Go plugin to latest

### DIFF
--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,5 +1,5 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v0.4.0",
+    revision = "v0.4.1",
 )


### PR DESCRIPTION
Now works with Go 1.19 (tested locally with beta1, not moving any of the CI on to it yet)