### PR TITLE
Expose `go_binary` sources when included as a `go_test` dependency

### DIFF
--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -102,7 +102,7 @@ def go_library(name:str, srcs:list, resources:list=None, asm_srcs:list=None, hdr
                _needs_transitive_deps=False, _all_srcs=False, cover:bool=True,
                filter_srcs:bool=True, _link_private:bool=False, _link_extra:bool=True, _abi:str=None,
                _generate_import_config:bool=True, import_path:str='', labels:list=[], package:str=None,
-               requires:list=None, provides:dict=None):
+               _requires:list=[], _provides:dict={}):
     """Generates a Go library which can be reused by other rules.
 
     Args:
@@ -125,9 +125,6 @@ def go_library(name:str, srcs:list, resources:list=None, asm_srcs:list=None, hdr
       import_path (str): If set, this will override the import path of the generated go package.
       package (str): The package as it would appear at the top of the go source files. Defaults
                      to name.
-      requires (list): Kinds of output from other rules that this one requires.
-      provides (dict): Kinds of output that this provides for other rules (see genrule() for a
-                       more in-depth discussion of this).
     """
     assert srcs, "Cannot provide an empty srcs list to go_library"
     cover = cover and CONFIG.BUILD_CONFIG == "cover"
@@ -215,8 +212,8 @@ def go_library(name:str, srcs:list, resources:list=None, asm_srcs:list=None, hdr
             _generate_import_config=False,
             labels=labels,
             import_path=package_path,
-            requires = requires,
-            provides = provides,
+            requires = _requires,
+            provides = _provides,
         )
         asm_rule = build_rule(
             name = name,
@@ -244,9 +241,9 @@ def go_library(name:str, srcs:list, resources:list=None, asm_srcs:list=None, hdr
             cmd = 'cp $SRCS_LIB "$OUT" && chmod +w "$OUT" && "$TOOL" tool pack r "$OUT" $SRCS_ASM',
             visibility = visibility,
             building_description = 'Packing...',
-            requires = ['go'] + (requires or []),
+            requires = ['go'] + _requires,
             labels = labels+link_labels,
-            provides =  {'go': ':' + name, 'go_src': lib_rule} | (provides or {}),
+            provides =  {'go': ':' + name, 'go_src': lib_rule} | _provides,
             test_only = test_only,
             exported_deps = exported_deps,
             deps = deps,
@@ -292,8 +289,8 @@ def go_library(name:str, srcs:list, resources:list=None, asm_srcs:list=None, hdr
         cmd=_go_library_cmds(import_path=package_path, complete=complete, all_srcs=_all_srcs, cover=cover, filter_srcs=filter_srcs, abi=_abi, embedcfg=embedcfg),
         visibility=visibility,
         building_description="Compiling...",
-        requires=['go'] + (requires or []),
-        provides={'go': ':' + name, 'go_src': src_rule} | (provides or {}),
+        requires=['go'] + _requires,
+        provides={'go': ':' + name, 'go_src': src_rule} | _provides,
         labels = labels+link_labels + [f"go_package:{package_path}"] if _generate_import_config else [],
         test_only=test_only,
         tools=tools,
@@ -670,7 +667,7 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
         complete = False,
         _generate_import_config=False,
         import_path = test_package,
-        requires = ["test"],
+        _requires = ["test"],
     )
 
     if cgo:

--- a/rules/go_rules.build_defs
+++ b/rules/go_rules.build_defs
@@ -101,7 +101,8 @@ def go_library(name:str, srcs:list, resources:list=None, asm_srcs:list=None, hdr
                visibility:list=None, test_only:bool&testonly=False, complete:bool=True,
                _needs_transitive_deps=False, _all_srcs=False, cover:bool=True,
                filter_srcs:bool=True, _link_private:bool=False, _link_extra:bool=True, _abi:str=None,
-               _generate_import_config:bool=True, import_path:str='', labels:list=[], package:str=None):
+               _generate_import_config:bool=True, import_path:str='', labels:list=[], package:str=None,
+               requires:list=None, provides:dict=None):
     """Generates a Go library which can be reused by other rules.
 
     Args:
@@ -124,6 +125,9 @@ def go_library(name:str, srcs:list, resources:list=None, asm_srcs:list=None, hdr
       import_path (str): If set, this will override the import path of the generated go package.
       package (str): The package as it would appear at the top of the go source files. Defaults
                      to name.
+      requires (list): Kinds of output from other rules that this one requires.
+      provides (dict): Kinds of output that this provides for other rules (see genrule() for a
+                       more in-depth discussion of this).
     """
     assert srcs, "Cannot provide an empty srcs list to go_library"
     cover = cover and CONFIG.BUILD_CONFIG == "cover"
@@ -211,6 +215,8 @@ def go_library(name:str, srcs:list, resources:list=None, asm_srcs:list=None, hdr
             _generate_import_config=False,
             labels=labels,
             import_path=package_path,
+            requires = requires,
+            provides = provides,
         )
         asm_rule = build_rule(
             name = name,
@@ -238,9 +244,9 @@ def go_library(name:str, srcs:list, resources:list=None, asm_srcs:list=None, hdr
             cmd = 'cp $SRCS_LIB "$OUT" && chmod +w "$OUT" && "$TOOL" tool pack r "$OUT" $SRCS_ASM',
             visibility = visibility,
             building_description = 'Packing...',
-            requires = ['go'],
+            requires = ['go'] + (requires or []),
             labels = labels+link_labels,
-            provides =  {'go': ':' + name, 'go_src': lib_rule},
+            provides =  {'go': ':' + name, 'go_src': lib_rule} | (provides or {}),
             test_only = test_only,
             exported_deps = exported_deps,
             deps = deps,
@@ -286,8 +292,8 @@ def go_library(name:str, srcs:list, resources:list=None, asm_srcs:list=None, hdr
         cmd=_go_library_cmds(import_path=package_path, complete=complete, all_srcs=_all_srcs, cover=cover, filter_srcs=filter_srcs, abi=_abi, embedcfg=embedcfg),
         visibility=visibility,
         building_description="Compiling...",
-        requires=['go'],
-        provides={'go': ':' + name, 'go_src': src_rule},
+        requires=['go'] + (requires or []),
+        provides={'go': ':' + name, 'go_src': src_rule} | (provides or {}),
         labels = labels+link_labels + [f"go_package:{package_path}"] if _generate_import_config else [],
         test_only=test_only,
         tools=tools,
@@ -603,6 +609,9 @@ def go_binary(name:str, srcs:list=[], resources:list=None, asm_srcs:list=[], out
         visibility=visibility,
         labels=labels,
         requires=['go'],
+        provides={
+            'test': lib,
+        },
         pre_build=_collect_linker_flags(static, definitions),
         stamp = stamp,
     )
@@ -661,6 +670,7 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
         complete = False,
         _generate_import_config=False,
         import_path = test_package,
+        requires = ["test"],
     )
 
     if cgo:
@@ -750,7 +760,7 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
         size = size,
         flaky = flaky,
         test_outputs = test_outputs,
-        requires = ['go', 'test'],
+        requires = ['go'],
         labels = labels,
         binary = True,
         test = True,


### PR DESCRIPTION
Currently, the binary outputted by a `go_binary` is brought in as an input to a `go_test` when the `go_binary` is included as a dependency. This prevents the sources of a `go_binary` from being tested by a `go_test` without either mirroring the `srcs` and `deps` from the `go_binary` into the `go_test` (which is repetitive), or splitting the bits to be tested into a `go_library` that is then included as a dependency of the `go_binary` (which is cumbersome).

Use the `requires`/`provides` mechanism to output a `go_binary`'s sources instead of a binary when a `go_test` is being built, thus avoiding the need for either of the above workarounds.