### PR TITLE
Do not iterate over ls output in install script

### DIFF
--- a/tools/misc/get_plz.sh
+++ b/tools/misc/get_plz.sh
@@ -37,9 +37,10 @@ mkdir -p "$DIR"
 echo "Downloading Please ${VERSION}..."
 curl -fsSL "${PLEASE_URL}" | tar -xzpf- --strip-components=1 -C "$DIR"
 # Link it all back up a dir
-for x in `ls "$DIR"`; do
+for x in "${DIR}/"*; do
     ln -sf "${DIR}/${x}" "$LOCATION"
 done
+
 ln -sf "${LOCATION}/please" "${LOCATION}/plz"
 mkdir "${LOCATION}/bin"
 curl https://get.please.build/pleasew -s --output "${LOCATION}/bin/plz"


### PR DESCRIPTION
Iterating over `ls` output is fragile, and prone to breakage. It is best practice to use globbing.

Additional Reading
- https://www.shellcheck.net/wiki/SC2045