### PR TITLE
Disallow recursive dirs

### DIFF
--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -403,6 +403,11 @@ func (b *dirBuilder) Tree(root string) *pb.Tree {
 func (b *dirBuilder) tree(tree *pb.Tree, root string, dir *pb.Directory) {
 	tree.Children = append(tree.Children, dir)
 	for _, d := range dir.Directories {
+		// Some upstreams may convert an empty directory to one with a single dir named '.'
+		// We need to skip this otherwise we end up infinitely recursing.
+		if d.Name == "." {
+			continue
+		}
 		name := path.Join(root, d.Name)
 		b.tree(tree, name, b.dirs[name])
 	}


### PR DESCRIPTION
Seems that the SDK will incorrectly convert an empty directory to one containing a single directory named `.`. This causes us to infinitely recurse if we encounter such a thing.

This fixes that by simply ignoring it. It pretty much seems to work except for downloading the outputs of that action (which I currently can't find a nice solution for) - so this is strictly better but not a complete solution.