### PR TITLE
Bump gopsutil version

### DIFF
--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -516,7 +516,7 @@ go_module(
     ],
     licences = ["BSD-3-Clause"],
     module = "github.com/shirou/gopsutil/v3",
-    version = "v3.21.8",
+    version = "v3.22.6",
     visibility = ["PUBLIC"],
     deps = [
         ":sysconf",


### PR DESCRIPTION
This should fix the `Error getting CPU info: not implemented yet` error on Apple M1 platform, Please version 16.21.3