### PR TITLE
REX: Remove old specific path code

### DIFF
--- a/rules/java_rules.build_defs
+++ b/rules/java_rules.build_defs
@@ -342,7 +342,7 @@ def java_test(name:str, srcs:list, resources:list=None, resources_root:str=None,
         deps=deps,
         visibility=visibility,
         test_sandbox=sandbox,
-        labels=labels + ['test_results_dir'],
+        labels=labels,
         test_timeout=timeout,
         size = size,
         flaky=flaky,
@@ -513,7 +513,7 @@ def _jarcat_cmd(main_class=None, preamble=None, manifest=None):
     return cmd, {'jarcat': [CONFIG.JARCAT_TOOL]}
 
 # This function is exposed as java_toolchain unless Bazel compatibility is enabled in which case it is exposed as
-# please_java_toolchain. This is to avoid namespace conflicts with Bazel's java_toolchain rule. 
+# please_java_toolchain. This is to avoid namespace conflicts with Bazel's java_toolchain rule.
 def _java_toolchain(name : str, jdk_url : str|dict='', jdk:str='', visibility:list = ["PUBLIC"], hashes = []) -> str:
     """Downloads the JDK so language rules can use the toolchain"""
     if jdk_url and jdk:
@@ -603,4 +603,3 @@ if CONFIG.BAZEL_COMPATIBILITY:
             test_only = test_only,
             visibility = visibility,
         )
-

--- a/rules/python_rules.build_defs
+++ b/rules/python_rules.build_defs
@@ -326,7 +326,7 @@ def python_test(name:str, srcs:list, data:list|dict=[], resources:list=[], deps:
         #      is faster for unittest as well (because we don't need to rebuild the pex if they change).
         data=data | {'_srcs': srcs} if isinstance(data, dict) else data + srcs,
         outs=[f'{name}.pex'],
-        labels=labels + ['test_results_dir'],
+        labels=labels,
         cmd='$TOOL z -i . -s .pex.zip -s .whl --preamble_from="$SRC" --include_other --add_init_py --strict',
         test_cmd=test_cmd,
         debug_cmd=debug_cmd,

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -52,11 +52,6 @@ const TestResultsFile = "test.results"
 // This is similarly defined via an environment variable.
 const CoverageFile = "test.coverage"
 
-// TestResultsDirLabel is a known label that indicates that the test will output results
-// into a directory rather than a file. Please can internally handle either but the remote
-// execution API requires that we specify which is which.
-const TestResultsDirLabel = "test_results_dir"
-
 // tempOutputSuffix is the suffix we attach to temporary outputs to avoid name clashes.
 const tempOutputSuffix = ".out"
 

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -144,18 +144,12 @@ func (c *Client) stampedBuildEnvironment(state *core.BuildState, target *core.Bu
 
 // buildTestCommand builds a command for a target when testing.
 func (c *Client) buildTestCommand(state *core.BuildState, target *core.BuildTarget) (*pb.Command, error) {
-	// TODO(peterebden): Remove all this nonsense once API v2.1 is released.
-	files := target.Test.Outputs
-	dirs := []string{}
+	paths := target.Test.Outputs
 	if target.NeedCoverage(state) {
-		files = append(files, core.CoverageFile)
+		paths = append(paths, core.CoverageFile)
 	}
 	if !target.Test.NoOutput {
-		if target.HasLabel(core.TestResultsDirLabel) {
-			dirs = []string{core.TestResultsFile}
-		} else {
-			files = append(files, core.TestResultsFile)
-		}
+		paths = append(paths, core.TestResultsFile)
 	}
 	commandPrefix := "export TMP_DIR=\"`pwd`\" TEST_DIR=\"`pwd`\" && "
 	if outs := target.Outputs(); len(outs) > 0 {
@@ -176,9 +170,7 @@ func (c *Client) buildTestCommand(state *core.BuildState, target *core.BuildTarg
 		},
 		Arguments:            process.BashCommand(c.shellPath, commandPrefix+cmd, state.Config.Build.ExitOnError),
 		EnvironmentVariables: c.buildEnv(nil, core.TestEnvironment(state, target, "."), target.Test.Sandbox),
-		OutputFiles:          files,
-		OutputDirectories:    dirs,
-		OutputPaths:          append(files, dirs...),
+		OutputPaths:          paths,
 	}, err
 }
 


### PR DESCRIPTION
Implementing the TODO to remove this stuff. It was useful for compat but we don't support a rex server without non-specific output paths support; in practice many things will fail before we get to tests running.