### PR TITLE
Queue data of targets before downloading outputs during `plz run`

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -85,6 +85,8 @@ func Build(tid int, state *core.BuildState, label core.BuildLabel, remote bool) 
 	target.FinishBuild()
 	if target.IsTest() && state.NeedTests && state.IsOriginalTarget(target) {
 		state.QueueTestTarget(target)
+	} else if state.NeedRun && state.IsOriginalTarget(target) {
+		state.QueueTargetData(target)
 	}
 }
 

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -85,8 +85,6 @@ func Build(tid int, state *core.BuildState, label core.BuildLabel, remote bool) 
 	target.FinishBuild()
 	if target.IsTest() && state.NeedTests && state.IsOriginalTarget(target) {
 		state.QueueTestTarget(target)
-	} else if state.NeedRun && state.IsOriginalTarget(target) {
-		state.QueueTargetData(target)
 	}
 }
 

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -951,18 +951,19 @@ func (state *BuildState) queueTarget(label, dependent BuildLabel, forceBuild, ne
 	return nil
 }
 
+// QueueTestTarget adds a target to the queue to be tested.
 func (state *BuildState) QueueTestTarget(target *BuildTarget) {
-	// TODO: Can this be made async?
-	state.queueTestTarget(target)
+	state.QueueTargetData(target)
+	state.AddPendingTest(target)
 }
 
-func (state *BuildState) queueTestTarget(target *BuildTarget) {
+// QueueTargetData queues up builds of the target's runtime data.
+func (state *BuildState) QueueTargetData(target *BuildTarget) {
 	for _, data := range target.AllData() {
 		if l, ok := data.Label(); ok {
 			state.WaitForBuiltTarget(l, target.Label)
 		}
 	}
-	state.AddPendingTest(target)
 }
 
 // queueResolvedTarget is like queueTarget but once we have a resolved target.


### PR DESCRIPTION
Fixes a case where running a test with `plz run` can fail complaining about `could not find action digest for label`.
This is fairly obscure; the case we found was a test with data & a require/provide setup on that data (which is fulfilled differently for data than for a normal dependency).