### PR TITLE
Add debug flag that implies plain output for breakpoint()

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -223,9 +223,7 @@
           ><span class="fn-p">()</span></code
         >
         - breaks into an interactive debugger allowing inspection of the current
-        scope. It would be a good idea to run Please with the
-        <code class="code">-p</code> /
-        <code class="code">--plain_output</code> flag if intending to use this.
+        scope. To enable breakpoints, pass the <code class="code">--debug</code> flag.
       </span>
     </li>
     <li>

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	golang.org/x/net v0.0.0-20210917221730-978cfadd31cf
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678
+	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 	golang.org/x/tools v0.1.5
 	google.golang.org/genproto v0.0.0-20210917145530-b395a37504d4
 	google.golang.org/grpc v1.40.0
@@ -77,7 +78,6 @@ require (
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
-	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20210920135941-2c5829bbf927 h1:OSZDIq6u4iqaEjBZ8BmlEAwM4x8bRLHRWzzOkbv/Jvc=
 github.com/ProtonMail/go-crypto v0.0.0-20210920135941-2c5829bbf927/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -213,6 +213,9 @@ type BuildState struct {
 	CurrentSubrepo string
 	// ParentState is the state of the repo containing this subrepo. Nil if this is the host repo.
 	ParentState *BuildState
+	// EnableBreakpoints enablese the breakpoint() build-in, and drops Please into an interactive debugger when
+	// they're encountered.
+	EnableBreakpoints bool
 }
 
 // ExcludedBuiltinRules returns a set of rules to exclude based on the feature flags

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1121,6 +1121,10 @@ func subrepo(s *scope, args []pyObject) pyObject {
 
 // breakpoint implements an interactive debugger for the breakpoint() builtin
 func breakpoint(s *scope, args []pyObject) pyObject {
+	if !s.state.EnableBreakpoints {
+		log.Warningf("Skipping breakpoint. Use --debug to enable breakpoints.")
+		return None
+	}
 	// Take this mutex to ensure only one debugger runs at a time
 	s.interpreter.breakpointMutex.Lock()
 	defer s.interpreter.breakpointMutex.Unlock()

--- a/src/please.go
+++ b/src/please.go
@@ -87,6 +87,7 @@ var opts struct {
 		NoLock             bool    `long:"nolock" description:"Don't attempt to lock the repo exclusively. Use with care."`
 		KeepWorkdirs       bool    `long:"keep_workdirs" description:"Don't clean directories in plz-out/tmp after successfully building targets."`
 		HTTPProxy          cli.URL `long:"http_proxy" env:"HTTP_PROXY" description:"HTTP proxy to use for downloads"`
+		Debug              bool    `long:"debug" description:"When enabled, Please will enter into an interactive debugger when breakpoint() is called during parsing."`
 	} `group:"Options that enable / disable certain features"`
 
 	HelpFlags struct {
@@ -1109,6 +1110,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	state.DebugFailingTests = debugFailingTests
 	state.ShowAllOutput = opts.OutputFlags.ShowAllOutput
 	state.ParsePackageOnly = opts.ParsePackageOnly
+	state.EnableBreakpoints = opts.FeatureFlags.Debug
 
 	// What outputs get downloaded in remote execution.
 	if debug {
@@ -1160,7 +1162,7 @@ func runPlease(state *core.BuildState, targets []core.BuildLabel) {
 	streamTests := opts.Test.StreamResults || opts.Cover.StreamResults
 	shell := opts.Build.Shell != "" || opts.Test.Shell != "" || opts.Cover.Shell != ""
 	shellRun := opts.Build.Shell == "run" || opts.Test.Shell == "run" || opts.Cover.Shell == "run"
-	pretty := prettyOutput(opts.OutputFlags.InteractiveOutput, opts.OutputFlags.PlainOutput, opts.OutputFlags.Verbosity) && state.NeedBuild && !streamTests
+	pretty := prettyOutput(opts.OutputFlags.InteractiveOutput, opts.OutputFlags.PlainOutput || opts.FeatureFlags.Debug, opts.OutputFlags.Verbosity) && state.NeedBuild && !streamTests
 	state.Cache = cache.NewCache(state)
 
 	// Run the display


### PR DESCRIPTION
Currently we drop into the interactive debugger which fights with the interactive output and leaves the terminal in a seemingly irrecoverable state. I think gating breakpoints behind this flag is a nice feature anyway, but it can also imply plain output to avoid this issue. 