### PR TITLE
Output options for `plz exec parallel`

### DIFF
--- a/src/exec/exec.go
+++ b/src/exec/exec.go
@@ -89,7 +89,7 @@ func exec(state *core.BuildState, outputMode process.OutputMode, target *core.Bu
 		}
 
 		env = append(core.ExecEnvironment(state, target, filepath.Join(core.RepoRoot, runtimeDir)), env...)
-		out, _, err := state.ProcessExecutor.ExecWithTimeoutShellStdStreams(target, runtimeDir, env, time.Duration(math.MaxInt64), false, foreground, sandbox, cmd, true)
+		out, _, err := state.ProcessExecutor.ExecWithTimeoutShellStdStreams(target, runtimeDir, env, time.Duration(math.MaxInt64), false, foreground, sandbox, cmd, outputMode == process.Default)
 		return out, err
 	}); err != nil {
 		log.Error("Failed to execute %s: %s", target, err)

--- a/src/exec/exec_test.go
+++ b/src/exec/exec_test.go
@@ -16,7 +16,7 @@ import (
 func TestNoBinaryTargetNoOverrideCommand(t *testing.T) {
 	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
 
-	err := exec(core.NewDefaultBuildState(), target, ".", nil, nil, nil, "", false, process.NoSandbox)
+	err := exec(core.NewDefaultBuildState(), process.Default, target, ".", nil, nil, nil, "", false, process.NoSandbox)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "target needs to be a binary")
 }
@@ -95,7 +95,7 @@ func TestExec(t *testing.T) {
 	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
 	state.Graph.AddTarget(target)
 
-	err := exec(state, target, "test", nil, []string{"echo", "foo"}, nil, "", false, process.NoSandbox)
+	err := exec(state, process.Default, target, "test", nil, []string{"echo", "foo"}, nil, "", false, process.NoSandbox)
 	assert.Nil(t, err)
 }
 

--- a/src/please.go
+++ b/src/please.go
@@ -224,7 +224,6 @@ var opts struct {
 			Target              core.AnnotatedOutputLabel `positional-arg-name:"target" required:"true" description:"Target to execute"`
 			OverrideCommandArgs []string                  `positional-arg-name:"override_command" description:"Override command"`
 		} `positional-args:"true"`
-		XOutput    process.OutputMode `long:"output" default:"default" choice:"default" choice:"quiet" choice:"group_immediate" description:"Controls how output from subprocesses is handled."`
 		Sequential struct {
 			Args struct {
 				Targets TargetsOrArgs `positional-arg-name:"target" required:"true" description:"Targets to execute, or arguments to them"`

--- a/src/please.go
+++ b/src/please.go
@@ -1097,7 +1097,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 	state.NeedCoverage = opts.Cover.active
 	state.NeedBuild = shouldBuild
 	state.NeedTests = shouldTest
-	state.NeedRun = !opts.Run.Args.Target.IsEmpty() || len(opts.Run.Parallel.PositionalArgs.Targets) > 0 || len(opts.Run.Sequential.PositionalArgs.Targets) > 0 || !opts.Exec.Args.Target.IsEmpty() || opts.Tool.Args.Tool != "" || debug
+	state.NeedRun = !opts.Run.Args.Target.IsEmpty() || len(opts.Run.Parallel.PositionalArgs.Targets) > 0 || len(opts.Run.Sequential.PositionalArgs.Targets) > 0 || !opts.Exec.Args.Target.IsEmpty() || len(opts.Exec.Sequential.Args.Targets) > 0 || len(opts.Exec.Parallel.Args.Targets) > 0 || opts.Tool.Args.Tool != "" || debug
 	state.NeedHashesOnly = len(opts.Hash.Args.Targets) > 0
 	if opts.Build.Prepare {
 		log.Warningf("--prepare has been deprecated in favour of --shell and will be removed in v17.")

--- a/src/please.go
+++ b/src/please.go
@@ -224,16 +224,19 @@ var opts struct {
 			Target              core.AnnotatedOutputLabel `positional-arg-name:"target" required:"true" description:"Target to execute"`
 			OverrideCommandArgs []string                  `positional-arg-name:"override_command" description:"Override command"`
 		} `positional-args:"true"`
+		XOutput    process.OutputMode `long:"output" default:"default" choice:"default" choice:"quiet" choice:"group_immediate" description:"Controls how output from subprocesses is handled."`
 		Sequential struct {
 			Args struct {
 				Targets TargetsOrArgs `positional-arg-name:"target" required:"true" description:"Targets to execute, or arguments to them"`
 			} `positional-args:"true"`
+			Output process.OutputMode `long:"output" default:"default" choice:"default" choice:"quiet" choice:"group_immediate" description:"Controls how output from subprocesses is handled."`
 		} `command:"sequential" description:"Execute a series of targets sequentially"`
 		Parallel struct {
 			NumTasks int `short:"n" long:"num_tasks" default:"10" description:"Maximum number of subtasks to run in parallel"`
 			Args     struct {
 				Targets TargetsOrArgs `positional-arg-name:"target" required:"true" description:"Targets to execute, or arguments to them"`
 			} `positional-args:"true"`
+			Output process.OutputMode `long:"output" default:"default" choice:"default" choice:"quiet" choice:"group_immediate" description:"Controls how output from subprocesses is handled."`
 		} `command:"parallel" description:"Execute a number of targets in parallel"`
 	} `command:"exec" subcommands-optional:"true" description:"Executes a single target in a hermetic build environment"`
 

--- a/src/process/BUILD
+++ b/src/process/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//src/cli",
         "//src/cli/logging",
         "//third_party/go:deferred_regex",
+        "//third_party/go:go-flags",
     ],
 )
 

--- a/src/process/output.go
+++ b/src/process/output.go
@@ -1,0 +1,39 @@
+package process
+
+import (
+	"fmt"
+	"os"
+)
+
+// An OutputMode defines how we emit output from subprocesses.
+type OutputMode string
+
+const (
+	// Default emits everything to stdout/stderr, interleaved with no buffering.
+	Default OutputMode = "default"
+	// Quiet suppresses all output apart from for failed subprocesses.
+	Quiet OutputMode = "quiet"
+	// GroupImmediate displays output from each process as it completes.
+	GroupImmediate OutputMode = "group_immediate"
+)
+
+// RunWithOutput runs a subprocess with the given output mechanism.
+// The actual running is done via a callback which should return the output and any error;
+// it will need to arrange to attach stdout/err appropriately for Default mode.
+func RunWithOutput(mode OutputMode, label string, f func() ([]byte, error)) error {
+	switch mode {
+	case GroupImmediate:
+		out, err := f()
+		fmt.Println(label)
+		if err == nil {
+			os.Stdout.Write(out)
+		}
+		return err
+	case Quiet, Default:
+		fallthrough
+	default:
+		_, err := f()
+		return err
+	}
+
+}

--- a/src/process/output.go
+++ b/src/process/output.go
@@ -35,5 +35,4 @@ func RunWithOutput(mode OutputMode, label string, f func() ([]byte, error)) erro
 		_, err := f()
 		return err
 	}
-
 }

--- a/src/run/BUILD
+++ b/src/run/BUILD
@@ -19,6 +19,7 @@ go_test(
     data = ["test_data"],
     deps = [
         ":run",
+        "//src/process",
         "//third_party/go:testify",
     ],
 )

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -25,14 +25,6 @@ import (
 
 var log = logging.Log
 
-type ProcessOutput string
-
-const (
-	Default        ProcessOutput = "default"
-	Quiet          ProcessOutput = "quiet"
-	GroupImmediate ProcessOutput = "group_immediate"
-)
-
 // Run implements the running part of 'plz run'.
 func Run(state *core.BuildState, label core.AnnotatedOutputLabel, args []string, remote, env, inTmp bool, dir, overrideCmd string) {
 	prepareRun()
@@ -44,7 +36,7 @@ func Run(state *core.BuildState, label core.AnnotatedOutputLabel, args []string,
 // Returns a relevant exit code (i.e. if at least one subprocess exited unsuccessfully, it will be
 // that code, otherwise 0 if all were successful).
 // The given context can be used to control the lifetime of the subprocesses.
-func Parallel(ctx context.Context, state *core.BuildState, labels []core.AnnotatedOutputLabel, args []string, numTasks int, output ProcessOutput, remote, env, detach, inTmp bool, dir string) int {
+func Parallel(ctx context.Context, state *core.BuildState, labels []core.AnnotatedOutputLabel, args []string, numTasks int, outputMode process.OutputMode, remote, env, detach, inTmp bool, dir string) int {
 	prepareRun()
 
 	limiter := make(chan struct{}, numTasks)
@@ -55,7 +47,7 @@ func Parallel(ctx context.Context, state *core.BuildState, labels []core.Annotat
 			limiter <- struct{}{}
 			defer func() { <-limiter }()
 
-			err := runWithOutput(ctx, state, label, args, output, remote, env, detach, inTmp, dir)
+			err := runWithOutput(ctx, state, label, args, outputMode, remote, env, detach, inTmp, dir)
 			if err != nil && ctx.Err() == nil {
 				log.Error("Command failed: %s", err)
 			}
@@ -72,34 +64,21 @@ func Parallel(ctx context.Context, state *core.BuildState, labels []core.Annotat
 }
 
 // runWithOutput runs a subprocess with the given output mechanism.
-func runWithOutput(ctx context.Context, state *core.BuildState, label core.AnnotatedOutputLabel, args []string, output ProcessOutput, remote, env, detach, inTmp bool, dir string) error {
-	switch output {
-	case GroupImmediate:
-		out, _, err := run(ctx, state, label, args, true, true, remote, env, detach, inTmp, dir, "")
-		fmt.Println(label)
-		if err == nil {
-			os.Stdout.Write(out)
-		}
-		return err
-	case Quiet:
-		_, _, err := run(ctx, state, label, args, true, true, remote, env, detach, inTmp, dir, "")
-		return err
-	case Default:
-		fallthrough
-	default:
-		_, _, err := run(ctx, state, label, args, true, false, remote, env, detach, inTmp, dir, "")
-		return err
-	}
+func runWithOutput(ctx context.Context, state *core.BuildState, label core.AnnotatedOutputLabel, args []string, outputMode process.OutputMode, remote, env, detach, inTmp bool, dir string) error {
+	return process.RunWithOutput(outputMode, label.String(), func() ([]byte, error) {
+		out, _, err := run(ctx, state, label, args, true, outputMode != process.Default, remote, env, detach, inTmp, dir, "")
+		return out, err
+	})
 }
 
 // Sequential runs a series of targets sequentially.
 // Returns a relevant exit code (i.e. if at least one subprocess exited unsuccessfully, it will be
 // that code, otherwise 0 if all were successful).
-func Sequential(state *core.BuildState, labels []core.AnnotatedOutputLabel, args []string, output ProcessOutput, remote, env, inTmp bool, dir string) int {
+func Sequential(state *core.BuildState, labels []core.AnnotatedOutputLabel, args []string, outputMode process.OutputMode, remote, env, inTmp bool, dir string) int {
 	prepareRun()
 	for _, label := range labels {
 		log.Notice("Running %s", label)
-		if err := runWithOutput(context.Background(), state, label, args, output, remote, env, false, inTmp, dir); err != nil {
+		if err := runWithOutput(context.Background(), state, label, args, outputMode, remote, env, false, inTmp, dir); err != nil {
 			log.Error("%s", err)
 			return err.(*exitError).code
 		}

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/process"
 )
 
 func init() {
@@ -18,17 +19,17 @@ func init() {
 
 func TestSequential(t *testing.T) {
 	state, labels1, labels2 := makeState(core.DefaultConfiguration())
-	code := Sequential(state, labels1, nil, Quiet, false, false, false, "")
+	code := Sequential(state, labels1, nil, process.Quiet, false, false, false, "")
 	assert.Equal(t, 0, code)
-	code = Sequential(state, labels2, nil, Default, false, false, false, "")
+	code = Sequential(state, labels2, nil, process.Default, false, false, false, "")
 	assert.Equal(t, 1, code)
 }
 
 func TestParallel(t *testing.T) {
 	state, labels1, labels2 := makeState(core.DefaultConfiguration())
-	code := Parallel(context.Background(), state, labels1, nil, 5, Default, false, false, false, false, "")
+	code := Parallel(context.Background(), state, labels1, nil, 5, process.Default, false, false, false, false, "")
 	assert.Equal(t, 0, code)
-	code = Parallel(context.Background(), state, labels2, nil, 5, Quiet, false, false, false, false, "")
+	code = Parallel(context.Background(), state, labels2, nil, 5, process.Quiet, false, false, false, false, "")
 	assert.Equal(t, 1, code)
 }
 

--- a/src/watch/BUILD
+++ b/src/watch/BUILD
@@ -7,6 +7,7 @@ go_library(
         "//src/cli/logging",
         "//src/core",
         "//src/fs",
+        "//src/process",
         "//src/run",
         "//third_party/go:fsnotify",
     ],

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
+	"github.com/thought-machine/please/src/process"
 	"github.com/thought-machine/please/src/run"
 )
 
@@ -177,6 +178,6 @@ func build(ctx context.Context, state *core.BuildState, labels []core.BuildLabel
 				BuildLabel: l,
 			}
 		}
-		go run.Parallel(ctx, state, als, nil, state.Config.Please.NumThreads, run.Default, false, false, false, false, "")
+		go run.Parallel(ctx, state, als, nil, state.Config.Please.NumThreads, process.Default, false, false, false, false, "")
 	}
 }


### PR DESCRIPTION
This commonises the output modes from `run` and applies them to `plz exec sequential` and `plz exec parallel`.