### PR TITLE
Implement updates from subprocesses using `plz exec parallel`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	go.uber.org/automaxprocs v1.4.0
 	golang.org/x/crypto v0.0.0-20210920023735-84f357641f63
 	golang.org/x/net v0.0.0-20210917221730-978cfadd31cf
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678
 	golang.org/x/tools v0.1.5
 	google.golang.org/genproto v0.0.0-20210917145530-b395a37504d4

--- a/go.sum
+++ b/go.sum
@@ -434,6 +434,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/src/exec/exec.go
+++ b/src/exec/exec.go
@@ -1,11 +1,13 @@
 package exec
 
 import (
+	"context"
 	"fmt"
 	"math"
 	osExec "os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -27,6 +29,7 @@ func Exec(state *core.BuildState, label core.AnnotatedOutputLabel, dir string, e
 // It returns the exit code from the last executed target; if that's zero then they were all successful.
 func Sequential(state *core.BuildState, outputMode process.OutputMode, labels []core.AnnotatedOutputLabel, args []string, shareNetwork, shareMount bool) int {
 	for _, label := range labels {
+		log.Notice("Executing %s...", label)
 		target := state.Graph.TargetOrDie(label.BuildLabel)
 		sandbox := process.NewSandboxConfig(target.Sandbox && !shareNetwork, target.Sandbox && !shareMount)
 		if err := exec(state, outputMode, target, target.ExecDir(), nil, nil, args, label.Annotation, false, sandbox); err != nil {
@@ -39,18 +42,35 @@ func Sequential(state *core.BuildState, outputMode process.OutputMode, labels []
 // Parallel executes a series of targets in parallel (to a limit of simultaneous processes).
 // Returns a relevant exit code (i.e. if at least one subprocess exited unsuccessfully, it will be
 // that code, otherwise 0 if all were successful).
-func Parallel(state *core.BuildState, outputMode process.OutputMode, labels []core.AnnotatedOutputLabel, args []string, numTasks int, shareNetwork, shareMount bool) int {
-	limiter := make(chan struct{}, numTasks)
+func Parallel(state *core.BuildState, outputMode process.OutputMode, updateFrequency time.Duration, labels []core.AnnotatedOutputLabel, args []string, numTasks int, shareNetwork, shareMount bool) int {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	var g errgroup.Group
+	g.SetLimit(numTasks)
+	var done, started atomic.Int64
+	total := len(labels)
+
+	if updateFrequency > 0 && outputMode != process.Default {
+		go func() {
+			t := time.NewTicker(updateFrequency)
+			d := ctx.Done()
+			for {
+				select {
+				case <-t.C:
+					log.Notice("Executing, %d tasks started, %d completed of %d total", int(started.Load()), int(done.Load()), total)
+				case <-d:
+					return
+				}
+			}
+		}()
+	}
 
 	for _, label := range labels {
 		target := state.Graph.TargetOrDie(label.BuildLabel)
 		annotation := label.Annotation
 		g.Go(func() error {
-			limiter <- struct{}{}
-			defer func() { <-limiter }()
-
-			log.Notice("Executing %s...", target)
+			started.Add(1)
+			defer done.Add(1)
 			sandbox := process.NewSandboxConfig(target.Sandbox && !shareNetwork, target.Sandbox && !shareMount)
 			return exec(state, outputMode, target, target.ExecDir(), nil, nil, args, annotation, false, sandbox)
 		})

--- a/src/please.go
+++ b/src/please.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/thought-machine/go-flags"
 	"go.uber.org/automaxprocs/maxprocs"
@@ -236,6 +237,7 @@ var opts struct {
 				Targets TargetsOrArgs `positional-arg-name:"target" required:"true" description:"Targets to execute, or arguments to them"`
 			} `positional-args:"true"`
 			Output process.OutputMode `long:"output" default:"default" choice:"default" choice:"quiet" choice:"group_immediate" description:"Controls how output from subprocesses is handled."`
+			Update cli.Duration       `long:"update" default:"10s" description:"Frequency to log updates on running subprocesses. Has no effect for 'default' output mode."`
 		} `command:"parallel" description:"Execute a number of targets in parallel"`
 	} `command:"exec" subcommands-optional:"true" description:"Executes a single target in a hermetic build environment"`
 
@@ -569,7 +571,7 @@ var buildFunctions = map[string]func() int{
 		if !success {
 			return toExitCode(success, state)
 		}
-		if code := exec.Parallel(state, opts.Exec.Parallel.Output, annotated, args, opts.Exec.Parallel.NumTasks, opts.Exec.Share.Network, opts.Exec.Share.Mount); code != 0 {
+		if code := exec.Parallel(state, opts.Exec.Parallel.Output, time.Duration(opts.Exec.Parallel.Update), annotated, args, opts.Exec.Parallel.NumTasks, opts.Exec.Share.Network, opts.Exec.Share.Mount); code != 0 {
 			return code
 		}
 		return 0

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -503,7 +503,7 @@ go_module(
     ],
     licences = ["BSD-3-Clause"],
     module = "golang.org/x/sync",
-    version = "v0.0.0-20210220032951-036812b2e83c",
+    version = "v0.0.0-20220722155255-886fb9371eb4",
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
Produces periodic log messages showing the state of subprocesses, which can otherwise be a bit opaque for `quiet` / `group_immediate` output.

Bonus: `errgroup` can now rate-limit itself so get rid of our channel \o/