### PR TITLE
Rewrite `pleasew` in POSIX shell

### DIFF
--- a/pleasew
+++ b/pleasew
@@ -24,14 +24,14 @@ else
 fi
 
 get_profile () {
-	 while [ "${#}" -gt 0 ]
-	 do
-		  case "${1}" in
-			   --profile=*) echo "${1#*=}"; return;;
-			   --profile) echo "${2}"; return;;
-			   *) shift;;
-		  esac
-	 done
+    while [ "${#}" -gt 0 ]
+    do
+        case "${1}" in
+            --profile=*) echo "${1#*=}"; return;;
+            --profile) echo "${2}"; return;;
+            *) shift;;
+        esac
+    done
 }
 
 # Check `PLZ_CONFIG_PROFILE` or fall back to arguments for a profile.
@@ -49,13 +49,13 @@ EOS
 )"
 
 read_config() {
-	 # Disable globbing to ensure word-splitting is safe.
-	 set -f
+    # Disable globbing to ensure word-splitting is safe.
+    set -f
 
-	 old_ifs="${IFS}"
-	 search_term="${1}"
+    old_ifs="${IFS}"
+    search_term="${1}"
 
-	 IFS='
+    IFS='
 '
 
     # This is intended, we *do* want word-splitting here.
@@ -64,7 +64,7 @@ read_config() {
 
     grep -i "${search_term}" "${@}" 2> /dev/null | head -n 1
 
-	 IFS="${old_ifs}"
+    IFS="${old_ifs}"
     set +f
 }
 
@@ -106,8 +106,8 @@ VERSION="$(echo "${VERSION}" | tr -d ' ')" # Remove all spaces
 VERSION="${VERSION#>=}"                    # Strip any initial >=
 
 if [ "${VERSION:+x}" != 'x' ]; then
-  	 printf >&2 "%bCan't determine version, will use latest.%b\n" "${YELLOW}" "${RESET}"
-  	 VERSION=$(curl -fsSL "${URL_BASE}"/latest_version)
+    printf >&2 "%bCan't determine version, will use latest.%b\n" "${YELLOW}" "${RESET}"
+    VERSION=$(curl -fsSL "${URL_BASE}"/latest_version)
 fi
 
 # Find the os / arch to download. You can do this quite nicely with go env

--- a/pleasew
+++ b/pleasew
@@ -23,12 +23,18 @@ else
     ARCH='amd64'
 fi
 
+get_profile () {
+	 while [ "${#}" -gt 0 ]
+	 do
+		  case "${1}" in
+			   --profile) echo "${2}"; return;;
+			   *) shift;;
+		  esac
+	 done
+}
+
 # Check `PLZ_CONFIG_PROFILE` or fall back to arguments for a profile.
-PROFILE="${PLZ_CONFIG_PROFILE:-$(
-	sed -E 's/.*--profile[= ]([^ ]+).*/\1/g' <<-EOS
-		"${*}"
-	EOS
-)}"
+PROFILE="${PLZ_CONFIG_PROFILE:-$(get_profile "${@}")}"
 
 # Config files on order of precedence high to low.
 CONFIGS="$(cat <<- EOS
@@ -42,7 +48,23 @@ EOS
 )"
 
 read_config() {
-    printf "%s" "${CONFIGS}" | xargs grep -i "${1}" 2>/dev/null | head -n 1
+	 # Disable globbing to ensure word-splitting is safe.
+	 set -f
+
+	 old_ifs="${IFS}"
+	 search_term="${1}"
+
+	 IFS='
+'
+
+    # This is intended, we *do* want word-splitting here.
+    # shellcheck disable=2086
+    set -- ${CONFIGS}
+
+    grep -i "${search_term}" "${@}" 2> /dev/null | head -n 1
+
+	 IFS="${old_ifs}"
+    set +f
 }
 
 # We might already have it downloaded...

--- a/pleasew
+++ b/pleasew
@@ -15,12 +15,12 @@ DEFAULT_URL_BASE='https://get.please.build'
 OS="$(uname)"
 
 if [ "${OS}" = 'Darwin' ]; then
-   # switch between mac amd64/arm64
-   ARCH="$(uname -m)"
+    # switch between mac amd64/arm64
+    ARCH="$(uname -m)"
 else
-   # default to amd64 on other operating systems
-   # because we only build intel binaries
-   ARCH='amd64'
+    # default to amd64 on other operating systems
+    # because we only build intel binaries
+    ARCH='amd64'
 fi
 
 # Check `PLZ_CONFIG_PROFILE` or fall back to arguments for a profile.
@@ -42,37 +42,37 @@ EOS
 )"
 
 read_config() {
-   printf "%s" "${CONFIGS}" | xargs grep -i "${1}" 2>/dev/null | head -n 1
+    printf "%s" "${CONFIGS}" | xargs grep -i "${1}" 2>/dev/null | head -n 1
 }
 
 # We might already have it downloaded...
 LOCATION="$(read_config '^location' | cut -d '=' -f 2 | tr -d ' ')"
 
 if [ "${LOCATION:+x}" != "x" ]; then
-   if [ "${HOME:+x}" != "x" ]; then
-      # shellcheck disable=2016
-      printf >&2 '%b$HOME not set, not sure where to look for Please.%b\n' "${RED}" "${RESET}"
-      exit 1
-   fi
+    if [ "${HOME:+x}" != "x" ]; then
+        # shellcheck disable=2016
+        printf >&2 '%b$HOME not set, not sure where to look for Please.%b\n' "${RED}" "${RESET}"
+        exit 1
+    fi
 
-   LOCATION="${HOME}/.please"
+    LOCATION="${HOME}/.please"
 else
-   # It can contain a literal ~, need to explicitly handle that.
-   LOCATION="$(echo "${LOCATION}" | sed "s|~|${HOME}|")"
+    # It can contain a literal ~, need to explicitly handle that.
+    LOCATION="$(echo "${LOCATION}" | sed "s|~|${HOME}|")"
 fi
 
 # If this exists at any version, let it handle any update.
 TARGET="${LOCATION}/please"
 
 if [ -f "${TARGET}" ]; then
-   # shellcheck disable=2086
-   exec "${TARGET}" ${PLZ_ARGS:-} "${@}"
+    # shellcheck disable=2086
+    exec "${TARGET}" ${PLZ_ARGS:-} "${@}"
 fi
 
 URL_BASE="$(read_config '^downloadlocation' | cut -d '=' -f 2 | tr -d ' ')"
 
 if [ -z "${URL_BASE}" ]; then
-   URL_BASE="${DEFAULT_URL_BASE}"
+    URL_BASE="${DEFAULT_URL_BASE}"
 fi
 
 URL_BASE="${URL_BASE%/}"
@@ -83,21 +83,21 @@ VERSION="$(echo "${VERSION}" | tr -d ' ')" # Remove all spaces
 VERSION="${VERSION#>=}"                    # Strip any initial >=
 
 if [ -z "${VERSION}" ]; then
-   printf >&2 "%bCan't determine version, will use latest.%b\n" "${YELLOW}" "${RESET}"
-   VERSION=$(curl -fsSL "${URL_BASE}"/latest_version)
+  	 printf >&2 "%bCan't determine version, will use latest.%b\n" "${YELLOW}" "${RESET}"
+  	 VERSION=$(curl -fsSL "${URL_BASE}"/latest_version)
 fi
 
 # Find the os / arch to download. You can do this quite nicely with go env
 # but we use this script on machines that don't necessarily have Go itself.
 if [ "${OS}" = 'Linux' ]; then
-   GOOS='linux'
+    GOOS='linux'
 elif [ "${OS}" = 'Darwin' ]; then
-   GOOS='darwin'
+    GOOS='darwin'
 elif [ "${OS}" = 'FreeBSD' ]; then
-   GOOS='freebsd'
+    GOOS='freebsd'
 else
-   printf >&2 '%bUnknown operating system %s%b\n' "${RED}" "${OS}" "${RESET}"
-   exit 1
+    printf >&2 '%bUnknown operating system %s%b\n' "${RED}" "${OS}" "${RESET}"
+    exit 1
 fi
 
 PLEASE_URL="${URL_BASE}/${GOOS}_${ARCH}/${VERSION}/please_${VERSION}.tar.xz"
@@ -105,7 +105,7 @@ DIR="${LOCATION}/${VERSION}"
 
 # Potentially we could reuse this but it's easier not to really.
 if [ ! -d "${DIR}" ]; then
-   rm -Rf "${DIR}"
+    rm -Rf "${DIR}"
 fi
 
 printf >&2 '%bDownloading Please %s to %s...%b\n' "${GREEN}" "${VERSION}" "${DIR}" "${RESET}"
@@ -114,7 +114,7 @@ curl -fsSL "${PLEASE_URL}" | tar -xJpf- --strip-components=1 -C "${DIR}"
 
 # Link it all back up a dir
 for x in "${DIR}"/*; do
-   ln -sf "${x}" "${LOCATION}"
+    ln -sf "${x}" "${LOCATION}"
 done
 
 printf >&2 '%bShould be good to go now, running plz...%b\n' "${GREEN}" "${RESET}"

--- a/pleasew
+++ b/pleasew
@@ -1,99 +1,122 @@
-#!/usr/bin/env bash
+#!/bin/sh
+
+set -e
 set -u
 
-RED="\x1B[31m"
-GREEN="\x1B[32m"
-YELLOW="\x1B[33m"
-RESET="\x1B[0m"
+set -o errexit
 
-DEFAULT_URL_BASE="https://get.please.build"
+RED='\x1B[31m'
+GREEN='\x1B[32m'
+YELLOW='\x1B[33m'
+RESET='\x1B[0m'
+
+DEFAULT_URL_BASE='https://get.please.build'
 
 OS="$(uname)"
 
-if [[ $OS == "Darwin" ]]; then
-    # switch between mac amd64/arm64 
-    ARCH="$(uname -m)"
+if [ "${OS}" = 'Darwin' ]; then
+   # switch between mac amd64/arm64
+   ARCH="$(uname -m)"
 else
-    # default to amd64 on other operating systems
-    # because we only build intel binaries
-    ARCH="amd64"
+   # default to amd64 on other operating systems
+   # because we only build intel binaries
+   ARCH='amd64'
 fi
 
-# Check PLZ_CONFIG_PROFILE or fall back to arguments for a profile.
-PROFILE="${PLZ_CONFIG_PROFILE:-$(sed -E 's/.*--profile[= ]([^ ]+).*/\1/g' <<< "$*")}"
+# Check `PLZ_CONFIG_PROFILE` or fall back to arguments for a profile.
+PROFILE="${PLZ_CONFIG_PROFILE:-$(
+	sed -E 's/.*--profile[= ]([^ ]+).*/\1/g' <<-EOS
+		"${*}"
+	EOS
+)}"
 
 # Config files on order of precedence high to low.
-CONFIGS=(
-  ".plzconfig.local"
-  "${PROFILE:+.plzconfig.$PROFILE}"
-  ".plzconfig_${OS}_${ARCH}"
-  ".plzconfig"
-  "$HOME/.config/please/plzconfig"
-  "/etc/please/plzconfig"
-)
+CONFIGS="$(cat <<- EOS
+	.plzconfig.local
+	${PROFILE:+.plzconfig.${PROFILE}}
+	.plzconfig_${OS}_${ARCH}
+	.plzconfig
+	${HOME}/.config/please/plzconfig
+	/etc/please/plzconfig
+EOS
+)"
 
-function read_config() {
-   grep -i "$1" "${CONFIGS[@]}" 2>/dev/null | head -n 1
+read_config() {
+   printf "%s" "${CONFIGS}" | xargs grep -i "${1}" 2>/dev/null | head -n 1
 }
 
 # We might already have it downloaded...
-LOCATION="$(read_config "^location" | cut -d '=' -f 2 | tr -d ' ')"
-if [ -z "$LOCATION" ]; then
-    if [ -z "$HOME" ]; then
-        echo -e >&2 "${RED}\$HOME not set, not sure where to look for Please.${RESET}"
-        exit 1
-    fi
-    LOCATION="${HOME}/.please"
+LOCATION="$(read_config '^location' | cut -d '=' -f 2 | tr -d ' ')"
+
+if [ "${LOCATION:+x}" != "x" ]; then
+   if [ "${HOME:+x}" != "x" ]; then
+      # shellcheck disable=2016
+      printf >&2 '%b$HOME not set, not sure where to look for Please.%b\n' "${RED}" "${RESET}"
+      exit 1
+   fi
+
+   LOCATION="${HOME}/.please"
 else
-    # It can contain a literal ~, need to explicitly handle that.
-    LOCATION="${LOCATION/\~/$HOME}"
+   # It can contain a literal ~, need to explicitly handle that.
+   LOCATION="$(echo "${LOCATION}" | sed "s|~|${HOME}|")"
 fi
+
 # If this exists at any version, let it handle any update.
 TARGET="${LOCATION}/please"
-if [ -f "$TARGET" ]; then
-    exec "$TARGET" ${PLZ_ARGS:-} "$@"
+
+if [ -f "${TARGET}" ]; then
+   # shellcheck disable=2086
+   exec "${TARGET}" ${PLZ_ARGS:-} "${@}"
 fi
 
-URL_BASE="$(read_config "^downloadlocation" | cut -d '=' -f 2 | tr -d ' ')"
-if [ -z "$URL_BASE" ]; then
-    URL_BASE=$DEFAULT_URL_BASE
+URL_BASE="$(read_config '^downloadlocation' | cut -d '=' -f 2 | tr -d ' ')"
+
+if [ -z "${URL_BASE}" ]; then
+   URL_BASE="${DEFAULT_URL_BASE}"
 fi
+
 URL_BASE="${URL_BASE%/}"
 
-VERSION="$(read_config "^version[^a-z]")"
-VERSION="${VERSION#*=}"    # Strip until after first =
-VERSION="${VERSION/ /}"    # Remove all spaces
-VERSION="${VERSION#>=}"    # Strip any initial >=
-if [ -z "$VERSION" ]; then
-    echo -e >&2 "${YELLOW}Can't determine version, will use latest.${RESET}"
-    VERSION=$(curl -fsSL ${URL_BASE}/latest_version)
+VERSION="$(read_config '^version[^a-z]')"
+VERSION="${VERSION#*=}"                    # Strip until after first =
+VERSION="$(echo "${VERSION}" | tr -d ' ')" # Remove all spaces
+VERSION="${VERSION#>=}"                    # Strip any initial >=
+
+if [ -z "${VERSION}" ]; then
+   printf >&2 "%bCan't determine version, will use latest.%b\n" "${YELLOW}" "${RESET}"
+   VERSION=$(curl -fsSL "${URL_BASE}"/latest_version)
 fi
 
 # Find the os / arch to download. You can do this quite nicely with go env
 # but we use this script on machines that don't necessarily have Go itself.
-if [ "$OS" = "Linux" ]; then
-    GOOS="linux"
-elif [ "$OS" = "Darwin" ]; then
-    GOOS="darwin"
-elif [ "$OS" = "FreeBSD" ]; then
-    GOOS="freebsd"
+if [ "${OS}" = 'Linux' ]; then
+   GOOS='linux'
+elif [ "${OS}" = 'Darwin' ]; then
+   GOOS='darwin'
+elif [ "${OS}" = 'FreeBSD' ]; then
+   GOOS='freebsd'
 else
-    echo -e >&2 "${RED}Unknown operating system $OS${RESET}"
-    exit 1
+   printf >&2 '%bUnknown operating system %s%b\n' "${RED}" "${OS}" "${RESET}"
+   exit 1
 fi
 
 PLEASE_URL="${URL_BASE}/${GOOS}_${ARCH}/${VERSION}/please_${VERSION}.tar.xz"
 DIR="${LOCATION}/${VERSION}"
+
 # Potentially we could reuse this but it's easier not to really.
-if [ ! -d "$DIR" ]; then
-    rm -rf "$DIR"
+if [ ! -d "${DIR}" ]; then
+   rm -Rf "${DIR}"
 fi
-echo -e >&2 "${GREEN}Downloading Please ${VERSION} to ${DIR}...${RESET}"
-mkdir -p "$DIR"
-curl -fsSL "${PLEASE_URL}" | tar -xJpf- --strip-components=1 -C "$DIR"
+
+printf >&2 '%bDownloading Please %s to %s...%b\n' "${GREEN}" "${VERSION}" "${DIR}" "${RESET}"
+mkdir -p "${DIR}"
+curl -fsSL "${PLEASE_URL}" | tar -xJpf- --strip-components=1 -C "${DIR}"
+
 # Link it all back up a dir
-for x in $(ls "$DIR"); do
-    ln -sf "${DIR}/${x}" "$LOCATION"
+for x in "${DIR}"/*; do
+   ln -sf "${x}" "${LOCATION}"
 done
-echo -e >&2 "${GREEN}Should be good to go now, running plz...${RESET}"
-exec "$TARGET" ${PLZ_ARGS:-} "$@"
+
+printf >&2 '%bShould be good to go now, running plz...%b\n' "${GREEN}" "${RESET}"
+# shellcheck disable=2086
+exec "${TARGET}" ${PLZ_ARGS:-} "${@}"

--- a/pleasew
+++ b/pleasew
@@ -27,6 +27,7 @@ get_profile () {
 	 while [ "${#}" -gt 0 ]
 	 do
 		  case "${1}" in
+			   --profile=*) echo "${1#*=}"; return;;
 			   --profile) echo "${2}"; return;;
 			   *) shift;;
 		  esac

--- a/pleasew
+++ b/pleasew
@@ -48,8 +48,8 @@ read_config() {
 # We might already have it downloaded...
 LOCATION="$(read_config '^location' | cut -d '=' -f 2 | tr -d ' ')"
 
-if [ "${LOCATION:+x}" != "x" ]; then
-    if [ "${HOME:+x}" != "x" ]; then
+if [ "${LOCATION:+x}" != 'x' ]; then
+    if [ "${HOME:+x}" != 'x' ]; then
         # shellcheck disable=2016
         printf >&2 '%b$HOME not set, not sure where to look for Please.%b\n' "${RED}" "${RESET}"
         exit 1
@@ -71,7 +71,7 @@ fi
 
 URL_BASE="$(read_config '^downloadlocation' | cut -d '=' -f 2 | tr -d ' ')"
 
-if [ -z "${URL_BASE}" ]; then
+if [ "${URL_BASE:+x}" != 'x' ]; then
     URL_BASE="${DEFAULT_URL_BASE}"
 fi
 
@@ -82,7 +82,7 @@ VERSION="${VERSION#*=}"                    # Strip until after first =
 VERSION="$(echo "${VERSION}" | tr -d ' ')" # Remove all spaces
 VERSION="${VERSION#>=}"                    # Strip any initial >=
 
-if [ -z "${VERSION}" ]; then
+if [ "${VERSION:+x}" != 'x' ]; then
   	 printf >&2 "%bCan't determine version, will use latest.%b\n" "${YELLOW}" "${RESET}"
   	 VERSION=$(curl -fsSL "${URL_BASE}"/latest_version)
 fi


### PR DESCRIPTION
As promised, here's the working rewrite of the main `pleasew` script using a bit more defensive approach to string interpolation considering there are more footguns when using POSIX shell than say bash or zsh.

My understanding from skimming through the code is that [this build step](https://github.com/thought-machine/please/blob/ab7c8ce1e373ae94b41f47a74fc7b432c9b5a622/BUILD#L28-L33) pulls the main script before embedding it [here](https://github.com/thought-machine/please/blob/ab7c8ce1e373ae94b41f47a74fc7b432c9b5a622/src/plzinit/init.go#L117). Please do correct me if I'm wrong.

This is but an initial rewrite and there are more enhancements to be done. It would be my pleasure to take care of it in a following PR.