### PR TITLE
Reduce log level of a couple of warnings

### DIFF
--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -494,7 +494,7 @@ func (label BuildLabel) CanSee(state *BuildState, dep *BuildTarget) bool {
 		return true
 	}
 	if label.isExperimental(state) {
-		log.Warning("Visibility restrictions suppressed for %s since %s is in the experimental tree", dep.Label, label)
+		log.Info("Visibility restrictions suppressed for %s since %s is in the experimental tree", dep.Label, label)
 		return true
 	}
 	return false

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -859,7 +859,7 @@ func (target *BuildTarget) CheckDependencyVisibility(state *BuildState) error {
 			return fmt.Errorf("Target %s isn't visible to %s", dep.Label, target.Label)
 		} else if dep.TestOnly && !(target.IsTest() || target.TestOnly) {
 			if target.Label.isExperimental(state) {
-				log.Warning("Test-only restrictions suppressed for %s since %s is in the experimental tree", dep.Label, target.Label)
+				log.Info("Test-only restrictions suppressed for %s since %s is in the experimental tree", dep.Label, target.Label)
 			} else {
 				return fmt.Errorf("Target %s can't depend on %s, it's marked test_only", target.Label, dep.Label)
 			}


### PR DESCRIPTION
These are a bit unnecessarily verbose; a 'large' set of stuff in experimental can result in tens of these, and you never really do anything about them anyway.

An alternative could have been to use a `sync.Once` to calm them down but I'm not sure it's really worth even emitting these once.