### PR TITLE
remote_file: log body of the http response on non-200 error codes

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -1127,6 +1127,10 @@ func fetchOneRemoteFile(state *core.BuildState, target *core.BuildTarget, url st
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		bs, _ := io.ReadAll(resp.Body)
+		if len(bs) != 0 {
+			return fmt.Errorf("Error retrieving %s: %s\n%s", url, resp.Status, string(bs))
+		}
 		return fmt.Errorf("Error retrieving %s: %s", url, resp.Status)
 	}
 	var r io.Reader = resp.Body

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -1129,7 +1129,7 @@ func fetchOneRemoteFile(state *core.BuildState, target *core.BuildTarget, url st
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		bs, _ := io.ReadAll(resp.Body)
 		if len(bs) != 0 {
-			return fmt.Errorf("Error retrieving %s: %s\n%s", url, resp.Status, string(bs))
+			log.Debug("Error retrieving %s: %s, Body:\n%s", url, resp.Status, string(bs))
 		}
 		return fmt.Errorf("Error retrieving %s: %s", url, resp.Status)
 	}


### PR DESCRIPTION
Lyudmil is having an issue with GitHub returning a 503 on downloading release assets. It seems that they will populate the body of the request with some extra information, but we're not logging that anywhere. 