### PR TITLE
fix(core/package): Fix dependency resolution before showing warning

### DIFF
--- a/src/core/package.go
+++ b/src/core/package.go
@@ -213,7 +213,7 @@ func (pkg *Package) verifyOutputs() []string {
 	ret := []string{}
 	for filename, target := range pkg.Outputs {
 		for dir := path.Dir(filename); dir != "."; dir = path.Dir(dir) {
-			if target2, present := pkg.Outputs[dir]; present && target2 != target && !target.HasDependency(target2.Label.Parent()) {
+			if target2, present := pkg.Outputs[dir]; present && target2 != target && !(target.HasDependency(target2.Label.Parent()) || target.HasDependency(target2.Label)) {
 				ret = append(ret, fmt.Sprintf("Target %s outputs files into the directory %s, which is separately output by %s. This can cause errors based on build order - you should add a dependency.", target.Label, dir, target2.Label))
 			}
 		}


### PR DESCRIPTION
When two rules output to the same directory, the condition used to check for the parent of the rule only, this adds a check for the rule itself before showing the warning.

A better version of this would be to check whether there is a conflict of files between the two rules but I'm not sufficiently accustomed with the codebase yet to attempt that endeavor. For now, this PR opens an escape hatch for those who know what they're doing to at least silence the warning.