### PR TITLE
Fix artefact (artifact?) name in sha256 list

### DIFF
--- a/tools/misc/BUILD
+++ b/tools/misc/BUILD
@@ -21,6 +21,7 @@ python_test(
     name = "gen_release_test",
     srcs = ["gen_release_test.py"],
     deps = [":gen_release"],
+    data=["data"],
 )
 
 sh_binary(

--- a/tools/misc/data/linux_amd64/release_asset_13.2.7
+++ b/tools/misc/data/linux_amd64/release_asset_13.2.7
@@ -1,0 +1,1 @@
+wibble wibble wibble

--- a/tools/misc/gen_release.py
+++ b/tools/misc/gen_release.py
@@ -83,12 +83,16 @@ class ReleaseGen:
         data = response.json()
         self.upload_url = data['upload_url'].replace('{?name,label}', '?name=')
         log.info('Release id %s created', data['id'])
-
+    
+    def artifact_name(self, artifact):
+        arch = self._arch(artifact)
+        return os.path.basename(artifact).replace(self.version, self.version + '_' + arch)
+    
     def upload(self, artifact:str):
         """Uploads the given artifact to the new release."""
         # Artifact names aren't unique between OSs; make them so.
-        arch = self._arch(artifact)
-        filename = os.path.basename(artifact).replace(self.version, self.version + '_' + arch)
+        
+        filename = self.artifact_name(artifact)
         _, ext = os.path.splitext(filename)
         content_type = self.known_content_types.get(ext, 'application/octet-stream')
         url = self.upload_url + filename
@@ -126,7 +130,7 @@ class ReleaseGen:
         with open(artifact, 'rb') as f:
             checksum = hashlib.sha256(f.read()).hexdigest()
         with open(out, 'w') as f:
-            basename = os.path.basename(artifact)
+            basename = self.artifact_name(artifact)
             f.write(f'{checksum}  {basename}\n')
         return out
 

--- a/tools/misc/gen_release_test.py
+++ b/tools/misc/gen_release_test.py
@@ -23,3 +23,22 @@ class GenReleaseTest(unittest.TestCase):
 
         """).lstrip()
         self.assertEqual(expected, '\n'.join(r.get_release_notes()))
+
+    def test_sha256(self):
+        r = ReleaseGen('', dry_run=True)
+        r.version = '13.2.7'
+
+        path = "tools/misc/data/linux_amd64/release_asset_13.2.7"
+
+        arch = r._arch(path)
+        name = r.artifact_name(path)
+
+        self.assertEqual("release_asset_13.2.7_linux_amd64", name)
+        self.assertEqual("linux_amd64", arch)
+
+        r.checksum(path)
+
+        with open(f"{path}.sha256") as f:
+            self.assertTrue(name in f.read())
+
+


### PR DESCRIPTION
Fixes #2556

We upload the artefacts with the Please version number in the filename, but locally they don't include this. This PR refactors the release generator to make sure the filename is correct in the checksum file. 