### PR TITLE
Introduce atomicFloat32 to avoid data race

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -1217,7 +1217,7 @@ type progressReader struct {
 func (r *progressReader) Read(b []byte) (int, error) {
 	n, err := r.Reader.Read(b)
 	r.Done += float32(n)
-	r.Target.Progress = 100.0 * r.Done / r.Total
+	r.Target.Progress.Store(100.0 * r.Done / r.Total)
 	return n, err
 }
 

--- a/src/core/atomic_float32.go
+++ b/src/core/atomic_float32.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"math"
+	"sync/atomic"
+)
+
+// Inspired by the go.uber.org/atomic Float32 type
+
+type atomicFloat32 struct {
+	v uint32
+}
+
+func (f *atomicFloat32) Load() float32 {
+	return math.Float32frombits(atomic.LoadUint32(&f.v))
+}
+
+func (f *atomicFloat32) Store(val float32) {
+	atomic.StoreUint32(&f.v, math.Float32bits(val))
+}

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -139,7 +139,7 @@ type BuildTarget struct {
 	// Debug related fields.
 	Debug *DebugFields
 	// If ShowProgress is true, this is used to store the current progress of the target.
-	Progress float32 `print:"false"`
+	Progress atomicFloat32 `print:"false"`
 	// For remote_files, this is the total size of the download (if known)
 	FileSize uint64 `print:"false"`
 	// Description displayed while the command is building.
@@ -1758,7 +1758,7 @@ func (target *BuildTarget) ShouldExitOnError() bool {
 
 // SetProgress sets the current progress of this target.
 func (target *BuildTarget) SetProgress(progress float32) {
-	target.Progress = progress
+	target.Progress.Store(progress)
 }
 
 // BuildCouldModifyTarget will return true when the action of building this target could change the target itself e.g.

--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -158,12 +158,17 @@ func (d *interactiveDisplay) printLines(local, remote []buildingTarget) {
 func (d *interactiveDisplay) printRow(target *buildingTarget, now time.Time, remote bool) int {
 	label := target.Label.Parent()
 	duration := now.Sub(target.Started).Seconds()
-	if target.Active && target.Target != nil && target.Target.ShouldShowProgress() && target.Target.Progress > 0.0 {
-		if target.Target.Progress > 1.0 && target.Target.Progress < 100.0 && target.Target.Progress != target.LastProgress {
-			proportionDone := target.Target.Progress / 100.0
+	progress := float32(0.0)
+	if target.Target != nil {
+		progress = target.Target.Progress.Load()
+	}
+	if target.Active && target.Target.ShouldShowProgress() && progress > 0.0 {
+
+		if progress > 1.0 && progress < 100.0 && progress != target.LastProgress {
+			proportionDone := progress / 100.0
 			perPercent := float32(duration) / proportionDone
 			target.Eta = time.Duration(perPercent * (1.0 - proportionDone) * float32(time.Second)).Truncate(time.Second)
-			target.LastProgress = target.Target.Progress
+			target.LastProgress = progress
 			fileSize := atomic.LoadUint64(&target.Target.FileSize)
 			if fileSize > 0 {
 				// Round the download speed to a multiple of 10kB which makes the display jitter around less


### PR DESCRIPTION
This change introduces a new type atomicFloat32, analogous to atomic_bool, that wraps and provides atomic read and write to a float32 value. It is used for the BuildTarget.Progress field to prevent potential data races as this field is concurrently accessed.

Closes #2528