### PR TITLE
improve the behaviour of update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__
 *.iml
 /venv
 /out
+*.sw?
 
 .DS_Store
 # For local testing

--- a/src/generate/generate.go
+++ b/src/generate/generate.go
@@ -17,25 +17,41 @@ var log = logging.Log
 func UpdateGitignore(graph *core.BuildGraph, labels []core.BuildLabel, gitignore string) error {
 	pkg := filepath.Dir(gitignore)
 	files := make([]string, 0, len(labels))
+	vcs := scm.NewFallback(core.RepoRoot)
 
 	for _, l := range labels {
 		t := graph.TargetOrDie(l)
-		if t.HasLabel("codegen") {
-			for _, out := range t.Outputs() {
-				relativePkg := t.Label.PackageName
-				if pkg != "." {
-					if strings.HasPrefix(t.Label.PackageName, pkg) {
-						relativePkg = strings.TrimPrefix(strings.TrimPrefix(t.Label.PackageName, pkg), "/")
-					} else {
-						// Don't add files that are not under this package to the .gitignore
-						continue
-					}
+		if !t.HasLabel("codegen") {
+			continue
+		}
+		for _, out := range t.Outputs() {
+			relativePkg := t.Label.PackageName
+			if pkg != "." {
+				if !strings.HasPrefix(t.Label.PackageName, pkg) {
+					// Don't add files that are not under this package to the .gitignore
+					continue
 				}
-				files = append(files, filepath.Join(relativePkg, out))
+				relativePkg = strings.TrimPrefix(strings.TrimPrefix(t.Label.PackageName, pkg), "/")
 			}
+			if vcs.AreIgnored(out) {
+				continue
+			}
+			files = append(files, filepath.Join(relativePkg, out))
 		}
 	}
-	return scm.NewFallback(core.RepoRoot).IgnoreFiles(gitignore, files)
+	return vcs.IgnoreFiles(gitignore, files)
+}
+
+func allLabelGenOuts(graph *core.BuildGraph, labels []core.BuildLabel) []string {
+	outs := []string{}
+	for _, l := range labels {
+		t := graph.TargetOrDie(l)
+		if !t.HasLabel("codegen") {
+			continue
+		}
+		outs = append(outs, t.Outputs()...)
+	}
+	return outs
 }
 
 // LinkGeneratedSources will link any generated sources for the outputs of the given labels
@@ -45,20 +61,30 @@ func LinkGeneratedSources(state *core.BuildState, labels []core.BuildLabel) {
 		linker = fs.Link
 	}
 
+	updateGitIgnore := state.Config.Build.UpdateGitignore
 	vcs := scm.NewFallback(core.RepoRoot)
+	if updateGitIgnore && vcs.AreIgnored(allLabelGenOuts(state.Graph, labels)...) {
+		updateGitIgnore = false
+	}
 
 	for _, l := range labels {
 		target := state.Graph.TargetOrDie(l)
-		if target.HasLabel("codegen") {
-			for _, out := range target.Outputs() {
-				destDir := filepath.Join(core.RepoRoot, target.Label.PackageDir())
-				srcDir := filepath.Join(core.RepoRoot, target.OutDir())
-				fs.LinkDestination(filepath.Join(srcDir, out), filepath.Join(destDir, out), linker)
+		if !target.HasLabel("codegen") {
+			continue
+		}
+		for _, out := range target.Outputs() {
+			destDir := filepath.Join(core.RepoRoot, target.Label.PackageDir())
+			srcDir := filepath.Join(core.RepoRoot, target.OutDir())
+			fs.LinkDestination(filepath.Join(srcDir, out), filepath.Join(destDir, out), linker)
+		}
+		if updateGitIgnore {
+			gitignore, err := vcs.FindOrCreateIgnoreFile(target.Label.PackageDir())
+			if err != nil {
+				log.Warningf("failed to find or create gitignore: %v", err)
+				continue
 			}
-			if state.Config.Build.UpdateGitignore {
-				if err := UpdateGitignore(state.Graph, labels, vcs.FindClosestIgnoreFile(target.Label.PackageDir())); err != nil {
-					log.Warningf("failed to link generated sources: %v", err)
-				}
+			if err := UpdateGitignore(state.Graph, labels, gitignore); err != nil {
+				log.Warningf("failed to update gitignore: %v", err)
 			}
 		}
 	}

--- a/src/generate/generate.go
+++ b/src/generate/generate.go
@@ -78,12 +78,7 @@ func LinkGeneratedSources(state *core.BuildState, labels []core.BuildLabel) {
 			fs.LinkDestination(filepath.Join(srcDir, out), filepath.Join(destDir, out), linker)
 		}
 		if updateGitIgnore {
-			gitignore, err := vcs.FindOrCreateIgnoreFile(target.Label.PackageDir())
-			if err != nil {
-				log.Warningf("failed to find or create gitignore: %v", err)
-				continue
-			}
-			if err := UpdateGitignore(state.Graph, labels, gitignore); err != nil {
+			if err := UpdateGitignore(state.Graph, labels, vcs.GetIgnoreFile(target.Label.PackageDir())); err != nil {
 				log.Warningf("failed to update gitignore: %v", err)
 			}
 		}

--- a/src/scm/git.go
+++ b/src/scm/git.go
@@ -4,7 +4,6 @@ package scm
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -189,34 +188,8 @@ func (g *git) IgnoreFiles(path string, files []string) error {
 	return nil
 }
 
-func (g *git) FindClosestIgnoreFile(path string) string {
-	_, err := os.Lstat(filepath.Join(g.repoRoot, path, ignoreFileName))
-	if err == nil {
-		return filepath.Join(path, ignoreFileName)
-	}
-
-	if filepath.Clean(path) == "." {
-		return ignoreFileName
-	}
-	return g.FindClosestIgnoreFile(filepath.Dir(path))
-}
-
-func (g *git) FindOrCreateIgnoreFile(path string) (string, error) {
-	_, err := os.Lstat(filepath.Join(g.repoRoot, path, ignoreFileName))
-	fqPath := filepath.Join(path, ignoreFileName)
-	if err == nil {
-		return fqPath, nil
-	}
-
-	if errors.Is(err, os.ErrNotExist) {
-		f, err := os.Create(fqPath)
-		if err != nil {
-			return "", err
-		}
-		defer f.Close()
-	}
-
-	return fqPath, nil
+func (g *git) GetIgnoreFile(path string) string {
+	return filepath.Join(path, ignoreFileName)
 }
 
 func (g *git) Remove(names []string) error {

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -25,8 +25,8 @@ type SCM interface {
 	ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) []string
 	// IgnoreFiles marks a file to be ignored by the SCM.
 	IgnoreFiles(gitignore string, files []string) error
-	// FindOrCreateIgnoreFile gets the ignore file name for the version control system
-	FindOrCreateIgnoreFile(path string) (string, error)
+	// GetIgnoreFile gets the ignore file name for the given path within the version control system
+	GetIgnoreFile(path string) string
 	// Remove deletes the given files from the SCM.
 	Remove(names []string) error
 	// ChangedLines returns the set of lines that have been modified,

--- a/src/scm/scm.go
+++ b/src/scm/scm.go
@@ -25,8 +25,8 @@ type SCM interface {
 	ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) []string
 	// IgnoreFiles marks a file to be ignored by the SCM.
 	IgnoreFiles(gitignore string, files []string) error
-	// IgnoreFileName gets the ignore file name for the version control system
-	FindClosestIgnoreFile(path string) string
+	// FindOrCreateIgnoreFile gets the ignore file name for the version control system
+	FindOrCreateIgnoreFile(path string) (string, error)
 	// Remove deletes the given files from the SCM.
 	Remove(names []string) error
 	// ChangedLines returns the set of lines that have been modified,
@@ -36,6 +36,8 @@ type SCM interface {
 	Checkout(revision string) error
 	// CurrentRevDate returns the commit date of the current revision, formatted according to the given format string.
 	CurrentRevDate(format string) string
+	// AreIgnored returns whether the files are all ignored or not
+	AreIgnored(files ...string) bool
 }
 
 // New returns a new SCM instance for this repo root.

--- a/src/scm/stub.go
+++ b/src/scm/stub.go
@@ -4,8 +4,8 @@ import "fmt"
 
 type stub struct{}
 
-func (s *stub) FindClosestIgnoreFile(string) string {
-	return "<unknown>"
+func (s *stub) FindOrCreateIgnoreFile(string) (string, error) {
+	return "<unknown>", fmt.Errorf("unknown SCM, can't create ignore file")
 }
 
 func (s *stub) DescribeIdentifier(sha string) string {
@@ -42,4 +42,8 @@ func (s *stub) Checkout(revision string) error {
 
 func (s *stub) CurrentRevDate(format string) string {
 	return "Unknown"
+}
+
+func (s *stub) AreIgnored(files ...string) bool {
+	return false
 }

--- a/src/scm/stub.go
+++ b/src/scm/stub.go
@@ -4,8 +4,8 @@ import "fmt"
 
 type stub struct{}
 
-func (s *stub) FindOrCreateIgnoreFile(string) (string, error) {
-	return "<unknown>", fmt.Errorf("unknown SCM, can't create ignore file")
+func (s *stub) GetIgnoreFile(string) string {
+	return "<unknown>"
 }
 
 func (s *stub) DescribeIdentifier(sha string) string {

--- a/test/plz_generate/BUILD
+++ b/test/plz_generate/BUILD
@@ -44,8 +44,30 @@ please_repo_e2e_test(
 please_repo_e2e_test(
     name = "auto_update_generate_bar_test",
     expected_output = {
-        "src/bar/.gitignore": f"\n{do_not_edit_warning}\nbaz/baz.gen",
+        "src/bar/baz/.gitignore": f"\n{do_not_edit_warning}\nbaz.gen",
     },
-    plz_command = f"git init && touch src/bar/.gitignore && plz build --profile auto //src/bar/baz",
+    plz_command = f"git init && plz build --profile auto //src/bar/baz",
+    repo = "test_repo",
+)
+
+please_repo_e2e_test(
+    name = "auto_update_generate_glob_test",
+    expected_output = {
+        ".gitignore": f"\n{do_not_edit_warning}\nsrc/bar/baz/*.gen",
+        "src/bar/.gitignore": f"\n{do_not_edit_warning}\nbar.gen",
+        "src/.gitignore": f"\n{do_not_edit_warning}\nfoo.gen",
+    },
+    plz_command = f"git init && echo '\n{do_not_edit_warning}\nsrc/bar/baz/*.gen' > .gitignore && plz build --profile auto",
+    repo = "test_repo",
+)
+
+please_repo_e2e_test(
+    name = "auto_update_generate_glob_all_gen_test",
+    expected_output = {
+        ".gitignore": f"\n{do_not_edit_warning}\n*.gen",
+        "src/bar/.gitignore": "",
+        "src/.gitignore": "",
+    },
+    plz_command = f"git init && echo '\n{do_not_edit_warning}\n*.gen' > .gitignore && touch src/bar/.gitignore && touch src/.gitignore && plz build --profile auto",
     repo = "test_repo",
 )


### PR DESCRIPTION
We now check if the file is ignored first using `git check-ignored` this matches based on globbing so allows us to add ignores to the root .gitignore file. If the generated file doesn't match already we generate a gitignore file in the targets pkg and add the files there rather than finding the closest gitignore file.