### PR TITLE
Fix darwin_arm64 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
            command: tar -xzf /tmp/workspace/darwin_amd64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch darwin_arm64 -o go.cgoenabled:1 -o go.cgocctool:clang -o "go.cflags:-target arm64-apple-macos11" //package:release_files
+           command: ./please/please build -p --profile ci --arch darwin_arm64 -o plugin.go.cgoenabled:1 -o plugin.go.cctool:clang -o "plugin.go.cflags:-target arm64-apple-macos11" //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,5 +1,5 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v0.4.4",
+    revision = "v0.5.1",
 )

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -888,11 +888,12 @@ func (config *Configuration) ApplyOverrides(overrides map[string]string) error {
 	for k, v := range overrides {
 		split := strings.Split(strings.ToLower(k), ".")
 		if len(split) == 3 && split[0] == "plugin" {
-			if plugin, ok := config.Plugin[split[1]]; ok {
-				plugin.ExtraValues[strings.ToLower(split[2])] = []string{v}
-				continue
+			plugin, ok := config.Plugin[split[1]]
+			if !ok {
+				return fmt.Errorf("No plugin with ID %v", split[1])
 			}
-			log.Fatalf("No plugin with ID %v", split[1])
+			plugin.ExtraValues[strings.ToLower(split[2])] = []string{v}
+			continue
 		}
 		if len(split) != 2 {
 			return fmt.Errorf("Bad option format: %s", k)

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -890,7 +890,7 @@ func (config *Configuration) ApplyOverrides(overrides map[string]string) error {
 		if len(split) == 3 && split[0] == "plugin" {
 			if plugin, ok := config.Plugin[split[1]]; ok {
 				plugin.ExtraValues[strings.ToLower(split[2])] = []string{v}
-				return nil
+				continue
 			}
 			log.Fatalf("No plugin with ID %v", split[1])
 		}


### PR DESCRIPTION
Fixes: #2514

Seems we broke this when we migrated to the Go plugin. We were passing the overrides to the built-in rules config rather than the plugin config. 