### PR TITLE
feat: Print out the Global Config object from within the BUILD file

### DIFF
--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -111,6 +111,7 @@ func (i *interpreter) interpretAll(pkg *core.Package, forLabel, dependent *core.
 	}
 
 	s.config = i.config.Copy()
+
 	s.Set("CONFIG", s.config)
 	_, err := i.interpretStatements(s, statements)
 	if err == nil {

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -498,5 +498,5 @@ func TestLogConfigVariable(t *testing.T) {
 	setLogCode(s, "info", capture)
 	s.interpretStatements(statements)
 
-	assert.Equal(t, `//: {"baz": 6, "foo": bar}`, capturedOutput)
+	assert.Contains(t, `//: {"baz": 6, "foo": bar}`, capturedOutput)
 }

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -498,5 +498,5 @@ func TestLogConfigVariable(t *testing.T) {
 	setLogCode(s, "info", capture)
 	s.interpretStatements(statements)
 
-	assert.Equal(t, "//: GlobalConfig{\"baz\":6,\"foo\":\"bar\"}", capturedOutput)
+	assert.Equal(t, `//: {"baz": 6, "foo": bar}`, capturedOutput)
 }

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -498,5 +498,5 @@ func TestLogConfigVariable(t *testing.T) {
 	setLogCode(s, "info", capture)
 	s.interpretStatements(statements)
 
-	assert.Contains(t, `//: {"baz": 6, "foo": bar}`, capturedOutput)
+	assert.Equal(t, `//: {"baz": 6, "foo": bar}`, capturedOutput)
 }

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -824,6 +824,11 @@ func (c *pyConfig) MarshalJSON() ([]byte, error) {
 	if c.overlay == nil {
 		return json.Marshal(c.base.dict)
 	}
+
+	return json.Marshal(c.Config())
+}
+
+func (c *pyConfig) Config() pyDict {
 	merged := make(pyDict, len(c.base.dict)+len(c.overlay))
 	for k, v := range c.base.dict {
 		merged[k] = v
@@ -831,15 +836,26 @@ func (c *pyConfig) MarshalJSON() ([]byte, error) {
 	for k, v := range c.overlay {
 		merged[k] = v
 	}
-	return json.Marshal(merged)
+	return merged
 }
 
 func (c *pyConfig) String() string {
-	marshalledConfig, err := c.MarshalJSON()
-	if err != nil {
-		panic(fmt.Sprintf("failed to marshal object: %s", err))
+	config := c.Config()
+	var b strings.Builder
+	b.WriteByte('{')
+	started := false
+	for k, v := range config {
+		if started {
+			b.WriteString(", ")
+		}
+		started = true
+		b.WriteByte('"')
+		b.WriteString(k)
+		b.WriteString(`": `)
+		b.WriteString(v.String())
 	}
-	return fmt.Sprintf("GlobalConfig%s", string(marshalledConfig))
+	b.WriteByte('}')
+	return b.String()
 }
 
 func (c *pyConfig) Type() string {

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -844,15 +844,15 @@ func (c *pyConfig) String() string {
 	var b strings.Builder
 	b.WriteByte('{')
 	started := false
-	for k, v := range config {
+	for _, key := range config.Keys() {
 		if started {
 			b.WriteString(", ")
 		}
 		started = true
 		b.WriteByte('"')
-		b.WriteString(k)
+		b.WriteString(key)
 		b.WriteString(`": `)
-		b.WriteString(v.String())
+		b.WriteString(config[key].String())
 	}
 	b.WriteByte('}')
 	return b.String()

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -825,10 +825,10 @@ func (c *pyConfig) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.base.dict)
 	}
 
-	return json.Marshal(c.Config())
+	return json.Marshal(c.toPyDict())
 }
 
-func (c *pyConfig) Config() pyDict {
+func (c *pyConfig) toPyDict() pyDict {
 	merged := make(pyDict, len(c.base.dict)+len(c.overlay))
 	for k, v := range c.base.dict {
 		merged[k] = v
@@ -840,22 +840,7 @@ func (c *pyConfig) Config() pyDict {
 }
 
 func (c *pyConfig) String() string {
-	config := c.Config()
-	var b strings.Builder
-	b.WriteByte('{')
-	started := false
-	for _, key := range config.Keys() {
-		if started {
-			b.WriteString(", ")
-		}
-		started = true
-		b.WriteByte('"')
-		b.WriteString(key)
-		b.WriteString(`": `)
-		b.WriteString(config[key].String())
-	}
-	b.WriteByte('}')
-	return b.String()
+	return c.toPyDict().String()
 }
 
 func (c *pyConfig) Type() string {

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -822,7 +822,7 @@ type pyConfig struct {
 
 func (c *pyConfig) MarshalJSON() ([]byte, error) {
 	if c.overlay == nil {
-		return json.Marshal(c.overlay)
+		return json.Marshal(c.base.dict)
 	}
 	merged := make(pyDict, len(c.base.dict)+len(c.overlay))
 	for k, v := range c.base.dict {
@@ -835,7 +835,11 @@ func (c *pyConfig) MarshalJSON() ([]byte, error) {
 }
 
 func (c *pyConfig) String() string {
-	return "<global config object>"
+	marshalledConfig, err := c.MarshalJSON()
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal object: %s", err))
+	}
+	return fmt.Sprintf("GlobalConfig%s", string(marshalledConfig))
 }
 
 func (c *pyConfig) Type() string {

--- a/src/parse/asp/test_data/log_config.build
+++ b/src/parse/asp/test_data/log_config.build
@@ -1,0 +1,1 @@
+log.info("%s", CONFIG)


### PR DESCRIPTION
This change allows printing out the builtin `CONFIG` file from the BUILD files. 