### PR TITLE
Activate the target on local subinclude

### DIFF
--- a/test/local_subinclude_test/BUILD
+++ b/test/local_subinclude_test/BUILD
@@ -15,6 +15,6 @@ please_repo_e2e_test(
         "plz-out/gen/local/out": "constant",
         "plz-out/gen/local/foo/out": "constant",
     },
-    plz_command = "plz build --profile local //local/...",
+    plz_command = "plz build //local/...",
     repo = "test_repo",
 )


### PR DESCRIPTION
Related to #2523 

We only activate the target when parsing the package when we queue up the package parse for that specific target. There was a race condition that occurs when we have two original targets. It would block if `//local/foo` beat `//local` to the `WaitForSubincludeTarget()` call, but `//local` beats `//local/foo` to the `SyncParsePackage()` call. It succeeds under the following circumstances: 

1) Queue up parse tasks for the two original targets (`//local:all` and `//local/foo:all`)
2) Parse `//local/foo`
3) Queue up a parse on `//local` for `//local:constant` for the subinclude
4) Start parsing `//local`, and activate `//local:constant` in `build_rule()` as that's what we queued it up for
5) Parse `//local` then returns the already parsed package

It failed when we parse `//local:all` first, but `//local/foo` calls `WaitForSubincludedTarget` first:

1) Queue up parse tasks for the two original targets (`//local:all` and `//local/foo:all`)
2) Parse `//local` for `:all`
3) Parse `//local/foo` for `:all`
4) `//local/foo` beats `//local` to the `WaitForSubincludedTarget()` call. This submits a parse task that blocks on `SyncParsePackage()` in `parse_step()` as `//local:all` got there first
5) We skip activating the target in `build_rule()` because we're parsing for `:all` not `:constant` now 
6) `WaitForSubincludedTarget()` from `//local` now blocks as `//local/foo` has the lock

By activating the target in the subinclude step, it doesn't matter if we queued up the package parse for `:all` or `:constant`. 