### PR TITLE
Fix flake in plz-run test

### DIFF
--- a/test/plz_run/BUILD
+++ b/test/plz_run/BUILD
@@ -29,10 +29,12 @@ please_repo_e2e_test(
 
 please_repo_e2e_test(
     name = "std_in_parallel_test",
-    expected_output = {
-        "wibble.txt": "wibble\nwobble",
+    expect_output_contains = {
+        # Bit of a hack... dicts can only have the file once so we copy it to check it contains both.
+        "wibble.txt": "wibble",
+        "wobble.txt": "wobble",
     },
-    plz_command = "echo //src:wibble //src:wobble | plz run parallel - > wibble.txt",
+    plz_command = "echo //src:wibble //src:wobble | plz run parallel - > wibble.txt && cp wibble.txt wobble.txt",
     repo = "test_repo",
 )
 

--- a/test/plz_run/test_repo/src/BUILD_FILE
+++ b/test/plz_run/test_repo/src/BUILD_FILE
@@ -14,7 +14,7 @@ sh_cmd(
 
 sh_cmd(
     name = "wobble",
-    cmd = "sleep 0.1 && echo wobble",
+    cmd = "echo wobble",
 )
 
 # Test add_data functionality with a file


### PR DESCRIPTION
The test was sensitive to the ordering that these targets get built in. We had a sleep to try and ensure the ordering, but this makes it insensitive to the order. 