### PR TITLE
Fix issue where plugin conf in profiles was merged into the extra-values instead of overriding

### DIFF
--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -100,7 +100,7 @@ func validateSubrepoNameAndPluginConfig(config, repoConfig *Configuration, subre
 	if plugin := config.Plugin[subrepo.Name]; plugin != nil {
 		for key := range plugin.ExtraValues {
 			if _, ok := definedKeys[strings.ToLower(key)]; !ok {
-				return fmt.Errorf("Unrecognised config key %q for plugin %q %v %v", key, subrepo.Name, plugin.ExtraValues, definedKeys)
+				return fmt.Errorf("Unrecognised config key %q for plugin %q", key, subrepo.Name)
 			}
 		}
 	}

--- a/test/plugins/BUILD
+++ b/test/plugins/BUILD
@@ -49,9 +49,17 @@ plugin_e2e_test(
 plugin_e2e_test(
     name = "override_test",
     expected_output = {
-        "plz-out/gen/override/fooc": "tool: overriden, path: something, flags: [compileflagoverride]",
+        "plz-out/gen/override/fooc": "fooc: overriden, bar: bar, path: something, flags: [compileflagoverride]",
     },
     plz_command = "plz build -o plugin.foo.modulepath:something -o plugin.foo.compileflag:compileflagoverride //override:override_test",
+)
+
+plugin_e2e_test(
+    name = "profile_test",
+    expected_output = {
+        "plz-out/gen/override/fooc": "fooc: overriden, bar: barc-dev, path: something, flags: []",
+    },
+    plz_command = "plz build -o plugin.foo.modulepath:something --profile dev --profile e2e //override:override_test",
 )
 
 # Test that fields are added to the config

--- a/test/plugins/BUILD
+++ b/test/plugins/BUILD
@@ -57,7 +57,7 @@ plugin_e2e_test(
 plugin_e2e_test(
     name = "profile_test",
     expected_output = {
-        "plz-out/gen/override/fooc": "fooc: overriden, bar: barc-dev, path: something, flags: []",
+        "plz-out/gen/override/fooc": "fooc: overriden, bar: bar-dev, path: something, flags: []",
     },
     plz_command = "plz build -o plugin.foo.modulepath:something --profile dev --profile e2e //override:override_test",
 )

--- a/test/plugins/foo_plugin/.plzconfig
+++ b/test/plugins/foo_plugin/.plzconfig
@@ -10,17 +10,14 @@ CompileFlag = -sha1
 BarTool = bar_test_tool
 
 [PluginConfig "fooc_tool"]
-ConfigKey = FoocTool
 Inherit = true
 DefaultValue = fooc
 
 [PluginConfig "bar_tool"]
-ConfigKey = BarTool
 Inherit = true
 DefaultValue = bar
 
 [PluginConfig "module_path"]
-ConfigKey = ModulePath
 Optional = false
 
 [PluginConfig "compile_flags"]
@@ -28,11 +25,9 @@ ConfigKey = CompileFlag
 Repeatable = true
 
 [PluginConfig "bool_test"]
-ConfigKey = BoolTest
 Type = bool
 DefaultValue = True
 
 [PluginConfig "int_test"]
-ConfigKey = IntTest
 Type = int
 DefaultValue = 100

--- a/test/plugins/test_repo/.plzconfig
+++ b/test/plugins/test_repo/.plzconfig
@@ -1,6 +1,7 @@
 [Plugin "foo"]
 Target = //plugins:foo
 FoocTool = @foo//tools/fooc
+bartool = bar
 CompileFlag = -sha256
 BoolTest = False
 IntTest = 15

--- a/test/plugins/test_repo/.plzconfig.dev
+++ b/test/plugins/test_repo/.plzconfig.dev
@@ -1,0 +1,3 @@
+[Plugin "foo"]
+CompileFlag=
+BarTool=barc-dev

--- a/test/plugins/test_repo/.plzconfig.dev
+++ b/test/plugins/test_repo/.plzconfig.dev
@@ -1,3 +1,3 @@
 [Plugin "foo"]
 CompileFlag=
-BarTool=barc-dev
+bartool=bar-dev

--- a/test/plugins/test_repo/override/BUILD_FILE
+++ b/test/plugins/test_repo/override/BUILD_FILE
@@ -4,6 +4,6 @@ package(foo = {"fooc_tool": "overriden"})
 
 text_file(
     name = "override_test",
-    content = f"tool: {CONFIG.FOO.FOOC_TOOL}, path: {CONFIG.FOO.MODULE_PATH}, flags: {CONFIG.FOO.COMPILE_FLAGS}",
+    content = f"fooc: {CONFIG.FOO.FOOC_TOOL}, bar: {CONFIG.FOO.BAR_TOOL}, path: {CONFIG.FOO.MODULE_PATH}, flags: {CONFIG.FOO.COMPILE_FLAGS}",
     out = "fooc",
 )


### PR DESCRIPTION
Fixes: #2574 

This is a bit grungy as gcfg doesn't override the extra values map as we might expect. Perhaps changiong the behaviour up-stream makes more sense? I wonder how maps behave for core config?  

It looks like the library behaves the same way for aliases, i.e. it merges the aliases from the two config files. I think the library is behaving intentionally here, it's just it doesn't suite our use-case. 