### PR TITLE
Add a warning for output dir conflicts

### DIFF
--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -570,6 +570,7 @@ func newState(label string) (*core.BuildState, *core.BuildTarget) {
 	target.Command = fmt.Sprintf("echo 'output of %s' > $OUT", target.Label)
 	target.BuildTimeout = 100 * time.Second
 	state.Graph.AddTarget(target)
+	state.Graph.AddPackage(core.NewPackage(target.Label.PackageName))
 	state.Parser = &fakeParser{}
 	Init(state)
 	return state, target

--- a/src/core/package.go
+++ b/src/core/package.go
@@ -214,7 +214,7 @@ func (pkg *Package) VerifyOutputs() {
 func (pkg *Package) verifyOutputs() []string {
 	pkg.mutex.RLock()
 	defer pkg.mutex.RUnlock()
-	ret := []string{}
+	var ret []string
 	for filename, target := range pkg.Outputs {
 		for dir := filepath.Dir(filename); dir != "."; dir = filepath.Dir(dir) {
 			if target2, present := pkg.Outputs[dir]; present && target2 != target && !(target.HasDependency(target2.Label.Parent()) || target.HasDependency(target2.Label)) {


### PR DESCRIPTION
If we have `t1` that is depended on by `t2`, we:
1) Build `t1` and write its rule hash to the outputs
2) Build `t2`, writing its rule hash

When we next run a build, we:
1) Rebuild `t1` because an output has `t2`s rule hash
2) Write `t1`s hash to the output
3) Rebuild `t2` because it now has the wrong rule hash

This PR checks for this case, and logs a warning. 