### PR TITLE
Only verify filegroup hashes on change

### DIFF
--- a/src/build/filegroup.go
+++ b/src/build/filegroup.go
@@ -121,12 +121,12 @@ func buildFilegroup(state *core.BuildState, target *core.BuildTarget) (bool, err
 
 	// Check if any of our srcs that are other built targets have changed.
 	for _, bi := range target.AllSources() {
-		if l, ok := bi.(core.BuildLabel); ok {
-			depState := state.Graph.TargetOrDie(l).State()
-			if depState == core.Built || depState == core.BuiltRemotely {
-				changed = true
-				break
-			}
+		if changed {
+			break
+		}
+		l, ok := bi.Label()
+		if ok && state.Graph.TargetOrDie(l).State() < core.Unchanged {
+			changed = true
 		}
 	}
 

--- a/src/build/filegroup.go
+++ b/src/build/filegroup.go
@@ -119,12 +119,16 @@ func buildFilegroup(state *core.BuildState, target *core.BuildTarget) (bool, err
 		changed = changed || fileChanged
 	}
 
-	// Check if any of our srcs that are other built targets have changed.
+	// When src targets are in the same package as us, the `source` and `out` paths are the same so the files are
+	// considered unchanged. We should consider ourselves changed though, as the sources Might indeed have changed.
 	for _, bi := range target.AllSources() {
 		if changed {
 			break
 		}
 		l, ok := bi.Label()
+		if !ok || !target.Label.InSamePackageAs(l) {
+			continue
+		}
 		if ok && state.Graph.TargetOrDie(l).State() < core.Unchanged {
 			changed = true
 		}

--- a/src/build/filegroup.go
+++ b/src/build/filegroup.go
@@ -119,6 +119,17 @@ func buildFilegroup(state *core.BuildState, target *core.BuildTarget) (bool, err
 		changed = changed || fileChanged
 	}
 
+	// Check if any of our srcs that are other built targets have changed.
+	for _, bi := range target.AllSources() {
+		if l, ok := bi.(core.BuildLabel); ok {
+			depState := state.Graph.TargetOrDie(l).State()
+			if depState == core.Built || depState == core.BuiltRemotely {
+				changed = true
+				break
+			}
+		}
+	}
+
 	if target.HasLabel("py") && !target.IsBinary {
 		// Pre-emptively create __init__.py files so the outputs can be loaded dynamically.
 		// It's a bit cheeky to do non-essential language-specific logic but this enables

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -513,6 +513,10 @@ func (label BuildLabel) MarshalText() ([]byte, error) {
 	return []byte(label.String()), nil
 }
 
+func (label BuildLabel) InSamePackageAs(l BuildLabel) bool {
+	return l.PackageName == label.PackageName && l.Subrepo == label.Subrepo
+}
+
 // A packageKey is a cut-down version of BuildLabel that only contains the package part.
 // It's used to key maps and so forth that don't care about the target name.
 type packageKey struct {

--- a/test/filegroup/output_hash/BUILD
+++ b/test/filegroup/output_hash/BUILD
@@ -1,0 +1,21 @@
+subinclude("//test/build_defs")
+
+please_repo_e2e_test(
+    name = "output_hash_test",
+    plz_command = "plz build //srcs:filegroup",
+    repo = "test_repo",
+)
+
+please_repo_e2e_test(
+    name = "update_dep_hash_test",
+    plz_command = "plz build //srcs:filegroup && rm srcs/file2 && touch srcs/file2 && plz build //srcs:filegroup",
+    repo = "test_repo",
+    expected_failure=True,
+)
+
+please_repo_e2e_test(
+    name = "update_src_hash_test",
+    plz_command = "plz build //srcs:filegroup && rm srcs/file1 && touch srcs/file1 && plz build //srcs:filegroup",
+    repo = "test_repo",
+    expected_failure=True,
+)

--- a/test/filegroup/output_hash/test_repo/.plzconfig
+++ b/test/filegroup/output_hash/test_repo/.plzconfig
@@ -1,0 +1,2 @@
+[Parse]
+BuildFileName = BUILD_FILE

--- a/test/filegroup/output_hash/test_repo/srcs/BUILD_FILE
+++ b/test/filegroup/output_hash/test_repo/srcs/BUILD_FILE
@@ -1,0 +1,12 @@
+genrule(
+    name = "file1",
+    srcs = ["file1"],
+    cmd = "cp $SRC $OUT",
+    outs = ["file1.out"],
+)
+
+filegroup(
+    name = "filegroup",
+    srcs = ["file2", ":file1"],
+    hashes = ["sha256: 05421a2c674d447cc418ab3807bead1eabe2646faf4f6adcc01d751423349b7e"],
+)

--- a/test/filegroup/output_hash/test_repo/srcs/file1
+++ b/test/filegroup/output_hash/test_repo/srcs/file1
@@ -1,0 +1,1 @@
+wibble wiblle wiblle

--- a/test/filegroup/output_hash/test_repo/srcs/file2
+++ b/test/filegroup/output_hash/test_repo/srcs/file2
@@ -1,0 +1,1 @@
+wobble wobble wobble


### PR DESCRIPTION
Normally we don't verify hashes unless the target has changed. For filegroups this isn't the case. 

A `genrule()` that performs the same action as a filegroup might look like:
```
genrule(
    name = "filegroup",
    srcs = [":dep", "baz.txt], # this outputs "foo" and "bar",
    cmd = "cp $SRCS $TMP_DIR",
    outs = ["foo", "bar", "baz.txt"], # these are the outputs of "//some:dep"
)
```

If `needsBuild()` returns false in [build step](https://github.com/thought-machine/please/blob/master/src/build/build_step.go#L221), we skip the call to `calculateAndCheckRuleHashes()` [here](https://github.com/thought-machine/please/blob/master/src/build/build_step.go#L375). 

For filegroups, this doesn't work the same way because we might consider the filegroup unchanged even though it has `srcs` in the same package that change, which constitute its outputs. This is because the input and output paths are the same so we don't consider them changed in the [filegroup builder](https://github.com/thought-machine/please/blob/master/src/build/filegroup.go#L77).

This is a shame, because we then need to always call `calculateAndCheckRuleHashes()` which can be expensive when these files are large. This change just marks the target as built when it has a source in the same package that changed. This more closely mimics the behaviour of the above genrule. 
