### PR TITLE
Update blake3 implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,9 @@ require (
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
 	lukechampine.com/blake3 v1.1.5
+)
+
+require (
 	cloud.google.com/go v0.65.0 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -61,6 +64,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20210706145210-9283cdf370b5 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/klauspost/cpuid v1.3.1 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
@@ -74,6 +78,7 @@ require (
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
+	github.com/zeebo/blake3 v0.2.3 // indirect
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQ
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=
 github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
+github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=
+github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -325,6 +327,10 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/blake3 v0.2.3 h1:TFoLXsjeXqRNFxSbk35Dk4YtszE/MQQGK10BH4ptoTg=
+github.com/zeebo/blake3 v0.2.3/go.mod h1:mjJjZpnsyIVtVgTOSpJ9vmRE4wgDeyt2HU3qXvvKCaQ=
+github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
-	"lukechampine.com/blake3"
+	"github.com/zeebo/blake3"
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/cmap"
@@ -1256,8 +1256,7 @@ func newCRC64() hash.Hash {
 }
 
 func newBlake3() hash.Hash {
-	// 32 bytes == 256 bits
-	return blake3.New(32, nil)
+	return blake3.New()
 }
 
 func newXXHash() hash.Hash {

--- a/src/fs/BUILD
+++ b/src/fs/BUILD
@@ -18,7 +18,7 @@ go_test(
     name = "fs_test",
     srcs = glob(
         ["*_test.go"],
-        exclude = ["glob_integration_test.go"],
+        exclude = ["glob_integration_test.go", "*_benchmark_test.go"],
     ),
     data = ["test_data"],
     deps = [

--- a/src/fs/BUILD
+++ b/src/fs/BUILD
@@ -40,7 +40,6 @@ go_benchmark(
     deps = [
         ":fs",
         "//third_party/go:blake3",
-        "//third_party/go:zeebo_blake3",
         "//third_party/go:testify",
         "//third_party/go:xxhash",
     ],

--- a/src/fs/BUILD
+++ b/src/fs/BUILD
@@ -33,3 +33,14 @@ go_test(
     # This must remain a glob because the tests rely on data being loaded in via globs
     data = glob(["test_data/**"]),
 )
+
+go_benchmark(
+    name = "hash_benchmark",
+    srcs = ["hash_benchmark_test.go"],
+    deps = [
+        ":fs",
+        "//third_party/go:blake3",
+        "//third_party/go:testify",
+        "//third_party/go:xxhash",
+    ],
+)

--- a/src/fs/BUILD
+++ b/src/fs/BUILD
@@ -40,6 +40,7 @@ go_benchmark(
     deps = [
         ":fs",
         "//third_party/go:blake3",
+        "//third_party/go:zeebo_blake3",
         "//third_party/go:testify",
         "//third_party/go:xxhash",
     ],

--- a/src/fs/hash_benchmark_test.go
+++ b/src/fs/hash_benchmark_test.go
@@ -12,10 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/cespare/xxhash/v2"
 	"github.com/zeebo/blake3"
 )
 
@@ -48,6 +47,7 @@ func BenchmarkHashes(b *testing.B) {
 }
 
 func writeTestFile(b *testing.B, filename string, sizeKB int) {
+	b.Helper()
 	f, err := os.Create(filename)
 	require.NoError(b, err)
 	defer f.Close()

--- a/src/fs/hash_benchmark_test.go
+++ b/src/fs/hash_benchmark_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cespare/xxhash/v2"
+	zb3 "github.com/zeebo/blake3"
 	"lukechampine.com/blake3"
 )
 
@@ -25,12 +26,13 @@ func BenchmarkHashes(b *testing.B) {
 		testFile := fmt.Sprintf("test%d.dat", size)
 		writeTestFile(b, testFile, size)
 		for name, hash := range map[string]func() hash.Hash{
-			"sha1":   sha1.New,
-			"sha256": sha256.New,
-			"crc32":  func() hash.Hash { return hash.Hash(crc32.NewIEEE()) },
-			"crc64":  func() hash.Hash { return hash.Hash(crc64.New(crc64.MakeTable(crc64.ISO))) },
-			"blake3": func() hash.Hash { return blake3.New(32, nil) },
-			"xxhash": func() hash.Hash { return xxhash.New() },
+			"sha1":         sha1.New,
+			"sha256":       sha256.New,
+			"crc32":        func() hash.Hash { return hash.Hash(crc32.NewIEEE()) },
+			"crc64":        func() hash.Hash { return hash.Hash(crc64.New(crc64.MakeTable(crc64.ISO))) },
+			"blake3":       func() hash.Hash { return blake3.New(32, nil) },
+			"zeebo_blake3": func() hash.Hash { return zb3.New() },
+			"xxhash":       func() hash.Hash { return xxhash.New() },
 		} {
 			b.Run(fmt.Sprintf("%s/%dkb", name, size), func(b *testing.B) {
 				hasher := NewPathHasher("", false, hash, name)

--- a/src/fs/hash_benchmark_test.go
+++ b/src/fs/hash_benchmark_test.go
@@ -1,0 +1,55 @@
+package fs
+
+import (
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"hash/crc32"
+	"hash/crc64"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cespare/xxhash/v2"
+	"lukechampine.com/blake3"
+)
+
+func BenchmarkHashes(b *testing.B) {
+	// Data sizes in kb
+	for _, size := range []int{1, 4, 8, 16, 32, 256, 1024, 32 * 1024} {
+		testFile := fmt.Sprintf("test%d.dat", size)
+		writeTestFile(b, testFile, size)
+		for name, hash := range map[string]func() hash.Hash{
+			"sha1":   sha1.New,
+			"sha256": sha256.New,
+			"crc32":  func() hash.Hash { return hash.Hash(crc32.NewIEEE()) },
+			"crc64":  func() hash.Hash { return hash.Hash(crc64.New(crc64.MakeTable(crc64.ISO))) },
+			"blake3": func() hash.Hash { return blake3.New(32, nil) },
+			"xxhash": func() hash.Hash { return xxhash.New() },
+		} {
+			b.Run(fmt.Sprintf("%s/%dkb", name, size), func(b *testing.B) {
+				hasher := NewPathHasher("", false, hash, name)
+				for i := 0; i < b.N; i++ {
+					_, err := hasher.hash(testFile, false, false, false)
+					assert.NoError(b, err)
+				}
+			})
+		}
+	}
+}
+
+func writeTestFile(b *testing.B, filename string, sizeKB int) {
+	f, err := os.Create(filename)
+	require.NoError(b, err)
+	defer f.Close()
+	data := make([]byte, 1024)
+	for i := 0; i < sizeKB; i++ {
+		rand.Read(data)
+		_, err := f.Write(data)
+		require.NoError(b, err)
+	}
+}

--- a/src/fs/hash_benchmark_test.go
+++ b/src/fs/hash_benchmark_test.go
@@ -16,8 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cespare/xxhash/v2"
-	zb3 "github.com/zeebo/blake3"
-	"lukechampine.com/blake3"
+	"github.com/zeebo/blake3"
 )
 
 func BenchmarkHashes(b *testing.B) {
@@ -26,13 +25,12 @@ func BenchmarkHashes(b *testing.B) {
 		testFile := fmt.Sprintf("test%d.dat", size)
 		writeTestFile(b, testFile, size)
 		for name, hash := range map[string]func() hash.Hash{
-			"sha1":         sha1.New,
-			"sha256":       sha256.New,
-			"crc32":        func() hash.Hash { return hash.Hash(crc32.NewIEEE()) },
-			"crc64":        func() hash.Hash { return hash.Hash(crc64.New(crc64.MakeTable(crc64.ISO))) },
-			"blake3":       func() hash.Hash { return blake3.New(32, nil) },
-			"zeebo_blake3": func() hash.Hash { return zb3.New() },
-			"xxhash":       func() hash.Hash { return xxhash.New() },
+			"sha1":   sha1.New,
+			"sha256": sha256.New,
+			"crc32":  func() hash.Hash { return hash.Hash(crc32.NewIEEE()) },
+			"crc64":  func() hash.Hash { return hash.Hash(crc64.New(crc64.MakeTable(crc64.ISO))) },
+			"blake3": func() hash.Hash { return blake3.New() },
+			"xxhash": func() hash.Hash { return xxhash.New() },
 		} {
 			b.Run(fmt.Sprintf("%s/%dkb", name, size), func(b *testing.B) {
 				hasher := NewPathHasher("", false, hash, name)

--- a/src/fs/hash_benchmark_test.go
+++ b/src/fs/hash_benchmark_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func BenchmarkHashes(b *testing.B) {
+	b3 := blake3.New()
 	// Data sizes in kb
 	for _, size := range []int{32 * 1024, 256 * 1024, 1024 * 1024} {
 		testFile := fmt.Sprintf("test%d.dat", size)
@@ -30,6 +31,7 @@ func BenchmarkHashes(b *testing.B) {
 			"crc32":  func() hash.Hash { return hash.Hash(crc32.NewIEEE()) },
 			"crc64":  func() hash.Hash { return hash.Hash(crc64.New(crc64.MakeTable(crc64.ISO))) },
 			"blake3": func() hash.Hash { return blake3.New() },
+			"b3_rst": func() hash.Hash { b3.Reset(); return b3 },
 			"xxhash": func() hash.Hash { return xxhash.New() },
 		} {
 			b.Run(fmt.Sprintf("%s/%dkb", name, size), func(b *testing.B) {

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -911,10 +911,28 @@ go_module(
 )
 
 go_module(
+    name = "zeebo_blake3",
+    licences = ["MIT"],
+    module = "github.com/zeebo/blake3",
+    install = ["..."],
+    version = "v0.2.3",
+    visibility = ["PUBLIC"],
+    deps = [":cpuid_v2"],
+)
+
+go_module(
     name = "cpuid",
     licences = ["MIT"],
     module = "github.com/klauspost/cpuid",
     version = "v1.3.1",
+    visibility = ["PUBLIC"],
+)
+
+go_module(
+    name = "cpuid_v2",
+    licences = ["MIT"],
+    module = "github.com/klauspost/cpuid/v2",
+    version = "v2.2.1",
     visibility = ["PUBLIC"],
 )
 

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -904,32 +904,15 @@ go_module(
 go_module(
     name = "blake3",
     licences = ["MIT"],
-    module = "lukechampine.com/blake3",
-    version = "v1.1.5",
+    module = "github.com/zeebo/blake3",
+    install = ["..."],
+    version = "v0.2.3",
     visibility = ["PUBLIC"],
     deps = [":cpuid"],
 )
 
 go_module(
-    name = "zeebo_blake3",
-    licences = ["MIT"],
-    module = "github.com/zeebo/blake3",
-    install = ["..."],
-    version = "v0.2.3",
-    visibility = ["PUBLIC"],
-    deps = [":cpuid_v2"],
-)
-
-go_module(
     name = "cpuid",
-    licences = ["MIT"],
-    module = "github.com/klauspost/cpuid",
-    version = "v1.3.1",
-    visibility = ["PUBLIC"],
-)
-
-go_module(
-    name = "cpuid_v2",
     licences = ["MIT"],
     module = "github.com/klauspost/cpuid/v2",
     version = "v2.2.1",

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -917,6 +917,7 @@ go_module(
     module = "github.com/klauspost/cpuid/v2",
     version = "v2.2.1",
     visibility = ["PUBLIC"],
+    deps = [":xsys"],
 )
 
 go_module(


### PR DESCRIPTION
Added a benchmark and did some comparisons; it's remarkably noisy but this implementation is consistently 25-50% faster than the previous one we had. Answers returned are the same across a number of random inputs.

We should probably consider pushing blake3 harder (maybe using internally more too), it is considerably faster than sha256.