### PR TITLE
Fix race condition in subrepo parse

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -790,7 +790,8 @@ func (state *BuildState) SyncParsePackage(label BuildLabel) *Package {
 	return state.Graph.PackageByLabel(label) // Important to check again; it's possible to race against this whole lot.
 }
 
-// WaitForPackage is similar to WaitForBuiltTarget however
+// WaitForPackage is similar to WaitForBuiltTarget however it waits for the package to be parsed, queuing it for parse
+// if necessary
 func (state *BuildState) WaitForPackage(l, dependent BuildLabel) *Package {
 	if p := state.Graph.PackageByLabel(l); p != nil {
 		return p

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -95,42 +95,63 @@ func checkSubrepo(tid int, state *core.BuildState, label, dependent core.BuildLa
 	// Local subincludes are when we subinclude from a subrepo defined in the current package
 	localSubinclude := label.Subrepo == dependent.Subrepo && label.PackageName == dependent.PackageName && forSubinclude
 
-	// If we're including from the same package, we don't want to parse the subrepo package
-	if !localSubinclude {
-		if handled, err := parseSubrepoPackage(tid, state, sl.PackageName, "", label); err != nil {
-			return nil, err
-		} else if !handled {
-			// They may have meant a subrepo that was defined in the dependent label's subrepo rather than the host
-			// repo
-			if _, err := parseSubrepoPackage(tid, state, sl.PackageName, dependent.Subrepo, label); err != nil {
-				return nil, err
-			}
-		}
+	// If we're including from the same package, we don't want to parse the subrepo package. It must already be
+	// defined by this point in the file.
+	if localSubinclude {
+		// For local subincludes, the subrepo has to already be defined at this point in the BUILD file
+		return nil, fmt.Errorf("Subrepo %v is not defined yet. It must appear before it is used by subinclude()", sl)
 	}
-	if subrepo := state.Graph.Subrepo(label.Subrepo); subrepo != nil {
-		return subrepo, nil
-	} else if subrepo := state.CheckArchSubrepo(label.Subrepo); subrepo != nil {
-		return subrepo, nil
+
+	// The package could Try parsing the package in the host repo first.
+	s, err := parseSubrepoPackage(tid, state, sl.PackageName, "", label)
+	if err != nil {
+		return nil, err
 	}
-	if !localSubinclude {
-		// Fix for #577; fallback like above, it might be defined within the subrepo.
-		if handled, err := parseSubrepoPackage(tid, state, sl.PackageName, dependent.Subrepo, label); handled && err == nil {
-			return state.Graph.Subrepo(label.Subrepo), nil
-		}
+
+	if s != nil {
+		return s, nil
+	}
+
+	// They may have meant a subrepo that was defined in the dependent label's subrepo rather than the host
+	// repo
+	s, err = parseSubrepoPackage(tid, state, sl.PackageName, dependent.Subrepo, label)
+	if err != nil {
+		return nil, err
+	}
+
+	if s != nil {
+		return s, nil
+	}
+
+	// Fix for #577; fallback like above, it might be defined within the subrepo.
+	s, err = parseSubrepoPackage(tid, state, sl.PackageName, dependent.Subrepo, label)
+	if err != nil {
+		return nil, err
+	}
+
+	if s == nil {
 		return nil, fmt.Errorf("Subrepo %s is not defined (referenced by %s)", label.Subrepo, dependent)
 	}
-	// For local subincludes, the subrepo has to already be defined at this point in the BUILD file
-	return nil, fmt.Errorf("Subrepo %v is not defined yet. It must appear before it is used by subinclude()", sl)
+	return s, nil
 }
 
 // parseSubrepoPackage parses a package to make sure subrepos are available.
-func parseSubrepoPackage(tid int, state *core.BuildState, pkg, subrepo string, dependent core.BuildLabel) (bool, error) {
+func parseSubrepoPackage(tid int, state *core.BuildState, pkg, subrepo string, dependent core.BuildLabel) (*core.Subrepo, error) {
 	if state.Graph.Package(pkg, subrepo) == nil {
 		// Don't have it already, must parse.
 		label := core.BuildLabel{Subrepo: subrepo, PackageName: pkg, Name: "all"}
-		return true, parse(tid, state, label, dependent, true)
+		if err := parse(tid, state, label, dependent, true); err != nil {
+			return nil, err
+		}
 	}
-	return false, nil
+
+	s := state.Graph.Subrepo(dependent.Subrepo)
+	if s != nil {
+		// Another thread might've parsed the above package, so we should check if the subrepo has appeared now
+		return s, nil
+	}
+
+	return state.CheckArchSubrepo(dependent.Subrepo), nil
 }
 
 // parsePackage parses a BUILD file and adds the package to the build graph

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -114,12 +114,6 @@ func checkSubrepo(tid int, state *core.BuildState, label, dependent core.BuildLa
 		return s, err
 	}
 
-	// Fix for #577; fallback like above, it might be defined within the subrepo.
-	s, err = parseSubrepoPackage(tid, state, sl.PackageName, dependent.Subrepo, label)
-	if err != nil || s != nil {
-		return s, err
-	}
-
 	return nil, fmt.Errorf("Subrepo %s is not defined (referenced by %s)", label.Subrepo, dependent)
 }
 

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -98,41 +98,29 @@ func checkSubrepo(tid int, state *core.BuildState, label, dependent core.BuildLa
 	// If we're including from the same package, we don't want to parse the subrepo package. It must already be
 	// defined by this point in the file.
 	if localSubinclude {
-		// For local subincludes, the subrepo has to already be defined at this point in the BUILD file
 		return nil, fmt.Errorf("Subrepo %v is not defined yet. It must appear before it is used by subinclude()", sl)
 	}
 
-	// The package could Try parsing the package in the host repo first.
+	// Try parsing the package in the host repo first.
 	s, err := parseSubrepoPackage(tid, state, sl.PackageName, "", label)
-	if err != nil {
-		return nil, err
-	}
-
-	if s != nil {
-		return s, nil
+	if err != nil || s != nil {
+		return s, err
 	}
 
 	// They may have meant a subrepo that was defined in the dependent label's subrepo rather than the host
 	// repo
 	s, err = parseSubrepoPackage(tid, state, sl.PackageName, dependent.Subrepo, label)
-	if err != nil {
-		return nil, err
-	}
-
-	if s != nil {
-		return s, nil
+	if err != nil || s != nil {
+		return s, err
 	}
 
 	// Fix for #577; fallback like above, it might be defined within the subrepo.
 	s, err = parseSubrepoPackage(tid, state, sl.PackageName, dependent.Subrepo, label)
-	if err != nil {
-		return nil, err
+	if err != nil || s != nil {
+		return s, err
 	}
 
-	if s == nil {
-		return nil, fmt.Errorf("Subrepo %s is not defined (referenced by %s)", label.Subrepo, dependent)
-	}
-	return s, nil
+	return nil, fmt.Errorf("Subrepo %s is not defined (referenced by %s)", label.Subrepo, dependent)
 }
 
 // parseSubrepoPackage parses a package to make sure subrepos are available.


### PR DESCRIPTION
We were seeing errors like this occasionally:
```
15:55:44.161   ERROR: ///cc/abseil-cpp/abseil-cpp//absl/strings:str_format failed:
///cc/abseil-cpp/abseil-cpp//absl/strings:str_format depends on ///cc/grpc/grpc//cc/abseil-cpp:all, but the directory plz-out/subrepos/cc/grpc/grpc/cc/abseil-cpp doesn't exist: cc/abseil-cpp
```

The issue was that another thread could parse the package between when we check if the subrepo already exists, and when we try and parse the subrepo package. 

1) We check for the subrepo already existing [here](https://github.com/thought-machine/please/blob/master/src/parse/parse_step.go#L89). 
2) We then attempt to parse the subrepo package [here](https://github.com/thought-machine/please/blob/master/src/parse/parse_step.go#L100). At this point, it might've been parsed by another thread. 
3) We find the package in the graph, so we return `false` to indicate that we didn't handle the package parse. The subrepo does exist at this point as the other thread has finished parsing. 
4) We then look for the subrepo relative to the current subrepo, which results in the above error because it doesn't exist there.

This PR checks for the subrepo if the package exists, which resolves this race condition. 