### PR TITLE
Revert "Add a warning for output dir conflicts (#2593)"

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -230,9 +230,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 					return fmt.Errorf("failed to load build metadata for %s: %w", target.Label, err)
 				}
 
-				if err := addOutDirOutsFromMetadata(state, target, metadata); err != nil {
-					return err
-				}
+				addOutDirOutsFromMetadata(target, metadata)
 
 				if target.PostBuildFunction != nil {
 					if err := runPostBuildFunction(tid, state, target, string(metadata.Stdout), ""); err != nil {
@@ -292,9 +290,7 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 			if target.BuildCouldModifyTarget() {
 				log.Debug("Checking for build metadata for %s in cache...", target.Label)
 				if metadata = retrieveFromCache(state.Cache, target, cacheKey, nil); metadata != nil {
-					if err := addOutDirOutsFromMetadata(state, target, metadata); err != nil {
-						return err
-					}
+					addOutDirOutsFromMetadata(target, metadata)
 					if target.PostBuildFunction != nil && !haveRunPostBuildFunction {
 						postBuildOutput = string(metadata.Stdout)
 						if err := runPostBuildFunction(tid, state, target, postBuildOutput, ""); err != nil {
@@ -331,11 +327,9 @@ func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runR
 			metadata.OptionalOutputs = append(metadata.OptionalOutputs, output)
 		}
 
-		if len(target.OutputDirectories) != 0 {
-			metadata.OutputDirOuts, err = addOutputDirectoriesToBuildOutput(state, target)
-			if err != nil {
-				return err
-			}
+		metadata.OutputDirOuts, err = addOutputDirectoriesToBuildOutput(target)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -430,15 +424,10 @@ func outputHashOrNil(target *core.BuildTarget, outputs []string, hasher *fs.Path
 	return h
 }
 
-func addOutDirOutsFromMetadata(state *core.BuildState, target *core.BuildTarget, md *core.BuildMetadata) error {
-	pkg := state.Graph.Package(target.Label.PackageName, target.Label.Subrepo)
+func addOutDirOutsFromMetadata(target *core.BuildTarget, md *core.BuildMetadata) {
 	for _, o := range md.OutputDirOuts {
 		target.AddOutput(o)
-		if err := pkg.RegisterOutput(state, o, target); err != nil {
-			return err
-		}
 	}
-	return nil
 }
 
 func retrieveFromCache(cache core.Cache, target *core.BuildTarget, cacheKey []byte, files []string) *core.BuildMetadata {
@@ -618,8 +607,7 @@ func prepareSources(state *core.BuildState, graph *core.BuildGraph, target *core
 
 // addOutputDirectoriesToBuildOutput moves all the files from the output dirs into the root of the build temp dir
 // and adds them as outputs to the build target
-func addOutputDirectoriesToBuildOutput(state *core.BuildState, target *core.BuildTarget) ([]string, error) {
-	pkg := state.Graph.Package(target.Label.PackageName, target.Label.Subrepo)
+func addOutputDirectoriesToBuildOutput(target *core.BuildTarget) ([]string, error) {
 	outs := make([]string, 0, len(target.OutputDirectories))
 	for _, dir := range target.OutputDirectories {
 		o, err := addOutputDirectoryToBuildOutput(target, dir)
@@ -627,12 +615,6 @@ func addOutputDirectoriesToBuildOutput(state *core.BuildState, target *core.Buil
 			return nil, fmt.Errorf("failed to move output dir (%s) contents to rule root: %w", dir, err)
 		}
 		outs = append(outs, o...)
-
-		for _, out := range o {
-			if err := pkg.RegisterOutput(state, out, target); err != nil {
-				return nil, err
-			}
-		}
 	}
 	return outs, nil
 }

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -570,7 +570,6 @@ func newState(label string) (*core.BuildState, *core.BuildTarget) {
 	target.Command = fmt.Sprintf("echo 'output of %s' > $OUT", target.Label)
 	target.BuildTimeout = 100 * time.Second
 	state.Graph.AddTarget(target)
-	state.Graph.AddPackage(core.NewPackage(target.Label.PackageName))
 	state.Parser = &fakeParser{}
 	Init(state)
 	return state, target

--- a/src/core/package.go
+++ b/src/core/package.go
@@ -214,7 +214,7 @@ func (pkg *Package) VerifyOutputs() {
 func (pkg *Package) verifyOutputs() []string {
 	pkg.mutex.RLock()
 	defer pkg.mutex.RUnlock()
-	var ret []string
+	ret := []string{}
 	for filename, target := range pkg.Outputs {
 		for dir := filepath.Dir(filename); dir != "."; dir = filepath.Dir(dir) {
 			if target2, present := pkg.Outputs[dir]; present && target2 != target && !(target.HasDependency(target2.Label.Parent()) || target.HasDependency(target2.Label)) {


### PR DESCRIPTION
This reverts commit 75e2d26f06d0be535a3f7ad8b9ce80766869772a.

There's a race condition that results in an nil pointer. If we subinclude a target with output directories, we might: 

1) parse the package for subinclude
2) activate the target before we finish parsing
3) attempt to register subincludes on the package, but it's still pending so hasn't been added to the graph.

The fix is to try and add the package to the graph in a "pending" state but the change is risky. Reverting this to get a patch release out so we can properly test the fix. 