### PR TITLE
Fix add warning on out dir

### DIFF
--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -570,6 +570,7 @@ func newState(label string) (*core.BuildState, *core.BuildTarget) {
 	target.Command = fmt.Sprintf("echo 'output of %s' > $OUT", target.Label)
 	target.BuildTimeout = 100 * time.Second
 	state.Graph.AddTarget(target)
+	state.Graph.AddPackage(core.NewPackage(target.Label.PackageName))
 	state.Parser = &fakeParser{}
 	Init(state)
 	return state, target

--- a/src/core/package.go
+++ b/src/core/package.go
@@ -214,7 +214,7 @@ func (pkg *Package) VerifyOutputs() {
 func (pkg *Package) verifyOutputs() []string {
 	pkg.mutex.RLock()
 	defer pkg.mutex.RUnlock()
-	ret := []string{}
+	var ret []string
 	for filename, target := range pkg.Outputs {
 		for dir := filepath.Dir(filename); dir != "."; dir = filepath.Dir(dir) {
 			if target2, present := pkg.Outputs[dir]; present && target2 != target && !(target.HasDependency(target2.Label.Parent()) || target.HasDependency(target2.Label)) {


### PR DESCRIPTION
Draft PR fixing #2599 

Unfortunately, we can't be sure that the package will be in the build graph when we build the target. Packages are added at the end of parsing the package. We now activate targets early for subincludes, and might actually build the target before we have finished parsing the package. 

To fix this, we'd need to add packages to the graph in a pending state. We could potentially replace the pending packages map, moving the channel into the Packages struct. 