### PR TITLE
Allow subrepos to output into a package root to avoid collisions

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -67,7 +67,8 @@ def subinclude(target:str):
     pass
 def load(target:str, names:str=None):
     pass
-def subrepo(name:str, dep:str='', path:str=None, config:str=None, bazel_compat:bool=False, arch:str=None, plugin:bool=False):
+def subrepo(name:str, dep:str='', path:str=None, config:str=None, bazel_compat:bool=False, arch:str=None,
+    plugin:bool=False, package_root:str=None):
     pass
 
 

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -45,7 +45,7 @@ func GeneralBuildEnvironment(state *BuildState) BuildEnv {
 func TargetEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 	env := append(GeneralBuildEnvironment(state),
 		"PKG="+target.Label.PackageName,
-		"PKG_DIR="+target.Label.PackageDir(),
+		"PKG_DIR="+target.PackageDir(),
 		"NAME="+target.Label.Name,
 	)
 	if state.Config.Remote.URL == "" || target.Local {

--- a/src/core/build_input.go
+++ b/src/core/build_input.go
@@ -4,6 +4,7 @@ package core
 
 import (
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/thought-machine/please/src/fs"
@@ -122,10 +123,11 @@ func NewFileLabel(src string, pkg *Package) BuildInput {
 	if pkg.Subrepo != nil {
 		return SubrepoFileLabel{
 			File:        src,
-			Package:     pkg.Name,
+			Package:     filepath.Join(pkg.Subrepo.PackageRoot, pkg.Name),
 			FullPackage: pkg.Subrepo.Dir(pkg.Name),
 		}
 	}
+
 	return FileLabel{File: src, Package: pkg.Name}
 }
 
@@ -238,7 +240,8 @@ func (label AnnotatedOutputLabel) Paths(graph *BuildGraph) []string {
 	if _, ok := target.EntryPoints[label.Annotation]; ok {
 		return label.BuildLabel.Paths(graph)
 	}
-	return addPathPrefix(target.NamedOutputs(label.Annotation), label.PackageName)
+
+	return addPathPrefix(target.NamedOutputs(label.Annotation), target.PackageDir())
 }
 
 // FullPaths is like Paths but includes the leading plz-out/gen directory.

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -291,7 +291,8 @@ func (label BuildLabel) Less(other BuildLabel) bool {
 
 // Paths is an implementation of BuildInput interface; we use build labels directly as inputs.
 func (label BuildLabel) Paths(graph *BuildGraph) []string {
-	return addPathPrefix(graph.TargetOrDie(label).Outputs(), label.PackageName)
+	target := graph.TargetOrDie(label)
+	return addPathPrefix(target.Outputs(), target.PackageDir())
 }
 
 // FullPaths is an implementation of BuildInput interface.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1791,6 +1791,13 @@ func (target *BuildTarget) HasLinks(state *BuildState) bool {
 	return false
 }
 
+func (target *BuildTarget) PackageDir() string {
+	if target.Subrepo != nil {
+		return filepath.Join(target.Subrepo.PackageRoot, target.Label.PackageDir())
+	}
+	return target.Label.PackageDir()
+}
+
 // BuildTargets makes a slice of build targets sortable by their labels.
 type BuildTargets []*BuildTarget
 

--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -16,6 +16,8 @@ type Subrepo struct {
 	Name string
 	// The root directory to load it from.
 	Root string
+	// A root directory for outputs of this subrpo's targets
+	PackageRoot string
 	// If this repo is output by a target, this is the target that creates it. Can be nil.
 	Target *BuildTarget
 	// The build state instance that tracks this subrepo (it's different from the host one if

--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -16,7 +16,7 @@ type Subrepo struct {
 	Name string
 	// The root directory to load it from.
 	Root string
-	// A root directory for outputs of this subrpo's targets
+	// A root directory for outputs of this subrepo's targets
 	PackageRoot string
 	// If this repo is output by a target, this is the target that creates it. Can be nil.
 	Target *BuildTarget

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1121,6 +1121,10 @@ func subrepo(s *scope, args []pyObject) pyObject {
 		state = state.ForArch(arch)
 		isCrossCompile = true
 	}
+	pkgRoot := ""
+	if args[PackageRootIdx].IsTruthy() {
+		pkgRoot = args[PackageRootIdx].String()
+	}
 
 	// Subrepo
 	sr := &core.Subrepo{
@@ -1130,7 +1134,7 @@ func subrepo(s *scope, args []pyObject) pyObject {
 		State:          state,
 		Arch:           arch,
 		IsCrossCompile: isCrossCompile,
-		PackageRoot:    args[PackageRootIdx].String(),
+		PackageRoot:    pkgRoot,
 	}
 
 	// Typically this would be deferred until we have built the subrepo target and have its config available. As we

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1075,6 +1075,7 @@ func subrepo(s *scope, args []pyObject) pyObject {
 		BazelCompatArgIdx
 		ArchArgIdx
 		PluginArgIdx
+		PackageRootIdx
 	)
 
 	s.NAssert(s.pkg == nil, "Cannot create new subrepos in this scope")
@@ -1129,6 +1130,7 @@ func subrepo(s *scope, args []pyObject) pyObject {
 		State:          state,
 		Arch:           arch,
 		IsCrossCompile: isCrossCompile,
+		PackageRoot:    args[PackageRootIdx].String(),
 	}
 
 	// Typically this would be deferred until we have built the subrepo target and have its config available. As we

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/peterebden/go-cli-init/v5/flags"
 
@@ -147,7 +146,6 @@ func findOriginalTask(state *core.BuildState, target core.BuildLabel, addToList 
 		prefix := ""
 		if target.Subrepo != "" {
 			state.WaitForInitialTargetAndEnsureDownload(target.SubrepoLabel(state, ""), target)
-			time.Sleep(time.Millisecond * 100)
 			subrepo := state.Graph.SubrepoOrDie(target.Subrepo)
 			dir = subrepo.Dir(dir)
 			prefix = subrepo.Dir(prefix)

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/peterebden/go-cli-init/v5/flags"
 
@@ -146,6 +147,7 @@ func findOriginalTask(state *core.BuildState, target core.BuildLabel, addToList 
 		prefix := ""
 		if target.Subrepo != "" {
 			state.WaitForInitialTargetAndEnsureDownload(target.SubrepoLabel(state, ""), target)
+			time.Sleep(time.Millisecond * 100)
 			subrepo := state.Graph.SubrepoOrDie(target.Subrepo)
 			dir = subrepo.Dir(dir)
 			prefix = subrepo.Dir(prefix)


### PR DESCRIPTION
This seems to work nicely and allows us to depend on targets from multiple subrepos without worrying about them clobbering each other in the build directory!  