### PR TITLE
Wildcard matching for includes and excludes

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1055,11 +1055,22 @@ func (target *BuildTarget) AddLabel(label string) {
 // HasLabel returns true if target has the given label.
 func (target *BuildTarget) HasLabel(label string) bool {
 	for _, l := range target.Labels {
-		if l == label {
+		if match(label, l) {
 			return true
 		}
 	}
 	return label == "test" && target.IsTest()
+}
+
+// match returns true if the given label matches the given pattern.
+func match(pattern, s string) bool {
+	if pattern == s {
+		return true
+	}
+	if strings.HasSuffix(pattern, "*") && strings.HasPrefix(s, pattern[:len(pattern)-1]) {
+		return true
+	}
+	return false
 }
 
 // PrefixedLabels returns all labels of this target with the given prefix.

--- a/test/include/BUILD
+++ b/test/include/BUILD
@@ -1,20 +1,23 @@
 subinclude("//test/build_defs")
 
 # Just to guard against any regressions
-plz_e2e_test(
+please_repo_e2e_test(
     name = "normal_include_test",
-    cmd = "plz query alltargets //third_party/go/...",
+    plz_command = "numtargets=$(plz query alltargets //... | wc -l) && if [[ $numtargets -ne 2 ]]; then echo \"Expected 2 targets. Got $numtargets\" && exit 1; fi",
+    repo = "test_repo",
 )
 
 # Test that we can include targets using a wildcard
-plz_e2e_test(
+please_repo_e2e_test(
     name = "include_contains_wildcard_test",
-    cmd = "numtargets=$(plz query alltargets //third_party/go/... --include 'go_package:*' | wc -l) && if [[ $numtargets -gt 0 ]]; then exit 0; fi; exit 1",
+    plz_command = "numtargets=$(plz query alltargets //... --include 'f*' | wc -l) && if [[ $numtargets -ne 1 ]]; then echo \"Expected 1 target. Got $numtargets\" && exit 1; fi",
+    repo = "test_repo",
 )
 
 # Test that we can exclude targets using a wildcard
-plz_e2e_test(
+please_repo_e2e_test(
     name = "exclude_contains_wildcard_test",
-    cmd = "numtargets=$(plz query alltargets //third_party/go/... --exclude 'go*' --exclude 'bin' | wc -l) && if [[ $numtargets -eq 0 ]]; then exit 0; fi; exit 1",
+    repo = "test_repo",
+    plz_command = "numtargets=$(plz query alltargets //... --exclude 'b*' | wc -l) && if [[ $numtargets -ne 1 ]]; then echo \"Expected 1 target. Got $numtargets\" && exit 1; fi",
 )
 

--- a/test/include/BUILD
+++ b/test/include/BUILD
@@ -18,6 +18,6 @@ please_repo_e2e_test(
 please_repo_e2e_test(
     name = "exclude_contains_wildcard_test",
     repo = "test_repo",
-    plz_command = "numtargets=$(plz query alltargets //... --exclude 'b*' | wc -l) && if [[ $numtargets -ne 1 ]]; then echo \"Expected 1 target. Got $numtargets\" && exit 1; fi",
+    plz_command = "numtargets=$(plz query alltargets //... --exclude 'ba*' | wc -l) && if [[ $numtargets -ne 1 ]]; then echo \"Expected 1 target. Got $numtargets\" && exit 1; fi",
 )
 

--- a/test/include/BUILD
+++ b/test/include/BUILD
@@ -1,0 +1,20 @@
+subinclude("//test/build_defs")
+
+# Just to guard against any regressions
+plz_e2e_test(
+    name = "normal_include_test",
+    cmd = "plz query alltargets //third_party/go/...",
+)
+
+# Test that we can include targets using a wildcard
+plz_e2e_test(
+    name = "include_contains_wildcard_test",
+    cmd = "numtargets=$(plz query alltargets //third_party/go/... --include 'go_package:*' | wc -l) && if [[ $numtargets -gt 0 ]]; then exit 0; fi; exit 1",
+)
+
+# Test that we can exclude targets using a wildcard
+plz_e2e_test(
+    name = "exclude_contains_wildcard_test",
+    cmd = "numtargets=$(plz query alltargets //third_party/go/... --exclude 'go*' --exclude 'bin' | wc -l) && if [[ $numtargets -eq 0 ]]; then exit 0; fi; exit 1",
+)
+

--- a/test/include/test_repo/.plzconfig
+++ b/test/include/test_repo/.plzconfig
@@ -1,0 +1,2 @@
+[parse]
+BuildFileName = BUILD_FILE

--- a/test/include/test_repo/BUILD_FILE
+++ b/test/include/test_repo/BUILD_FILE
@@ -1,0 +1,11 @@
+sh_cmd(
+    name = "target1",
+    cmd = "echo foo",
+    labels = ["foo"],
+)
+
+sh_cmd(
+    name = "target2",
+    cmd = "echo bar",
+    labels = ["bar"],
+)


### PR DESCRIPTION
Works for patterns with an asterisk at the end. I did try with `filepath.Match` and with `path.Match` but they don't seem to like there being a colon in the label, which I think labels will quite often have.

Closes #2532.