### PR TITLE
Handle DeadlineExceeded from remote execution request

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -722,7 +722,7 @@ func (c *Client) reallyExecute(tid int, target *core.BuildTarget, command *pb.Co
 			if respErr != nil {
 				if !strings.Contains(respErr.Error(), c.state.Config.Remote.DisplayURL) {
 					if url := c.actionURL(digest, false); url != "" {
-						respErr = fmt.Errorf("%s\nAction URL: %s", respErr, url)
+						respErr = fmt.Errorf("%w\nAction URL: %s", respErr, url)
 					}
 				}
 			}

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -290,7 +290,12 @@ func convertError(err *rpcstatus.Status) error {
 	if err.Code == int32(codes.OK) {
 		return nil
 	}
-	msg := fmt.Errorf("%s", err.Message)
+
+	if err.Code == int32(codes.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+
+	msg := status.ErrorProto(err)
 	for _, detail := range err.Details {
 		msg = fmt.Errorf("%s %s", msg, detail.Value)
 	}

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -366,7 +367,7 @@ func doTest(tid int, state *core.BuildState, target *core.BuildTarget, runRemote
 		Package:    strings.ReplaceAll(target.Label.PackageName, "/", "."),
 		Name:       target.Label.Name,
 		Duration:   duration,
-		TimedOut:   err == context.DeadlineExceeded,
+		TimedOut:   errors.Unwrap(err) == context.DeadlineExceeded,
 		Properties: parsedSuite.Properties,
 		TestCases:  parsedSuite.TestCases,
 		Cached:     metadata.Cached,


### PR DESCRIPTION
A counterpart to https://github.com/thought-machine/please-servers/pull/212

Handles deadline exceeded from the remote server. Results in timeouts being presented the same way as they would locally to the user:

Before:
```
$ plz test :slow_boy
15:37:23.669 WARNING: Downgrading to Please version 16.24.0 skipped (current version: 16.25.1)
Fail: //:slow_boy   0 passed   0 skipped   0 failed   1 errored Took 3.77s
Error: TestFailed in slow_boy
Test failed
Remotely executed command exited with -1
    Execution failed: signal: terminated
Failed action details: https://mettle-browser-lofi.iap.tmachine.io/uncached_action_result/mettle/51ebc05f7ce8728399216bb687db0b47fcfa321f1b0e6bc0947358b3a4ece8aa/469/
      Original action: https://mettle-browser-lofi.iap.tmachine.io/action/mettle/2c00a9db0b9d47d27b3ac9ecb5db72b37ff874724f9691484520ca5f59ca1ddc/145/
//:slow_boy 1 test run in 3.774s; 0 passed, 1 errored
    slow_boy  ERROR
1 test target and 1 test run; 0 passed, 1 errored.
Total time: 3.91s real, 3.77s compute.
Messages:
15:37:27.541   ERROR: //:slow_boy failed: Test failed

```

After:
```
$  plz test --profile localremote :slow_boy
Fail: //:slow_boy   0 passed   0 skipped   0 failed   1 errored Took 1.01s
Error: TestFailed in slow_boy
Test failed
context deadline exceeded
Action URL: https://blah.com/action//2351e2dc7c2b2f8115647bf93e4503c2c399b4dd546814d94c857625610bcdc3/145/
//:slow_boy 1 test run in 1.006s; 0 passed, 1 errored, TIMED OUT
    slow_boy  ERROR
1 test target and 1 test run; 0 passed, 1 errored.
Total time: 1.03s real, 1.01s compute.
Messages:
19:34:17.466   ERROR: //:slow_boy failed: Test failed
```