### PR TITLE
[Fix] update codelabs web page asset sources

### DIFF
--- a/docs/build_defs/codelab_template.html
+++ b/docs/build_defs/codelab_template.html
@@ -7,7 +7,7 @@
     <title>{{.Meta.Title}}</title>
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
     <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href="{{.Prefix}}/codelab-elements/codelab-elements.css">
+    <link rel="stylesheet" href="{{.Prefix}}/claat-public/codelab-elements.css">
     <link rel="stylesheet" href="/codelabs/style.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png">
@@ -36,10 +36,10 @@
     {{end}}{{end}}
 </google-codelab>
 
-<script src="{{.Prefix}}/codelab-elements/native-shim.js"></script>
-<script src="{{.Prefix}}/codelab-elements/custom-elements.min.js"></script>
-<script src="{{.Prefix}}/codelab-elements/prettify.js"></script>
-<script src="{{.Prefix}}/codelab-elements/codelab-elements.js"></script>
+<script src="{{.Prefix}}/claat-public/native-shim.js"></script>
+<script src="{{.Prefix}}/claat-public/custom-elements.min.js"></script>
+<script src="{{.Prefix}}/claat-public/prettify.js"></script>
+<script src="{{.Prefix}}/claat-public/codelab-elements.js"></script>
 <script src="//support.google.com/inapp/api.js"></script>
 <script src="/codelabs/codelab.js"></script>
 

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -891,7 +891,7 @@ go_module(
         "util",
     ],
     module = "github.com/googlecodelabs/tools/claat",
-    version = "v0.0.0-20210914205149-d1177395e3b8",
+    version = "v0.0.0-20221205204018-228dc9ce5925",
     visibility = ["PUBLIC"],
     deps = [
         ":csslex",

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -891,7 +891,7 @@ go_module(
         "util",
     ],
     module = "github.com/googlecodelabs/tools/claat",
-    version = "v0.0.0-20221205204018-228dc9ce5925",
+    version = "v0.0.0-20210914205149-d1177395e3b8",
     visibility = ["PUBLIC"],
     deps = [
         ":csslex",


### PR DESCRIPTION
In the `claat` library, the path to the bucket for codelabs elements has been updated. This PR fixes our codelabs webpages, which are attempting to use CSS and JS assets from the old bucket (and therefore not working).