### PR TITLE
Put plz query whatinputs errors on stderr & return exit code

### DIFF
--- a/src/query/whatinputs.go
+++ b/src/query/whatinputs.go
@@ -22,11 +22,7 @@ func WhatInputs(graph *core.BuildGraph, files []string, hidden, printFiles bool)
 				fmt.Printf("%s\n", label)
 			}
 		} else {
-			if printFiles {
-				fmt.Printf("%s Error: Not a source to any current target\n", file)
-			} else {
-				fmt.Printf("Error: '%s' is not a source to any current target\n", file)
-			}
+			log.Fatalf("%s is not a source to any current target", file)
 		}
 	}
 }

--- a/test/whatinputs/BUILD
+++ b/test/whatinputs/BUILD
@@ -10,13 +10,13 @@ plz_e2e_test(
 plz_e2e_test(
     name = "source_and_no_source",
     cmd = "plz query whatinputs making/up/a/file/path/should/be/easy test/whatinputs/test_package/foo.txt",
-    expected_failure = False,
-    expected_output = "source_and_no_source.txt",
+    expected_failure = True,
+    expect_output_contains = "making/up/a/file/path/should/be/easy is not a source to any current target",
 )
 
 plz_e2e_test(
     name = "source_and_no_source_print",
     cmd = "plz query whatinputs making/up/a/file/path/should/be/easy test/whatinputs/test_package/foo.txt --echo_files",
-    expected_failure = False,
-    expected_output = "source_and_no_source_print.txt",
+    expected_failure = True,
+    expect_output_contains = "making/up/a/file/path/should/be/easy is not a source to any current target",
 )

--- a/test/whatinputs/source_and_no_source.txt
+++ b/test/whatinputs/source_and_no_source.txt
@@ -1,2 +1,0 @@
-Error: 'making/up/a/file/path/should/be/easy' is not a source to any current target
-//test/whatinputs/test_package:target1

--- a/test/whatinputs/source_and_no_source_print.txt
+++ b/test/whatinputs/source_and_no_source_print.txt
@@ -1,2 +1,0 @@
-making/up/a/file/path/should/be/easy Error: Not a source to any current target
-test/whatinputs/test_package/foo.txt //test/whatinputs/test_package:target1


### PR DESCRIPTION
If you do `plz query whatinputs nonsense` you currently get back a zero exit code and `Error: 'nonsense' is not a source to any current target` on stdout, which generally confuses a machine that's calling it (because it _looks_ like the call has been successful, and it'll try to interpret that string as build labels).

This makes it just error out instead. Maybe a nicer version would be to log errors and later exit with a code?