### PR TITLE
Add log file rotation

### DIFF
--- a/src/cli/logging.go
+++ b/src/cli/logging.go
@@ -298,7 +298,6 @@ func rotateLogFiles(logFile string) {
 		}
 		return logFile + "." + strconv.Itoa(n)
 	}
-	os.RemoveAll(nth(maxLogFiles - 1)) // Always drop the last one
 	for i := maxLogFiles - 1; i > 0; i-- {
 		if err := os.Rename(nth(i-1), nth(i)); err != nil && !os.IsNotExist(err) {
 			log.Warning("Failed to rotate log file %s: %s", nth(i-1), err)

--- a/src/core/lock_test.go
+++ b/src/core/lock_test.go
@@ -58,11 +58,11 @@ func TestAcquireExclusiveRepoRoot(t *testing.T) {
 }
 
 func TestAcquireRepoRootOverride(t *testing.T) {
-	err := acquireRepoLock(syscall.LOCK_SH | syscall.LOCK_NB)
+	err := acquireRepoLock(syscall.LOCK_SH|syscall.LOCK_NB, log.Warning)
 	assert.NoError(t, err)
 
 	// It is able to immediately override the lock mode since it uses the same file descriptor.
-	err = acquireRepoLock(syscall.LOCK_EX | syscall.LOCK_NB)
+	err = acquireRepoLock(syscall.LOCK_EX|syscall.LOCK_NB, log.Warning)
 	assert.NoError(t, err)
 
 	ReleaseRepoLock()
@@ -71,7 +71,7 @@ func TestAcquireRepoRootOverride(t *testing.T) {
 // This attempts to mimic how 2 plz processes acquire a shared repo lock.
 func TestAcquireSharedRepoRootTwice(t *testing.T) {
 	// 1st process.
-	err := acquireRepoLock(syscall.LOCK_SH | syscall.LOCK_NB)
+	err := acquireRepoLock(syscall.LOCK_SH|syscall.LOCK_NB, log.Warning)
 	assert.NoError(t, err)
 
 	// Keep file descriptor reference alive.
@@ -81,7 +81,7 @@ func TestAcquireSharedRepoRootTwice(t *testing.T) {
 	// 2nd process.
 	repoLockFile = nil // Reset.
 	// It is able to immediately acquire another shared lock via a different file descriptor.
-	err = acquireRepoLock(syscall.LOCK_SH | syscall.LOCK_NB)
+	err = acquireRepoLock(syscall.LOCK_SH|syscall.LOCK_NB, log.Warning)
 	assert.NoError(t, err)
 
 	ReleaseRepoLock()
@@ -90,7 +90,7 @@ func TestAcquireSharedRepoRootTwice(t *testing.T) {
 // This attempts to mimic how 1 plz process acquires a shared repo lock and another tries to acquire an exclusive one.
 func TestAcquireSharedAndExclusiveRepoRoot(t *testing.T) {
 	// 1st process.
-	err := acquireRepoLock(syscall.LOCK_SH | syscall.LOCK_NB)
+	err := acquireRepoLock(syscall.LOCK_SH|syscall.LOCK_NB, log.Warning)
 	assert.NoError(t, err)
 
 	// Keep file descriptor reference alive.
@@ -100,7 +100,7 @@ func TestAcquireSharedAndExclusiveRepoRoot(t *testing.T) {
 	// 2nd process.
 	repoLockFile = nil // Reset.
 	// It errors immediately trying to acquire an exclusive lock as a shared one already exists from process 1.
-	err = acquireRepoLock(syscall.LOCK_EX | syscall.LOCK_NB)
+	err = acquireRepoLock(syscall.LOCK_EX|syscall.LOCK_NB, log.Warning)
 	assert.Error(t, err)
 
 	ReleaseRepoLock()
@@ -109,7 +109,7 @@ func TestAcquireSharedAndExclusiveRepoRoot(t *testing.T) {
 // This attempts to mimic how 1 plz process acquires an exclusive repo lock and another tries to acquire a shared one.
 func TestAcquireExclusiveAndSharedRepoRoot(t *testing.T) {
 	// 1st process.
-	err := acquireRepoLock(syscall.LOCK_EX | syscall.LOCK_NB)
+	err := acquireRepoLock(syscall.LOCK_EX|syscall.LOCK_NB, log.Warning)
 	assert.NoError(t, err)
 
 	// Keep file descriptor reference alive.
@@ -119,7 +119,7 @@ func TestAcquireExclusiveAndSharedRepoRoot(t *testing.T) {
 	// 2nd process.
 	repoLockFile = nil // Reset.
 	// It errors immediately trying to acquire a shared lock as an exclusive one already exists from process 1.
-	err = acquireRepoLock(syscall.LOCK_SH | syscall.LOCK_NB)
+	err = acquireRepoLock(syscall.LOCK_SH|syscall.LOCK_NB, log.Warning)
 	assert.Error(t, err)
 
 	ReleaseRepoLock()

--- a/src/please.go
+++ b/src/please.go
@@ -1346,7 +1346,7 @@ func mustReadConfigAndSetRoot(forceUpdate bool) *core.Configuration {
 }
 
 func initLogging() {
-	core.AcquireExclusiveRepoLock()
+	core.AcquireExclusiveRepoLockQuietly()
 	defer core.ReleaseRepoLock()
 	cli.InitFileLogging(string(opts.OutputFlags.LogFile), opts.OutputFlags.LogFileLevel, opts.OutputFlags.LogAppend)
 }

--- a/src/please.go
+++ b/src/please.go
@@ -1328,7 +1328,7 @@ func mustReadConfigAndSetRoot(forceUpdate bool) *core.Configuration {
 		if !filepath.IsAbs(string(opts.OutputFlags.LogFile)) {
 			opts.OutputFlags.LogFile = cli.Filepath(filepath.Join(core.RepoRoot, string(opts.OutputFlags.LogFile)))
 		}
-		cli.InitFileLogging(string(opts.OutputFlags.LogFile), opts.OutputFlags.LogFileLevel, opts.OutputFlags.LogAppend)
+		initLogging()
 	}
 	if opts.BehaviorFlags.NoHashVerification {
 		log.Warning("You've disabled hash verification; this is intended to help temporarily while modifying build targets. You shouldn't use this regularly.")
@@ -1343,6 +1343,12 @@ func mustReadConfigAndSetRoot(forceUpdate bool) *core.Configuration {
 	}
 	update.CheckAndUpdate(config, !opts.BehaviorFlags.NoUpdate, forceUpdate, opts.Update.Force, !opts.Update.NoVerify, !opts.OutputFlags.PlainOutput, opts.Update.LatestPrerelease)
 	return config
+}
+
+func initLogging() {
+	core.AcquireExclusiveRepoLock()
+	defer core.ReleaseRepoLock()
+	cli.InitFileLogging(string(opts.OutputFlags.LogFile), opts.OutputFlags.LogFileLevel, opts.OutputFlags.LogAppend)
 }
 
 // handleCompletions handles shell completion. Typically it just prints to stdout but


### PR DESCRIPTION
Have been wanting this for a while; sometimes you see something but you need the _previous_ build's logs to understand what's happened (e.g. if you're asking "why is this target building again", you ideally want all the details in the log of the previous time it built to compare the two, but that's just been stomped all over).

This doesn't do anything clever like gzipping old files and isn't configurable (log setup happens pretty much first thing so we don't have access to any config at this point). I imagine this will be sufficient but we can always do more later.