### PR TITLE
Check HTTP status code on downloading plugin

### DIFF
--- a/src/plzinit/plugins.go
+++ b/src/plzinit/plugins.go
@@ -246,6 +246,8 @@ func getLatestRevision(plugin string) (string, error) {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
+	} else if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Failed to download plugin: %s %s", resp.Status, string(body))
 	}
 
 	var result Response


### PR DESCRIPTION
This makes failures in #2630 more obvious but doesn't actually fix anything.