### PR TITLE
Don't hit github API during tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ issues:
     - halp  # Make misspell be quiet about this.
     - exitAfterDefer # Potentially useful but not in any cases it fires right now.
     - receiver-naming # Think this is confused about generics
+    - error-strings
   exclude-rules:
     - path: _test\.go
       linters:

--- a/src/please.go
+++ b/src/please.go
@@ -286,7 +286,8 @@ var opts struct {
 		Pleasew struct {
 		} `command:"pleasew" description:"Initialises the pleasew wrapper script"`
 		Plugin struct {
-			Args struct {
+			Version string `short:"v" long:"version" description:"Version of plugin to install. If not set, the latest is found."`
+			Args    struct {
 				Plugins []string `positional-arg-name:"plugin" required:"true" description:"Plugins to install"`
 			} `positional-args:"true"`
 		} `command:"plugin" hidden:"true" description:"Install a plugin and migrate any language-specific config values"`
@@ -725,7 +726,9 @@ var buildFunctions = map[string]func() int{
 		return 0
 	},
 	"init.plugin": func() int {
-		plzinit.InitPlugins(opts.Init.Plugin.Args.Plugins)
+		if err := plzinit.InitPlugins(opts.Init.Plugin.Args.Plugins, opts.Init.Plugin.Version); err != nil {
+			log.Fatalf("%s", err)
+		}
 		return 0
 	},
 	"export": func() int {

--- a/src/plzinit/plugins.go
+++ b/src/plzinit/plugins.go
@@ -246,6 +246,8 @@ func getLatestRevision(plugin string) (string, error) {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
+	} else if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Failed to download plugin: %s %s", resp.Status, string(body))
 	}
 
 	var result Response

--- a/src/plzinit/plugins.go
+++ b/src/plzinit/plugins.go
@@ -51,8 +51,7 @@ func InitPlugins(plugins []string, version string) error {
 	for _, p := range plugins {
 		file, err = initPlugin(p, version, file)
 		if err != nil {
-			log.Errorf("Could not initialise plugin %s. Got error: %s", p, err)
-			return err
+			return fmt.Errorf("Could not initialise plugin %s. Got error: %s", p, err)
 		}
 	}
 

--- a/test/plugins/BUILD
+++ b/test/plugins/BUILD
@@ -69,7 +69,7 @@ plugin_e2e_test(
         ".plzconfig": "[Plugin \"python\"]*Target = //plugins:python",
     },
     # Need to break hard link here so init_plugin_test's actual .plzconfig doesn't get updated.
-    plz_command = "cp .plzconfig .foo; mv .foo .plzconfig; plz init plugin python",
+    plz_command = "cp .plzconfig .foo; mv .foo .plzconfig; plz init plugin python --version v1.2.0",
 )
 
 # Test that the target is created in plugins/BUILD
@@ -79,14 +79,14 @@ plugin_e2e_test(
         "plugins/BUILD": "plugin_repo*name = \\\"cc\\\"*plugin = \\\"cc-rules\\\"",
     },
     # Need to break hard link here so init_plugin_test's actual .plzconfig doesn't get updated.
-    plz_command = "cp .plzconfig .foo; mv .foo .plzconfig; plz init plugin cc",
+    plz_command = "cp .plzconfig .foo; mv .foo .plzconfig; plz init plugin cc --version v0.3.2",
 )
 
 # Test that we don't add the build target again if it's already there
 plugin_e2e_test(
     name = "init_only_add_target_once_test",
     # Need to break hard link here so init_plugin_test's actual .plzconfig doesn't get updated.
-    plz_command = "cp .plzconfig .foo; mv .foo .plzconfig; plz init plugin cc; plz init plugin cc; lines=$(cat plugins/BUILD | wc -l); if [ $lines -gt 6 ]; then exit 1; else exit 0; fi",
+    plz_command = "cp .plzconfig .foo; mv .foo .plzconfig; plz init plugin cc --version v0.3.2; plz init plugin cc --version v0.3.2; lines=$(cat plugins/BUILD | wc -l); if [ $lines -gt 6 ]; then exit 1; else exit 0; fi",
 )
 
 plugin_e2e_test(


### PR DESCRIPTION
This lets `plz init plugin` take a version, which means we don't need to hit the Github API during the test. The default is still the same as before.

Resolves #2630 