### PR TITLE
Fix a couple things in the release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ jobs:
        - add_ssh_keys:
            fingerprints:
              - "cc:57:b9:67:31:65:a6:70:8c:e3:e7:90:ca:e6:a6:41"
-       - run: echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+       - run: echo $GCLOUD_SERVICE_KEY > service_account.json && export GOOGLE_APPLICATION_CREDENTIALS=$PWD/service_account.json
        - run: /tmp/workspace/gen_release.pex --signer /tmp/workspace/release_signer /tmp/workspace/{*_amd64,*_arm64}/*
 
    # Releases the docs and the binaries to s3 for please.build and get.please.build

--- a/.circleci/release_s3.sh
+++ b/.circleci/release_s3.sh
@@ -23,9 +23,11 @@ aws s3 sync /tmp/workspace/linux_amd64 s3://please-releases/linux_amd64/$VERSION
 aws s3 sync /tmp/workspace/freebsd_amd64 s3://please-releases/freebsd_amd64/$VERSION
 
 # Sign the download script with our release key
-/tmp/workspace/release_signer -o get_plz.sh.asc -i tools/misc/get_plz.sh
+/tmp/workspace/release_signer pgp -o get_plz.sh.asc -i tools/misc/get_plz.sh
+/tmp/workspace/release_signer kms -o get_plz.sh.sig -i tools/misc/get_plz.sh
 aws s3 cp tools/misc/get_plz.sh s3://please-releases/get_plz.sh --content-type text/x-shellscript
 aws s3 cp get_plz.sh.asc s3://please-releases/get_plz.sh.asc --content-type text/plain
+aws s3 cp get_plz.sh.sig s3://please-releases/get_plz.sh.sig --content-type application/octet-stream
 
 if [[ "$VERSION" == *"beta"* ]] || [[ "$VERSION" == *"alpha"* ]] || [[ "$VERSION" == *"prerelease"* ]]; then
   echo "$VERSION is a prerelease, only setting latest_prerelease_version"


### PR DESCRIPTION
The auth command only works for the gcloud CLI... We have to set this env var to have the application code auth using this service account. We also need to update the usage of the release signer when uploading the get script. 