### PR TITLE
Make --pre work with plz query print

### DIFF
--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -110,6 +110,8 @@ func findOriginalTasks(state *core.BuildState, preTargets, targets []core.BuildL
 		state.Graph.AddSubrepo(core.SubrepoForArch(state, arch))
 	}
 	if len(preTargets) > 0 {
+		needBuild := state.NeedBuild
+		state.NeedBuild = true // Always need this now since --pre implies actually building the thing.
 		findOriginalTaskSet(state, preTargets, false, arch)
 		for _, target := range preTargets {
 			if target.IsAllTargets() {
@@ -120,9 +122,10 @@ func findOriginalTasks(state *core.BuildState, preTargets, targets []core.BuildL
 		}
 		for _, target := range state.ExpandLabels(preTargets) {
 			log.Debug("Waiting for pre-target %s...", target)
-			state.WaitForInitialTargetAndEnsureDownload(target, targets[0])
+			state.WaitForInitialTargetAndEnsureDownload(target, core.OriginalTarget)
 			log.Debug("Pre-target %s built, continuing...", target)
 		}
+		state.NeedBuild = needBuild
 	}
 	findOriginalTaskSet(state, targets, true, arch)
 	log.Debug("Original target scan complete")

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -110,8 +110,6 @@ func findOriginalTasks(state *core.BuildState, preTargets, targets []core.BuildL
 		state.Graph.AddSubrepo(core.SubrepoForArch(state, arch))
 	}
 	if len(preTargets) > 0 {
-		needBuild := state.NeedBuild
-		state.NeedBuild = true // Always need this now since --pre implies actually building the thing.
 		findOriginalTaskSet(state, preTargets, false, arch)
 		for _, target := range preTargets {
 			if target.IsAllTargets() {
@@ -122,10 +120,9 @@ func findOriginalTasks(state *core.BuildState, preTargets, targets []core.BuildL
 		}
 		for _, target := range state.ExpandLabels(preTargets) {
 			log.Debug("Waiting for pre-target %s...", target)
-			state.WaitForInitialTargetAndEnsureDownload(target, core.OriginalTarget)
+			state.WaitForTargetAndEnsureDownload(target, core.OriginalTarget)
 			log.Debug("Pre-target %s built, continuing...", target)
 		}
-		state.NeedBuild = needBuild
 	}
 	findOriginalTaskSet(state, targets, true, arch)
 	log.Debug("Original target scan complete")


### PR DESCRIPTION
Currently it hangs, because it doesn't think it needs to build things, but the pre-target addition code is waiting for it. This fixes by forcing the build as though it were needed for a subinclude.

e.g.
```
$ plz plz query print //test:_add_out_gen --pre //test:_add_out_gen
# //test:_add_out_gen:
build_rule(
    name = '_add_out_gen',
    cmd = 'echo hello > _add_out_gen.txt',
    outs = ['_add_out_gen.txt'],
    output_is_complete = True,
    build_timeout = 600,
    post_build = '<function <lambda>>',
)
```
observe that `outs` is set on the result (it is not without `--pre`)