### PR TITLE
Fix race condition in parser

### DIFF
--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -110,6 +110,8 @@ func findOriginalTasks(state *core.BuildState, preTargets, targets []core.BuildL
 		state.Graph.AddSubrepo(core.SubrepoForArch(state, arch))
 	}
 	if len(preTargets) > 0 {
+		needBuild := state.NeedBuild
+		state.NeedBuild = true // Always need this now since --pre implies actually building the thing.
 		findOriginalTaskSet(state, preTargets, false, arch)
 		for _, target := range preTargets {
 			if target.IsAllTargets() {
@@ -120,9 +122,10 @@ func findOriginalTasks(state *core.BuildState, preTargets, targets []core.BuildL
 		}
 		for _, target := range state.ExpandLabels(preTargets) {
 			log.Debug("Waiting for pre-target %s...", target)
-			state.WaitForInitialTargetAndEnsureDownload(target, targets[0])
+			state.WaitForInitialTargetAndEnsureDownload(target, core.OriginalTarget)
 			log.Debug("Pre-target %s built, continuing...", target)
 		}
+		state.NeedBuild = needBuild
 	}
 	findOriginalTaskSet(state, targets, true, arch)
 	log.Debug("Original target scan complete")

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -110,8 +110,6 @@ func findOriginalTasks(state *core.BuildState, preTargets, targets []core.BuildL
 		state.Graph.AddSubrepo(core.SubrepoForArch(state, arch))
 	}
 	if len(preTargets) > 0 {
-		needBuild := state.NeedBuild
-		state.NeedBuild = true // Always need this now since --pre implies actually building the thing.
 		findOriginalTaskSet(state, preTargets, false, arch)
 		for _, target := range preTargets {
 			if target.IsAllTargets() {
@@ -122,10 +120,9 @@ func findOriginalTasks(state *core.BuildState, preTargets, targets []core.BuildL
 		}
 		for _, target := range state.ExpandLabels(preTargets) {
 			log.Debug("Waiting for pre-target %s...", target)
-			state.WaitForInitialTargetAndEnsureDownload(target, core.OriginalTarget)
+			state.WaitForTargetAndEnsureDownload(target, core.OriginalTarget)
 			log.Debug("Pre-target %s built, continuing...", target)
 		}
-		state.NeedBuild = needBuild
 	}
 	findOriginalTaskSet(state, targets, true, arch)
 	log.Debug("Original target scan complete")


### PR DESCRIPTION
Found this while fiddling with #2653; there's a concurrent map read/write on the top-level scope between the global subincludes (writing) and interpreting another file (reading). While the changes there definitely make this occur more often (for whatever reason) I don't think they are actually causing the problem.

This adds a mutex which fixes the race condition. Interestingly it then nearly always breaks with undefined names (`go_test` in this case but could be anything from a global subinclude) - so this is definitely not the real / full solution. I think it illustrates that something is wrong though.

What I'd ideally like to do is force `Init` to complete before `ParseFile` can begin (essentially removing `WaitForInit` and making that implicit. That's very hard though because the subincludes in `Init` may themselves queue targets which then call back to `ParseFile`...