### PR TITLE
Handle plugin and host in original task

### DIFF
--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -57,6 +57,18 @@ func SubrepoArchName(subrepo string, arch cli.Arch) string {
 	return subrepo + "_" + arch.String()
 }
 
+func LabelForArch(label BuildLabel, arch cli.Arch) BuildLabel {
+	if label.Subrepo == "" {
+		label.Subrepo = arch.String()
+		return label
+	}
+	if strings.HasSuffix(label.Subrepo, arch.String()) {
+		return label
+	}
+	label.Subrepo = SubrepoArchName(label.Subrepo, arch)
+	return label
+}
+
 // Dir returns the directory for a package of this name.
 func (s *Subrepo) Dir(dir string) string {
 	return filepath.Join(s.Root, dir)

--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -57,7 +57,8 @@ func SubrepoArchName(subrepo string, arch cli.Arch) string {
 	return subrepo + "_" + arch.String()
 }
 
-func LabelForArch(label BuildLabel, arch cli.Arch) BuildLabel {
+// LabelToArch converts the provided label to the given architecture
+func LabelToArch(label BuildLabel, arch cli.Arch) BuildLabel {
 	if label.Subrepo == "" {
 		label.Subrepo = arch.String()
 		return label

--- a/src/plz/BUILD
+++ b/src/plz/BUILD
@@ -15,3 +15,13 @@ go_library(
         "//third_party/go:cli-init",
     ],
 )
+
+go_test(
+    name = "plz_test",
+    srcs = ["plz_test.go"],
+    deps = [
+        ":plz",
+        "//src/core",
+        "//third_party/go:testify",
+    ]
+)

--- a/src/plz/BUILD
+++ b/src/plz/BUILD
@@ -22,6 +22,7 @@ go_test(
     deps = [
         ":plz",
         "//src/core",
+        "//src/cli",
         "//third_party/go:testify",
     ]
 )

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -144,13 +144,13 @@ func stripHostRepoName(config *core.Configuration, label core.BuildLabel) core.B
 		label.Subrepo = ""
 		return label
 	}
-	label.Subrepo = strings.TrimPrefix(label.Subrepo, config.PluginDefinition.Name + "_")
+	label.Subrepo = strings.TrimPrefix(label.Subrepo, config.PluginDefinition.Name+"_")
 
 	hostArch := cli.HostArch()
 	if label.Subrepo == hostArch.String() {
 		label.Subrepo = ""
 	}
-	label.Subrepo = strings.TrimSuffix(label.Subrepo, "_" + hostArch.String())
+	label.Subrepo = strings.TrimSuffix(label.Subrepo, "_"+hostArch.String())
 
 	return label
 }

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -150,13 +150,14 @@ func stripHostRepoName(config *core.Configuration, label core.BuildLabel) core.B
 	if label.Subrepo == hostArch.String() {
 		label.Subrepo = ""
 	}
+	label.Subrepo = strings.TrimSuffix(label.Subrepo, "_" + hostArch.String())
 
 	return label
 }
 
 func findOriginalTask(state *core.BuildState, target core.BuildLabel, addToList bool, arch cli.Arch) {
 	if arch != cli.HostArch() {
-		target = core.LabelForArch(target, arch)
+		target = core.LabelToArch(target, arch)
 	}
 	target = stripHostRepoName(state.Config, target)
 	if target.IsAllSubpackages() {

--- a/src/plz/plz_test.go
+++ b/src/plz/plz_test.go
@@ -1,0 +1,71 @@
+package plz
+
+import (
+	"fmt"
+	"github.com/thought-machine/please/src/cli"
+	"testing"
+
+	"github.com/thought-machine/please/src/core"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripHost(t *testing.T) {
+	hostArch := cli.HostArch()
+	testData := []struct{
+		Name string
+		Plugin string
+		Label string
+		Expected string
+	} {
+		{
+			Name: "Leaves no subrepo",
+			Label: "//foo:bar",
+			Expected: "//foo:bar",
+		},
+		{
+			Name: "Strips host arch",
+			Label: fmt.Sprintf("@%v//foo:bar", hostArch.String()),
+			Expected: "//foo:bar",
+		},
+		{
+			Name: "Leaves target arch",
+			Label: fmt.Sprintf("@%v//foo:bar", "foo_bar64"),
+			Expected: "@foo_bar64//foo:bar",
+		},
+		{
+			Name: "Strips plugin repo",
+			Label: "@go//foo:bar",
+			Plugin: "go",
+			Expected: "//foo:bar",
+		},
+		{
+			Name: "Leaves different subrepo",
+			Label: "@python//foo:bar",
+			Plugin: "go",
+			Expected: "@python//foo:bar",
+		},
+		{
+			Name: "Strips host plugin repo",
+			Label: fmt.Sprintf("@%v//foo:bar", core.SubrepoArchName("go", cli.HostArch())),
+			Plugin: "go",
+			Expected: "//foo:bar",
+		},
+		{
+			Name: "Strips host but leaves different subrepo",
+			Label: fmt.Sprintf("@%v//foo:bar", core.SubrepoArchName("python", cli.HostArch())),
+			Plugin: "go",
+			Expected: "@python//foo:bar",
+		},
+
+	}
+
+	for _, test := range testData {
+		t.Run(test.Name, func(t *testing.T) {
+			config := core.DefaultConfiguration()
+			config.PluginDefinition.Name = test.Plugin
+			actual := stripHostRepoName(config, core.ParseBuildLabel(test.Label, ""))
+			assert.Equal(t, core.ParseBuildLabel(test.Expected,  ""), actual)
+		})
+	}
+}

--- a/src/plz/plz_test.go
+++ b/src/plz/plz_test.go
@@ -2,62 +2,61 @@ package plz
 
 import (
 	"fmt"
-	"github.com/thought-machine/please/src/cli"
 	"testing"
 
-	"github.com/thought-machine/please/src/core"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/core"
 )
 
 func TestStripHost(t *testing.T) {
 	hostArch := cli.HostArch()
-	testData := []struct{
-		Name string
-		Plugin string
-		Label string
+	testData := []struct {
+		Name     string
+		Plugin   string
+		Label    string
 		Expected string
-	} {
+	}{
 		{
-			Name: "Leaves no subrepo",
-			Label: "//foo:bar",
+			Name:     "Leaves no subrepo",
+			Label:    "//foo:bar",
 			Expected: "//foo:bar",
 		},
 		{
-			Name: "Strips host arch",
-			Label: fmt.Sprintf("@%v//foo:bar", hostArch.String()),
+			Name:     "Strips host arch",
+			Label:    fmt.Sprintf("@%v//foo:bar", hostArch.String()),
 			Expected: "//foo:bar",
 		},
 		{
-			Name: "Leaves target arch",
-			Label: fmt.Sprintf("@%v//foo:bar", "foo_bar64"),
+			Name:     "Leaves target arch",
+			Label:    fmt.Sprintf("@%v//foo:bar", "foo_bar64"),
 			Expected: "@foo_bar64//foo:bar",
 		},
 		{
-			Name: "Strips plugin repo",
-			Label: "@go//foo:bar",
-			Plugin: "go",
+			Name:     "Strips plugin repo",
+			Label:    "@go//foo:bar",
+			Plugin:   "go",
 			Expected: "//foo:bar",
 		},
 		{
-			Name: "Leaves different subrepo",
-			Label: "@python//foo:bar",
-			Plugin: "go",
+			Name:     "Leaves different subrepo",
+			Label:    "@python//foo:bar",
+			Plugin:   "go",
 			Expected: "@python//foo:bar",
 		},
 		{
-			Name: "Strips host plugin repo",
-			Label: fmt.Sprintf("@%v//foo:bar", core.SubrepoArchName("go", cli.HostArch())),
-			Plugin: "go",
+			Name:     "Strips host plugin repo",
+			Label:    fmt.Sprintf("@%v//foo:bar", core.SubrepoArchName("go", cli.HostArch())),
+			Plugin:   "go",
 			Expected: "//foo:bar",
 		},
 		{
-			Name: "Strips host but leaves different subrepo",
-			Label: fmt.Sprintf("@%v//foo:bar", core.SubrepoArchName("python", cli.HostArch())),
-			Plugin: "go",
+			Name:     "Strips host but leaves different subrepo",
+			Label:    fmt.Sprintf("@%v//foo:bar", core.SubrepoArchName("python", cli.HostArch())),
+			Plugin:   "go",
 			Expected: "@python//foo:bar",
 		},
-
 	}
 
 	for _, test := range testData {
@@ -65,7 +64,7 @@ func TestStripHost(t *testing.T) {
 			config := core.DefaultConfiguration()
 			config.PluginDefinition.Name = test.Plugin
 			actual := stripHostRepoName(config, core.ParseBuildLabel(test.Label, ""))
-			assert.Equal(t, core.ParseBuildLabel(test.Expected,  ""), actual)
+			assert.Equal(t, core.ParseBuildLabel(test.Expected, ""), actual)
 		})
 	}
 }


### PR DESCRIPTION
We strip the plugin and host repo when parsing build files, but leave them in when finding the original targets. We also were overriding the subrepo on the command line when passing `--arch`. This PR fixes these issues. 