### PR TITLE
Remove per-function profiling metrics in asp

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -685,9 +685,6 @@ type Configuration struct {
 
 	// buildEnvStored is a cached form of BuildEnv.
 	buildEnvStored *storedBuildEnv
-	// Profiling can be set to true by a caller to enable CPU profiling in any areas that might
-	// want to take special effort about it.
-	Profiling bool
 
 	FeatureFlags struct {
 		JavaBinaryExecutableByDefault bool `help:"Makes java_binary rules self executable by default. Target release version 16." var:"FF_JAVA_SELF_EXEC"`

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -1,7 +1,6 @@
 package asp
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -631,7 +630,7 @@ func (f *pyFunc) String() string {
 	return fmt.Sprintf("<function %s>", f.name)
 }
 
-func (f *pyFunc) Call(ctx context.Context, s *scope, c *Call) pyObject {
+func (f *pyFunc) Call(s *scope, c *Call) pyObject {
 	if f.nativeCode != nil {
 		if f.kwargs {
 			return f.callNative(s.NewScope("<builtin code>"), c)
@@ -639,7 +638,6 @@ func (f *pyFunc) Call(ctx context.Context, s *scope, c *Call) pyObject {
 		return f.callNative(s, c)
 	}
 	s2 := f.scope.newScope(s.pkg, f.scope.filename, len(f.args)+1)
-	s2.ctx = ctx
 	s2.config = s.config
 	s2.Set("CONFIG", s.config) // This needs to be copied across too :(
 	s2.Callback = s.Callback

--- a/src/please.go
+++ b/src/please.go
@@ -1335,7 +1335,6 @@ func mustReadConfigAndSetRoot(forceUpdate bool) *core.Configuration {
 	}
 	config := readConfig()
 	// Now apply any flags that override this
-	config.Profiling = opts.Profile != ""
 	if opts.Update.Latest || opts.Update.LatestPrerelease {
 		config.Please.Version.Unset()
 	} else if opts.Update.Version.IsSet {


### PR DESCRIPTION
This reverts commit 444a626645424258096d9e05aecd6b367a864a59.

I ran it and only seem to be getting functions that _are_ labelled, which is a small minority of them, making profiling a lot less useful overall (since the metrics never seemed super accurate). It seems like this is a change in a more recent Go version although I can't find any notes to that effect.
Code is also simpler without.