### PR TITLE
Named Outputs can only be depended as a source

### DIFF
--- a/docs/build_rules.html
+++ b/docs/build_rules.html
@@ -185,7 +185,7 @@
     <p>
       The variables <code class="code">$OUTS_SRC</code> and
       <code class="code">$OUTS_LIB</code> will be set. These outputs can then be
-      depended on individually from other rules:
+      depended on individually from other rules as sources only:
     </p>
 
     <pre class="code-container">
@@ -194,7 +194,6 @@
     genrule(
         ...
         srcs = [":my_rule|srcs"],
-        deps = [":my_rule|libs"],
         ...
     )
       </code>


### PR DESCRIPTION
Per #2257, deps/exported_deps don't accept named outputs as inputs deliberately. Update the documentation to remove references to using named outputs in deps, and clarify that it can be depended on as sources only.