### PR TITLE
Specific file label output for filegroup proposal

### DIFF
--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -320,6 +320,12 @@ func (label BuildLabel) Label() (BuildLabel, bool) {
 	return label, true
 }
 
+// SpecificPathLabel returns the AnnotatedOutputLabel associated with this input, if it is a
+// label with a specified path. This is not the case for BuildLabel.
+func (label BuildLabel) SpecificPathLabel(graph *BuildGraph) (AnnotatedOutputLabel, bool) {
+	return AnnotatedOutputLabel{}, false
+}
+
 func (label BuildLabel) nonOutputLabel() (BuildLabel, bool) {
 	return label, true
 }


### PR DESCRIPTION
This was meant to be raised as an issue, but I have included an implementation of what I'm proposing since I wanted to check whether it would work as expected.

# Proposal

I would like to propose a mechanism to allow `filegroup`s to output a specific output artifact from a target at the filegroup's package level. For instance, by extending how annotated labels currently work, this could be achieved as:

```python
filegroup(
   name = "foo",
   srcs = ["//path/to:target|dir1/dir2/file.txt"],
)
```

Where the `filegroup` above would output the `file.txt` at the package level of the filegroup - disregarding the non-base path of the requested file.

# Prior work

Annotated labels already exist for entry points and named outputs, which provide a mechanism to reference the outputs of targets in more specific ways. 

# How
Given the requirements for the above proposal, extending the usage of annotated labels to target a specific file output seems a natural fitting.

How it should work:
- `//path/to:target|dir1/dir2/file.txt` references are to be supported in sources of `filegroup`'s only.
- Previous use cases of annotated labels take precedence, and only then the above is considered.
- The base name of the specified file path of a target's output artifacts becomes the output of the `filegroup`.

Note: I know I'm constraining what `//path/to:target|dir1/dir2/file.txt` is meant to mean and where to be used. A pattern like this could also mean to only pull this artifact but keep its full path, and be used in non-filegroup rules too. Happy to hear other suggestions :-) 

# Why

The necessity for this came up when I was running performance tests against https://github.com/tiagovtristao/please-js/ .

Those rules were written to be as incremental as possible. Each TypeScript file is essentially a module/library that can be compiled individually. Although this is great for incrementality, it turned out to be very slow and resource intensive to build projects.
This is happening because projects can have hundreds of TypeScript files (i.e. Ops Dash has around 1500) and the TypeScript compiler has a very slow start up time (around 3-4s on my machine). Even with build parallelisation provided out of the box by Please, firing the compiler for each target takes a long time to build the whole project - well above 10m on my machine for a mocked version of Ops Dash.

Firing the TypeScript compiler once to build the whole of Ops Dash (the mocked version) in one go instead took around ~20 seconds. This is great, but there's no incrementality at the file level...

## Finding another solution

Looking into how to build projects (spanning nested trees) in one go (due to speed) and making their sources individual targets, I came up with some abstractions similar to:

```python
# Package: common/js/react
subinclude("//common/js/react/build_defs:ts_project")

ts_project(
  entry_points = ["//common/js/react/src:index"]
)
```

```python
# Package: common/js/react/src
subinclude("//common/js/react/build_defs:ts_project")

ts_module(
  name = "react",
  src = "index.tsx",
)
```

The above achieves the following:
- `ts_project`: It is responsible for compiling the whole project in one go, and the `entry_points` will guarantee that transitive TypeScript files are included.
- `ts_module`: It provides the TypeScript source file when required by `ts_project`, but provides _only the compiled files_ when requested by other rules. It uses `requires`/`provides` under the hood, and the `ts_module`  rule is dependent on the `ts_project` rule (via some boilerplate in `//common/js/react/build_defs:ts_project`) to retrieve the compiled file.

Besides an initial build definition file setup and a `subinclude` statement in each `BUILD` file for a TypeScript project, the above allows for all sources to be compiled at once (which is then cached) and then each source target can be referenced by others targets to provide its compiled artifacts.

## Results

The approach above reduced the build times of 10+ minutes to a couple of minutes!

## Improvements

The reason why it's still taking a couple of minutes and not less than a minute (as discussed above about how compiling a mocked version of Ops Dash took ~20m) is due to the movement of files.
The way that `ts_module` rules are able to provide their compiled sources is by copying the respective compiled artifacts from the `ts_project` rule. Something similar to the following:

```python
# Package: common/js/react/src
# This is internal to `ts_module`
genrule(
  name = "index",
  cmd = "mv common/js/react/ts-project-out/src/index.js ."
  outs = ["index.js"],
  deps = ["//common/js/react:_ts_project"] + ["dependencies of original index.tsx file"] 
)
```

This makes the building of all targets in a project slower.

Since the above is trying to output an artifact from a target having something similar to:

```python
# Package: common/js/react/src
# This is internal to `ts_module`
filegroup(
  name = "index",
  srcs = ["//common/js/react:_ts_project|ts-project-out/src/index.js"]
  deps = ["dependencies of original index.tsx file"] 
)
```

It would speed up the builds even further. I have been able to build the same project in ~1m with these changes implemented locally, which is close to the time taken to build the same project just using the TypeScript compiler.