### PR TITLE
Option to selectively build targets locally

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -571,6 +571,7 @@ type Configuration struct {
 		Secure        bool         `help:"Whether to use TLS for communication or not."`
 		VerifyOutputs bool         `help:"Whether to verify all outputs are present after a cached remote execution action. Depending on your server implementation, you may require this to ensure files are really present."`
 		UploadDirs    bool         `help:"Uploads individual directory blobs after build actions. This might not be necessary with some servers, but if you aren't sure, you should leave it on."`
+		PreferLocal   bool         `help:"Prefer to use local execution for unbuilt tasks when remote execution is active."`
 		Shell         string       `help:"Path to the shell to use to execute actions in. Default looks up bash based on the build.path setting."`
 		Platform      []string     `help:"Platform properties to request from remote workers, in the format key=value."`
 		CacheDuration cli.Duration `help:"Length of time before we re-check locally cached build actions. Default is unlimited."`

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -94,6 +94,14 @@ type RemoteClient interface {
 	Disconnect() error
 }
 
+// A LocalClient is the interface to a local execution service. Used for callbacks from the remote service.
+type LocalClient interface {
+	// Build invokes a build of the target locally.
+	Build(tid int, target *BuildTarget) (*BuildMetadata, error)
+	// Test invokes a test run of the target locally.
+	Test(tid int, target *BuildTarget, run int) (*BuildMetadata, error)
+}
+
 // A TargetHasher is a thing that knows how to create hashes for targets.
 type TargetHasher interface {
 	// OutputHash calculates the output hash for a given build target.
@@ -138,6 +146,8 @@ type BuildState struct {
 	Cache Cache
 	// Client to remote execution service, if configured.
 	RemoteClient RemoteClient
+	// Client to local execution service, only if remote execution is configured.
+	LocalClient LocalClient
 	// Hasher for targets
 	TargetHasher TargetHasher
 	// Arguments to tests.

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -29,6 +29,7 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, config *
 	build.Init(state)
 	if state.Config.Remote.URL != "" {
 		state.RemoteClient = remote.New(state)
+		state.LocalClient = localClient{state: state}
 	}
 	if config.Display.SystemStats {
 		go state.UpdateResources()
@@ -247,4 +248,17 @@ func ReadStdinLabels(labels []core.BuildLabel) []core.BuildLabel {
 		}
 	}
 	return ret
+}
+
+// A localClient fulfils the LocalClient interface from src/core
+type localClient struct {
+	state *core.BuildState
+}
+
+func (client localClient) Build(tid int, target *core.BuildTarget) (*core.BuildMetadata, error) {
+	return build.BuildLocally(tid, client.state, target)
+}
+
+func (client localClient) Test(tid int, target *core.BuildTarget, run int) (*core.BuildMetadata, error) {
+	return test.TestLocally(tid, client.state, target, run)
 }

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -599,9 +599,11 @@ func (c *Client) execute(tid int, target *core.BuildTarget, command *pb.Command,
 		}
 	}
 	if local := c.state.Config.Remote.PreferLocal; local && isTest {
+		target.Local = true
 		metadata, err := c.state.LocalClient.Test(tid, target, testRun)
 		return metadata, nil, err
 	} else if local && !isRun {
+		target.Local = true
 		metadata, err := c.state.LocalClient.Build(tid, target)
 		return metadata, nil, err
 	}

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -406,6 +406,12 @@ func doTestResults(tid int, state *core.BuildState, target *core.BuildTarget, ru
 	return metadata, data, coverage, err
 }
 
+// TestLocally runs a single test run locally.
+func TestLocally(tid int, state *core.BuildState, target *core.BuildTarget, run int) (*core.BuildMetadata, error) {
+	stdout, err := prepareAndRunTest(tid, state, target, run)
+	return &core.BuildMetadata{Stdout: stdout}, err
+}
+
 // prepareAndRunTest sets up a test directory and runs the test.
 func prepareAndRunTest(tid int, state *core.BuildState, target *core.BuildTarget, run int) (stdout []byte, err error) {
 	if err = core.PrepareRuntimeDir(state, target, target.TestDir(run)); err != nil {


### PR DESCRIPTION
If they can't be retrieved from the remote cache, build them locally instead of remotely. Should be useful when making small iterative changes (e.g. on a test) where local execution is lower latency.

Doesn't fully work yet - getting some nil pointers, but I've run out of time for today so wanted to get something up.

All feels a bit awkward tbh with the calls back and forth between different parts of the system, and them not really being fully mutually intelligible. I think the ideal solution is a huge refactor to make remote and local execution much more similar internally, but I'm honestly unsure at this point that I'll find time for such a thing.