### PR TITLE
Add field for accepted licences in stamp file

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -986,21 +986,8 @@ func runPostBuildFunction(tid int, state *core.BuildState, target *core.BuildTar
 // checkLicences checks the licences for the target match what we've accepted / rejected in the config
 // and panics if they don't match.
 func checkLicences(state *core.BuildState, target *core.BuildTarget) {
-	for _, licence := range target.Licences {
-		for _, reject := range state.Config.Licences.Reject {
-			if strings.EqualFold(reject, licence) {
-				panic(fmt.Sprintf("Target %s is licensed %s, which is explicitly rejected for this repository", target.Label, licence))
-			}
-		}
-		for _, accept := range state.Config.Licences.Accept {
-			if strings.EqualFold(accept, licence) {
-				log.Info("Licence %s is accepted in this repository", licence)
-				return // Note licences are assumed to be an 'or', ie. any one of them can be accepted.
-			}
-		}
-	}
-	if len(target.Licences) > 0 && len(state.Config.Licences.Accept) > 0 {
-		panic(fmt.Sprintf("None of the licences for %s are accepted in this repository: %s", target.Label, strings.Join(target.Licences, ", ")))
+	if _, err := target.CheckLicences(state.Config); err != nil {
+		panic(err)
 	}
 }
 

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -594,7 +594,7 @@ func prepareSources(state *core.BuildState, graph *core.BuildGraph, target *core
 		}
 	}
 	if target.Stamp {
-		if err := fs.WriteFile(bytes.NewReader(core.StampFile(target)), filepath.Join(target.TmpDir(), target.StampFileName()), 0644); err != nil {
+		if err := fs.WriteFile(bytes.NewReader(core.StampFile(state.Config, target)), filepath.Join(target.TmpDir(), target.StampFileName()), 0644); err != nil {
 			return err
 		}
 	}

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -940,6 +940,23 @@ func TestIsTool(t *testing.T) {
 	assert.True(t, target.IsTool(l))
 }
 
+func TestCheckLicences(t *testing.T) {
+	config := DefaultConfiguration()
+	config.Licences.Accept = []string{"BSD"}
+	config.Licences.Reject = []string{"GPL"}
+
+	target := makeTarget1("//src/core/test_data/project", "PUBLIC")
+	target.Licences = []string{"BSD", "GPL"}
+	accepted, err := target.CheckLicences(config)
+	assert.NoError(t, err)
+	assert.Equal(t, "BSD", accepted)
+
+	target.Licences = []string{"MIT", "GPL"}
+	accepted, err = target.CheckLicences(config)
+	assert.Error(t, err)
+	assert.Equal(t, "", accepted)
+}
+
 func makeTarget1(label, visibility string, deps ...*BuildTarget) *BuildTarget {
 	target := NewBuildTarget(ParseBuildLabel(label, ""))
 	if visibility == "PUBLIC" {

--- a/src/core/stamp_test.go
+++ b/src/core/stamp_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestStampFile(t *testing.T) {
+	config := DefaultConfiguration()
+	config.Licences.Accept = []string{"bsd-2-clause"}
 	t1 := NewBuildTarget(ParseBuildLabel("//src/core:core", ""))
 	t2 := NewBuildTarget(ParseBuildLabel("//src/fs:fs", ""))
 	t3 := NewBuildTarget(ParseBuildLabel("//third_party/go:errors", ""))
@@ -33,9 +35,10 @@ func TestStampFile(t *testing.T) {
       ],
       "licences": [
         "bsd-2-clause"
-      ]
+      ],
+      "accepted_licence": "bsd-2-clause"
     }
   }
 }`)
-	assert.Equal(t, expected, StampFile(t1))
+	assert.Equal(t, expected, StampFile(config, t1))
 }

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -262,7 +262,7 @@ func (c *Client) uploadInputDir(ch chan<- *uploadinfo.Entry, target *core.BuildT
 		}
 	}
 	if !isTest && target.Stamp {
-		stamp := core.StampFile(target)
+		stamp := core.StampFile(c.state.Config, target)
 		entry := uploadinfo.EntryFromBlob(stamp)
 		if ch != nil {
 			ch <- entry


### PR DESCRIPTION
For packages that have multiple (indicating dual licensing where either is an option) we may not want to show the others. For example, consider a package that's dual-licenced under BSD and GPL, and you accept BSD but not GPL, you may not want to display GPL alongside that package at all since that's not what you're using.