### PR TITLE
Update golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,5 +18,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.47.3
+          version: v1.51.2
           args: src/... tools/...

--- a/src/assets/assets.go
+++ b/src/assets/assets.go
@@ -6,9 +6,11 @@ import (
 )
 
 // Pleasew is the please wrapper script
+//
 //go:embed pleasew
 var Pleasew []byte
 
 // PlzComplete is the plz completion script
+//
 //go:embed plz_complete.sh
 var PlzComplete []byte

--- a/src/cmap/hash_test.go
+++ b/src/cmap/hash_test.go
@@ -131,7 +131,8 @@ func BenchmarkXXHash_20Sx(b *testing.B) {
 
 // ref is our reference implementation, from OneOfOne/cmap/hashers
 // N.B. As of Go 1.18 the workaround is no longer needed (hence why we have our own), this
-//      is reproduced verbatim as a reference implementation.
+//
+//	is reproduced verbatim as a reference implementation.
 func ref(s string) (hash uint64) {
 	const prime32 = 16777619
 	if hash = 2166136261; s == "" {

--- a/src/parse/asp/exec.go
+++ b/src/parse/asp/exec.go
@@ -249,7 +249,8 @@ func execGitCommit(s *scope, args []pyObject) pyObject {
 // git_show() returns the output of `git show -s --format=%{fmt}`
 //
 // %ci == commit-date:
-//   `git show -s --format=%ci` = 2018-12-10 00:53:35 -0800
+//
+//	`git show -s --format=%ci` = 2018-12-10 00:53:35 -0800
 func execGitShow(s *scope, args []pyObject) pyObject {
 	formatVerb := args[0].(pyString)
 	switch formatVerb {

--- a/src/process/exec_linux.go
+++ b/src/process/exec_linux.go
@@ -10,7 +10,8 @@ import (
 // ExecCommand executes an external command.
 // We set Pdeathsig to try to make sure commands don't outlive us if we die.
 // N.B. This does not start the command - the caller must handle that (or use one
-//      of the other functions which are higher-level interfaces).
+//
+//	of the other functions which are higher-level interfaces).
 func (e *Executor) ExecCommand(sandbox SandboxConfig, foreground bool, command string, args ...string) *exec.Cmd {
 	shouldNamespace := e.namespace == NamespaceAlways || ((e.namespace == NamespaceSandbox || e.usePleaseSandbox) && sandbox != NoSandbox)
 

--- a/src/query/query_step.go
+++ b/src/query/query_step.go
@@ -1,26 +1,27 @@
 // Package query implements a set of query operations for Please.
 //
 // Currently supported operations:
-//   'deps': 'plz query deps //src:please'
-//           shows the dependency graph of this target.
-//   'somepath': 'plz query somepath //src:please //rules:java_rules_pyc'
-//               finds a route between these two targets, if there is one.
-//               useful for saying 'why on earth do I depend on that thing?'
-//   'alltargets': 'plz query alltargets //src/...'
-//                 shows all targets currently in the graph. careful in large repos!
-//   'print': 'plz query print //src:please'
-//            produces a python-like function call that would define the rule.
-//   'completions': 'plz query completions //sr'
-//            produces a list of possible completions for the given stem.
-//   'changes': 'plz query changes path/to/changed_file.py'
-//            produces a list of targets which have a transitive dependency on
-//            the given file.
-//   'input': 'plz query input //src:label' produces a list of all the files
-//            (including transitive deps) that are referenced by this rule.
-//   'output': 'plz query output //src:label' produces a list of all the files
-//             that are output by this rule.
-//   'graph': 'plz query graph' produces a JSON representation of the build graph
-//            that other programs can interpret for their own uses.
+//
+//	'deps': 'plz query deps //src:please'
+//	        shows the dependency graph of this target.
+//	'somepath': 'plz query somepath //src:please //rules:java_rules_pyc'
+//	            finds a route between these two targets, if there is one.
+//	            useful for saying 'why on earth do I depend on that thing?'
+//	'alltargets': 'plz query alltargets //src/...'
+//	              shows all targets currently in the graph. careful in large repos!
+//	'print': 'plz query print //src:please'
+//	         produces a python-like function call that would define the rule.
+//	'completions': 'plz query completions //sr'
+//	         produces a list of possible completions for the given stem.
+//	'changes': 'plz query changes path/to/changed_file.py'
+//	         produces a list of targets which have a transitive dependency on
+//	         the given file.
+//	'input': 'plz query input //src:label' produces a list of all the files
+//	         (including transitive deps) that are referenced by this rule.
+//	'output': 'plz query output //src:label' produces a list of all the files
+//	          that are output by this rule.
+//	'graph': 'plz query graph' produces a JSON representation of the build graph
+//	         that other programs can interpret for their own uses.
 package query
 
 import "github.com/thought-machine/please/src/cli/logging"

--- a/src/test/gcov_coverage.go
+++ b/src/test/gcov_coverage.go
@@ -48,9 +48,10 @@ func parseGcovCoverageResults(target *core.BuildTarget, coverage *core.TestCover
 
 // translateGcovCount coverts gcov's format to ours.
 // AFAICT the format is:
-//       -: Not executable
-//   #####: Not covered
-//      32: line was hit 32 times
+//
+//	    -: Not executable
+//	#####: Not covered
+//	   32: line was hit 32 times
 func translateGcovCount(gcov []byte) core.LineCoverage {
 	if len(gcov) > 0 && gcov[0] == '-' {
 		return core.NotExecutable


### PR DESCRIPTION
It seems unhappy on newer PRs. This should fix.

`gofmt` and `gci` seem to have changed output a bit, so let them rewrite the relevant files.