### PR TITLE
Delete reference to non-existent struct field that was breaking `plz help`

### DIFF
--- a/src/help/help.go
+++ b/src/help/help.go
@@ -331,7 +331,7 @@ func printMessage(msg string) {
 
 const docstringTemplate = `${BLUE}{{ .Name }}${RESET} is
 {{- if .IsBuiltin }} a built-in build rule in Please.
-{{- else }} an add-on build rule for Please defined in ${YELLOW}{{ .EoDef.Filename }}${RESET}.
+{{- else }} an add-on build rule for Please${RESET}.
 {{- end }} Instructions for use & its arguments:
 
 ${BOLD_YELLOW}{{ .Name }}${RESET}(


### PR DESCRIPTION
Think it would be nice to implement something here so that the function knows which plugin it was defined in, and then include that in the doc string instead?