### PR TITLE
Fix issues with `pleasew`

### DIFF
--- a/pleasew
+++ b/pleasew
@@ -3,12 +3,12 @@
 set -e
 set -u
 
-set -o errexit
+ESC="$(printf '\033')"
 
-RED='\x1B[31m'
-GREEN='\x1B[32m'
-YELLOW='\x1B[33m'
-RESET='\x1B[0m'
+RED="${ESC}[31m"
+GREEN="${ESC}[32m"
+YELLOW="${ESC}[33m"
+RESET="${ESC}[0m"
 
 DEFAULT_URL_BASE='https://get.please.build'
 
@@ -22,6 +22,11 @@ else
     # because we only build intel binaries
     ARCH='amd64'
 fi
+
+case "${ARCH}" in
+	aarch64_be|aarch64|armv8b|armv8l) ARCH='arm64' ;;
+	x86_64) ARCH='amd64' ;;
+esac
 
 get_profile () {
     while [ "${#}" -gt 0 ]
@@ -69,7 +74,7 @@ read_config() {
 }
 
 # We might already have it downloaded...
-LOCATION="$(read_config '^location' | cut -d '=' -f 2 | tr -d ' ')"
+LOCATION="$(read_config '^\s*location' | cut -d '=' -f 2 | tr -d ' ')"
 
 if [ "${LOCATION:+x}" != 'x' ]; then
     if [ "${HOME:+x}" != 'x' ]; then
@@ -92,7 +97,7 @@ if [ -f "${TARGET}" ]; then
     exec "${TARGET}" ${PLZ_ARGS:-} "${@}"
 fi
 
-URL_BASE="$(read_config '^downloadlocation' | cut -d '=' -f 2 | tr -d ' ')"
+URL_BASE="$(read_config '^\s*downloadlocation' | cut -d '=' -f 2 | tr -d ' ')"
 
 if [ "${URL_BASE:+x}" != 'x' ]; then
     URL_BASE="${DEFAULT_URL_BASE}"
@@ -100,7 +105,7 @@ fi
 
 URL_BASE="${URL_BASE%/}"
 
-VERSION="$(read_config '^version[^a-z]')"
+VERSION="$(read_config '^\s*version[^a-z]')"
 VERSION="${VERSION#*=}"                    # Strip until after first =
 VERSION="$(echo "${VERSION}" | tr -d ' ')" # Remove all spaces
 VERSION="${VERSION#>=}"                    # Strip any initial >=
@@ -133,7 +138,7 @@ fi
 
 printf >&2 '%bDownloading Please %s to %s...%b\n' "${GREEN}" "${VERSION}" "${DIR}" "${RESET}"
 mkdir -p "${DIR}"
-curl -fsSL "${PLEASE_URL}" | tar -xJpf- --strip-components=1 -C "${DIR}"
+curl -#fSL "${PLEASE_URL}" | tar -xJpf- --strip-components=1 -C "${DIR}"
 
 # Link it all back up a dir
 for x in "${DIR}"/*; do

--- a/pleasew
+++ b/pleasew
@@ -125,7 +125,7 @@ VERSION="${VERSION#>=}"                    # Strip any initial >=
 if has_command curl; then
     TRANSFER_TOOL='curl'
     TRANSFER_SILENT_OPTS='-fsSL'
-    TRANSFER_PROGRESS_OPTS='-#fSL'
+    TRANSFER_PROGRESS_OPTS='-fSL'
 elif has_command wget; then
     TRANSFER_TOOL='wget'
     TRANSFER_SILENT_OPTS='-qO-'

--- a/pleasew
+++ b/pleasew
@@ -5,10 +5,18 @@ set -u
 
 ESC="$(printf '\033')"
 
-RED="${ESC}[31m"
-GREEN="${ESC}[32m"
-YELLOW="${ESC}[33m"
-RESET="${ESC}[0m"
+if [ "${NOCOLOR+x}" = 'x' ] || [ "${NO_COLOR+x}" = 'x' ]; then
+	RED="${ESC}[31m"
+	GREEN="${ESC}[32m"
+	YELLOW="${ESC}[33m"
+	RESET="${ESC}[0m"
+else
+	RED=''
+	GREEN=''
+	YELLOW=''
+	RESET=''
+fi
+
 
 DEFAULT_URL_BASE='https://get.please.build'
 

--- a/pleasew
+++ b/pleasew
@@ -6,15 +6,15 @@ set -u
 ESC="$(printf '\033')"
 
 if [ "${NOCOLOR+x}" != 'x' ] || [ "${NO_COLOR+x}" != 'x' ]; then
-	RED="${ESC}[31m"
-	GREEN="${ESC}[32m"
-	YELLOW="${ESC}[33m"
-	RESET="${ESC}[0m"
+    RED="${ESC}[31m"
+    GREEN="${ESC}[32m"
+    YELLOW="${ESC}[33m"
+    RESET="${ESC}[0m"
 else
-	RED=''
-	GREEN=''
-	YELLOW=''
-	RESET=''
+    RED=''
+    GREEN=''
+    YELLOW=''
+    RESET=''
 fi
 
 
@@ -32,8 +32,8 @@ else
 fi
 
 case "${ARCH}" in
-	aarch64_be|aarch64|armv8b|armv8l) ARCH='arm64' ;;
-	x86_64) ARCH='amd64' ;;
+    aarch64_be|aarch64|armv8b|armv8l) ARCH='arm64' ;;
+    x86_64) ARCH='amd64' ;;
 esac
 
 get_profile () {

--- a/pleasew
+++ b/pleasew
@@ -36,6 +36,10 @@ case "${ARCH}" in
     x86_64) ARCH='amd64' ;;
 esac
 
+has_command () {
+    command -v "${1}" > /dev/null 2>&1
+}
+
 get_profile () {
     while [ "${#}" -gt 0 ]
     do
@@ -118,9 +122,23 @@ VERSION="${VERSION#*=}"                    # Strip until after first =
 VERSION="$(echo "${VERSION}" | tr -d ' ')" # Remove all spaces
 VERSION="${VERSION#>=}"                    # Strip any initial >=
 
+if has_command curl; then
+    TRANSFER_TOOL='curl'
+    TRANSFER_SILENT_OPTS='-fsSL'
+    TRANSFER_PROGRESS_OPTS='-#fSL'
+elif has_command wget; then
+    TRANSFER_TOOL='wget'
+    TRANSFER_SILENT_OPTS='-qO-'
+    TRANSFER_PROGRESS_OPTS='-O-'
+else
+    printf >&2 '%bUnable to find a command for network operations%b\n' "${RED}" "${RESET}"
+    printf >&2 'Please install either curl or wget\n'
+    exit 1
+fi
+
 if [ "${VERSION:+x}" != 'x' ]; then
     printf >&2 "%bCan't determine version, will use latest.%b\n" "${YELLOW}" "${RESET}"
-    VERSION=$(curl -fsSL "${URL_BASE}"/latest_version)
+    VERSION=$(${TRANSFER_TOOL} ${TRANSFER_SILENT_OPTS} "${URL_BASE}"/latest_version)
 fi
 
 # Find the os / arch to download. You can do this quite nicely with go env
@@ -146,7 +164,7 @@ fi
 
 printf >&2 '%bDownloading Please %s to %s...%b\n' "${GREEN}" "${VERSION}" "${DIR}" "${RESET}"
 mkdir -p "${DIR}"
-curl -#fSL "${PLEASE_URL}" | tar -xJpf- --strip-components=1 -C "${DIR}"
+${TRANSFER_TOOL} ${TRANSFER_PROGRESS_OPTS} "${PLEASE_URL}" | tar -xJpf- --strip-components=1 -C "${DIR}"
 
 # Link it all back up a dir
 for x in "${DIR}"/*; do

--- a/pleasew
+++ b/pleasew
@@ -5,7 +5,7 @@ set -u
 
 ESC="$(printf '\033')"
 
-if [ "${NOCOLOR+x}" = 'x' ] || [ "${NO_COLOR+x}" = 'x' ]; then
+if [ "${NOCOLOR+x}" != 'x' ] || [ "${NO_COLOR+x}" != 'x' ]; then
 	RED="${ESC}[31m"
 	GREEN="${ESC}[32m"
 	YELLOW="${ESC}[33m"


### PR DESCRIPTION
- Remove redundant top-level set

 `set -o errexit` is equivalent to `set -e`.

- Better eye-candy

  - Add download progress bar.
  - Fix coloring on some terminals.
  - Support `$NOCOLOR`.

- Add .plzconfig indentation support

 `please` (the binary) supports indented config but `pleasew` does not.
 Now it does.

- Normalize `uname -m` output. Fixes #2717.