### PR TITLE
Exclude targets in plugin subrepos from `plz query changes`

### DIFF
--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -26,11 +26,13 @@ type Subrepo struct {
 	Arch cli.Arch
 	// True if this subrepo was created for a different architecture
 	IsCrossCompile bool
+	// True if this subrepo was created by a plugin
+	IsPlugin bool
 	// AdditionalConfigFiles corresponds to the config parameter on `subrepo()`
 	AdditionalConfigFiles []string
 }
 
-func NewSubrepo(state *BuildState, name, root string, target *BuildTarget, arch cli.Arch, isCrosscompile bool) *Subrepo {
+func NewSubrepo(state *BuildState, name, root string, target *BuildTarget, arch cli.Arch, isCrosscompile, isPlugin bool) *Subrepo {
 	return &Subrepo{
 		Name:           name,
 		Root:           root,
@@ -38,12 +40,13 @@ func NewSubrepo(state *BuildState, name, root string, target *BuildTarget, arch 
 		Target:         target,
 		Arch:           arch,
 		IsCrossCompile: isCrosscompile,
+		IsPlugin:       isPlugin,
 	}
 }
 
 // SubrepoForArch creates a new subrepo for the given architecture.
 func SubrepoForArch(state *BuildState, arch cli.Arch) *Subrepo {
-	s := NewSubrepo(state.ForArch(arch), arch.String(), "", nil, arch, true)
+	s := NewSubrepo(state.ForArch(arch), arch.String(), "", nil, arch, true, false)
 	if err := s.State.Initialise(s); err != nil {
 		// We always return nil as we shortcut loading config for architecture subrepos, but check non-the-less incase
 		// somebody changes something.

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1122,7 +1122,14 @@ func subrepo(s *scope, args []pyObject) pyObject {
 		state = state.ForArch(arch)
 		isCrossCompile = true
 	}
-	sr := core.NewSubrepo(state, s.pkg.SubrepoArchName(subrepoName), root, target, arch, isCrossCompile)
+
+	// Created for plugin
+	isPlugin := false
+	if args[PluginArgIdx].IsTruthy() {
+		isPlugin = true
+	}
+
+	sr := core.NewSubrepo(state, s.pkg.SubrepoArchName(subrepoName), root, target, arch, isCrossCompile, isPlugin)
 	if args[PackageRootIdx].IsTruthy() {
 		sr.PackageRoot = args[PackageRootIdx].String()
 	}

--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -99,7 +99,7 @@ func createBazelSubrepo(state *core.BuildState) {
 		return
 	}
 	dir := filepath.Join(core.OutDir, "bazel_tools")
-	state.Graph.AddSubrepo(core.NewSubrepo(state, "bazel_tools", dir, nil, cli.HostArch(), false))
+	state.Graph.AddSubrepo(core.NewSubrepo(state, "bazel_tools", dir, nil, cli.HostArch(), false, false))
 	// TODO(peterebden): This is a bit yuck... would be nice if we could avoid hardcoding all
 	//                   this upfront and add a build target to do it for us.
 	dir = filepath.Join(dir, "tools/build_defs/repo")

--- a/src/please.go
+++ b/src/please.go
@@ -416,6 +416,7 @@ var opts struct {
 		Changes struct {
 			Since            string `short:"s" long:"since" default:"origin/master" description:"Revision to compare against"`
 			IncludeDependees string `long:"include_dependees" default:"none" choice:"none" choice:"direct" choice:"transitive" description:"Deprecated: use level 1 for direct and -1 for transitive. Include direct or transitive dependees of changed targets."`
+			IncludePlugins   bool   `long:"include_plugins" description:"Include changed targets that belong to plugin subrepos."`
 			Level            int    `long:"level" default:"-2" description:"Levels of the dependencies of changed targets (-1 for unlimited)." default-mask:"0"`
 			Inexact          bool   `long:"inexact" description:"Calculate changes more quickly and without doing any SCM checkouts, but may miss some targets."`
 			In               string `long:"in" description:"Calculate changes contained within given scm spec (commit range/sha/ref/etc). Implies --inexact."`
@@ -858,6 +859,7 @@ var buildFunctions = map[string]func() int{
 	"query.changes": func() int {
 		// query changes always excludes 'manual' targets.
 		opts.BuildFlags.Exclude = append(opts.BuildFlags.Exclude, "manual", "manual:"+core.OsArch)
+		includePlugins := opts.Query.Changes.IncludePlugins
 		level := opts.Query.Changes.Level // -2 means unset -1 means all transitive
 		transitive := opts.Query.Changes.IncludeDependees == "transitive"
 		direct := opts.Query.Changes.IncludeDependees == "direct"
@@ -878,7 +880,7 @@ var buildFunctions = map[string]func() int{
 		}
 		runInexact := func(files []string) int {
 			return runQuery(true, core.WholeGraph, func(state *core.BuildState) {
-				for _, target := range query.Changes(state, files, level) {
+				for _, target := range query.Changes(state, files, level, includePlugins) {
 					fmt.Println(target.String())
 				}
 			})
@@ -910,7 +912,7 @@ var buildFunctions = map[string]func() int{
 		if !success {
 			return 1
 		}
-		for _, target := range query.DiffGraphs(before, after, files, level) {
+		for _, target := range query.DiffGraphs(before, after, files, level, includePlugins) {
 			fmt.Println(target.String())
 		}
 		return 0

--- a/src/query/changes_test.go
+++ b/src/query/changes_test.go
@@ -16,15 +16,15 @@ func TestDiffGraphs(t *testing.T) {
 	t2 := addTarget(s2, "//src/query:changes", nil, "src/query/changes.go")
 	addTarget(s1, "//src/query:changes_test", t1, "src/query/changes_test.go")
 	t4 := addTarget(s2, "//src/query:changes_test", t2, "src/query/changes_test.go")
-	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil, -1))
+	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil, -1, false))
 
 	t2.Command = "nope nope nope"
-	assert.EqualValues(t, []core.BuildLabel{t2.Label, t4.Label}, DiffGraphs(s1, s2, nil, -1))
+	assert.EqualValues(t, []core.BuildLabel{t2.Label, t4.Label}, DiffGraphs(s1, s2, nil, -1, false))
 
 	t2.AddLabel("nope")
 	t4.AddLabel("test")
 	s2.SetIncludeAndExclude(nil, []string{"nope", "test"})
-	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil, -1))
+	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil, -1, false))
 }
 
 func TestDiffGraphsIncludeNothing(t *testing.T) {
@@ -36,7 +36,7 @@ func TestDiffGraphsIncludeNothing(t *testing.T) {
 	t1 = addTarget(s2, "//src/core:core", nil, "src/core/core_changed.go")
 	t2 = addTarget(s2, "//src/query:changes", t1, "src/query/changes.go")
 	addTarget(s2, "//src/query:changes_test", t2, "src/query/changes_test.go")
-	assert.EqualValues(t, []core.BuildLabel{t1.Label}, DiffGraphs(s1, s2, nil, 0))
+	assert.EqualValues(t, []core.BuildLabel{t1.Label}, DiffGraphs(s1, s2, nil, 0, false))
 }
 
 func TestDiffGraphsIncludeDirect(t *testing.T) {
@@ -48,7 +48,7 @@ func TestDiffGraphsIncludeDirect(t *testing.T) {
 	t1 = addTarget(s2, "//src/core:core", nil, "src/core/core_changed.go")
 	t2 = addTarget(s2, "//src/query:changes", t1, "src/query/changes.go")
 	addTarget(s2, "//src/query:changes_test", t2, "src/query/changes_test.go")
-	assert.EqualValues(t, []core.BuildLabel{t1.Label, t2.Label}, DiffGraphs(s1, s2, nil, 1))
+	assert.EqualValues(t, []core.BuildLabel{t1.Label, t2.Label}, DiffGraphs(s1, s2, nil, 1, false))
 }
 
 func TestDiffGraphsLevel(t *testing.T) {
@@ -62,7 +62,7 @@ func TestDiffGraphsLevel(t *testing.T) {
 	t2 = addTarget(s2, "//src/query:changes", t1, "src/query/changes.go")
 	t3 = addTarget(s2, "//src/query:changes_test", t2, "src/query/changes_test.go")
 	addTarget(s2, "//src/query:changes_test2", t3, "src/query/changes_test2.go")
-	assert.EqualValues(t, []core.BuildLabel{t1.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, nil, 2))
+	assert.EqualValues(t, []core.BuildLabel{t1.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, nil, 2, false))
 }
 
 func TestDiffGraphsIncludeTransitive(t *testing.T) {
@@ -74,7 +74,7 @@ func TestDiffGraphsIncludeTransitive(t *testing.T) {
 	t1 = addTarget(s2, "//src/core:core", nil, "src/core/core_changed.go")
 	t2 = addTarget(s2, "//src/query:changes", t1, "src/query/changes.go")
 	t3 := addTarget(s2, "//src/query:changes_test", t2, "src/query/changes_test.go")
-	assert.EqualValues(t, core.BuildLabels{t1.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, nil, -1))
+	assert.EqualValues(t, core.BuildLabels{t1.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, nil, -1, false))
 }
 
 func TestChangesIncludesDataDirs(t *testing.T) {
@@ -83,7 +83,7 @@ func TestChangesIncludesDataDirs(t *testing.T) {
 	t2 := addTarget(s, "//src/query:changes", t1, "src/query/changes.go")
 	t3 := addTarget(s, "//src/query:changes_test", t2, "src/query/changes_test.go")
 	t3.AddDatum(core.FileLabel{Package: "src/query", File: "test_data"})
-	assert.EqualValues(t, []core.BuildLabel{t3.Label}, Changes(s, []string{"src/query/test_data/some_dir/test_file1.txt"}, 0))
+	assert.EqualValues(t, []core.BuildLabel{t3.Label}, Changes(s, []string{"src/query/test_data/some_dir/test_file1.txt"}, 0, false))
 }
 
 func TestSameToolHashNoChange(t *testing.T) {
@@ -93,13 +93,13 @@ func TestSameToolHashNoChange(t *testing.T) {
 	target.AddTool(core.SystemPathLabel{Name: "non-existent", Path: s1.Config.Path()})
 	target = addTarget(s2, "//src/core:core", nil, "src/core/core.go")
 	target.AddTool(core.SystemPathLabel{Name: "non-existent", Path: s2.Config.Path()})
-	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil, -1))
+	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil, -1, false))
 }
 
 func TestChangesIncludesRootTarget(t *testing.T) {
 	s := core.NewDefaultBuildState()
 	t1 := addTarget(s, "//:file", nil, "file.go")
-	assert.EqualValues(t, []core.BuildLabel{t1.Label}, Changes(s, []string{"file.go"}, 0))
+	assert.EqualValues(t, []core.BuildLabel{t1.Label}, Changes(s, []string{"file.go"}, 0, false))
 }
 
 func addTarget(state *core.BuildState, label string, dep *core.BuildTarget, sources ...string) *core.BuildTarget {


### PR DESCRIPTION
Changing a `plugin_repo()` target causes all of the plugin subrepo's child targets to be outputted by `plz query changes`. This is problematic because it isn't necessarily desirable (or even possible, depending on the environment) to build every single target in the plugin subrepo.

Exclude all plugin subrepo child targets from the output of `plz query changes` by default, and add an `--include_plugins` option to revert to the previous behaviour if desired.