### PR TITLE
[v16] Exclude targets in subrepos from `plz query changes`

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -419,6 +419,7 @@ var opts struct {
 		Changes struct {
 			Since            string `short:"s" long:"since" default:"origin/master" description:"Revision to compare against"`
 			IncludeDependees string `long:"include_dependees" default:"none" choice:"none" choice:"direct" choice:"transitive" description:"Deprecated: use level 1 for direct and -1 for transitive. Include direct or transitive dependees of changed targets."`
+			IncludeSubrepos  bool   `long:"include_subrepos" description:"Include changed targets that belong to subrepos."`
 			Level            int    `long:"level" default:"-2" description:"Levels of the dependencies of changed targets (-1 for unlimited)." default-mask:"0"`
 			Inexact          bool   `long:"inexact" description:"Calculate changes more quickly and without doing any SCM checkouts, but may miss some targets."`
 			In               string `long:"in" description:"Calculate changes contained within given scm spec (commit range/sha/ref/etc). Implies --inexact."`
@@ -880,6 +881,7 @@ var buildFunctions = map[string]func() int{
 	"query.changes": func() int {
 		// query changes always excludes 'manual' targets.
 		opts.BuildFlags.Exclude = append(opts.BuildFlags.Exclude, "manual", "manual:"+core.OsArch)
+		includeSubrepos := opts.Query.Changes.IncludeSubrepos
 		level := opts.Query.Changes.Level // -2 means unset -1 means all transitive
 		transitive := opts.Query.Changes.IncludeDependees == "transitive"
 		direct := opts.Query.Changes.IncludeDependees == "direct"
@@ -900,7 +902,7 @@ var buildFunctions = map[string]func() int{
 		}
 		runInexact := func(files []string) int {
 			return runQuery(true, core.WholeGraph, func(state *core.BuildState) {
-				for _, target := range query.Changes(state, files, level) {
+				for _, target := range query.Changes(state, files, level, includeSubrepos) {
 					fmt.Println(target.String())
 				}
 			})
@@ -932,7 +934,7 @@ var buildFunctions = map[string]func() int{
 		if !success {
 			return 1
 		}
-		for _, target := range query.DiffGraphs(before, after, files, level) {
+		for _, target := range query.DiffGraphs(before, after, files, level, includeSubrepos) {
 			fmt.Println(target.String())
 		}
 		return 0

--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -15,19 +15,19 @@ var toolNotFoundHashValue = []byte{1}
 // DiffGraphs calculates the difference between two build graphs.
 // Note that this is not symmetric; targets that have been removed from 'before' do not appear
 // (because this is designed to be fed into 'plz test' and we can't test targets that no longer exist).
-func DiffGraphs(before, after *core.BuildState, files []string, level int) core.BuildLabels {
+func DiffGraphs(before, after *core.BuildState, files []string, level int, includeSubrepos bool) core.BuildLabels {
 	log.Notice("Calculating difference...")
 	changed := diffGraphs(before, after)
 	log.Debugf("Number of changed targets on a non-recursive diff between before and after build graphs: %d", len(changed))
 
 	log.Info("Including changed files...")
-	return changedTargets(after, files, changed, level)
+	return changedTargets(after, files, changed, level, includeSubrepos)
 }
 
 // Changes calculates changes for a given set of files. It does a subset of what DiffGraphs does due to not having
 // the "before" state so is less accurate (but faster).
-func Changes(state *core.BuildState, files []string, level int) core.BuildLabels {
-	return changedTargets(state, files, map[*core.BuildTarget]struct{}{}, level)
+func Changes(state *core.BuildState, files []string, level int, includeSubrepos bool) core.BuildLabels {
+	return changedTargets(state, files, map[*core.BuildTarget]struct{}{}, level, includeSubrepos)
 }
 
 // diffGraphs performs a non-recursive diff of two build graphs.
@@ -45,7 +45,7 @@ func diffGraphs(before, after *core.BuildState) map[*core.BuildTarget]struct{} {
 }
 
 // changedTargets returns the set of targets that have changed for the given files.
-func changedTargets(state *core.BuildState, files []string, changed map[*core.BuildTarget]struct{}, level int) core.BuildLabels {
+func changedTargets(state *core.BuildState, files []string, changed map[*core.BuildTarget]struct{}, level int, includeSubrepos bool) core.BuildLabels {
 	for _, filename := range files {
 		for dir := filename; dir != "." && dir != "/"; {
 			dir = filepath.Dir(dir)
@@ -80,7 +80,8 @@ func changedTargets(state *core.BuildState, files []string, changed map[*core.Bu
 
 	ls := make(core.BuildLabels, 0, len(labels))
 	for _, l := range labels {
-		if state.ShouldInclude(state.Graph.TargetOrDie(l)) {
+		t := state.Graph.TargetOrDie(l)
+		if state.ShouldInclude(t) && (includeSubrepos || t.Subrepo == nil) {
 			ls = append(ls, l)
 		}
 	}

--- a/src/query/changes_test.go
+++ b/src/query/changes_test.go
@@ -16,15 +16,15 @@ func TestDiffGraphs(t *testing.T) {
 	t2 := addTarget(s2, "//src/query:changes", nil, "src/query/changes.go")
 	addTarget(s1, "//src/query:changes_test", t1, "src/query/changes_test.go")
 	t4 := addTarget(s2, "//src/query:changes_test", t2, "src/query/changes_test.go")
-	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil, -1))
+	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil, -1, false))
 
 	t2.Command = "nope nope nope"
-	assert.EqualValues(t, []core.BuildLabel{t2.Label, t4.Label}, DiffGraphs(s1, s2, nil, -1))
+	assert.EqualValues(t, []core.BuildLabel{t2.Label, t4.Label}, DiffGraphs(s1, s2, nil, -1, false))
 
 	t2.AddLabel("nope")
 	t4.AddLabel("test")
 	s2.SetIncludeAndExclude(nil, []string{"nope", "test"})
-	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil, -1))
+	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil, -1, false))
 }
 
 func TestDiffGraphsIncludeNothing(t *testing.T) {
@@ -36,7 +36,7 @@ func TestDiffGraphsIncludeNothing(t *testing.T) {
 	t1 = addTarget(s2, "//src/core:core", nil, "src/core/core_changed.go")
 	t2 = addTarget(s2, "//src/query:changes", t1, "src/query/changes.go")
 	addTarget(s2, "//src/query:changes_test", t2, "src/query/changes_test.go")
-	assert.EqualValues(t, []core.BuildLabel{t1.Label}, DiffGraphs(s1, s2, nil, 0))
+	assert.EqualValues(t, []core.BuildLabel{t1.Label}, DiffGraphs(s1, s2, nil, 0, false))
 }
 
 func TestDiffGraphsIncludeDirect(t *testing.T) {
@@ -48,7 +48,7 @@ func TestDiffGraphsIncludeDirect(t *testing.T) {
 	t1 = addTarget(s2, "//src/core:core", nil, "src/core/core_changed.go")
 	t2 = addTarget(s2, "//src/query:changes", t1, "src/query/changes.go")
 	addTarget(s2, "//src/query:changes_test", t2, "src/query/changes_test.go")
-	assert.EqualValues(t, []core.BuildLabel{t1.Label, t2.Label}, DiffGraphs(s1, s2, nil, 1))
+	assert.EqualValues(t, []core.BuildLabel{t1.Label, t2.Label}, DiffGraphs(s1, s2, nil, 1, false))
 }
 
 func TestDiffGraphsLevel(t *testing.T) {
@@ -62,7 +62,7 @@ func TestDiffGraphsLevel(t *testing.T) {
 	t2 = addTarget(s2, "//src/query:changes", t1, "src/query/changes.go")
 	t3 = addTarget(s2, "//src/query:changes_test", t2, "src/query/changes_test.go")
 	addTarget(s2, "//src/query:changes_test2", t3, "src/query/changes_test2.go")
-	assert.EqualValues(t, []core.BuildLabel{t1.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, nil, 2))
+	assert.EqualValues(t, []core.BuildLabel{t1.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, nil, 2, false))
 }
 
 func TestDiffGraphsIncludeTransitive(t *testing.T) {
@@ -74,7 +74,7 @@ func TestDiffGraphsIncludeTransitive(t *testing.T) {
 	t1 = addTarget(s2, "//src/core:core", nil, "src/core/core_changed.go")
 	t2 = addTarget(s2, "//src/query:changes", t1, "src/query/changes.go")
 	t3 := addTarget(s2, "//src/query:changes_test", t2, "src/query/changes_test.go")
-	assert.EqualValues(t, core.BuildLabels{t1.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, nil, -1))
+	assert.EqualValues(t, core.BuildLabels{t1.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, nil, -1, false))
 }
 
 func TestChangesIncludesDataDirs(t *testing.T) {
@@ -83,7 +83,7 @@ func TestChangesIncludesDataDirs(t *testing.T) {
 	t2 := addTarget(s, "//src/query:changes", t1, "src/query/changes.go")
 	t3 := addTarget(s, "//src/query:changes_test", t2, "src/query/changes_test.go")
 	t3.AddDatum(core.FileLabel{Package: "src/query", File: "test_data"})
-	assert.EqualValues(t, []core.BuildLabel{t3.Label}, Changes(s, []string{"src/query/test_data/some_dir/test_file1.txt"}, 0))
+	assert.EqualValues(t, []core.BuildLabel{t3.Label}, Changes(s, []string{"src/query/test_data/some_dir/test_file1.txt"}, 0, false))
 }
 
 func TestSameToolHashNoChange(t *testing.T) {
@@ -93,13 +93,13 @@ func TestSameToolHashNoChange(t *testing.T) {
 	target.AddTool(core.SystemPathLabel{Name: "non-existent", Path: s1.Config.Path()})
 	target = addTarget(s2, "//src/core:core", nil, "src/core/core.go")
 	target.AddTool(core.SystemPathLabel{Name: "non-existent", Path: s2.Config.Path()})
-	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil, -1))
+	assert.EqualValues(t, []core.BuildLabel{}, DiffGraphs(s1, s2, nil, -1, false))
 }
 
 func TestChangesIncludesRootTarget(t *testing.T) {
 	s := core.NewDefaultBuildState()
 	t1 := addTarget(s, "//:file", nil, "file.go")
-	assert.EqualValues(t, []core.BuildLabel{t1.Label}, Changes(s, []string{"file.go"}, 0))
+	assert.EqualValues(t, []core.BuildLabel{t1.Label}, Changes(s, []string{"file.go"}, 0, false))
 }
 
 func addTarget(state *core.BuildState, label string, dep *core.BuildTarget, sources ...string) *core.BuildTarget {


### PR DESCRIPTION
Exclude all subrepo child targets from the output of `plz query changes` by default, and add an `--include_subrepos` option to revert to the previous behaviour if desired.