### PR TITLE
Remove please_pex from target list

### DIFF
--- a/src/parse/internal_package.go
+++ b/src/parse/internal_package.go
@@ -38,7 +38,6 @@ func GetInternalPackage(config *core.Configuration) (string, error) {
 			"please_go",
 			"please_go_embed",
 			"please_go_filter",
-			"please_pex",
 			"please_sandbox",
 		},
 	}


### PR DESCRIPTION
It isn't there any more in v17. It isn't _used_ but can break builds (e.g. if you're looking for stuff changing with `plz query changes` or whatever).