### PR TITLE
CircleCI: correct `gsutil` option order in release script

### DIFF
--- a/.circleci/release_s3.sh
+++ b/.circleci/release_s3.sh
@@ -24,7 +24,7 @@ release_file() {
     gsutil cp $file gs://get.please.build/$path
   else
     aws s3 cp $file s3://please-releases//$path --content-type $content_type
-    gsutil cp -h "Content-Type:$content_type" $file gs://get.please.build/$path
+    gsutil -h "Content-Type:$content_type" cp $file gs://get.please.build/$path
   fi
 }
 


### PR DESCRIPTION
`-h` is a global option to `gsutil` - its current position appears to be causing a `CommandException: Incorrect option(s) specified` error when a file with a specific Content-Type is uploaded.