### PR TITLE
CircleCI: allow empty globs in performance test `BUILD` files

### DIFF
--- a/tools/performance/gen_parse_tree.py
+++ b/tools/performance/gen_parse_tree.py
@@ -51,13 +51,13 @@ subinclude("///{lang}//build_defs:{lang}")
 
 {lang}_library(
     name = "{name}",
-    srcs = glob(["*.{ext}"], exclude=["*_test.{ext}"]),
+    srcs = glob(["*.{ext}"], exclude=["*_test.{ext}"], allow_empty=True),
     deps = {deps},
 )
 
 {lang}_test(
     name = "{name}_test",
-    srcs = glob(["*_test.{ext}"]),
+    srcs = glob(["*_test.{ext}"], allow_empty=True),
     deps = {test_deps},
 )
 """


### PR DESCRIPTION
Empty globs are now forbidden by default, but the purpose of this test is to benchmark parsing performance, so there's no need for the source files referenced in the generated `BUILD` file to actually exist.