### PR TITLE
Return new state object when constructing cross compile subrepos 

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1167,7 +1168,7 @@ func (state *BuildState) ForArch(arch cli.Arch) *BuildState {
 	defer state.progress.mutex.Unlock()
 
 	for _, s := range state.progress.allStates {
-		if s.Arch == arch {
+		if s.Arch == arch && strings.HasPrefix(s.CurrentSubrepo, strings.TrimSuffix(state.CurrentSubrepo, "_"+state.Arch.String())) {
 			return s
 		}
 	}

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1168,7 +1167,7 @@ func (state *BuildState) ForArch(arch cli.Arch) *BuildState {
 	defer state.progress.mutex.Unlock()
 
 	for _, s := range state.progress.allStates {
-		if s.Arch == arch && strings.HasPrefix(s.CurrentSubrepo, strings.TrimSuffix(state.CurrentSubrepo, "_"+state.Arch.String())) {
+		if s.Arch == arch && s.CurrentSubrepo == state.CurrentSubrepo {
 			return s
 		}
 	}

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1121,6 +1121,8 @@ func subrepo(s *scope, args []pyObject) pyObject {
 		}
 		state = state.ForArch(arch)
 		isCrossCompile = true
+	} else if state.Arch != arch {
+		state = state.ForArch(arch)
 	}
 	sr := core.NewSubrepo(state, s.pkg.SubrepoArchName(subrepoName), root, target, arch, isCrossCompile)
 	if args[PackageRootIdx].IsTruthy() {


### PR DESCRIPTION
It seems we were returning the state object for the host variant of subrepos when cross compiling. 