### PR TITLE
Increase resources for test-rex build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
      working_directory: ~/please
      docker:
        - image: thoughtmachine/please_ubuntu:20220516
-     resource_class: large
+     resource_class: xlarge
      steps:
        - checkout
        - attach_workspace:


### PR DESCRIPTION
Looking at [the resource usage for the last failure](https://app.circleci.com/pipelines/github/thought-machine/please/5618/workflows/a0747830-58a6-481d-ab0c-07cc5305870b/jobs/44282/resources), it seems to have hit the mem limit. That makes sense for the symptoms - suddenly one of the servers explodes (presumably the OOM killer gets it, or the Go runtime when it can't allocate), then everything starts failing. Also explains why it only happens sometimes.

One could imagine cleverer things with the new soft memory limit, although that's of limited use given everything's in a single namespace. I don't think the cost here is too bad given that we will (presumably) get things built quicker as well.