### PR TITLE
Optimise generate of plugin config

### DIFF
--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -223,17 +223,18 @@ func pkg(s *scope, args []pyObject) pyObject {
 
 		// Merge in the existing config for dictionaries
 		if overrides, ok := v.(pyDict); ok {
-			if pluginConfig, ok := configVal.(pyDict); ok {
-				newPluginConfig := pluginConfig.Copy()
+			if pluginConfig, ok := configVal.(*pyConfig); ok {
+				if pluginConfig.overlay == nil {
+					pluginConfig.overlay = make(pyDict, len(overrides))
+				}
 				for pluginKey, override := range overrides {
 					pluginKey = strings.ToUpper(pluginKey)
-					if _, ok := newPluginConfig[pluginKey]; !ok {
+					if _, ok := pluginConfig.base.dict[pluginKey]; !ok {
 						s.Error("error calling package(): %s.%s is not a known config value", k, pluginKey)
 					}
-
-					newPluginConfig.IndexAssign(pyString(pluginKey), override)
+					pluginConfig.overlay[pluginKey] = override
 				}
-				v = newPluginConfig
+				continue
 			} else {
 				s.Error("error calling package(): can't assign a dict to %s as it's not a dict", k)
 			}

--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -213,7 +213,7 @@ func (i *interpreter) loadPluginConfig(s *scope, pluginState *core.BuildState) {
 }
 
 func (i *interpreter) pluginConfig(name string, pluginState *core.BuildState, pkgState *core.BuildState) *pyConfigBase {
-	key := pluginConfigKey{Name: name, State: pluginState}
+	key := pluginConfigKey{Name: name, State: pkgState}
 	if cfg, wait, first := i.pluginConfigs.GetOrWait(key); cfg != nil {
 		return cfg
 	} else if !first {

--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -212,7 +212,8 @@ func (i *interpreter) loadPluginConfig(s *scope, pluginState *core.BuildState) {
 	s.config.overlay[key] = &pyConfig{base: i.pluginConfig(key, pluginState, s.state)}
 }
 
-func (i *interpreter) pluginConfig(key string, pluginState *core.BuildState, pkgState *core.BuildState) *pyConfigBase {
+func (i *interpreter) pluginConfig(name string, pluginState *core.BuildState, pkgState *core.BuildState) *pyConfigBase {
+	key := pluginConfigKey{Name: name, State: pluginState}
 	if cfg, wait, first := i.pluginConfigs.GetOrWait(key); cfg != nil {
 		return cfg
 	} else if !first {

--- a/src/parse/asp/grammar.go
+++ b/src/parse/asp/grammar.go
@@ -114,7 +114,7 @@ type OptimisedExpression struct {
 	// Similarly applied to optimise simple lookups of local variables.
 	Local string
 	// And similarly applied to optimise lookups into configuration.
-	Config string
+	Config, SubConfig string
 }
 
 // An OpExpression is a operator combined with its following expression.


### PR DESCRIPTION
Been looking at the [performance graphs](https://please.build/performance.html) which have gone in the bad direction during the v17 work. I can imagine it will be a _bit_ slower but this seems more than I'd expect, and defo wouldn't expect the memory usage to increase the way it has.

Turns out we're spending quite a bit of time & memory in v17 recreating the plugin config (it's redone each time at every `subinclude`, even the global ones). This caches the initial config for each plugin. It also represents the plugin configs as nested config objects rather than normal dicts, so we can take advantage of its base/overlay behaviour to override things.

Before:
```
INFO: Run 1 of 5
INFO: Complete in 7.94s, using 12859852 KB
INFO: Run 2 of 5
INFO: Complete in 7.97s, using 12466732 KB
INFO: Run 3 of 5
INFO: Complete in 7.89s, using 11885564 KB
INFO: Run 4 of 5
INFO: Complete in 7.66s, using 11138540 KB
INFO: Run 5 of 5
INFO: Complete in 7.86s, using 11697292 KB
INFO: Complete, median time: 7.89s, median mem: 11885564.00 KB
```
After:
```
INFO: Run 1 of 5
INFO: Complete in 6.97s, using 9329508 KB
INFO: Run 2 of 5
INFO: Complete in 6.86s, using 9855560 KB
INFO: Run 3 of 5
INFO: Complete in 6.96s, using 9520748 KB
INFO: Run 4 of 5
INFO: Complete in 7.07s, using 9695692 KB
INFO: Run 5 of 5
INFO: Complete in 7.07s, using 10228892 KB
INFO: Complete, median time: 6.97s, median mem: 9695692.00 KB
```
This will do better vs. our normal benchmark (the CPU is faster and has more cores than CircleCI's `xlarge` resource class) but we should see improvement there.