### PR TITLE
Don't consume $vars from test output 

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.2.4",
     "java": "v0.3.0",
-    "go": "v1.2.1",
+    "go": "v1.3.0",
     "cc": "v0.3.2",
     "shell": "v0.1.2",
     "go-proto": "v0.2.0",

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -63,7 +63,7 @@ plugins = {
     "cc": "v0.3.2",
     "shell": "v0.1.2",
     "go-proto": "v0.2.0",
-    "proto": "v0.2.0",
+    "proto": "v0.2.1",
 }
 
 plugin_targets = []

--- a/src/output/print.go
+++ b/src/output/print.go
@@ -31,7 +31,10 @@ func printf(format string, args ...interface{}) {
 }
 
 func replace(s string) string {
-	return replacements[s]
+	if repl, present := replacements[s]; present {
+		return repl
+	}
+	return "$" + s
 }
 
 // These are the standard set of replacements we use.

--- a/src/output/print.go
+++ b/src/output/print.go
@@ -11,7 +11,9 @@ import (
 // initPrintf sets up the replacements used by printf.
 func initPrintf(config *core.Configuration) {
 	if !cli.ShowColouredOutput {
-		replacements = map[string]string{}
+		for k := range replacements {
+			replacements[k] = ""
+		}
 	} else {
 		if config.Display.ColourScheme == "light" {
 			for k, v := range lightOverrides {

--- a/test/BUILD
+++ b/test/BUILD
@@ -479,4 +479,5 @@ plz_e2e_test(
     name = "shell_output_test",
     cmd = "plz test //test:shell_output_test_case",
     expect_output_contains = "$TEST",
+    expected_failure = True,
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -172,7 +172,6 @@ plz_e2e_test(
     labels = ["python3"],
 )
 
-
 # Test re-runs.
 go_test(
     name = "num_runs_go_test",
@@ -467,4 +466,17 @@ build_rule(
 plz_e2e_test(
     name = "non_test_target_with_test_fields_set_test",
     cmd = "plz test //test:non_test_target_with_test_fields_set",
+)
+
+gentest(
+    name = "shell_output_test_case",
+    labels = ["manual"],
+    no_test_output = True,
+    test_cmd = "echo '$TEST'; exit 1",
+)
+
+plz_e2e_test(
+    name = "shell_output_test",
+    cmd = "plz test //test:shell_output_test_case",
+    expect_output_contains = "$TEST",
 )

--- a/test/build_defs/test.build_defs
+++ b/test/build_defs/test.build_defs
@@ -26,10 +26,10 @@ def please_repo_e2e_test(
         test_cmd += [f"$TOOLS_CONTENT_CHECKER '{o}' '{c}'" for o, c in expected_output.items()]
 
     if expect_output_contains:
-        test_cmd += [f'_STR="$(cat {o})" _SUBSTR=\'{c}\' && if [ "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi' for o, c in expect_output_contains.items()]
+        test_cmd += [f'_STR="$(cat {o})" _SUBSTR="{c}" && if [ "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi' for o, c in expect_output_contains.items()]
 
     if expect_output_doesnt_contain:
-        test_cmd += [f'_STR="$(cat {o})" _SUBSTR=\'{c}\' && if [ -z "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi' for o, c in expect_output_contains.items()]
+        test_cmd += [f'_STR="$(cat {o})" _SUBSTR="{c}" && if [ -z "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi' for o, c in expect_output_contains.items()]
 
     test_cmd = ' && '.join(test_cmd)
 
@@ -76,9 +76,11 @@ def plz_e2e_test(name:str, cmd:str, pre_cmd:str=None, expected_output:str=None,
         elif expected_output:
             test_cmd += 'diff -au output $(location %s)' % expected_output
         elif expect_output_contains:
-            test_cmd += f'_STR="$(cat output)" _SUBSTR=\'{expect_output_contains}\' && if [ "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi'
+            substr = _quote(expect_output_contains)
+            test_cmd += f'_STR="$(cat output)" _SUBSTR={substr} && if [ "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi'
         elif expect_output_doesnt_contain:
-            test_cmd += f'_STR="$(cat output)" _SUBSTR=\'{expect_output_doesnt_contain}\' && if [ -z "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi'
+            substr = _quote(expect_output_doesnt_contain)
+            test_cmd += f'_STR="$(cat output)" _SUBSTR={substr} && if [ -z "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi'
         elif expect_file_exists:
             test_cmd += 'if [ ! -f %s ]; then cat output; exit 1; fi' % expect_file_exists
         elif expect_file_doesnt_exist:
@@ -111,3 +113,9 @@ def plz_e2e_test(name:str, cmd:str, pre_cmd:str=None, expected_output:str=None,
         exit_on_error = False,
         timeout = timeout,
     )
+
+
+def _quote(s):
+    if '$' in s:
+        return "'" + s + "'"
+    return '"' + s + '"'

--- a/test/build_defs/test.build_defs
+++ b/test/build_defs/test.build_defs
@@ -26,10 +26,10 @@ def please_repo_e2e_test(
         test_cmd += [f"$TOOLS_CONTENT_CHECKER '{o}' '{c}'" for o, c in expected_output.items()]
 
     if expect_output_contains:
-        test_cmd += [f'_STR="$(cat {o})" _SUBSTR="{c}" && if [ "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi' for o, c in expect_output_contains.items()]
+        test_cmd += [f'_STR="$(cat {o})" _SUBSTR=\'{c}\' && if [ "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi' for o, c in expect_output_contains.items()]
 
     if expect_output_doesnt_contain:
-        test_cmd += [f'_STR="$(cat {o})" _SUBSTR="{c}" && if [ -z "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi' for o, c in expect_output_contains.items()]
+        test_cmd += [f'_STR="$(cat {o})" _SUBSTR=\'{c}\' && if [ -z "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi' for o, c in expect_output_contains.items()]
 
     test_cmd = ' && '.join(test_cmd)
 
@@ -76,9 +76,9 @@ def plz_e2e_test(name:str, cmd:str, pre_cmd:str=None, expected_output:str=None,
         elif expected_output:
             test_cmd += 'diff -au output $(location %s)' % expected_output
         elif expect_output_contains:
-            test_cmd += f'_STR="$(cat output)" _SUBSTR="{expect_output_contains}" && if [ "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi'
+            test_cmd += f'_STR="$(cat output)" _SUBSTR=\'{expect_output_contains}\' && if [ "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi'
         elif expect_output_doesnt_contain:
-            test_cmd += f'_STR="$(cat output)" _SUBSTR="{expect_output_doesnt_contain}" && if [ -z "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi'
+            test_cmd += f'_STR="$(cat output)" _SUBSTR=\'{expect_output_doesnt_contain}\' && if [ -z "${_STR##*$_SUBSTR*}" ]; then echo "$_STR"; exit 1; fi'
         elif expect_file_exists:
             test_cmd += 'if [ ! -f %s ]; then cat output; exit 1; fi' % expect_file_exists
         elif expect_file_doesnt_exist:


### PR DESCRIPTION
Sadly can't easily move the replace call, almost immediately found cases where the vars passed in also have formatting directives. This should work pretty well though.