### PR TITLE
Stop loading the config for the subrepo

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1180,9 +1180,6 @@ func (state *BuildState) ForArch(arch cli.Arch) *BuildState {
 	s := state.Copy()
 
 	configPath := ".plzconfig_" + arch.String()
-	if state.CurrentSubrepo != "" {
-		configPath = filepath.Join(state.Graph.SubrepoOrDie(state.CurrentSubrepo).Root, configPath)
-	}
 
 	config := state.Config.copyConfig()
 	if err := readConfigFile(config, configPath, false); err != nil {


### PR DESCRIPTION
There was a race condition. We should do this when we initialise the subrepo because it may not be built yet. I'll try and get that done in a followup PR. 