### PR TITLE
Support subrepo package output dir in rex

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -218,9 +218,9 @@ func (c *Client) uploadInputDir(ch chan<- *uploadinfo.Entry, target *core.BuildT
 					return nil, fmt.Errorf("Outputs not known for %s (should be built by now)", l)
 				}
 			}
-			pkgName := l.PackageName
+			pkgName := c.state.Graph.TargetOrDie(l).PackageDir()
 			if target.IsFilegroup {
-				pkgName = target.Label.PackageName
+				pkgName = target.PackageDir()
 			} else if isTest && l == target.Label {
 				// At test time the target itself is put at the root rather than in the normal dir.
 				// This is just How Things Are, so mimic it here.

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -865,8 +865,8 @@ func (c *Client) buildFilegroup(target *core.BuildTarget, command *pb.Command, a
 		defer close(ch)
 		inputDir.Build(ch)
 		for _, out := range command.OutputPaths {
-			if d, f := inputDir.Node(filepath.Join(target.Label.PackageName, out)); d != nil {
-				entry, digest := c.protoEntry(inputDir.Tree(filepath.Join(target.Label.PackageName, out)))
+			if d, f := inputDir.Node(filepath.Join(target.PackageDir(), out)); d != nil {
+				entry, digest := c.protoEntry(inputDir.Tree(filepath.Join(target.PackageDir(), out)))
 				ch <- entry
 				ar.OutputDirectories = append(ar.OutputDirectories, &pb.OutputDirectory{
 					Path:       out,


### PR DESCRIPTION
This feature needed a bit more fandangling to get working in remote execution. 