### PR TITLE
Parse subincludes in the scope of the subrepo they're subincluded from

### DIFF
--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -279,7 +279,7 @@ func bazelLoad(s *scope, args []pyObject) pyObject {
 		}
 		filename = subrepo.Dir(filename)
 	}
-	s.SetAll(s.interpreter.Subinclude(filename, l), false)
+	s.SetAll(s.interpreter.Subinclude(s, filename, l), false)
 	return None
 }
 
@@ -315,7 +315,7 @@ func subinclude(s *scope, args []pyObject) pyObject {
 		s.interpreter.loadPluginConfig(s, incPkgState)
 
 		for _, out := range t.Outputs() {
-			s.SetAll(s.interpreter.Subinclude(filepath.Join(t.OutDir(), out), t.Label), false)
+			s.SetAll(s.interpreter.Subinclude(s, filepath.Join(t.OutDir(), out), t.Label), false)
 		}
 	}
 	return None

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -2,6 +2,7 @@ package asp
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"runtime/debug"
 	"strings"
@@ -144,7 +145,7 @@ func (i *interpreter) preloadSubincludes(s *scope) (err error) {
 
 		s.interpreter.loadPluginConfig(s, includeState)
 		for _, out := range t.FullOutputs() {
-			s.SetAll(s.interpreter.Subinclude(out, t.Label), false)
+			s.SetAll(s.interpreter.Subinclude(s, out, t.Label), false)
 		}
 	}
 	return
@@ -202,15 +203,16 @@ func (i *interpreter) interpretStatements(s *scope, statements []*Statement) (re
 }
 
 // Subinclude returns the global values corresponding to subincluding the given file.
-func (i *interpreter) Subinclude(path string, label core.BuildLabel) pyDict {
-	globals, wait, first := i.subincludes.GetOrWait(path)
+func (i *interpreter) Subinclude(pkgScope *scope, path string, label core.BuildLabel) pyDict {
+	key := filepath.Join(path, pkgScope.state.CurrentSubrepo)
+	globals, wait, first := i.subincludes.GetOrWait(key)
 	if globals != nil {
 		return globals
 	} else if !first {
 		i.limiter.Release()
 		defer i.limiter.Acquire()
 		<-wait
-		return i.subincludes.Get(path)
+		return i.subincludes.Get(key)
 	}
 	// If we get here, it falls to us to parse this.
 	stmts, err := i.parser.parse(path)
@@ -219,6 +221,7 @@ func (i *interpreter) Subinclude(path string, label core.BuildLabel) pyDict {
 	}
 	stmts = i.parser.optimise(stmts)
 	s := i.scope.NewScope(path)
+	s.state = pkgScope.state
 	// Scope needs a local version of CONFIG
 	s.config = i.scope.config.Copy()
 	s.subincludeLabel = &label
@@ -229,7 +232,7 @@ func (i *interpreter) Subinclude(path string, label core.BuildLabel) pyDict {
 	if s.config.overlay == nil {
 		delete(locals, "CONFIG") // Config doesn't have any local modifications
 	}
-	i.subincludes.Set(path, locals)
+	i.subincludes.Set(key, locals)
 	return locals
 }
 

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -286,7 +286,7 @@ func TestInterpreterFStrings(t *testing.T) {
 func TestInterpreterSubincludeConfig(t *testing.T) {
 	s, err := parseFile("src/parse/asp/test_data/interpreter/partition.build")
 	assert.NoError(t, err)
-	s.SetAll(s.interpreter.Subinclude("src/parse/asp/test_data/interpreter/subinclude_config.build", core.NewPackage("test").Label()), false)
+	s.SetAll(s.interpreter.Subinclude(s, "src/parse/asp/test_data/interpreter/subinclude_config.build", core.NewPackage("test").Label()), false)
 	assert.EqualValues(t, "test test", s.config.Get("test", None))
 }
 


### PR DESCRIPTION
We were having issues when subincluding the cgo rules. The issues arrise because of the following:

- We parse subincludes once, in the host repo's scope. 
- When we  subinclude in this scope (i.e. to get the go rules from the cgo rules), we load in the plugin config from the host repo

Because we merge the CONFIG object back into the BUILD file scope that had the original subinclude, we end up with the host repo's plugin config in BUIDL files of subrepos.

This change means that we re-evaluate the subincludes for each subrepo so this ends up being the correct plugin config.  
