### PR TITLE
Store and retrieve dirs from remote execution

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -247,7 +247,8 @@ type BuildMetadata struct {
 	// Standard output & error
 	Stdout, Stderr []byte
 	// Serialised build action metadata.
-	RemoteAction []byte
+	RemoteAction  []byte
+	RemoteOutputs []byte
 	// Time this action was written. Used for remote execution to determine if
 	// the action is stale and needs re-checking or not.
 	Timestamp time.Time

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -693,6 +693,7 @@ type Configuration struct {
 	buildEnvStored *storedBuildEnv
 
 	FeatureFlags struct {
+		CacheRemoteDirs bool `help:"Activates experimental additional caching of directories from remotely executed actions"`
 	} `help:"Flags controlling preview features for the next release. Typically these config options gate breaking changes and only have a lifetime of one major release."`
 	Metrics struct {
 		PrometheusGatewayURL string       `help:"The gateway URL to push prometheus updates to."`

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -693,7 +693,6 @@ type Configuration struct {
 	buildEnvStored *storedBuildEnv
 
 	FeatureFlags struct {
-		CacheRemoteDirs bool `help:"Activates experimental additional caching of directories from remotely executed actions"`
 	} `help:"Flags controlling preview features for the next release. Typically these config options gate breaking changes and only have a lifetime of one major release."`
 	Metrics struct {
 		PrometheusGatewayURL string       `help:"The gateway URL to push prometheus updates to."`

--- a/src/metrics/prometheus.go
+++ b/src/metrics/prometheus.go
@@ -20,6 +20,16 @@ var registerer = prometheus.WrapRegistererWith(prometheus.Labels{
 
 // Push performs a single push of all registered metrics to the pushgateway (if configured).
 func Push(config *core.Configuration) {
+	if family, err := prometheus.DefaultGatherer.Gather(); err == nil {
+		for _, fam := range family {
+			for _, metric := range fam.Metric {
+				if metric.Counter != nil {
+					log.Debug("Metric recorded: %s: %0.0f", *fam.Name, *metric.Counter.Value)
+				}
+			}
+		}
+	}
+
 	if config.Metrics.PrometheusGatewayURL == "" {
 		return
 	}

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -278,8 +278,8 @@ func (c *Client) uploadInputDir(ch chan<- *uploadinfo.Entry, target *core.BuildT
 
 // addChildDirs adds a set of child directories to a builder.
 func (c *Client) addChildDirs(b *dirBuilder, name string, dg *pb.Digest) error {
-	dir := &pb.Directory{}
-	if _, err := c.client.ReadProto(context.Background(), digest.NewFromProtoUnvalidated(dg), dir); err != nil {
+	dir, err := c.readDirectory(dg)
+	if err != nil {
 		return err
 	}
 	d := b.Dir(name)

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -78,6 +78,11 @@ type Client struct {
 	// This map is of effective type `map[*core.BuildTarget]*pendingDownload`
 	downloads sync.Map
 
+	// Used to store directories output from actions.
+	//
+	// This map is of effective type `map[string]*pb.Directory`
+	directories sync.Map
+
 	// Server-sent cache properties
 	maxBlobBatchSize int64
 

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -219,7 +219,7 @@ func (c *Client) locallyCacheResults(target *core.BuildTarget, dg *pb.Digest, me
 	metadata.RemoteAction = data
 	metadata.Timestamp = time.Now()
 
-	if c.state.Config.FeatureFlags.CacheRemoteDirs && len(ar.OutputDirectories) > 0 {
+	if len(ar.OutputDirectories) > 0 {
 		tree := pb.Tree{}
 		for _, d := range ar.OutputDirectories {
 			t := pb.Tree{}
@@ -252,7 +252,7 @@ func (c *Client) retrieveLocalResults(target *core.BuildTarget, digest *pb.Diges
 		if metadata != nil && len(metadata.RemoteAction) > 0 {
 			ar := &pb.ActionResult{}
 			if err := proto.Unmarshal(metadata.RemoteAction, ar); err == nil {
-				if c.state.Config.FeatureFlags.CacheRemoteDirs && len(metadata.RemoteOutputs) > 0 {
+				if len(metadata.RemoteOutputs) > 0 {
 					tree := pb.Tree{}
 					if err := proto.Unmarshal(metadata.RemoteOutputs, &tree); err == nil {
 						for _, dir := range tree.Children {

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -224,6 +224,7 @@ func (c *Client) locallyCacheResults(target *core.BuildTarget, dg *pb.Digest, me
 		for _, d := range ar.OutputDirectories {
 			t := pb.Tree{}
 			if _, err := c.client.ReadProto(context.Background(), digest.NewFromProtoUnvalidated(d.TreeDigest), &t); err == nil {
+				tree.Children = append(tree.Children, t.Root)
 				tree.Children = append(tree.Children, t.Children...)
 			}
 		}


### PR DESCRIPTION
This should alleviate (if not entirely stop) the time spent retrieving directories from the remote in `addChildDirs`. Basically we stash them in the build metadata so we can reuse them on a cache hit; that trades some memory & CPU for fewer RPCs which is almost certainly a good thing.

Thought about controlling this via a feature flag but I don't think it's worth it. `encoding/gob` should do a fine job of compatibility (it will ignore the new field when reading from an old version, if it's empty in the new one it has no effect, and it does everything by field name so order doesn't matter) and ultimately it's just a set of content-addressed blobs that we don't have to download so they can't be 'incorrect'.

Also added some metrics & logging out the counter values on exit so I can see them.