### PR TITLE
Fix lps (LSP build_langserver) tests

### DIFF
--- a/tools/build_langserver/lsp/BUILD
+++ b/tools/build_langserver/lsp/BUILD
@@ -23,7 +23,6 @@ go_test(
     size = "medium",
     srcs = glob(["*_test.go"]),
     data = ["test_data"],
-    labels = ["manual"],  # TODO(#1412): find out why this flakes
     deps = [
         ":lsp",
         "//src/cli",

--- a/tools/build_langserver/lsp/definition_test.go
+++ b/tools/build_langserver/lsp/definition_test.go
@@ -25,7 +25,7 @@ func TestDefinition(t *testing.T) {
 	assert.Equal(t, []lsp.Location{
 		{
 			URI:   lsp.DocumentURI("file://" + filepath.Join(cacheDir, "please/misc_rules.build_defs")),
-			Range: xrng(0, 0, 144, 5),
+			Range: xrng(3, 0, 144, 5),
 		},
 	}, locs)
 }
@@ -45,7 +45,7 @@ func TestDefinitionStatement(t *testing.T) {
 	assert.Equal(t, []lsp.Location{
 		{
 			URI:   lsp.DocumentURI("file://" + filepath.Join(cacheDir, "please/misc_rules.build_defs")),
-			Range: xrng(0, 0, 144, 5),
+			Range: xrng(3, 0, 144, 5),
 		},
 	}, locs)
 }

--- a/tools/build_langserver/lsp/definition_test.go
+++ b/tools/build_langserver/lsp/definition_test.go
@@ -71,7 +71,9 @@ func TestDefinitionBuiltin(t *testing.T) {
 }
 
 func TestDefinitionBuildLabel(t *testing.T) {
-	h := initHandlerText("go_bindata(\n    deps = ['//src/core'],\n)")
+	h := initHandlerText(`go_bindata(
+    deps = ['//src/core'],
+)`)
 	h.WaitForPackageTree()
 	var locs []lsp.Location
 	err := h.Request("textDocument/definition", &lsp.TextDocumentPositionParams{
@@ -84,7 +86,7 @@ func TestDefinitionBuildLabel(t *testing.T) {
 	assert.Equal(t, []lsp.Location{
 		{
 			URI:   lsp.DocumentURI("file://" + filepath.Join(os.Getenv("TEST_DIR"), "tools/build_langserver/lsp/test_data/src/core/test.build")),
-			Range: xrng(1, 1, 17, 2),
+			Range: xrng(1, 1, 18, 2),
 		},
 	}, locs)
 }

--- a/tools/build_langserver/lsp/lsp_test.go
+++ b/tools/build_langserver/lsp/lsp_test.go
@@ -399,25 +399,15 @@ func TestCompletionPartial(t *testing.T) {
 	}, completions)
 }
 
-const testCompletionContentFunction = `go_library(
-    name = "test",
-    srcs = glob(["*.go"]),
-    deps = [
-        "//src/core:core",
-    ],
-)
-`
-
 func TestCompletionFunction(t *testing.T) {
 	h := initHandler()
 	err := h.Request("textDocument/didOpen", &lsp.DidOpenTextDocumentParams{
 		TextDocument: lsp.TextDocumentItem{
 			URI:  testURI,
-			Text: testCompletionContentFunction,
+			Text: `plugin_repo()`,
 		},
 	}, nil)
 	assert.NoError(t, err)
-	h.WaitForPackage("src/core")
 	completions := &lsp.CompletionList{}
 	err = h.Request("textDocument/completion", &lsp.CompletionParams{
 		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
@@ -426,55 +416,54 @@ func TestCompletionFunction(t *testing.T) {
 			},
 			Position: lsp.Position{
 				Line:      0,
-				Character: 6,
+				Character: 4,
 			},
 		},
 	}, completions)
 	assert.NoError(t, err)
 	assert.Equal(t, &lsp.CompletionList{
 		IsIncomplete: false,
-		Items:        nil,
+		Items: []lsp.CompletionItem{{
+			Label:            "plugin_repo",
+			Kind:             lsp.CIKFunction,
+			InsertTextFormat: lsp.ITFPlainText,
+			TextEdit:         textEdit("in_repo", 0, 4),
+			Documentation:    h.builtins["plugin_repo"].Stmt.FuncDef.Docstring,
+		}},
 	}, completions)
 }
-
-const testCompletionContentPartialFunction = `
-go_libr
-`
 
 func TestCompletionPartialFunction(t *testing.T) {
 	h := initHandler()
 	err := h.Request("textDocument/didOpen", &lsp.DidOpenTextDocumentParams{
 		TextDocument: lsp.TextDocumentItem{
-			URI:  "file://test/test.build",
-			Text: testCompletionContentPartialFunction,
+			URI:  testURI,
+			Text: `plugin_re`,
 		},
 	}, nil)
 	assert.NoError(t, err)
-	h.WaitForPackage("src/core")
 	completions := &lsp.CompletionList{}
 	err = h.Request("textDocument/completion", &lsp.CompletionParams{
 		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
 			TextDocument: lsp.TextDocumentIdentifier{
-				URI: "file://test/test.build",
+				URI: testURI,
 			},
 			Position: lsp.Position{
-				Line:      1,
-				Character: 6,
+				Line:      0,
+				Character: 9,
 			},
 		},
 	}, completions)
 	assert.NoError(t, err)
 	assert.Equal(t, &lsp.CompletionList{
 		IsIncomplete: false,
-		Items: []lsp.CompletionItem{
-			{
-				Label:            "go_library",
-				Kind:             lsp.CIKFunction,
-				InsertTextFormat: lsp.ITFPlainText,
-				TextEdit:         textEdit("rary", 1, 6),
-				Documentation:    h.builtins["go_library"].Stmt.FuncDef.Docstring,
-			},
-		},
+		Items: []lsp.CompletionItem{{
+			Label:            "plugin_repo",
+			Kind:             lsp.CIKFunction,
+			InsertTextFormat: lsp.ITFPlainText,
+			TextEdit:         textEdit("po", 0, 9),
+			Documentation:    h.builtins["plugin_repo"].Stmt.FuncDef.Docstring,
+		}},
 	}, completions)
 }
 

--- a/tools/build_langserver/lsp/lsp_test.go
+++ b/tools/build_langserver/lsp/lsp_test.go
@@ -399,8 +399,7 @@ func TestCompletionPartial(t *testing.T) {
 	}, completions)
 }
 
-const testCompletionContentFunction = `
-go_library(
+const testCompletionContentFunction = `go_library(
     name = "test",
     srcs = glob(["*.go"]),
     deps = [
@@ -413,7 +412,7 @@ func TestCompletionFunction(t *testing.T) {
 	h := initHandler()
 	err := h.Request("textDocument/didOpen", &lsp.DidOpenTextDocumentParams{
 		TextDocument: lsp.TextDocumentItem{
-			URI:  "file://test/test.build",
+			URI:  testURI,
 			Text: testCompletionContentFunction,
 		},
 	}, nil)
@@ -423,10 +422,10 @@ func TestCompletionFunction(t *testing.T) {
 	err = h.Request("textDocument/completion", &lsp.CompletionParams{
 		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
 			TextDocument: lsp.TextDocumentIdentifier{
-				URI: "file://test/test.build",
+				URI: testURI,
 			},
 			Position: lsp.Position{
-				Line:      1,
+				Line:      0,
 				Character: 6,
 			},
 		},
@@ -434,15 +433,7 @@ func TestCompletionFunction(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, &lsp.CompletionList{
 		IsIncomplete: false,
-		Items: []lsp.CompletionItem{
-			{
-				Label:            "go_library",
-				Kind:             lsp.CIKFunction,
-				InsertTextFormat: lsp.ITFPlainText,
-				TextEdit:         textEdit("rary", 1, 6),
-				Documentation:    h.builtins["go_library"].Stmt.FuncDef.Docstring,
-			},
-		},
+		Items:        nil,
 	}, completions)
 }
 

--- a/tools/build_langserver/lsp/symbols_test.go
+++ b/tools/build_langserver/lsp/symbols_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const testURI = "file://test/test.build"
+const testURI = "file:///test_data/test.build"
 
 func TestSymbols(t *testing.T) {
 	h := initHandlerText(`"test"`)

--- a/tools/build_langserver/lsp/test_data/.plzconfig
+++ b/tools/build_langserver/lsp/test_data/.plzconfig
@@ -1,3 +1,6 @@
 [parse]
 buildfilename = test.build
 builddefsdir = build_defs
+
+[Plugin "go"]
+target = //plugins:go

--- a/tools/build_langserver/lsp/test_data/.plzconfig
+++ b/tools/build_langserver/lsp/test_data/.plzconfig
@@ -2,6 +2,7 @@
 buildfilename = test.build
 buildfilename = BUILD
 builddefsdir = build_defs
+preloadsubincludes = ///go//build_defs:go
 
 [Plugin "go"]
 target = //plugins:go

--- a/tools/build_langserver/lsp/test_data/.plzconfig
+++ b/tools/build_langserver/lsp/test_data/.plzconfig
@@ -1,5 +1,6 @@
 [parse]
 buildfilename = test.build
+buildfilename = BUILD
 builddefsdir = build_defs
 
 [Plugin "go"]

--- a/tools/build_langserver/lsp/test_data/plugins/test.build
+++ b/tools/build_langserver/lsp/test_data/plugins/test.build
@@ -1,0 +1,5 @@
+plugin_repo(
+    name = "go",
+    plugin = "go-rules",
+    revision = "v1.2.1",
+)

--- a/tools/build_langserver/lsp/test_data/src/core/test.build
+++ b/tools/build_langserver/lsp/test_data/src/core/test.build
@@ -1,3 +1,5 @@
+subinclude("///go//build_defs:go")
+
 go_library(
     name = "core",
     srcs = glob(

--- a/tools/build_langserver/lsp/test_data/src/core/test.build
+++ b/tools/build_langserver/lsp/test_data/src/core/test.build
@@ -1,5 +1,3 @@
-subinclude("///go//build_defs:go")
-
 go_library(
     name = "core",
     srcs = glob(

--- a/tools/build_langserver/lsp/test_data/src/core/test.build
+++ b/tools/build_langserver/lsp/test_data/src/core/test.build
@@ -8,9 +8,8 @@ go_library(
             "*_test.go",
             "version.go",
         ],
-    ) + [
-        ":version",
-    ],
+        allow_empty = True,
+    ),
     visibility = ["PUBLIC"],
     deps = [
         "//third_party/go:gcfg",
@@ -21,7 +20,7 @@ go_library(
 go_test(
     name = "config_test",
     srcs = ["config_test.go"],
-    data = glob(["test_data/*.plzconfig*"]),
+    data = glob(["test_data/*.plzconfig*"], allow_empty = True),
     deps = [
         ":core",
     ],

--- a/tools/build_langserver/lsp/test_data/src/core/test.build
+++ b/tools/build_langserver/lsp/test_data/src/core/test.build
@@ -7,7 +7,9 @@ go_library(
             "version.go",
         ],
         allow_empty = True,
-    ),
+    ) + [
+        ":version",
+    ],
     visibility = ["PUBLIC"],
     deps = [
         "//third_party/go:gcfg",

--- a/tools/build_langserver/lsp/test_data/third_party/go/test.build
+++ b/tools/build_langserver/lsp/test_data/third_party/go/test.build
@@ -1,5 +1,4 @@
 package(default_visibility = ["PUBLIC"])
-subinclude("///go//build_defs:go")
 
 go_module(
     name = "spew",

--- a/tools/build_langserver/lsp/test_data/third_party/go/test.build
+++ b/tools/build_langserver/lsp/test_data/third_party/go/test.build
@@ -1,4 +1,5 @@
 package(default_visibility = ["PUBLIC"])
+subinclude("///go//build_defs:go")
 
 go_get(
     name = "spew",

--- a/tools/build_langserver/lsp/test_data/third_party/go/test.build
+++ b/tools/build_langserver/lsp/test_data/third_party/go/test.build
@@ -1,42 +1,42 @@
 package(default_visibility = ["PUBLIC"])
 subinclude("///go//build_defs:go")
 
-go_get(
+go_module(
     name = "spew",
-    get = "github.com/davecgh/go-spew/spew",
+    module = "github.com/davecgh/go-spew/spew",
     patch = "spew_omit_empty.patch",
-    revision = "ecdeabc65495df2dec95d7c4a4c3e021903035e5",
+    version = "v1.1.1",
 )
 
-go_get(
+go_module(
     name = "testify",
-    get = "github.com/stretchr/testify",
+    module = "github.com/stretchr/testify",
     install = [
         "assert",
         "require",
         "vendor/github.com/davecgh/go-spew/spew",
         "vendor/github.com/pmezard/go-difflib/difflib",
     ],
-    revision = "f390dcf405f7b83c997eac1b06768bb9f44dec18",
+    version = "v1.8.2",
     deps = [":spew"],
 )
 
-go_get(
+go_module(
     name = "logging",
-    get = "gopkg.in/op/go-logging.v1",
-    revision = "b2cb9fa56473e98db8caba80237377e83fe44db5",
+    module = "gopkg.in/op/go-logging.v1",
+    version = "v1",
 )
 
-go_get(
+go_module(
     name = "warnings",
-    get = "gopkg.in/warnings.v0",
-    revision = "v0.1.2",
+    module = "gopkg.in/warnings.v0",
+    version = "v0.1.2",
 )
 
-go_get(
+go_module(
     name = "gcfg",
-    get = "github.com/peterebden/gcfg/...",
-    revision = "v1.3.0",
+    module = "github.com/peterebden/gcfg",
+    version = "v1.3.0",
     deps = [
         ":warnings",
     ],


### PR DESCRIPTION
#2772 

This doesn't yet work (times out), unsure why

```
14:21:30.045   DEBUG: Outputs for //plugins:go have changed
14:21:30.048   DEBUG: Attempting to read config from plz-out/subrepos/plugins/go/.plzconfig...
14:21:30.053   DEBUG: Read config from plz-out/subrepos/plugins/go/.plzconfig
14:21:35.054   DEBUG: Running cycle detection...
14:21:35.054   DEBUG: Cycle detection complete, no cycles found

//tools/build_langserver/lsp:lsp_test 1 test run in 5m1.007s; 0 passed, 1 errored
    lsp_test  ERROR
1 test target and 1 test run; 0 passed, 1 errored.
Total time: 5m1.15s real, 5m1.01s compute.
Messages:
14:26:30.539   ERROR: //tools/build_langserver/lsp:lsp_test failed: Test returned nonzero but reported no errors
```