### PR TITLE
sandbox: use bit mask to indicate sandbox features

### DIFF
--- a/tools/sandbox/main.c
+++ b/tools/sandbox/main.c
@@ -12,6 +12,8 @@
 #include "tools/sandbox/sandbox.h"
 
 int main(int argc, char* argv[]) {
+    int flags = 0;
+
     if (argc < 2) {
         fputs("please_sandbox implements sandboxing for Please.\n", stderr);
         fputs("It takes no flags, it simply executes the command given as arguments.\n", stderr);
@@ -21,11 +23,15 @@ int main(int argc, char* argv[]) {
 
     // Network namespace is sandboxed by default but it can be opted out if `SHARE_NETWORK=1` env is set
     const char* share_network_env = getenv("SHARE_NETWORK");
-    const bool unshare_network = share_network_env == NULL || strcmp(share_network_env, "1");
+    if (share_network_env == NULL || !strcmp(share_network_env, "1")) {
+        flags |= FLAG_SANDBOX_NET;
+    }
 
     // Mount namespace is sandboxed by default but it can be opted out if `SHARE_MOUNT=1` env is set
     const char* share_mount_env = getenv("SHARE_MOUNT");
-    const bool unshare_mount = share_mount_env == NULL || strcmp(share_mount_env, "1");
+    if (share_mount_env == NULL || !strcmp(share_mount_env, "1")) {
+        flags |= FLAG_SANDBOX_FS;
+    }
 
-    return contain(&argv[1], unshare_network, unshare_mount);
+    return contain(&argv[1], flags);
 }

--- a/tools/sandbox/nonet_main.c
+++ b/tools/sandbox/nonet_main.c
@@ -13,5 +13,5 @@ int main(int argc, char* argv[]) {
         fputs("Usage: nonet_sandbox command args...\n", stderr);
         return 1;
     }
-    return contain(&argv[1], false, true);
+    return contain(&argv[1], FLAG_SANDBOX_ALL & ~FLAG_SANDBOX_NET);
 }

--- a/tools/sandbox/sandbox.h
+++ b/tools/sandbox/sandbox.h
@@ -1,10 +1,15 @@
 #include <stdbool.h>
 
+#define FLAG_SANDBOX_NET (1 << 0)
+#define FLAG_SANDBOX_FS  (1 << 1)
+
+#define FLAG_SANDBOX_ALL (FLAG_SANDBOX_NET | FLAG_SANDBOX_FS)
+
 // contain separates the process into new namespaces to sandbox it.
-// It should be passed the argv for the new process, and booleans indicating
-// whether it should move to new network and mount namespaces.
+// It should be passed the argv for the new process, and a bit mask of FLAG_*s
+// indicating which sandboxing features should be enabled.
 // It returns an exit code (so 0 on success, nonzero on failure).
-int contain(char* argv[], bool net, bool mount);
+int contain(char* argv[], int flags);
 
 // exec_name returns the name of the new binary to exec() as.
 // old_name is the current name; if it's within old_dir it will be re-prefixed to new_dir.


### PR DESCRIPTION
Rather than passing individual booleans to `contain()` to control the sandboxing behaviour, define and use a bit mask scheme in which each feature is a separate bit flag. This allows additional sandboxing features to be added in future without blowing up `contain()`'s function signature.