### PR TITLE
Print end-of-test messages directly to stdout

### DIFF
--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -100,7 +100,10 @@ loop:
 		}
 		msgs, totalMessages, actualMessages := cli.CurrentBackend.GetMessageHistory()
 		if actualMessages > 0 && !plainOutput {
-			printf("Messages:\n%s\n", strings.Join(msgs, "\n"))
+			printf("Messages:\n")
+			for _, msg := range msgs {
+				printf("%s\n", msg)
+			}
 			if totalMessages != actualMessages {
 				printf("plus %d more... see plz-out/log/build.log\n", totalMessages-actualMessages)
 			}


### PR DESCRIPTION
At the end of a test run, messages are concatenated with newlines into a single string that is then printed, which unnecessarily consumes time and memory if a large number of messages is to be printed. Rather than concatenating the list into a single string, iterate over the list and print the messages directly to stdout.