### PR TITLE
Don't write coverage reports if the empty string is specified for the path

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -498,8 +498,12 @@ var buildFunctions = map[string]func() int{
 			}
 			stats = test.CalculateIncrementalStats(state, lines)
 		}
-		test.WriteCoverageToFileOrDie(state.Coverage, string(opts.Cover.CoverageResultsFile), stats)
-		test.WriteXMLCoverageToFileOrDie(targets, state.Coverage, string(opts.Cover.CoverageXMLReport))
+		if opts.Cover.CoverageResultsFile != "" {
+			test.WriteCoverageToFileOrDie(state.Coverage, string(opts.Cover.CoverageResultsFile), stats)
+		}
+		if opts.Cover.CoverageXMLReport != "" {
+			test.WriteXMLCoverageToFileOrDie(targets, state.Coverage, string(opts.Cover.CoverageXMLReport))
+		}
 
 		if opts.Cover.LineCoverageReport && success {
 			output.PrintLineCoverageReport(state, opts.Cover.IncludeFile.AsStrings())

--- a/src/please.go
+++ b/src/please.go
@@ -153,8 +153,8 @@ var opts struct {
 		IncludeFile         cli.Filepaths `long:"include_file" description:"Filenames to filter coverage display to. Supports shell pattern matching e.g. file/path/*."`
 		TestResultsFile     cli.Filepath  `long:"test_results_file" default:"plz-out/log/test_results.xml" description:"File to write combined test results to."`
 		SurefireDir         cli.Filepath  `long:"surefire_dir" default:"plz-out/surefire-reports" description:"Directory to copy XML test results to."`
-		CoverageResultsFile cli.Filepath  `long:"coverage_results_file" default:"plz-out/log/coverage.json" description:"File to write combined coverage results to."`
-		CoverageXMLReport   cli.Filepath  `long:"coverage_xml_report" default:"plz-out/log/coverage.xml" description:"XML File to write combined coverage results to."`
+		CoverageResultsFile cli.Filepath  `long:"coverage_results_file" env:"COVERAGE_RESULTS_FILE" default:"plz-out/log/coverage.json" description:"File to write combined coverage results to."`
+		CoverageXMLReport   cli.Filepath  `long:"coverage_xml_report" env:"COVERAGE_XML_REPORT" default:"plz-out/log/coverage.xml" description:"XML File to write combined coverage results to."`
 		Incremental         bool          `short:"i" long:"incremental" description:"Calculates summary statistics for incremental coverage, i.e. stats for just the lines currently modified."`
 		ShowOutput          bool          `short:"s" long:"show_output" description:"Always show output of tests, even on success."`
 		DebugFailingTest    bool          `short:"d" long:"debug" description:"Allows starting an interactive debugger on test failure. Does not work with all test types (currently only python/pytest). Implies -c dbg unless otherwise set."`


### PR DESCRIPTION
This could be useful if one doesn't need one of the formats. It just fails if they're the empty string atm so should be uncontroversial.

Also adding env vars so one could set e.g. `COVERAGE_XML_REPORT=""`  which would only be picked up by newer versions.