### PR TITLE
Allow provides to be a list

### DIFF
--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -241,14 +241,16 @@ func ruleHash(state *core.BuildState, target *core.BuildTarget, runtime bool) []
 		h.Write([]byte(require))
 	}
 	// Indeterminate iteration order, yay...
-	languages := []string{}
+	var provides []string
 	for k := range target.Provides {
-		languages = append(languages, k)
+		provides = append(provides, k)
 	}
-	sort.Strings(languages)
-	for _, lang := range languages {
-		h.Write([]byte(lang))
-		h.Write([]byte(target.Provides[lang].String()))
+	sort.Strings(provides)
+	for _, p := range provides {
+		h.Write([]byte(p))
+		for _, l := range target.Provides[p] {
+			h.Write([]byte(l.String()))
+		}
 	}
 	// We don't need to hash the functions themselves because they get rerun every time -
 	// we just need to check whether one is added or removed, which is good since it's

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -241,7 +241,7 @@ func ruleHash(state *core.BuildState, target *core.BuildTarget, runtime bool) []
 		h.Write([]byte(require))
 	}
 	// Indeterminate iteration order, yay...
-	var provides []string
+	provides := make([]string, 0, len(target.Provides))
 	for k := range target.Provides {
 		provides = append(provides, k)
 	}

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -166,7 +166,7 @@ type BuildTarget struct {
 	// one rule but only compile the appropriate code for each library that consumes it).
 	Requires []string
 	// Dependent rules this rule provides for each language. Matches up to Requires as described above.
-	Provides map[string]BuildLabel
+	Provides map[string][]BuildLabel
 	// Stores the hash of this build rule before any post-build function is run.
 	RuleHash []byte `name:"exported_deps"` // bit of a hack to call this exported_deps...
 	// Tools that this rule will use, ie. other rules that it may use at build time which are not
@@ -1146,9 +1146,9 @@ func (target *BuildTarget) ShouldInclude(includes, excludes []string) bool {
 }
 
 // AddProvide adds a new provide entry to this target.
-func (target *BuildTarget) AddProvide(language string, label BuildLabel) {
+func (target *BuildTarget) AddProvide(language string, label []BuildLabel) {
 	if target.Provides == nil {
-		target.Provides = map[string]BuildLabel{language: label}
+		target.Provides = map[string][]BuildLabel{language: label}
 	} else {
 		target.Provides[language] = label
 	}
@@ -1181,11 +1181,11 @@ func (target *BuildTarget) provideFor(other *BuildTarget) []BuildLabel {
 	}
 	var ret []BuildLabel
 	for _, require := range other.Requires {
-		if label, present := target.Provides[require]; present {
+		if labels, present := target.Provides[require]; present {
 			if ret == nil {
 				ret = make([]BuildLabel, 0, len(other.Requires))
 			}
-			ret = append(ret, label)
+			ret = append(ret, labels...)
 		}
 	}
 	return ret

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -851,8 +851,8 @@ func (target *BuildTarget) SourcePaths(graph *BuildGraph, sources []BuildInput) 
 // sourcePaths returns the source paths for a single source.
 func (target *BuildTarget) sourcePaths(graph *BuildGraph, source BuildInput, f buildPathsFunc) []string {
 	if label, ok := source.nonOutputLabel(); ok {
-		ret := []string{}
-		for _, providedLabel := range recursivelyProvideFor(graph, target, graph.TargetOrDie(label), label) {
+		var ret []string
+		for _, providedLabel := range recursivelyProvideFor(graph, target, target, label) {
 			ret = append(ret, f(providedLabel, graph)...)
 		}
 		return ret

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -852,7 +852,7 @@ func (target *BuildTarget) SourcePaths(graph *BuildGraph, sources []BuildInput) 
 func (target *BuildTarget) sourcePaths(graph *BuildGraph, source BuildInput, f buildPathsFunc) []string {
 	if label, ok := source.nonOutputLabel(); ok {
 		ret := []string{}
-		for _, providedLabel := range graph.TargetOrDie(label).ProvideFor(target) {
+		for _, providedLabel := range recursivelyProvideFor(graph, target, graph.TargetOrDie(label), label) {
 			ret = append(ret, f(providedLabel, graph)...)
 		}
 		return ret

--- a/src/core/build_target_benchmark_test.go
+++ b/src/core/build_target_benchmark_test.go
@@ -22,7 +22,7 @@ func BenchmarkProvideFor(b *testing.B) {
 	})
 
 	target1.Requires = []string{"go"}
-	target2.AddProvide("py", target3.Label)
+	target2.AddProvide("py", []BuildLabel{target3.Label})
 	b.Run("NoMatch", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
@@ -30,8 +30,8 @@ func BenchmarkProvideFor(b *testing.B) {
 		}
 	})
 
-	target2.AddProvide("go", target3.Label)
-	target2.AddProvide("go_src", target4.Label)
+	target2.AddProvide("go", []BuildLabel{target3.Label})
+	target2.AddProvide("go_src", []BuildLabel{target4.Label})
 	b.Run("OneMatch", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
@@ -48,7 +48,7 @@ func BenchmarkProvideFor(b *testing.B) {
 	})
 
 	target1.Requires = []string{"go", "go_src", "py", "py_src"}
-	target2.AddProvide("py_src", target5.Label)
+	target2.AddProvide("py_src", []BuildLabel{target5.Label})
 	b.Run("FourMatches", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -221,7 +221,7 @@ func TestProvideFor(t *testing.T) {
 	target2 := makeTarget1("//src/core:target2", "PUBLIC", target1)
 	assert.Equal(t, []BuildLabel{target1.Label}, target1.ProvideFor(target2))
 	// Now have target2 provide target1. target3 will get target1 instead.
-	target2.Provides = map[string]BuildLabel{"whatevs": target1.Label}
+	target2.Provides = map[string][]BuildLabel{"whatevs": {target1.Label}}
 	target3 := makeTarget1("//src/core:target3", "PUBLIC", target2)
 	target3.Requires = append(target3.Requires, "whatevs")
 	assert.Equal(t, []BuildLabel{target1.Label}, target2.ProvideFor(target3))
@@ -238,7 +238,7 @@ func TestAddProvide(t *testing.T) {
 	target2 := makeTarget1("//src/core:target2", "PUBLIC", target1)
 	target3 := makeTarget1("//src/core:target3", "PUBLIC", target2)
 	target2.AddDependency(target1.Label)
-	target2.AddProvide("go", ParseBuildLabel(":target1", "src/core"))
+	target2.AddProvide("go", []BuildLabel{ParseBuildLabel(":target1", "src/core")})
 	target3.Requires = append(target3.Requires, "go")
 	assert.Equal(t, []BuildLabel{target1.Label}, target2.ProvideFor(target3))
 }

--- a/src/core/graph_test.go
+++ b/src/core/graph_test.go
@@ -34,7 +34,7 @@ func TestDependentTargets(t *testing.T) {
 	target3 := makeTarget3("//src/core:target3")
 	target2.AddDependency(target1.Label)
 	target1.AddDependency(target3.Label)
-	target1.AddProvide("go", ParseBuildLabel(":target3", "src/core"))
+	target1.AddProvide("go", []BuildLabel{ParseBuildLabel(":target3", "src/core")})
 	target2.Requires = append(target2.Requires, "go")
 	graph.AddTarget(target1)
 	graph.AddTarget(target2)

--- a/src/core/lock_test.go
+++ b/src/core/lock_test.go
@@ -146,7 +146,7 @@ func TestAcquireExclusiveFileLock(t *testing.T) {
 // This attempts to mimic how 1 plz process acquires an exclusive file lock and another tries to do the same thing to the same file.
 func TestAcquireExclusiveFileLockTwice(t *testing.T) {
 	// 1st process.
-	fd1, err := acquireOpenFileLock("path/to/file", syscall.LOCK_EX|syscall.LOCK_NB)
+	fd1, err := openAndAcquireLockFile("path/to/file", syscall.LOCK_EX|syscall.LOCK_NB)
 	assert.NoError(t, err)
 
 	// Keep file descriptor reference alive.
@@ -155,7 +155,7 @@ func TestAcquireExclusiveFileLockTwice(t *testing.T) {
 
 	// 2nd process.
 	// It errors immediately trying to acquire an exclusive lock as the same lock mode was already placed by process 1.
-	fd2, err := acquireOpenFileLock("path/to/file", syscall.LOCK_EX|syscall.LOCK_NB)
+	fd2, err := openAndAcquireLockFile("path/to/file", syscall.LOCK_EX|syscall.LOCK_NB)
 	assert.Error(t, err)
 
 	ReleaseFileLock(fd2)

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -500,8 +500,15 @@ func addProvides(s *scope, name string, obj pyObject, t *core.BuildTarget) {
 		s.Assert(ok, "Argument %s must be a dict, not %s, %v", name, obj.Type(), obj)
 		for k, v := range d {
 			str, ok := v.(pyString)
-			s.Assert(ok, "%s values must be strings", name)
-			t.AddProvide(k, checkLabel(s, s.parseLabelInPackage(string(str), s.pkg)))
+			if ok {
+				t.AddProvide(k, []core.BuildLabel{checkLabel(s, s.parseLabelInPackage(string(str), s.pkg))})
+				continue
+			}
+			_, ok = v.(pyList)
+			s.Assert(ok, "%s values must be strings or a lists of strings", name)
+			addStrings(s, name, v, func(str string) {
+				t.AddProvide(k, []core.BuildLabel{checkLabel(s, s.parseLabelInPackage(str, s.pkg))})
+			})
 		}
 	}
 }


### PR DESCRIPTION
This changes 2 things:
1) it allows provides to be a list 
2) It recursively provides when building the sources env var. We were doing this when iterating through the sources to copy into the dir, but were only providing one level when building the sources list for the env vars. 