### PR TITLE
Tab completion for plugin config overrides

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -1006,27 +1006,9 @@ func (config *Configuration) ApplyOverrides(overrides map[string]string) error {
 
 // Completions returns a list of possible completions for the given option prefix.
 func (config *Configuration) Completions(prefix string) []flags.Completion {
-	return config.completions(strings.Split(prefix, "."), reflect.ValueOf(config).Elem(), reflect.TypeOf(config).Elem())
-}
-
-func (config *Configuration) completions(parts []string, v *reflect.Value, t reflect.Type) []flags.Completion {
-	if kind := t.Kind(); kind == reflect.Struct {
-		return config.structCompletions(parts, v, t)
-	} else if kind == reflect.Map {
-		return config.MapCompletions(parts, v, t)
-	}
-	return nil
-}
-
-func (config *Configuration) structCompletions(parts []string, v *reflect.Value, t reflect.Type) []flags.Completion {
-	if len(parts) > 1 {
-		// We have a complete prefix, so we must match it exactly
-	}
-}
-
-func (config *Configuration) blahCompletions(parts []string, v *reflect.Value, t reflect.Type) []flags.Completion {
+	v := reflect.ValueOf(config).Elem()
+	t := reflect.TypeOf(config).Elem()
 	ret := []flags.Completion{}
-
 	for i := 0; i < t.NumField(); i++ {
 		if field := t.Field(i); field.Type.Kind() == reflect.Struct {
 			for j := 0; j < field.Type.NumField(); j++ {
@@ -1043,8 +1025,11 @@ func (config *Configuration) blahCompletions(parts []string, v *reflect.Value, t
 				}
 			}
 		} else if field.Type.Kind() == reflect.Map {
-			for _, k := range v.Field(i).MapKeys() {
-				if name := strings.ToLower(field.Name + "." + k.String()); strings.HasPrefix(name, prefix) {
+			iter := v.Field(i).MapRange()
+			for iter.Next() {
+				k := iter.Key().String()
+				if name := strings.ToLower(field.Name + "." + k); strings.HasPrefix(name, prefix) {
+					ret = append(ret, flags.Completion{Item: name + ":"})
 				}
 			}
 		}

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -1006,8 +1006,27 @@ func (config *Configuration) ApplyOverrides(overrides map[string]string) error {
 
 // Completions returns a list of possible completions for the given option prefix.
 func (config *Configuration) Completions(prefix string) []flags.Completion {
+	return config.completions(strings.Split(prefix, "."), reflect.ValueOf(config).Elem(), reflect.TypeOf(config).Elem())
+}
+
+func (config *Configuration) completions(parts []string, v *reflect.Value, t reflect.Type) []flags.Completion {
+	if kind := t.Kind(); kind == reflect.Struct {
+		return config.structCompletions(parts, v, t)
+	} else if kind == reflect.Map {
+		return config.MapCompletions(parts, v, t)
+	}
+	return nil
+}
+
+func (config *Configuration) structCompletions(parts []string, v *reflect.Value, t reflect.Type) []flags.Completion {
+	if len(parts) > 1 {
+		// We have a complete prefix, so we must match it exactly
+	}
+}
+
+func (config *Configuration) blahCompletions(parts []string, v *reflect.Value, t reflect.Type) []flags.Completion {
 	ret := []flags.Completion{}
-	t := reflect.TypeOf(config).Elem()
+
 	for i := 0; i < t.NumField(); i++ {
 		if field := t.Field(i); field.Type.Kind() == reflect.Struct {
 			for j := 0; j < field.Type.NumField(); j++ {
@@ -1021,6 +1040,11 @@ func (config *Configuration) Completions(prefix string) []flags.Completion {
 					} else {
 						ret = append(ret, flags.Completion{Item: name + ":", Description: help})
 					}
+				}
+			}
+		} else if field.Type.Kind() == reflect.Map {
+			for _, k := range v.Field(i).MapKeys() {
+				if name := strings.ToLower(field.Name + "." + k.String()); strings.HasPrefix(name, prefix) {
 				}
 			}
 		}

--- a/src/core/graph.go
+++ b/src/core/graph.go
@@ -136,6 +136,15 @@ func (graph *BuildGraph) AllTargets() BuildTargets {
 	return targets
 }
 
+// AllSubrepos returns a consistently ordered slice of all the subrepos in the graph
+func (graph *BuildGraph) AllSubrepos() []*Subrepo {
+	subrepos := graph.subrepos.Values()
+	sort.Slice(subrepos, func(i, j int) bool {
+		return subrepos[i].Name < subrepos[j].Name
+	})
+	return subrepos
+}
+
 // PackageMap returns a copy of the graph's internal map of name to package.
 func (graph *BuildGraph) PackageMap() map[string]*Package {
 	packages := map[string]*Package{}

--- a/src/please.go
+++ b/src/please.go
@@ -783,6 +783,23 @@ var buildFunctions = map[string]func() int{
 				help.Topics(fragments[0], config)
 			}
 			return 0
+		} else if opts.Query.Completions.Cmd == "plugin_config" {
+			// Completing for plugin config
+			targets := make([]core.BuildLabel, 0, len(config.Plugin))
+			for _, plugin := range config.Plugin {
+				targets = append(targets, plugin.Target)
+			}
+			return runQuery(true, targets, func(state *core.BuildState) {
+				for _, subrepo := range state.Graph.AllSubrepos() {
+					for _, frag := range fragments {
+						for k := range subrepo.State.RepoConfig.PluginConfig {
+							if name := "plugin." + subrepo.Name + "." + k; strings.HasPrefix(name, frag) {
+								fmt.Printf("%s:\n", name)
+							}
+						}
+					}
+				}
+			})
 		}
 
 		var qry string

--- a/src/please.go
+++ b/src/please.go
@@ -1020,7 +1020,8 @@ type ConfigOverrides map[string]string
 
 // Complete implements the flags.Completer interface.
 func (overrides ConfigOverrides) Complete(match string) []flags.Completion {
-	return core.DefaultConfiguration().Completions(match)
+	config := readConfig()
+	return config.Completions(match)
 }
 
 // Get an absolute path from a relative path.

--- a/src/please.go
+++ b/src/please.go
@@ -1020,8 +1020,7 @@ type ConfigOverrides map[string]string
 
 // Complete implements the flags.Completer interface.
 func (overrides ConfigOverrides) Complete(match string) []flags.Completion {
-	config := readConfig()
-	return config.Completions(match)
+	return readConfig().Completions(match)
 }
 
 // Get an absolute path from a relative path.


### PR DESCRIPTION
This lets you explore options on plugins via `plz -o plugin.go. <tab>`

It's a bit of a fiddle; we have to delegate to a subprocess (ala build labels) because the main process is far too early on to build things, but we need to invoke the build machinery to find out the plugin definitions.