### PR TITLE
Change plz exec args

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ Version 17.0.0
     * Auth before releasing website and binaries (#2684)
     * Fix typo in gcloud command (#2685)
     * Exclude targets in subrepos from `plz query changes` (#2723)
+    * `plz exec` now follows a similar argument pattern to `plz run` (#2793)
 
 
 Version 16.27.1

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -655,15 +655,6 @@
   </p>
 
   <p>
-    How the target result gets executed can be customised after <code class="code"
-    >--</code>, where the <code class="code">$OUT</code> (or <code class="code"
-    >$TEST</code> for a test target) environment variable points to its location -
-    ie. <code class="code">plz exec //:target -- echo ./\$OUT</code>. This gives
-    the flexibility of the binary to be called with a set of flags, be wrapped in
-    another command, or something different.
-  </p>
-
-  <p>
     The <code class="code">--share_network</code> and <code class="code">--share_mount</code
     > flags are available (Linux only) for greater control over the sandboxed environment
     where the target is run. The <code class="code">--share_network</code> flag is useful
@@ -685,8 +676,9 @@
   </p>
 
   <p>
-    Because of how this command works and the options it offers, only a single target is supported
-    per execution.
+    Only a single command is supported per execution with <code>plz exec</code>.
+    Multiple can be run with <code>plz exec sequential</code> or <code>plz exec parallel</code>,
+    which are analogous to their <code>plz run</code> equivalents.
   </p>
 </section>
 

--- a/src/debug/debug.go
+++ b/src/debug/debug.go
@@ -34,5 +34,5 @@ func Debug(state *core.BuildState, label core.BuildLabel, args []string) int {
 	// be shared or not, otherwise clients (i.e. IDEs) might not be able to connect to the debugger.
 	shareNetwork := state.DebugPort != 0 || !sandbox
 
-	return exec.Exec(state, core.AnnotatedOutputLabel{BuildLabel: label}, dir, env, cmd, state.DebugPort == 0, process.NewSandboxConfig(!shareNetwork, sandbox))
+	return exec.Exec(state, core.AnnotatedOutputLabel{BuildLabel: label}, dir, env, cmd, nil, state.DebugPort == 0, process.NewSandboxConfig(!shareNetwork, sandbox))
 }

--- a/src/exec/exec.go
+++ b/src/exec/exec.go
@@ -21,9 +21,9 @@ import (
 var log = logging.Log
 
 // Exec allows the execution of a target or override command in a sandboxed environment that can also be configured to have some namespaces shared.
-func Exec(state *core.BuildState, label core.AnnotatedOutputLabel, dir string, env, overrideCmdArgs []string, foreground bool, sandbox process.SandboxConfig) int {
+func Exec(state *core.BuildState, label core.AnnotatedOutputLabel, dir string, env, args []string, foreground bool, sandbox process.SandboxConfig) int {
 	target := state.Graph.TargetOrDie(label.BuildLabel)
-	return exitCode(exec(state, process.Default, target, dir, env, overrideCmdArgs, nil, label.Annotation, foreground, sandbox))
+	return exitCode(exec(state, process.Default, target, dir, env, args, label.Annotation, foreground, sandbox))
 }
 
 // Sequential executes a series of targets in sequence, stopping when one fails.
@@ -33,7 +33,7 @@ func Sequential(state *core.BuildState, outputMode process.OutputMode, labels []
 		log.Notice("Executing %s...", label)
 		target := state.Graph.TargetOrDie(label.BuildLabel)
 		sandbox := process.NewSandboxConfig(target.Sandbox && !shareNetwork, target.Sandbox && !shareMount)
-		if err := exec(state, outputMode, target, target.ExecDir(), env, nil, args, label.Annotation, false, sandbox); err != nil {
+		if err := exec(state, outputMode, target, target.ExecDir(), env, args, label.Annotation, false, sandbox); err != nil {
 			return exitCode(err)
 		}
 	}
@@ -74,7 +74,7 @@ func Parallel(state *core.BuildState, outputMode process.OutputMode, updateFrequ
 			atomic.AddInt64(&started, 1)
 			defer atomic.AddInt64(&done, 1)
 			sandbox := process.NewSandboxConfig(target.Sandbox && !shareNetwork, target.Sandbox && !shareMount)
-			return exec(state, outputMode, target, target.ExecDir(), env, nil, args, annotation, false, sandbox)
+			return exec(state, outputMode, target, target.ExecDir(), env, args, annotation, false, sandbox)
 		})
 	}
 	return exitCode(g.Wait())
@@ -92,17 +92,17 @@ func exitCode(err error) int {
 }
 
 // exec runs the given command in the given directory, with the given environment and arguments.
-func exec(state *core.BuildState, outputMode process.OutputMode, target *core.BuildTarget, runtimeDir string, env []string, overrideCmdArgs, additionalArgs []string, entrypoint string, foreground bool, sandbox process.SandboxConfig) error {
+func exec(state *core.BuildState, outputMode process.OutputMode, target *core.BuildTarget, runtimeDir string, env []string, additionalArgs []string, entrypoint string, foreground bool, sandbox process.SandboxConfig) error {
 	if err := process.RunWithOutput(outputMode, target.Label.String(), func() ([]byte, error) {
-		if !target.IsBinary && len(overrideCmdArgs) == 0 {
-			return nil, fmt.Errorf("Either the target needs to be a binary or an override command must be provided")
+		if !target.IsBinary {
+			return nil, fmt.Errorf("Target %s to be executed is not marked as binary", target)
 		}
 
 		if err := core.PrepareRuntimeDir(state, target, runtimeDir); err != nil {
 			return nil, err
 		}
 
-		cmd, err := resolveCmd(state, target, overrideCmdArgs, entrypoint, runtimeDir, sandbox)
+		cmd, err := resolveCmd(state, target, entrypoint, runtimeDir, sandbox)
 		if err != nil {
 			return nil, err
 		}
@@ -121,17 +121,13 @@ func exec(state *core.BuildState, outputMode process.OutputMode, target *core.Bu
 }
 
 // resolveCmd resolves the command to run for the given target.
-func resolveCmd(state *core.BuildState, target *core.BuildTarget, overrideCmdArgs []string, entrypoint string, runtimeDir string, sandbox process.SandboxConfig) (string, error) {
+func resolveCmd(state *core.BuildState, target *core.BuildTarget, entrypoint string, runtimeDir string, sandbox process.SandboxConfig) (string, error) {
 	if entrypoint != "" {
 		if ep, ok := target.EntryPoints[entrypoint]; ok {
-			overrideCmdArgs = []string{ep}
+			return core.ReplaceSequences(state, target, ep)
 		} else {
-			log.Fatalf("%v has no such entry point %v", target, entrypoint)
+			return "", fmt.Errorf("%s has no such entry point %s", target, entrypoint)
 		}
-	}
-	// The override command takes precedence if provided
-	if len(overrideCmdArgs) > 0 {
-		return core.ReplaceSequences(state, target, strings.Join(overrideCmdArgs, " "))
 	}
 
 	outs := target.Outputs()

--- a/src/exec/exec_test.go
+++ b/src/exec/exec_test.go
@@ -16,9 +16,9 @@ import (
 func TestNoBinaryTargetNoOverrideCommand(t *testing.T) {
 	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
 
-	err := exec(core.NewDefaultBuildState(), process.Default, target, ".", nil, nil, "", false, process.NoSandbox)
+	err := exec(core.NewDefaultBuildState(), process.Default, target, ".", nil, nil, nil, "", false, process.NoSandbox)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "is not marked as binary")
+	assert.Contains(t, err.Error(), "target needs to be a binary")
 }
 
 func TestPrepareRuntimeDir(t *testing.T) {
@@ -41,12 +41,30 @@ func TestPrepareRuntimeDir(t *testing.T) {
 	assert.True(t, fs.FileExists("plz-out/exec/pkg/file1"))
 }
 
+func TestSimpleOverrideCommand(t *testing.T) {
+	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
+
+	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, []string{"ls", "-l"}, "", "runtime/dir", process.NoSandbox)
+	assert.Nil(t, err)
+	assert.Equal(t, "ls -l", cmd)
+}
+
+func TestOverrideCommandWithSequence(t *testing.T) {
+	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
+	target.AddOutput("my-binary")
+	target.IsBinary = true
+
+	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, []string{"$(out_exe", "//pkg:t)"}, "", "runtime/dir", process.NoSandbox)
+	assert.Nil(t, err)
+	assert.Equal(t, "plz-out/bin/pkg/my-binary", cmd)
+}
+
 func TestCommandWithMultipleOutputs(t *testing.T) {
 	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
 	target.AddOutput("my-out-1")
 	target.AddOutput("my-out-2")
 
-	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, "", "runtime/dir", process.NoSandbox)
+	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, nil, "", "runtime/dir", process.NoSandbox)
 	assert.Empty(t, cmd)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "it has 2 outputs")
@@ -58,7 +76,7 @@ func TestCommandMountNotSandboxed(t *testing.T) {
 	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
 	target.AddOutput("my-out")
 
-	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, "", "runtime/dir", process.NoSandbox)
+	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, nil, "", "runtime/dir", process.NoSandbox)
 	assert.Nil(t, err)
 	assert.Equal(t, filepath.Join(core.RepoRoot, "runtime/dir/my-out"), cmd)
 }
@@ -67,9 +85,27 @@ func TestCommandMountSandboxed(t *testing.T) {
 	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
 	target.AddOutput("my-out")
 
-	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, "", "runtime/dir", process.NewSandboxConfig(false, true))
+	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, nil, "", "runtime/dir", process.NewSandboxConfig(false, true))
 	assert.Nil(t, err)
 	assert.Equal(t, filepath.Join(core.SandboxDir, "my-out"), cmd)
+}
+
+func TestExec(t *testing.T) {
+	state := core.NewDefaultBuildState()
+	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
+	state.Graph.AddTarget(target)
+
+	err := exec(state, process.Default, target, "test", nil, []string{"echo", "foo"}, nil, "", false, process.NoSandbox)
+	assert.Nil(t, err)
+}
+
+func TestCommandExitCode(t *testing.T) {
+	state := core.NewDefaultBuildState()
+	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
+	state.Graph.AddTarget(target)
+
+	exitCode := Exec(state, core.AnnotatedOutputLabel{BuildLabel: target.Label}, "test", nil, []string{"exit", "5"}, nil, false, process.NoSandbox)
+	assert.Equal(t, 5, exitCode)
 }
 
 func TestConvertEnv(t *testing.T) {

--- a/src/exec/exec_test.go
+++ b/src/exec/exec_test.go
@@ -16,9 +16,9 @@ import (
 func TestNoBinaryTargetNoOverrideCommand(t *testing.T) {
 	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
 
-	err := exec(core.NewDefaultBuildState(), process.Default, target, ".", nil, nil, nil, "", false, process.NoSandbox)
+	err := exec(core.NewDefaultBuildState(), process.Default, target, ".", nil, nil, "", false, process.NoSandbox)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "target needs to be a binary")
+	assert.Contains(t, err.Error(), "is not marked as binary")
 }
 
 func TestPrepareRuntimeDir(t *testing.T) {
@@ -41,30 +41,12 @@ func TestPrepareRuntimeDir(t *testing.T) {
 	assert.True(t, fs.FileExists("plz-out/exec/pkg/file1"))
 }
 
-func TestSimpleOverrideCommand(t *testing.T) {
-	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
-
-	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, []string{"ls", "-l"}, "", "runtime/dir", process.NoSandbox)
-	assert.Nil(t, err)
-	assert.Equal(t, "ls -l", cmd)
-}
-
-func TestOverrideCommandWithSequence(t *testing.T) {
-	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
-	target.AddOutput("my-binary")
-	target.IsBinary = true
-
-	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, []string{"$(out_exe", "//pkg:t)"}, "", "runtime/dir", process.NoSandbox)
-	assert.Nil(t, err)
-	assert.Equal(t, "plz-out/bin/pkg/my-binary", cmd)
-}
-
 func TestCommandWithMultipleOutputs(t *testing.T) {
 	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
 	target.AddOutput("my-out-1")
 	target.AddOutput("my-out-2")
 
-	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, nil, "", "runtime/dir", process.NoSandbox)
+	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, "", "runtime/dir", process.NoSandbox)
 	assert.Empty(t, cmd)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "it has 2 outputs")
@@ -76,7 +58,7 @@ func TestCommandMountNotSandboxed(t *testing.T) {
 	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
 	target.AddOutput("my-out")
 
-	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, nil, "", "runtime/dir", process.NoSandbox)
+	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, "", "runtime/dir", process.NoSandbox)
 	assert.Nil(t, err)
 	assert.Equal(t, filepath.Join(core.RepoRoot, "runtime/dir/my-out"), cmd)
 }
@@ -85,27 +67,9 @@ func TestCommandMountSandboxed(t *testing.T) {
 	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
 	target.AddOutput("my-out")
 
-	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, nil, "", "runtime/dir", process.NewSandboxConfig(false, true))
+	cmd, err := resolveCmd(core.NewDefaultBuildState(), target, "", "runtime/dir", process.NewSandboxConfig(false, true))
 	assert.Nil(t, err)
 	assert.Equal(t, filepath.Join(core.SandboxDir, "my-out"), cmd)
-}
-
-func TestExec(t *testing.T) {
-	state := core.NewDefaultBuildState()
-	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
-	state.Graph.AddTarget(target)
-
-	err := exec(state, process.Default, target, "test", nil, []string{"echo", "foo"}, nil, "", false, process.NoSandbox)
-	assert.Nil(t, err)
-}
-
-func TestCommandExitCode(t *testing.T) {
-	state := core.NewDefaultBuildState()
-	target := core.NewBuildTarget(core.NewBuildLabel("pkg", "t"))
-	state.Graph.AddTarget(target)
-
-	exitCode := Exec(state, core.AnnotatedOutputLabel{BuildLabel: target.Label}, "test", nil, []string{"exit", "5"}, false, process.NoSandbox)
-	assert.Equal(t, 5, exitCode)
 }
 
 func TestConvertEnv(t *testing.T) {

--- a/src/please.go
+++ b/src/please.go
@@ -530,7 +530,7 @@ var buildFunctions = map[string]func() int{
 		target := state.Graph.TargetOrDie(opts.Exec.Args.Target.BuildLabel)
 		dir := target.ExecDir()
 		shouldSandbox := target.Sandbox
-		if code := exec.Exec(state, opts.Exec.Args.Target, dir, exec.ConvertEnv(opts.Exec.Env), opts.Exec.Args.Args, false, process.NewSandboxConfig(shouldSandbox && !opts.Exec.Share.Network, shouldSandbox && !opts.Exec.Share.Mount)); code != 0 {
+		if code := exec.Exec(state, opts.Exec.Args.Target, dir, exec.ConvertEnv(opts.Exec.Env), nil, opts.Exec.Args.Args, false, process.NewSandboxConfig(shouldSandbox && !opts.Exec.Share.Network, shouldSandbox && !opts.Exec.Share.Mount)); code != 0 {
 			return code
 		}
 

--- a/src/please.go
+++ b/src/please.go
@@ -219,8 +219,8 @@ var opts struct {
 			Mount   bool `long:"share_mount" description:"Share mount namespace"`
 		} `group:"Options to override mount and network namespacing on linux, if configured"`
 		Args struct {
-			Target              core.AnnotatedOutputLabel `positional-arg-name:"target" required:"true" description:"Target to execute"`
-			OverrideCommandArgs []string                  `positional-arg-name:"override_command" description:"Override command"`
+			Target core.AnnotatedOutputLabel `positional-arg-name:"target" required:"true" description:"Target to execute"`
+			Args   []string                  `positional-arg-name:"arg" description:"Arguments to the executed command"`
 		} `positional-args:"true"`
 		Sequential struct {
 			Args struct {
@@ -530,7 +530,7 @@ var buildFunctions = map[string]func() int{
 		target := state.Graph.TargetOrDie(opts.Exec.Args.Target.BuildLabel)
 		dir := target.ExecDir()
 		shouldSandbox := target.Sandbox
-		if code := exec.Exec(state, opts.Exec.Args.Target, dir, exec.ConvertEnv(opts.Exec.Env), opts.Exec.Args.OverrideCommandArgs, false, process.NewSandboxConfig(shouldSandbox && !opts.Exec.Share.Network, shouldSandbox && !opts.Exec.Share.Mount)); code != 0 {
+		if code := exec.Exec(state, opts.Exec.Args.Target, dir, exec.ConvertEnv(opts.Exec.Env), opts.Exec.Args.Args, false, process.NewSandboxConfig(shouldSandbox && !opts.Exec.Share.Network, shouldSandbox && !opts.Exec.Share.Mount)); code != 0 {
 			return code
 		}
 

--- a/test/exec/BUILD
+++ b/test/exec/BUILD
@@ -3,7 +3,7 @@ subinclude("//test/build_defs")
 please_repo_e2e_test(
     name = "exec_test",
     expected_output = {"plz-out/exec_test/out.txt": "test"},
-    plz_command = "plz exec --out out.txt --output_path plz-out/exec_test //:dummy -- \"echo test > out.txt\"",
+    plz_command = "plz exec --out out.txt --output_path plz-out/exec_test //:dummy",
     repo = "test_repo",
 )
 

--- a/test/exec/test_repo/BUILD_FILE
+++ b/test/exec/test_repo/BUILD_FILE
@@ -1,7 +1,8 @@
 genrule(
     name = "dummy",
-    cmd = "touch $OUT",
+    cmd = "echo 'echo test > out.txt' > $OUT",
     outs = ["dummy"],
+    binary = True,
 )
 
 genrule(


### PR DESCRIPTION
This makes them behave similarly to `plz exec sequential`, `plz exec parallel` and `plz run` (and its subcommands too), i.e. it removes the command override business. I think that is no longer necessary since the debugging functionality it supported now has `plz debug` but I think this is quite a bit easier to understand (before it was tricky to understand how to pass flags into `plz exec`).