### PR TITLE
Add strip option to text_file

### DIFF
--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -485,7 +485,7 @@ def remote_file(name:str, url:str|list, hashes:list=None, out:str=None, binary:b
         pass_env=pass_env
     )
 
-def text_file(name:str, content:str, hashes:list=None, data:list|dict=[], out:str=None,
+def text_file(name:str, content:str, strip:bool=False, hashes:list=None, data:list|dict=[], out:str=None,
               binary:bool=False, visibility:list=None, licences:list=None, test_only:bool&testonly=False,
               labels:list=[], deps:list|dict=None, exported_deps:list=None, _tag:str='', entry_points:dict={}):
     """Defines a rule to convert a string in the build language into a text file.
@@ -493,6 +493,7 @@ def text_file(name:str, content:str, hashes:list=None, data:list|dict=[], out:st
     Args:
       name (str): Name of the rule
       content (str): The text content of the file.
+      strip (bool): True to strip the input.
       hashes (list): List of hashes; the output must match at least one of these.
       out (str): Output name of the file. Chosen automatically if not given.
       binary (bool): True to mark the output as binary and runnable.
@@ -504,6 +505,11 @@ def text_file(name:str, content:str, hashes:list=None, data:list|dict=[], out:st
       data (list): List of runtime data for this rule.
       exported_deps (list): Dependencies that will become visible to any rules that depend on this rule.
     """
+
+    if strip:
+        content = '\n'.join(
+            [ line.lstrip(' \t') for line in content.removeprefix('\n').split('\n') ]
+        )
 
     return build_rule(
         name = name,

--- a/test/build_defs/test_file_content.sh
+++ b/test/build_defs/test_file_content.sh
@@ -1,13 +1,16 @@
 #!/bin/sh
 
-if ! test -f "$1"; then
-  echo "$1" doesnt exist
+file=$1
+
+if ! test -f "$file"; then
+  echo "$file" doesnt exist
   exit 1
 fi
 
-CONTENT=$(cat "$1")
+CONTENT=$(cat "$file")
+shift 1
 
-if [ "$CONTENT" != "$2" ]; then
-  echo "$1" doesnt contain "$2", it contains "$CONTENT"
+if [ "$CONTENT" != "$@" ]; then
+  echo "$file" doesnt contain "$@", it contains "$CONTENT"
   exit 1
 fi

--- a/test/text_file/BUILD
+++ b/test/text_file/BUILD
@@ -6,6 +6,16 @@ text_file(
 )
 
 text_file(
+    name = "multilines_file",
+    strip = True,
+    content = """
+        This is a multi lines file,
+        use strip option to remove first empty newline
+        and all empty spaces on the left of the text.
+    """,
+)
+
+text_file(
     name = "expand_file",
     content = "$(location :file)",
     deps = [":file"],
@@ -17,6 +27,20 @@ gentest(
     labels = ["rex"],
     no_test_output = True,
     test_cmd = "$TOOL $(location :file) wibble",
+    test_tools = ["//test/build_defs:content_checker"],
+)
+
+gentest(
+    name = "multilines_file_test",
+    data = [":multilines_file"],
+    labels = ["rex"],
+    no_test_output = True,
+    test_cmd = """
+        $TOOL $(location :multilines_file) \
+            'This is a multi lines file,' \
+            'use strip option to remove first empty newline' \
+            'and all empty spaces on the left of the text.'
+    """,
     test_tools = ["//test/build_defs:content_checker"],
 )
 


### PR DESCRIPTION
For multilines text_file it is usually convenient to strip all spaces on the leftside of the text so the text is correctly intended in the code.