### PR TITLE
Can generate dot graph on query deps command

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -338,6 +338,7 @@ var opts struct {
 
 	Query struct {
 		Deps struct {
+			DOT    bool `long:"dot" description:"Output in dot format"`
 			Hidden bool `long:"hidden" short:"h" description:"Output internal / hidden dependencies too"`
 			Level  int  `long:"level" default:"-1" description:"Levels of the dependencies to retrieve."`
 			Unique bool `long:"unique" hidden:"true" description:"Has no effect, only exists for compatibility."`
@@ -395,7 +396,7 @@ var opts struct {
 			Args struct {
 				Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to render graph for"`
 			} `positional-args:"true"`
-		} `command:"graph" description:"Prints a JSON representation of the build graph."`
+		} `command:"graph" description:"Prints a representation of the build graph."`
 		WhatInputs struct {
 			Hidden    bool `long:"hidden" short:"h" description:"Output internal / hidden targets too."`
 			EchoFiles bool `long:"echo_files" description:"Echo the file for which the printed output is responsible."`
@@ -733,7 +734,7 @@ var buildFunctions = map[string]func() int{
 	},
 	"query.deps": func() int {
 		return runQuery(true, opts.Query.Deps.Args.Targets, func(state *core.BuildState) {
-			query.Deps(state, state.ExpandOriginalLabels(), opts.Query.Deps.Hidden, opts.Query.Deps.Level)
+			query.Deps(state, state.ExpandOriginalLabels(), opts.Query.Deps.Hidden, opts.Query.Deps.Level, opts.Query.Deps.DOT)
 		})
 	},
 	"query.revdeps": func() int {

--- a/src/query/deps.go
+++ b/src/query/deps.go
@@ -9,14 +9,30 @@ import (
 )
 
 // Deps prints all transitive dependencies of a set of targets.
-func Deps(state *core.BuildState, labels []core.BuildLabel, hidden bool, targetLevel int) {
-	deps(os.Stdout, state, labels, hidden, targetLevel)
+func Deps(state *core.BuildState, labels []core.BuildLabel, hidden bool, targetLevel int, formatdot bool) {
+	deps(os.Stdout, state, labels, hidden, targetLevel, formatdot)
 }
 
-func deps(out io.Writer, state *core.BuildState, labels []core.BuildLabel, hidden bool, targetLevel int) {
+func deps(out io.Writer, state *core.BuildState, labels []core.BuildLabel, hidden bool, targetLevel int, formatdot bool) {
+	if formatdot {
+		fmt.Fprintf(out, "digraph deps {\n")
+		fmt.Fprintf(out, "  fontname=\"Helvetica,Arial,sans-serif\"\n")
+		fmt.Fprintf(out, "  node [fontname=\"Helvetica,Arial,sans-serif\"]\n")
+		fmt.Fprintf(out, "  edge [fontname=\"Helvetica,Arial,sans-serif\"]\n")
+		fmt.Fprintf(out, "  rankdir=\"LR\"\n")
+	}
 	done := map[core.BuildLabel]bool{}
 	for _, label := range labels {
-		printTarget(out, state, state.Graph.TargetOrDie(label), "", done, hidden, 0, targetLevel)
+		if formatdot {
+			fmt.Fprintf(out, "  subgraph \"%s\" {\n", label)
+			printTargetDot(out, state, state.Graph.TargetOrDie(label), nil, done, hidden, 0, targetLevel)
+			fmt.Fprintf(out, "  }\n")
+		} else {
+			printTarget(out, state, state.Graph.TargetOrDie(label), "", done, hidden, 0, targetLevel)
+		}
+	}
+	if formatdot {
+		fmt.Fprintf(out, "}\n")
 	}
 }
 
@@ -35,5 +51,37 @@ func printTarget(out io.Writer, state *core.BuildState, target *core.BuildTarget
 
 	for _, dep := range target.Dependencies() {
 		printTarget(out, state, dep, indent, done, hidden, currentLevel, targetLevel)
+	}
+}
+
+func printTargetDot(out io.Writer, state *core.BuildState, target *core.BuildTarget, parent *core.BuildTarget, done map[core.BuildLabel]bool, hidden bool, currentLevel int, targetLevel int) {
+	levelLimitReached := targetLevel != -1 && currentLevel == targetLevel
+
+	if state.ShouldInclude(target) && (hidden || !target.HasParent()) {
+		if !done[target.Label] {
+			shape := "ellipse"
+			if target.IsFilegroup {
+				shape = "folder"
+			} else if target.IsRemoteFile {
+				shape = "octagon"
+			} else if target.IsTextFile {
+				shape = "note"
+			} else if target.IsBinary {
+				shape = "component"
+			}
+			fmt.Fprintf(out, "   node [shape=%s] \"%s\";\n", shape, target)
+		}
+		if parent != nil {
+			fmt.Fprintf(out, "   \"%s\" -> \"%s\";\n", parent, target)
+		}
+		currentLevel++
+	}
+	if done[target.Label] || levelLimitReached {
+		return
+	}
+	done[target.Label] = true
+
+	for _, dep := range target.Dependencies() {
+		printTargetDot(out, state, dep, target, done, hidden, currentLevel, targetLevel)
 	}
 }


### PR DESCRIPTION
Add an option --dot on query deps which
generate a dot compatible graph.

Graph nodes will have different shapes depending
if it's a filegroup/remote_file/text_file/binary

One can get an image with
`plz query deps //src:please --dot | dot -Tpng > graph.png`

issue #2777