### PR TITLE
Add --notest flag to plz watch

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -246,8 +246,9 @@ var opts struct {
 	} `command:"clean" description:"Cleans build artifacts" subcommands-optional:"true"`
 
 	Watch struct {
-		Run  bool `short:"r" long:"run" description:"Runs the specified targets when they change (default is to build or test as appropriate)."`
-		Args struct {
+		Run    bool `short:"r" long:"run" description:"Runs the specified targets when they change (default is to build or test as appropriate)."`
+		NoTest bool `long:"notest" description:"If set, no tests will be ran. The targets will only be re-built."`
+		Args   struct {
 			Target core.BuildLabel `positional-arg-name:"target" description:"Target to watch for changes"`
 			Args   TargetsOrArgs   `positional-arg-name:"arguments" description:"Additional targets to watch, or test selectors"`
 		} `positional-args:"true" required:"true"`
@@ -944,7 +945,7 @@ var buildFunctions = map[string]func() int{
 		// Don't ask it to test now since we don't know if any of them are tests yet.
 		success, state := runBuild(targets, true, false, false)
 		state.NeedRun = opts.Watch.Run
-		watch.Watch(state, state.ExpandOriginalLabels(), args, runPlease)
+		watch.Watch(state, state.ExpandOriginalLabels(), args, opts.Watch.NoTest, runPlease)
 		return toExitCode(success, state)
 	},
 	"generate": func() int {

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -28,9 +28,11 @@ type CallbackFunc func(*core.BuildState, []core.BuildLabel)
 // Watch starts watching the sources of the given labels for changes and triggers
 // rebuilds whenever they change.
 // It never returns successfully, it will either watch forever or die.
-func Watch(state *core.BuildState, labels core.BuildLabels, testArgs []string, callback CallbackFunc) {
+func Watch(state *core.BuildState, labels core.BuildLabels, testArgs []string, noTest bool, callback CallbackFunc) {
 	// This hasn't been set before, do it now.
-	state.NeedTests = anyTests(state, labels)
+	if !noTest {
+		state.NeedTests = anyTests(state, labels)
+	}
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Fatalf("Error setting up watcher: %s", err)


### PR DESCRIPTION
A small feature request to facilitate rebuilding everything under a directory. This can be useful to do a quick smoke test when making changes that are likely to be caught at compile time. 