### PR TITLE
Implement `any` and `all` built-ins natively

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -78,17 +78,12 @@ def isinstance(obj, types:function|list) -> bool:
 
 def range(start:int, stop:int=None, step:int=1) -> str:
     pass
-def any(seq:list) -> bool:
-    for x in seq:
-        if x:
-            return True
-    return False
-def all(seq:list) -> bool:
-    for x in seq:
-        if not x:
-            return False
-    return True
 
+def any(seq:list) -> bool:
+    pass
+
+def all(seq:list) -> bool:
+    pass
 
 def bool(b) -> bool:
     pass

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -39,6 +39,8 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "range", pyRange)
 	setNativeCode(s, "enumerate", enumerate)
 	setNativeCode(s, "zip", zip, varargs)
+	setNativeCode(s, "any", anyFunc)
+	setNativeCode(s, "all", allFunc)
 	setNativeCode(s, "len", lenFunc)
 	setNativeCode(s, "glob", glob)
 	setNativeCode(s, "bool", boolType)
@@ -784,6 +786,28 @@ func enumerate(s *scope, args []pyObject) pyObject {
 		ret[i] = pyList{pyInt(i), li}
 	}
 	return ret
+}
+
+func anyFunc(s *scope, args []pyObject) pyObject {
+	l, ok := args[0].(pyList)
+	s.Assert(ok, "Argument to any must be a list, not %s", args[0].Type())
+	for _, li := range l {
+		if li.IsTruthy() {
+			return True
+		}
+	}
+	return False
+}
+
+func allFunc(s *scope, args []pyObject) pyObject {
+	l, ok := args[0].(pyList)
+	s.Assert(ok, "Argument to all must be a list, not %s", args[0].Type())
+	for _, li := range l {
+		if !li.IsTruthy() {
+			return False
+		}
+	}
+	return True
 }
 
 func zip(s *scope, args []pyObject) pyObject {

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -389,6 +389,32 @@ func TestFormat(t *testing.T) {
 	assert.EqualValues(t, `ARCH="linux_amd64"`, s.Lookup("arch2"))
 }
 
+func TestAny(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		s, err := parseFile("src/parse/asp/test_data/interpreter/any.build")
+		assert.NoError(t, err)
+		for i := 1; i <= 9; i++ {
+			assert.EqualValues(t, pyBool(true), s.Lookup(fmt.Sprintf("t%d", i)))
+		}
+		for i := 1; i <= 9; i++ {
+			assert.EqualValues(t, pyBool(false), s.Lookup(fmt.Sprintf("f%d", i)))
+		}
+	})
+}
+
+func TestAll(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		s, err := parseFile("src/parse/asp/test_data/interpreter/all.build")
+		assert.NoError(t, err)
+		for i := 1; i <= 9; i++ {
+			assert.EqualValues(t, pyBool(true), s.Lookup(fmt.Sprintf("t%d", i)))
+		}
+		for i := 1; i <= 9; i++ {
+			assert.EqualValues(t, pyBool(false), s.Lookup(fmt.Sprintf("f%d", i)))
+		}
+	})
+}
+
 func TestIsSemver(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		s, err := parseFile("src/parse/asp/test_data/interpreter/is_semver.build")

--- a/src/parse/asp/test_data/interpreter/all.build
+++ b/src/parse/asp/test_data/interpreter/all.build
@@ -1,0 +1,21 @@
+# true:
+t1 = all([True])
+t2 = all([1])
+t3 = all(["1"])
+t4 = all([{"1": "one"}])
+t5 = all([[1]])
+t6 = all([True, True])
+t7 = all([1, 1])
+t8 = all(["1", "1"])
+t9 = all([[1], [1]])
+
+# false:
+f1 = all([False])
+f2 = all([0])
+f3 = all([""])
+f4 = all([{}])
+f5 = all([[]])
+f6 = all([True, True, False])
+f7 = all([1, 1, 0])
+f8 = all(["1", "1", ""])
+f9 = all([[1], [1], []])

--- a/src/parse/asp/test_data/interpreter/any.build
+++ b/src/parse/asp/test_data/interpreter/any.build
@@ -1,0 +1,21 @@
+# true:
+t1 = any([True])
+t2 = any([1])
+t3 = any(["1"])
+t4 = any([{"1": "one"}])
+t5 = any([[1]])
+t6 = any([False, True])
+t7 = any([0, 1])
+t8 = any(["0", "1"])
+t9 = any([[0], [1]])
+
+# false:
+f1 = any([False])
+f2 = any([0])
+f3 = any([""])
+f4 = any([{}])
+f5 = any([[]])
+f6 = any([False, False, False])
+f7 = any([0, 0, 0])
+f8 = any(["", "", ""])
+f9 = any([[], [], []])


### PR DESCRIPTION
Switch from an ASP-based implementation of the `any` and `all` built-in functions to a native implementation. This significantly improves the worst-case performance of both functions.