### PR TITLE
Generate a random remote build ID if one is not set

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -561,7 +561,7 @@ type Configuration struct {
 		Shell         string       `help:"Path to the shell to use to execute actions in. Default looks up bash based on the build.path setting."`
 		Platform      []string     `help:"Platform properties to request from remote workers, in the format key=value."`
 		CacheDuration cli.Duration `help:"Length of time before we re-check locally cached build actions. Default is unlimited."`
-		BuildID       string       `help:"ID of the build action that's being run, to attach to remote requests."`
+		BuildID       string       `help:"ID of the build action that's being run, to attach to remote requests. If not set then one is automatically generated."`
 	} `help:"Settings related to remote execution & caching using the Google remote execution APIs. This section is still experimental and subject to change."`
 	Size  map[string]*Size `help:"Named sizes of targets; these are the definitions of what can be passed to the 'size' argument."`
 	Cover struct {

--- a/src/remote/BUILD
+++ b/src/remote/BUILD
@@ -17,6 +17,7 @@ go_library(
         "///third_party/go/github.com_bazelbuild_remote-apis//build/bazel/remote/asset/v1",
         "///third_party/go/github.com_bazelbuild_remote-apis//build/bazel/remote/execution/v2",
         "///third_party/go/github.com_bazelbuild_remote-apis//build/bazel/semver",
+        "///third_party/go/github.com_google_uuid//:uuid",
         "///third_party/go/github.com_grpc-ecosystem_go-grpc-middleware//retry",
         "///third_party/go/golang.org_x_sync//errgroup",
         "///third_party/go/google.golang.org_genproto//googleapis/rpc/status",

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -631,7 +631,7 @@ func (c *Client) contextWithMetadata(target *core.BuildTarget) context.Context {
 	const key = "build.bazel.remote.execution.v2.requestmetadata-bin" // as defined by the proto
 	b, _ := proto.Marshal(&pb.RequestMetadata{
 		ActionId:                target.Label.String(),
-		CorrelatedInvocationsId: c.state.Config.Remote.BuildID,
+		CorrelatedInvocationsId: c.buildID,
 		ToolDetails: &pb.ToolDetails{
 			ToolName:    "please",
 			ToolVersion: core.PleaseVersion,


### PR DESCRIPTION
Seems like this could be useful on the server side since this may often not get set.