### PR TITLE
Remove shell lookup from remote code

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -396,6 +396,7 @@ func DefaultConfiguration() *Configuration {
 	config.Remote.VerifyOutputs = true
 	config.Remote.UploadDirs = true
 	config.Remote.CacheDuration = cli.Duration(10000 * 24 * time.Hour) // Effectively forever.
+	config.Remote.Shell = "bash"
 	config.Go.GoTool = "go"
 	config.Go.CgoCCTool = "gcc"
 	config.Go.DelveTool = "dlv"
@@ -558,7 +559,7 @@ type Configuration struct {
 		Secure        bool         `help:"Whether to use TLS for communication or not."`
 		VerifyOutputs bool         `help:"Whether to verify all outputs are present after a cached remote execution action. Depending on your server implementation, you may require this to ensure files are really present."`
 		UploadDirs    bool         `help:"Uploads individual directory blobs after build actions. This might not be necessary with some servers, but if you aren't sure, you should leave it on."`
-		Shell         string       `help:"Path to the shell to use to execute actions in. Default looks up bash based on the build.path setting."`
+		Shell         string       `help:"Path to the shell to use to execute actions in. Default is 'bash' which will be looked up by the server."`
 		Platform      []string     `help:"Platform properties to request from remote workers, in the format key=value."`
 		CacheDuration cli.Duration `help:"Length of time before we re-check locally cached build actions. Default is unlimited."`
 		BuildID       string       `help:"ID of the build action that's being run, to attach to remote requests. If not set then one is automatically generated."`

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -244,18 +244,6 @@ func (c *Client) initExec() error {
 		// bit to allow a bit of serialisation overhead etc.
 		c.maxBlobBatchSize = 4000000
 	}
-	if c.shellPath == "" {
-		// We have to run everything through a shell since our commands are arbitrary.
-		// Unfortunately we can't just say "bash", we need an absolute path which is
-		// a bit weird since it assumes that our absolute path is the same as the
-		// remote one (which is probably OK on the same OS, but not between say Linux and
-		// FreeBSD where bash is not idiomatically in the same place).
-		bash, err := core.LookBuildPath("bash", c.state.Config)
-		if err != nil {
-			return fmt.Errorf("Failed to set path for bash: %w", err)
-		}
-		c.shellPath = bash
-	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("Failed to determine user home dir: %s", err)


### PR DESCRIPTION
They've (sensibly) changed REAPI to allow the server to look up a command like `bash` (technically before the API said they couldn't but apparently nobody ever implemented it that way). This assumes that we can take advantage of that behaviour.

This could be considered breaking, I don't think it's a real problem though since apparently Buildfarm, Buildgrid and Buildbarn all implemented lookups already (also I'm not sure if we really have anyone outside TM using Please for rex). We _could_ add a feature flag if we decide that's the Right Thing though.