### PR TITLE
Remove thread id

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -55,7 +55,7 @@ var successfulLocalTargetBuildDuration = metrics.NewHistogram(
 )
 
 // Build implements the core logic for building a single target.
-func Build(tid int, state *core.BuildState, label core.BuildLabel, remote bool) {
+func Build(state *core.BuildState, label core.BuildLabel, remote bool) {
 	target := state.Graph.TargetOrDie(label)
 	state = state.ForTarget(target)
 	target.SetState(core.Building)
@@ -114,7 +114,7 @@ func findFilegroupSourcesWithTmpDir(target *core.BuildTarget) []core.BuildLabel 
 	return srcs
 }
 
-func prepareOnly(tid int, state *core.BuildState, target *core.BuildTarget) error {
+func prepareOnly(state *core.BuildState, target *core.BuildTarget) error {
 	if target.IsFilegroup {
 		potentialTargets := findFilegroupSourcesWithTmpDir(target)
 		if len(potentialTargets) > 0 {
@@ -152,7 +152,7 @@ func prepareOnly(tid int, state *core.BuildState, target *core.BuildTarget) erro
 //     b) attempt to fetch the outputs from the cache based on the output hash
 //  3. Actually build the rule
 //  4. Store result in the cache
-func buildTarget(tid int, state *core.BuildState, target *core.BuildTarget, runRemotely bool) (err error) {
+func buildTarget(state *core.BuildState, target *core.BuildTarget, runRemotely bool) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if e, ok := r.(error); ok {
@@ -448,7 +448,7 @@ func storeInCache(cache core.Cache, target *core.BuildTarget, key []byte, files 
 //  1. if there are no declared outputs, return true; there's nothing to be done
 //  2. pull all the declared outputs from the cache has based on the short hash of the target
 //  3. check that pulling the artifacts changed the output hash and set the build state accordingly
-func retrieveArtifacts(tid int, state *core.BuildState, target *core.BuildTarget, oldOutputHash []byte) bool {
+func retrieveArtifacts(state *core.BuildState, target *core.BuildTarget, oldOutputHash []byte) bool {
 	// If there aren't any outputs, we don't have to do anything right now.
 	// Checks later will handle the case of something with a post-build function that
 	// later tries to add more outputs.
@@ -969,7 +969,7 @@ func checkRuleHashesOfType(target *core.BuildTarget, hashes, outputs []string, h
 // In some cases it may have already run; if so we compare the previous output and warn
 // if the two differ (they must be deterministic to ensure it's a pure function, since there
 // are a few different paths through here and we guarantee to only run them once).
-func runPostBuildFunction(tid int, state *core.BuildState, target *core.BuildTarget, output, prevOutput string) error {
+func runPostBuildFunction(state *core.BuildState, target *core.BuildTarget, output, prevOutput string) error {
 	if prevOutput != "" {
 		if output != prevOutput {
 			log.Warning("The build output for %s differs from what we got back from the cache earlier.\n"+

--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -124,12 +124,12 @@ func (fake *fakeParser) ParseReader(pkg *core.Package, r io.ReadSeeker, label, d
 }
 
 // RunPreBuildFunction stub
-func (fake *fakeParser) RunPreBuildFunction(threadID int, state *core.BuildState, target *core.BuildTarget) error {
+func (fake *fakeParser) RunPreBuildFunction(state *core.BuildState, target *core.BuildTarget) error {
 	return nil
 }
 
 // RunPostBuildFunction stub
-func (fake *fakeParser) RunPostBuildFunction(threadID int, state *core.BuildState, target *core.BuildTarget, output string) error {
+func (fake *fakeParser) RunPostBuildFunction(state *core.BuildState, target *core.BuildTarget, output string) error {
 	if f, present := fake.PostBuildFunctions[target]; present {
 		return f(target, output)
 	}

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -631,12 +631,12 @@ func (fake *fakeParser) ParseReader(pkg *core.Package, r io.ReadSeeker, label, d
 }
 
 // RunPreBuildFunction stub
-func (fake *fakeParser) RunPreBuildFunction(threadID int, state *core.BuildState, target *core.BuildTarget) error {
+func (fake *fakeParser) RunPreBuildFunction(state *core.BuildState, target *core.BuildTarget) error {
 	return target.PreBuildFunction.Call(target)
 }
 
 // RunPostBuildFunction stub
-func (fake *fakeParser) RunPostBuildFunction(threadID int, state *core.BuildState, target *core.BuildTarget, output string) error {
+func (fake *fakeParser) RunPostBuildFunction(state *core.BuildState, target *core.BuildTarget, output string) error {
 	return target.PostBuildFunction.Call(target, output)
 }
 

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,7 +30,7 @@ var cache core.Cache
 func TestBuildTargetWithNoDeps(t *testing.T) {
 	state, target := newState("//package1:target1")
 	target.AddOutput("file1")
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 }
@@ -39,7 +38,7 @@ func TestBuildTargetWithNoDeps(t *testing.T) {
 func TestFailedBuildTarget(t *testing.T) {
 	state, target := newState("//package1:target1a")
 	target.Command = "false"
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	assert.Error(t, err)
 }
 
@@ -48,7 +47,7 @@ func TestBuildTargetWhichNeedsRebuilding(t *testing.T) {
 	// because there's no rule hash file.
 	state, target := newState("//package1:target2")
 	target.AddOutput("file2")
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 }
@@ -59,7 +58,7 @@ func TestBuildTargetWhichDoesntNeedRebuilding(t *testing.T) {
 	target.AddOutput("file3")
 	StoreTargetMetadata(target, new(core.BuildMetadata))
 	assert.NoError(t, writeRuleHash(state, target))
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Reused, target.State())
 }
@@ -72,7 +71,7 @@ func TestModifiedBuildTargetStillNeedsRebuilding(t *testing.T) {
 	assert.NoError(t, writeRuleHash(state, target))
 	target.Command = "echo -n 'wibble wibble wibble' > $OUT"
 	target.RuleHash = nil // Have to force a reset of this
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 }
@@ -83,7 +82,7 @@ func TestSymlinkedOutputs(t *testing.T) {
 	target.AddOutput("file5")
 	target.AddSource(core.FileLabel{File: "src5", Package: "package1"})
 	target.Command = "ln -s $SRC $OUT"
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 }
@@ -97,7 +96,7 @@ func TestPreBuildFunction(t *testing.T) {
 		target.Command = "echo 'wibble wibble wibble' > $OUT"
 		return nil
 	})
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 }
@@ -111,7 +110,7 @@ func TestPostBuildFunction(t *testing.T) {
 		assert.Equal(t, "wibble wibble wibble", output)
 		return nil
 	})
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 	assert.Equal(t, []string{"file7"}, target.Outputs())
@@ -129,7 +128,7 @@ func TestOutputDir(t *testing.T) {
 
 	state, target := newTarget()
 
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"file7"}, target.Outputs())
 
@@ -141,7 +140,7 @@ func TestOutputDir(t *testing.T) {
 
 	// Run again to load the outputs from the metadata
 	state, target = newTarget()
-	err = buildTarget(1, state, target, false)
+	err = buildTarget(state, target, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"file7"}, target.Outputs())
 	assert.Equal(t, core.Reused, target.State())
@@ -164,7 +163,7 @@ func TestOutputDirDoubleStar(t *testing.T) {
 
 	state, target := newTarget(false)
 
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"foo"}, target.Outputs())
 
@@ -180,7 +179,7 @@ func TestOutputDirDoubleStar(t *testing.T) {
 
 	state, target = newTarget(true)
 
-	err = buildTarget(1, state, target, false)
+	err = buildTarget(state, target, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"foo/file7"}, target.Outputs())
 
@@ -195,7 +194,7 @@ func TestCacheRetrieval(t *testing.T) {
 	target.AddOutput("file8")
 	target.Command = "false" // Will fail if we try to build it.
 	state.Cache = cache
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Cached, target.State())
 }
@@ -213,7 +212,7 @@ func TestPostBuildFunctionAndCache(t *testing.T) {
 		return nil
 	})
 	state.Cache = cache
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
 	assert.True(t, called)
@@ -233,7 +232,7 @@ func TestPostBuildFunctionAndCache2(t *testing.T) {
 		return nil
 	})
 	state.Cache = cache
-	err := buildTarget(1, state, target, false)
+	err := buildTarget(state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Cached, target.State())
 	assert.True(t, called)
@@ -276,7 +275,7 @@ func TestCreatePlzOutGo(t *testing.T) {
 	target.AddLabel("link:plz-out/go/${PKG}/src")
 	target.AddOutput("file1.go")
 	assert.False(t, fs.PathExists("plz-out/go"))
-	assert.NoError(t, buildTarget(1, state, target, false))
+	assert.NoError(t, buildTarget(state, target, false))
 	assert.True(t, fs.PathExists("plz-out/go/package1/src/file1.go"))
 }
 
@@ -435,7 +434,7 @@ func TestBuildMetadatafileIsCreated(t *testing.T) {
 
 	state, target := newState("//package1:mdtest")
 	target.AddOutput("file1")
-	err := buildTarget(rand.Int(), state, target, false)
+	err := buildTarget(state, target, false)
 	require.NoError(t, err)
 	assert.False(t, target.BuildCouldModifyTarget())
 	assert.True(t, fs.FileExists(filepath.Join(target.OutDir(), target.TargetBuildMetadataFileName())))
@@ -447,7 +446,7 @@ func TestBuildMetadatafileIsCreated(t *testing.T) {
 		assert.Equal(t, stdOut, output)
 		return nil
 	})
-	err = buildTarget(rand.Int(), state, target, false)
+	err = buildTarget(state, target, false)
 	require.NoError(t, err)
 	assert.True(t, target.BuildCouldModifyTarget())
 	assert.True(t, fs.FileExists(filepath.Join(target.OutDir(), target.TargetBuildMetadataFileName())))

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -510,7 +510,6 @@ func (state *BuildState) LogParseResult(label BuildLabel, status BuildResultStat
 		return // We don't notify anything else on these.
 	}
 	state.logResult(&BuildResult{
-		ThreadID:    tid,
 		Label:       label,
 		Status:      status,
 		Err:         nil,
@@ -521,7 +520,6 @@ func (state *BuildState) LogParseResult(label BuildLabel, status BuildResultStat
 // LogBuildResult logs the result of a target building.
 func (state *BuildState) LogBuildResult(target *BuildTarget, status BuildResultStatus, description string) {
 	state.logResult(&BuildResult{
-		ThreadID:    tid,
 		Label:       target.Label,
 		target:      target,
 		Status:      status,
@@ -547,7 +545,6 @@ func (state *BuildState) ArchSubrepoInitialised(subrepoLabel BuildLabel) {
 // LogTestResult logs the result of a target once its tests have completed.
 func (state *BuildState) LogTestResult(target *BuildTarget, status BuildResultStatus, results *TestSuite, coverage *TestCoverage, err error, format string, args ...interface{}) {
 	state.logResult(&BuildResult{
-		ThreadID:    tid,
 		Label:       target.Label,
 		target:      target,
 		Status:      status,
@@ -563,7 +560,6 @@ func (state *BuildState) LogTestResult(target *BuildTarget, status BuildResultSt
 // LogBuildError logs a failure for a target to parse, build or test.
 func (state *BuildState) LogBuildError(label BuildLabel, status BuildResultStatus, err error, format string, args ...interface{}) {
 	state.logResult(&BuildResult{
-		ThreadID:    tid,
 		Label:       label,
 		Status:      status,
 		Err:         err,
@@ -660,7 +656,7 @@ func (state *BuildState) WaitForPreloadedSubincludeTargetsAndEnsureDownloaded() 
 // checkForCycles is run to detect a cycle in the graph. It converts any returned error into an async error.
 func (state *BuildState) checkForCycles() {
 	if err := state.progress.cycleDetector.Check(); err != nil {
-		state.LogBuildError(0, err.Cycle[0].Label, TargetBuildFailed, err, "")
+		state.LogBuildError(err.Cycle[0].Label, TargetBuildFailed, err, "")
 		state.Stop()
 	}
 }
@@ -1148,7 +1144,7 @@ func (state *BuildState) queueTargetAsync(target *BuildTarget, forceBuild, build
 // asyncError reports an error that's happened in an asynchronous function.
 func (state *BuildState) asyncError(label BuildLabel, err error) {
 	log.Error("Error queuing %s: %s", label, err)
-	state.LogBuildError(0, label, TargetBuildFailed, err, "")
+	state.LogBuildError(label, TargetBuildFailed, err, "")
 	state.Stop()
 }
 
@@ -1398,8 +1394,6 @@ func NewDefaultBuildState() *BuildState {
 // A BuildResult represents a single event in the build process, i.e. a target starting or finishing
 // building, or reaching some milestone within those steps.
 type BuildResult struct {
-	// Thread id (or goroutine id, really) that generated this result.
-	ThreadID int
 	// Timestamp of this event
 	Time time.Time
 	// Target which has just changed

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1252,7 +1252,7 @@ func (state *BuildState) GetPreloadedSubincludes() []BuildLabel {
 // DownloadInputsIfNeeded downloads all the inputs (or runtime files) for a target if we are building remotely.
 func (state *BuildState) DownloadInputsIfNeeded(target *BuildTarget, runtime bool) error {
 	if state.RemoteClient != nil {
-		state.LogBuildResult(tid, target, TargetBuilding, "Downloading inputs...")
+		state.LogBuildResult(target, TargetBuilding, "Downloading inputs...")
 		for input := range state.IterInputs(target, runtime) {
 			if l, ok := input.Label(); ok {
 				dep := state.Graph.TargetOrDie(l)

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -69,9 +69,9 @@ type Parser interface {
 	// ParseReader parses a single BUILD file into the given package.
 	ParseReader(pkg *Package, reader io.ReadSeeker, forLabel, dependent *BuildLabel, forSubinclude bool) error
 	// RunPreBuildFunction runs a pre-build function for a target.
-	RunPreBuildFunction(threadID int, state *BuildState, target *BuildTarget) error
+	RunPreBuildFunction(state *BuildState, target *BuildTarget) error
 	// RunPostBuildFunction runs a post-build function for a target.
-	RunPostBuildFunction(threadID int, state *BuildState, target *BuildTarget, output string) error
+	RunPostBuildFunction(state *BuildState, target *BuildTarget, output string) error
 	// BuildRuleArgOrder returns a map of the arguments to build rule and the order they appear in the source file
 	BuildRuleArgOrder() map[string]int
 }

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -79,9 +79,9 @@ type Parser interface {
 // A RemoteClient is the interface to a remote execution service.
 type RemoteClient interface {
 	// Build invokes a build of the target remotely.
-	Build(tid int, target *BuildTarget) (*BuildMetadata, error)
+	Build(target *BuildTarget) (*BuildMetadata, error)
 	// Test invokes a test run of the target remotely.
-	Test(tid int, target *BuildTarget, run int) (metadata *BuildMetadata, err error)
+	Test(target *BuildTarget, run int) (metadata *BuildMetadata, err error)
 	// Run executes the target remotely.
 	Run(target *BuildTarget) error
 	// Download downloads the outputs for the given target that has already been built remotely.
@@ -497,7 +497,7 @@ func (state *BuildState) OutputHashCheckers() []*fs.PathHasher {
 }
 
 // LogParseResult logs the result of a target parsing.
-func (state *BuildState) LogParseResult(tid int, label BuildLabel, status BuildResultStatus, description string) {
+func (state *BuildState) LogParseResult(label BuildLabel, status BuildResultStatus, description string) {
 	if status == PackageParsed {
 		// We may have parse tasks waiting for this package to exist, check for them.
 		key := packageKey{Name: label.PackageName, Subrepo: label.Subrepo}
@@ -519,7 +519,7 @@ func (state *BuildState) LogParseResult(tid int, label BuildLabel, status BuildR
 }
 
 // LogBuildResult logs the result of a target building.
-func (state *BuildState) LogBuildResult(tid int, target *BuildTarget, status BuildResultStatus, description string) {
+func (state *BuildState) LogBuildResult(target *BuildTarget, status BuildResultStatus, description string) {
 	state.logResult(&BuildResult{
 		ThreadID:    tid,
 		Label:       target.Label,
@@ -545,7 +545,7 @@ func (state *BuildState) ArchSubrepoInitialised(subrepoLabel BuildLabel) {
 }
 
 // LogTestResult logs the result of a target once its tests have completed.
-func (state *BuildState) LogTestResult(tid int, target *BuildTarget, status BuildResultStatus, results *TestSuite, coverage *TestCoverage, err error, format string, args ...interface{}) {
+func (state *BuildState) LogTestResult(target *BuildTarget, status BuildResultStatus, results *TestSuite, coverage *TestCoverage, err error, format string, args ...interface{}) {
 	state.logResult(&BuildResult{
 		ThreadID:    tid,
 		Label:       target.Label,
@@ -561,7 +561,7 @@ func (state *BuildState) LogTestResult(tid int, target *BuildTarget, status Buil
 }
 
 // LogBuildError logs a failure for a target to parse, build or test.
-func (state *BuildState) LogBuildError(tid int, label BuildLabel, status BuildResultStatus, err error, format string, args ...interface{}) {
+func (state *BuildState) LogBuildError(label BuildLabel, status BuildResultStatus, err error, format string, args ...interface{}) {
 	state.logResult(&BuildResult{
 		ThreadID:    tid,
 		Label:       label,
@@ -1250,7 +1250,7 @@ func (state *BuildState) GetPreloadedSubincludes() []BuildLabel {
 }
 
 // DownloadInputsIfNeeded downloads all the inputs (or runtime files) for a target if we are building remotely.
-func (state *BuildState) DownloadInputsIfNeeded(tid int, target *BuildTarget, runtime bool) error {
+func (state *BuildState) DownloadInputsIfNeeded(target *BuildTarget, runtime bool) error {
 	if state.RemoteClient != nil {
 		state.LogBuildResult(tid, target, TargetBuilding, "Downloading inputs...")
 		for input := range state.IterInputs(target, runtime) {

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -109,7 +109,7 @@ func TestAddTargetFilegroupPackageOutputs(t *testing.T) {
 
 func TestAddDepsToTarget(t *testing.T) {
 	state := NewDefaultBuildState()
-	_, builds, _ := state.TaskQueues()
+	_, builds := state.TaskQueues()
 	pkg := NewPackage("src/core")
 	target1 := addTargetDeps(state, pkg, "//src/core:target1", "//src/core:target2")
 	target2 := addTargetDeps(state, pkg, "//src/core:target2")

--- a/src/exec/exec_test.go
+++ b/src/exec/exec_test.go
@@ -34,7 +34,7 @@ func TestPrepareRuntimeDir(t *testing.T) {
 	if err := build.StoreTargetMetadata(target, &core.BuildMetadata{}); err != nil {
 		panic(err)
 	}
-	build.Build(0, state, target.Label, false)
+	build.Build(state, target.Label, false)
 
 	err := core.PrepareRuntimeDir(state, target, "plz-out/exec/pkg")
 	assert.Nil(t, err)

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -53,8 +53,8 @@ loop:
 			if !ok || (state.DebugFailingTests && result.Status == core.TargetTesting) {
 				break loop
 			}
-			if prev, threadID := bt.ProcessResult(result); tw != nil && !result.Status.IsParse() {
-				tw.AddTrace(threadID, result, prev, result.Status.IsActive())
+			if threadID := bt.ProcessResult(result); tw != nil && !result.Status.IsParse() {
+				tw.AddTrace(threadID, result, result.Status.IsActive())
 			}
 			if streamTestResults && (result.Status == core.TargetTested || result.Status == core.TargetTestFailed) {
 				os.Stdout.Write(test.SerialiseResultsToXML(state.Graph.TargetOrDie(result.Label), false, state.Config.Test.StoreTestOutputOnSuccess))

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -53,9 +53,8 @@ loop:
 			if !ok || (state.DebugFailingTests && result.Status == core.TargetTesting) {
 				break loop
 			}
-			prev := bt.ProcessResult(result)
-			if tw != nil && !result.Status.IsParse() {
-				tw.AddTrace(result, prev, result.Status.IsActive())
+			if prev, threadID := bt.ProcessResult(result); tw != nil && !result.Status.IsParse() {
+				tw.AddTrace(threadID, result, prev, result.Status.IsActive())
 			}
 			if streamTestResults && (result.Status == core.TargetTested || result.Status == core.TargetTestFailed) {
 				os.Stdout.Write(test.SerialiseResultsToXML(state.Graph.TargetOrDie(result.Label), false, state.Config.Test.StoreTestOutputOnSuccess))

--- a/src/output/targets.go
+++ b/src/output/targets.go
@@ -57,8 +57,8 @@ func (bt *buildingTargets) Targets() (local []buildingTarget, remote []buildingT
 }
 
 // ProcessResult updates with a single result.
-// It returns the label that was in this slot previously.
-func (bt *buildingTargets) ProcessResult(result *core.BuildResult) core.BuildLabel {
+// It returns the label that was in this slot previously and a 'thread id' for it (which is relevant for trace output)
+func (bt *buildingTargets) ProcessResult(result *core.BuildResult) (core.BuildLabel, int) {
 	label := result.Label
 	idx := bt.index(label)
 	prev := bt.targets[idx].Label
@@ -93,7 +93,7 @@ func (bt *buildingTargets) ProcessResult(result *core.BuildResult) core.BuildLab
 			}
 		}
 	}
-	return prev
+	return prev, idx
 }
 
 // index returns the index to use for a result

--- a/src/output/targets.go
+++ b/src/output/targets.go
@@ -59,18 +59,17 @@ func (bt *buildingTargets) Targets() []buildingTarget {
 }
 
 // ProcessResult updates with a single result.
-// It returns the label that was in this slot previously and a 'thread id' for it (which is relevant for trace output)
-func (bt *buildingTargets) ProcessResult(result *core.BuildResult) (core.BuildLabel, int) {
+// It returns a 'thread id' for it (which is relevant for trace output)
+func (bt *buildingTargets) ProcessResult(result *core.BuildResult) int {
 	defer bt.handleOutput(result)
-	if result.Status.IsParse() { // Parse tasks aren't displayed here
-		return core.BuildLabel{}, 0
+	if result.Status.IsParse() { // Parse tasks don't take a slot here
+		return 0
 	}
 	idx := bt.index(result.Label)
-	prev := bt.targets[idx].Label
 	if t := bt.state.Graph.Target(result.Label); t != nil {
 		bt.updateTarget(idx, result, t)
 	}
-	return prev, idx
+	return idx
 }
 
 func (bt *buildingTargets) handleOutput(result *core.BuildResult) {

--- a/src/output/trace.go
+++ b/src/output/trace.go
@@ -51,19 +51,19 @@ func (tw *traceWriter) Close() error {
 }
 
 // AddTrace adds a single trace to this writer.
-func (tw *traceWriter) AddTrace(result *core.BuildResult, previous core.BuildLabel, active bool) {
+func (tw *traceWriter) AddTrace(threadID int, result *core.BuildResult, previous core.BuildLabel, active bool) {
 	// It's a bit fiddly to keep all the phases in line here.
 	if !active {
-		tw.writeEvent(result, "E")
+		tw.writeEvent(threadID, result, "E")
 	} else if result.Label != previous {
-		tw.writeEvent(result, "B")
+		tw.writeEvent(threadID, result, "B")
 	} else {
-		tw.writeEvent(result, "E")
-		tw.writeEvent(result, "B")
+		tw.writeEvent(threadID, result, "E")
+		tw.writeEvent(threadID, result, "B")
 	}
 }
 
-func (tw *traceWriter) writeEvent(result *core.BuildResult, phase string) {
+func (tw *traceWriter) writeEvent(threadID int, result *core.BuildResult, phase string) {
 	if !tw.first {
 		tw.first = true
 	} else {
@@ -77,7 +77,7 @@ func (tw *traceWriter) writeEvent(result *core.BuildResult, phase string) {
 		Ts:    result.Time.UnixNano() / 1000,
 		Cname: "thread_state_runnable", // Colours have to fit available names, this is blueish.
 	}
-	entry.Tid = fmt.Sprintf("Builder %d", result.ThreadID)
+	entry.Tid = fmt.Sprintf("Builder %d", threadID)
 	entry.Args.Description = result.Description
 	if result.Err != nil {
 		entry.Args.Err = fmt.Sprintf("%s", result.Err)

--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -64,14 +64,14 @@ func (p *aspParser) ParseReader(pkg *core.Package, reader io.ReadSeeker, forLabe
 	return err
 }
 
-func (p *aspParser) RunPreBuildFunction(threadID int, state *core.BuildState, target *core.BuildTarget) error {
-	return p.runBuildFunction(threadID, state, target, "pre", func() error {
+func (p *aspParser) RunPreBuildFunction(state *core.BuildState, target *core.BuildTarget) error {
+	return p.runBuildFunction(state, target, "pre", func() error {
 		return target.PreBuildFunction.Call(target)
 	})
 }
 
-func (p *aspParser) RunPostBuildFunction(threadID int, state *core.BuildState, target *core.BuildTarget, output string) error {
-	return p.runBuildFunction(threadID, state, target, "post", func() error {
+func (p *aspParser) RunPostBuildFunction(state *core.BuildState, target *core.BuildTarget, output string) error {
+	return p.runBuildFunction(state, target, "post", func() error {
 		log.Debug("Running post-build function for %s. Build output:\n%s", target.Label, output)
 		return target.PostBuildFunction.Call(target, output)
 	})

--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -84,13 +84,13 @@ func (p *aspParser) BuildRuleArgOrder() map[string]int {
 
 // runBuildFunction runs either the pre- or post-build function.
 func (p *aspParser) runBuildFunction(state *core.BuildState, target *core.BuildTarget, callbackType string, f func() error) error {
-	state.LogBuildResult(tid, target, core.PackageParsing, fmt.Sprintf("Running %s-build function for %s", callbackType, target.Label))
+	state.LogBuildResult(target, core.PackageParsing, fmt.Sprintf("Running %s-build function for %s", callbackType, target.Label))
 	state.SyncParsePackage(target.Label)
 	if err := f(); err != nil {
-		state.LogBuildError(tid, target.Label, core.ParseFailed, err, "Failed %s-build function for %s", callbackType, target.Label)
+		state.LogBuildError(target.Label, core.ParseFailed, err, "Failed %s-build function for %s", callbackType, target.Label)
 		return err
 	}
-	state.LogBuildResult(tid, target, core.TargetBuilding, fmt.Sprintf("Finished %s-build function for %s", callbackType, target.Label))
+	state.LogBuildResult(target, core.TargetBuilding, fmt.Sprintf("Finished %s-build function for %s", callbackType, target.Label))
 	return nil
 }
 

--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -83,7 +83,7 @@ func (p *aspParser) BuildRuleArgOrder() map[string]int {
 }
 
 // runBuildFunction runs either the pre- or post-build function.
-func (p *aspParser) runBuildFunction(tid int, state *core.BuildState, target *core.BuildTarget, callbackType string, f func() error) error {
+func (p *aspParser) runBuildFunction(state *core.BuildState, target *core.BuildTarget, callbackType string, f func() error) error {
 	state.LogBuildResult(tid, target, core.PackageParsing, fmt.Sprintf("Running %s-build function for %s", callbackType, target.Label))
 	state.SyncParsePackage(target.Label)
 	if err := f(); err != nil {

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -27,13 +27,13 @@ var log = logging.Log
 // targets with at least one matching label are added. Any targets with a label in 'exclude' are not added.
 // 'forSubinclude' is set when the parse is required for a subinclude target so should proceed
 // even when we're not otherwise building targets.
-func Parse(tid int, state *core.BuildState, label, dependent core.BuildLabel, forSubinclude bool) {
+func Parse(state *core.BuildState, label, dependent core.BuildLabel, forSubinclude bool) {
 	if err := parse(tid, state, label, dependent, forSubinclude); err != nil {
 		state.LogBuildError(tid, label, core.ParseFailed, err, "Failed to parse package")
 	}
 }
 
-func parse(tid int, state *core.BuildState, label, dependent core.BuildLabel, forSubinclude bool) error {
+func parse(state *core.BuildState, label, dependent core.BuildLabel, forSubinclude bool) error {
 	subrepo, err := checkSubrepo(tid, state, label, dependent, forSubinclude)
 	if err != nil {
 		return err
@@ -82,7 +82,7 @@ func parse(tid int, state *core.BuildState, label, dependent core.BuildLabel, fo
 }
 
 // checkSubrepo checks whether this guy exists within a subrepo. If so we will need to make sure that's available first.
-func checkSubrepo(tid int, state *core.BuildState, label, dependent core.BuildLabel, forSubinclude bool) (*core.Subrepo, error) {
+func checkSubrepo(state *core.BuildState, label, dependent core.BuildLabel, forSubinclude bool) (*core.Subrepo, error) {
 	if label.Subrepo == "" {
 		return nil, nil
 	} else if subrepo := state.Graph.Subrepo(label.Subrepo); subrepo != nil {
@@ -117,7 +117,7 @@ func checkSubrepo(tid int, state *core.BuildState, label, dependent core.BuildLa
 }
 
 // parseSubrepoPackage parses a package to make sure subrepos are available.
-func parseSubrepoPackage(tid int, state *core.BuildState, pkg, subrepo string, dependent core.BuildLabel) (*core.Subrepo, error) {
+func parseSubrepoPackage(state *core.BuildState, pkg, subrepo string, dependent core.BuildLabel) (*core.Subrepo, error) {
 	if state.Graph.Package(pkg, subrepo) == nil {
 		// Don't have it already, must parse.
 		label := core.BuildLabel{Subrepo: subrepo, PackageName: pkg, Name: "all"}

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -139,7 +139,7 @@ func assertPendingBuilds(t *testing.T, state *core.BuildState, targets ...string
 }
 
 func getAllPending(state *core.BuildState) ([]string, []string) {
-	parses, builds, _ := state.TaskQueues()
+	parses, builds := state.TaskQueues()
 	state.Stop()
 	var pendingParses, pendingBuilds []string
 	for parses != nil || builds != nil {

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -86,7 +86,7 @@ func RunHost(targets []core.BuildLabel, state *core.BuildState) {
 	Run(targets, nil, state, state.Config, cli.HostArch())
 }
 
-func doTasks(tid int, state *core.BuildState, actions <-chan core.Task, remote bool) {
+func doTasks(state *core.BuildState, actions <-chan core.Task, remote bool) {
 	for task := range actions {
 		switch task.Type {
 		case core.TestTask:

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -49,7 +49,7 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, config *
 		// They manage concurrency control themselves.
 		for task := range parses {
 			go func(task core.ParseTask) {
-				parse.Parse(0, state, task.Label, task.Dependent, task.ForSubinclude)
+				parse.Parse(state, task.Label, task.Dependent, task.ForSubinclude)
 				state.TaskDone()
 			}(task)
 		}
@@ -103,7 +103,7 @@ func findOriginalTasks(state *core.BuildState, preTargets, targets []core.BuildL
 	if state.Config.Bazel.Compatibility && fs.FileExists("WORKSPACE") {
 		// We have to parse the WORKSPACE file before anything else to understand subrepos.
 		// This is a bit crap really since it inhibits parallelism for the first step.
-		parse.Parse(0, state, core.NewBuildLabel("workspace", "all"), core.OriginalTarget, false)
+		parse.Parse(state, core.NewBuildLabel("workspace", "all"), core.OriginalTarget, false)
 	}
 	if arch.Arch != "" && arch != cli.HostArch() {
 		// Set up a new subrepo for this architecture.

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -57,13 +57,13 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, config *
 	}()
 	for i := 0; i < config.Please.NumThreads; i++ {
 		go func(tid int) {
-			doTasks(tid, state, actions, false)
+			doTasks(state, actions, false)
 			wg.Done()
 		}(i)
 	}
 	for i := 0; i < config.NumRemoteExecutors(); i++ {
 		go func(tid int) {
-			doTasks(tid, state, remoteActions, true)
+			doTasks(state, remoteActions, true)
 			wg.Done()
 		}(config.Please.NumThreads + i)
 	}
@@ -90,9 +90,9 @@ func doTasks(state *core.BuildState, actions <-chan core.Task, remote bool) {
 	for task := range actions {
 		switch task.Type {
 		case core.TestTask:
-			test.Test(tid, state, task.Label, remote, int(task.Run))
+			test.Test(state, task.Label, remote, int(task.Run))
 		case core.BuildTask:
-			build.Build(tid, state, task.Label, remote)
+			build.Build(state, task.Label, remote)
 		}
 		state.TaskDone()
 	}

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -386,7 +386,7 @@ func (c *Client) Run(target *core.BuildTarget) error {
 		return err
 	}
 	// 24 hours is kind of an arbitrarily long timeout. Basically we just don't want to limit it here.
-	_, _, err = c.execute(0, target, cmd, digest, false, false)
+	_, _, err = c.execute(target, cmd, digest, false, false)
 	return err
 }
 

--- a/src/remote/remote_test.go
+++ b/src/remote/remote_test.go
@@ -55,7 +55,7 @@ func TestExecuteBuild(t *testing.T) {
 	// on success).
 	target.PostBuildFunction = testFunction{}
 	target.Command = "echo hello && echo test > $OUT"
-	metadata, err := c.Build(0, target)
+	metadata, err := c.Build(target)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("hello\n"), metadata.Stdout)
 }
@@ -81,7 +81,7 @@ func TestExecutePostBuildFunction(t *testing.T) {
 		assert.Equal(t, "wibble wibble wibble", output)
 		return nil
 	})
-	_, err := c.Build(0, target)
+	_, err := c.Build(target)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"somefile"}, target.Outputs())
 }
@@ -94,7 +94,7 @@ func TestExecuteFetch(t *testing.T) {
 	target.AddOutput("please_14.2.0.tar.gz")
 	target.Hashes = []string{"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"}
 	target.BuildTimeout = time.Minute
-	_, err := c.Build(0, target)
+	_, err := c.Build(target)
 	assert.NoError(t, err)
 }
 
@@ -110,7 +110,7 @@ func TestExecuteTest(t *testing.T) {
 	err := c.Store(target)
 	assert.NoError(t, err)
 	c.state.Graph.AddTarget(target)
-	_, err = c.Test(0, target, 1)
+	_, err = c.Test(target, 1)
 	assert.NoError(t, err)
 
 	results, err := os.ReadFile(filepath.Join(target.TestDir(1), core.TestResultsFile))
@@ -132,7 +132,7 @@ func TestExecuteTestWithCoverage(t *testing.T) {
 	assert.NoError(t, err)
 	target.SetState(core.Built)
 	c.state.Graph.AddTarget(target)
-	_, err = c.Test(0, target, 1)
+	_, err = c.Test(target, 1)
 	assert.NoError(t, err)
 
 	results, err := os.ReadFile(filepath.Join(target.TestDir(1), core.TestResultsFile))
@@ -263,7 +263,7 @@ func TestOutDirsSetOutsOnTarget(t *testing.T) {
 	// Doesn't actually get executed but gives an idea as to how this rule is mocked up
 	outDirTarget.Command = "touch foo/bar.txt && touch foo/baz.txt"
 	c.state.Graph.AddTarget(outDirTarget)
-	_, err := c.Build(0, outDirTarget)
+	_, err := c.Build(outDirTarget)
 	require.NoError(t, err)
 
 	assert.Len(t, outDirTarget.Outputs(), 2)

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -52,16 +52,16 @@ func Test(state *core.BuildState, label core.BuildLabel, remote bool, run int) {
 		}
 	}()
 
-	state.LogBuildResult(tid, target, core.TargetTesting, "Testing...")
-	test(tid, state.ForTarget(target), label, target, remote, run)
+	state.LogBuildResult(target, core.TargetTesting, "Testing...")
+	test(state.ForTarget(target), label, target, remote, run)
 }
 
 func test(state *core.BuildState, label core.BuildLabel, target *core.BuildTarget, runRemotely bool, run int) {
 	target.StartTestSuite()
 
-	hash, err := runtimeHash(tid, state, target, runRemotely, run)
+	hash, err := runtimeHash(state, target, runRemotely, run)
 	if err != nil {
-		state.LogBuildError(tid, label, core.TargetTestFailed, err, "Failed to calculate target hash")
+		state.LogBuildError(label, core.TargetTestFailed, err, "Failed to calculate target hash")
 		return
 	}
 
@@ -71,16 +71,16 @@ func test(state *core.BuildState, label core.BuildLabel, target *core.BuildTarge
 
 	// If the user passed --shell then just prepare the directory.
 	if state.PrepareOnly {
-		if err := state.DownloadInputsIfNeeded(tid, target, true); err != nil {
-			state.LogBuildError(tid, label, core.TargetTestFailed, err, "Failed to download test inputs")
+		if err := state.DownloadInputsIfNeeded(target, true); err != nil {
+			state.LogBuildError(label, core.TargetTestFailed, err, "Failed to download test inputs")
 			return
 		}
 		if err := core.PrepareRuntimeDir(state, target, target.TestDir(run)); err != nil {
-			state.LogBuildError(tid, label, core.TargetTestFailed, err, "Failed to prepare test directory")
+			state.LogBuildError(label, core.TargetTestFailed, err, "Failed to prepare test directory")
 			return
 		}
 		target.SetState(core.Stopped)
-		state.LogBuildResult(tid, target, core.TargetTestStopped, "Test stopped")
+		state.LogBuildResult(target, core.TargetTestStopped, "Test stopped")
 		return
 	}
 
@@ -100,7 +100,7 @@ func test(state *core.BuildState, label core.BuildLabel, target *core.BuildTarge
 			state.Cache.Clean(target)
 			return nil
 		} else {
-			logTestSuccess(state, tid, target, &results, coverage)
+			logTestSuccess(state, target, &results, coverage)
 		}
 		return &results
 	}
@@ -118,13 +118,13 @@ func test(state *core.BuildState, label core.BuildLabel, target *core.BuildTarge
 		}
 		outs := []string{filepath.Base(target.TestResultsFile())}
 		if err := moveOutputFile(state, hash, outputFile, target.TestResultsFile(), dummyOutput); err != nil {
-			state.LogTestResult(tid, target, core.TargetTestFailed, results, coverage, err, "Failed to move test output file")
+			state.LogTestResult(target, core.TargetTestFailed, results, coverage, err, "Failed to move test output file")
 			return false
 		}
 
 		if needCoverage || core.PathExists(coverageFile) {
 			if err := moveOutputFile(state, hash, coverageFile, target.CoverageFile(), dummyCoverage); err != nil {
-				state.LogTestResult(tid, target, core.TargetTestFailed, results, coverage, err, "Failed to move test coverage file")
+				state.LogTestResult(target, core.TargetTestFailed, results, coverage, err, "Failed to move test coverage file")
 				return false
 			}
 			outs = append(outs, filepath.Base(target.CoverageFile()))
@@ -133,7 +133,7 @@ func test(state *core.BuildState, label core.BuildLabel, target *core.BuildTarge
 			tmpFile := filepath.Join(target.TestDir(run), output)
 			outFile := filepath.Join(target.OutDir(), output)
 			if err := moveOutputFile(state, hash, tmpFile, outFile, ""); err != nil {
-				state.LogTestResult(tid, target, core.TargetTestFailed, results, coverage, err, "Failed to move test output file")
+				state.LogTestResult(target, core.TargetTestFailed, results, coverage, err, "Failed to move test output file")
 				return false
 			}
 			outs = append(outs, output)
@@ -171,10 +171,10 @@ func test(state *core.BuildState, label core.BuildLabel, target *core.BuildTarge
 	}
 
 	// Wait if another process is currently testing this target
-	state.LogBuildResult(tid, target, core.TargetTesting, "Acquiring target lock...")
+	state.LogBuildResult(target, core.TargetTesting, "Acquiring target lock...")
 	file := core.AcquireExclusiveFileLock(target.TestLockFile(run))
 	defer core.ReleaseFileLock(file)
-	state.LogBuildResult(tid, target, core.TargetTesting, "Testing...")
+	state.LogBuildResult(target, core.TargetTesting, "Testing...")
 
 	// Don't cache when doing multiple runs, presumably the user explicitly wants to check it.
 	if state.NumTestRuns == 1 && !runRemotely && !needToRun() {
@@ -186,18 +186,18 @@ func test(state *core.BuildState, label core.BuildLabel, target *core.BuildTarge
 
 	// Remove any cached test result file.
 	if err := RemoveTestOutputs(target); err != nil {
-		state.LogBuildError(tid, label, core.TargetTestFailed, err, "Failed to remove test output files")
+		state.LogBuildError(label, core.TargetTestFailed, err, "Failed to remove test output files")
 		return
 	}
-	if err := verifyWorkerNotNeeded(tid, state, target); err != nil {
-		state.LogBuildError(tid, label, core.TargetTestFailed, err, "Failed to verify worker not needed")
+	if err := verifyWorkerNotNeeded(state, target); err != nil {
+		state.LogBuildError(label, core.TargetTestFailed, err, "Failed to verify worker not needed")
 		return
 	}
 
 	coverage := &core.TestCoverage{}
 	if state.NumTestRuns == 1 {
 		var results core.TestSuite
-		results, coverage = doFlakeRun(tid, state, target, runRemotely)
+		results, coverage = doFlakeRun(state, target, runRemotely)
 		target.AddTestResults(results)
 
 		if target.Test.Results.TestCases.AllSucceeded() {
@@ -206,19 +206,19 @@ func test(state *core.BuildState, label core.BuildLabel, target *core.BuildTarge
 		}
 	} else if state.TestSequentially {
 		for run := 1; run <= int(state.NumTestRuns); run++ {
-			state.LogBuildResult(tid, target, core.TargetTesting, getRunStatus(run, int(state.NumTestRuns)))
+			state.LogBuildResult(target, core.TargetTesting, getRunStatus(run, int(state.NumTestRuns)))
 			var results core.TestSuite
-			results, coverage = doTest(tid, state, target, runRemotely, 1) // Sequential tests re-use run 1's test dir
+			results, coverage = doTest(state, target, runRemotely, 1) // Sequential tests re-use run 1's test dir
 			target.AddTestResults(results)
 		}
 	} else {
-		state.LogBuildResult(tid, target, core.TargetTesting, getRunStatus(run, int(state.NumTestRuns)))
+		state.LogBuildResult(target, core.TargetTesting, getRunStatus(run, int(state.NumTestRuns)))
 		var results core.TestSuite
-		results, coverage = doTest(tid, state, target, runRemotely, run)
+		results, coverage = doTest(state, target, runRemotely, run)
 		target.AddTestResults(results)
 	}
 
-	logTargetResults(tid, state, target, coverage, run)
+	logTargetResults(state, target, coverage, run)
 }
 
 func retrieveFromCache(state *core.BuildState, target *core.BuildTarget, hash []byte, files []string) bool {
@@ -248,9 +248,9 @@ func doFlakeRun(state *core.BuildState, target *core.BuildTarget, runRemotely bo
 
 	// New group of test cases for each group of flaky runs
 	for flakes := 1; flakes <= int(target.Test.Flakiness); flakes++ {
-		state.LogBuildResult(tid, target, core.TargetTesting, getFlakeStatus(flakes, int(target.Test.Flakiness)))
+		state.LogBuildResult(target, core.TargetTesting, getFlakeStatus(flakes, int(target.Test.Flakiness)))
 
-		testSuite, cov := doTest(tid, state, target, runRemotely, 1) // If we're running flakes, numRuns must be 1
+		testSuite, cov := doTest(state, target, runRemotely, 1) // If we're running flakes, numRuns must be 1
 
 		results.TimedOut = results.TimedOut || testSuite.TimedOut
 		results.Properties = testSuite.Properties
@@ -292,7 +292,7 @@ func logTargetResults(state *core.BuildState, target *core.BuildTarget, coverage
 				log.Warning("Failed to remove test directory for %s: %s", target.Label, err)
 			}
 		}
-		logTestSuccess(state, tid, target, target.Test.Results, coverage)
+		logTestSuccess(state, target, target.Test.Results, coverage)
 		return
 	}
 	var resultErr error
@@ -315,7 +315,7 @@ func logTargetResults(state *core.BuildState, target *core.BuildTarget, coverage
 		resultErr = fmt.Errorf("unknown error")
 		resultMsg = "Something went wrong"
 	}
-	state.LogTestResult(tid, target, core.TargetTestFailed, target.Test.Results, coverage, resultErr, resultMsg)
+	state.LogTestResult(target, core.TargetTestFailed, target.Test.Results, coverage, resultErr, resultMsg)
 }
 
 func logTestSuccess(state *core.BuildState, target *core.BuildTarget, results *core.TestSuite, coverage *core.TestCoverage) {
@@ -327,7 +327,7 @@ func logTestSuccess(state *core.BuildState, target *core.BuildTarget, results *c
 	} else {
 		description = fmt.Sprintf("%d %s passed.", len(results.TestCases), tests)
 	}
-	state.LogTestResult(tid, target, core.TargetTested, results, coverage, nil, description)
+	state.LogTestResult(target, core.TargetTested, results, coverage, nil, description)
 }
 
 func pluralise(word string, quantity int) string {
@@ -359,7 +359,7 @@ func runTest(state *core.BuildState, target *core.BuildTarget, run int) ([]byte,
 
 func doTest(state *core.BuildState, target *core.BuildTarget, runRemotely bool, run int) (core.TestSuite, *core.TestCoverage) {
 	startTime := time.Now()
-	metadata, resultsData, coverage, err := doTestResults(tid, state, target, runRemotely, run)
+	metadata, resultsData, coverage, err := doTestResults(state, target, runRemotely, run)
 	duration := time.Since(startTime)
 	parsedSuite := parseTestOutput(string(metadata.Stdout), string(metadata.Stderr), err, duration, target, resultsData)
 	return core.TestSuite{
@@ -378,13 +378,13 @@ func doTestResults(state *core.BuildState, target *core.BuildTarget, runRemotely
 	var metadata *core.BuildMetadata
 
 	if runRemotely {
-		metadata, err = state.RemoteClient.Test(tid, target, run)
+		metadata, err = state.RemoteClient.Test(target, run)
 		if metadata == nil {
 			metadata = new(core.BuildMetadata)
 		}
 	} else {
 		var stdout []byte
-		stdout, err = prepareAndRunTest(tid, state, target, run)
+		stdout, err = prepareAndRunTest(state, target, run)
 		metadata = &core.BuildMetadata{Stdout: stdout}
 	}
 
@@ -409,7 +409,7 @@ func doTestResults(state *core.BuildState, target *core.BuildTarget, runRemotely
 // prepareAndRunTest sets up a test directory and runs the test.
 func prepareAndRunTest(state *core.BuildState, target *core.BuildTarget, run int) (stdout []byte, err error) {
 	if err = core.PrepareRuntimeDir(state, target, target.TestDir(run)); err != nil {
-		state.LogBuildError(tid, target.Label, core.TargetTestFailed, err, "Failed to prepare test directory for %s: %s", target.Label, err)
+		state.LogBuildError(target.Label, core.TargetTestFailed, err, "Failed to prepare test directory for %s: %s", target.Label, err)
 		return []byte{}, err
 	}
 	return runTest(state, target, run)
@@ -568,7 +568,7 @@ func runtimeHash(state *core.BuildState, target *core.BuildTarget, runRemotely b
 	}
 	if target.Local {
 		// If the test is marked to run locally, download the inputs as we need these to calculate the runtime hash.
-		if err := state.DownloadInputsIfNeeded(tid, target, true); err != nil {
+		if err := state.DownloadInputsIfNeeded(target, true); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
This removes the 'thread id' concept everywhere, which is only actually relevant in the output package. We now start a goroutine for every incoming task & just limit them to a certain number processing at a time. That _might_ alter latency a bit (because there are lots more goroutines, most of which are blocking and 'ready to go' as soon as the previous one finishes) but I doubt it's measurable.
The remote and local task queues are unified into one, as is the output which now scales up & down more like the remote one did, which is probably the most externally visible change here.

Most of the files touched are a mechanical removal of the `tid` argument. The interesting bits are in the `plz` and `output` packages - particularly the latter has to do more bookkeeping to assign tasks into slots (which is a little subtle to make it 'feel nice').

I think this is quite a bit nicer. I've wanted to get rid of this concept for a while now but hadn't really gotten motivated until our conversation the other day.