### PR TITLE
Put targets on tasks instead of labels

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -55,8 +55,7 @@ var successfulLocalTargetBuildDuration = metrics.NewHistogram(
 )
 
 // Build implements the core logic for building a single target.
-func Build(state *core.BuildState, label core.BuildLabel, remote bool) {
-	target := state.Graph.TargetOrDie(label)
+func Build(state *core.BuildState, target *core.BuildTarget, remote bool) {
 	state = state.ForTarget(target)
 	target.SetState(core.Building)
 	start := time.Now()
@@ -66,7 +65,7 @@ func Build(state *core.BuildState, label core.BuildLabel, remote bool) {
 			state.LogBuildResult(target, core.TargetBuildStopped, "Build stopped")
 			return
 		}
-		state.LogBuildError(label, core.TargetBuildFailed, err, "Build failed: %s", err)
+		state.LogBuildError(target.Label, core.TargetBuildFailed, err, "Build failed: %s", err)
 		if err := RemoveOutputs(target); err != nil {
 			log.Errorf("Failed to remove outputs for %s: %s", target.Label, err)
 		}

--- a/src/cli/logging.go
+++ b/src/cli/logging.go
@@ -127,6 +127,7 @@ type LogBackend struct {
 	rows, cols, maxRecords, interactiveRows, maxInteractiveRows, maxLines int
 	messageCount                                                          int
 	passthrough                                                           bool
+	lineWrapRe                                                            *regexp.Regexp
 }
 
 // Log implements the logging.Backend interface.
@@ -227,6 +228,7 @@ func (backend *LogBackend) recalcWindowSize() {
 	backend.rows = rows - 4 // Give a little space at the edge for any off-by-ones
 	backend.cols = cols
 	backend.RecalcLines()
+	backend.lineWrapRe = regexp.MustCompilePOSIX(fmt.Sprintf(".{%d,%d}(\\x1b[^m]+m)?", cols/2, cols))
 }
 
 // MaxDimensions returns the maximum number of rows / columns available in the display.
@@ -249,7 +251,7 @@ func (backend *LogBackend) lineWrap(msg string) []string {
 	wrappedLines := make([]string, 0, len(lines))
 	for _, line := range lines {
 		for i := 0; i < len(line); {
-			split := i + findSplit(line[i:], backend.cols)
+			split := i + backend.findSplit(line[i:], backend.cols)
 			wrappedLines = append(wrappedLines, line[i:split])
 			i = split
 		}
@@ -273,12 +275,11 @@ func reverse(s []string) []string {
 
 // Tries to find an appropriate point to word wrap line, taking shell escape codes into account.
 // (Note that because the escape codes are not visible, we can run past the max length for one of them)
-func findSplit(line string, guess int) int {
+func (backend *LogBackend) findSplit(line string, guess int) int {
 	if guess >= len(line) {
 		return len(line)
 	}
-	r := regexp.MustCompilePOSIX(fmt.Sprintf(".{%d,%d}(\\x1b[^m]+m)?", guess/2, guess))
-	if m := r.FindStringIndex(line); m != nil {
+	if m := backend.lineWrapRe.FindStringIndex(line); m != nil {
 		return m[1] // second element in slice is the end index
 	}
 	return guess // Dunno what to do at this point. It's probably unlikely to happen often though.

--- a/src/cli/logging_test.go
+++ b/src/cli/logging_test.go
@@ -15,6 +15,7 @@ func TestLineWrap(t *testing.T) {
 	backend.cols = 80
 	backend.maxLines = 2
 	backend.interactiveRows = 2
+	backend.recalcWindowSize()
 
 	s := backend.lineWrap(strings.Repeat("a", 40))
 	assert.Equal(t, strings.Repeat("a", 40), strings.Join(s, "\n"))

--- a/src/core/state_test.go
+++ b/src/core/state_test.go
@@ -116,13 +116,13 @@ func TestAddDepsToTarget(t *testing.T) {
 	state.Graph.AddPackage(pkg)
 	state.QueueTarget(target1.Label, OriginalTarget, false)
 	task := <-builds
-	assert.Equal(t, Task{Label: target2.Label}, task)
+	assert.Equal(t, Task{Target: target2}, task)
 	// Now simulate target2 being built and adding a new dep to target1 in its post-build function.
 	target3 := addTargetDeps(state, pkg, "//src/core:target3")
 	target1.AddDependency(target3.Label)
 	target2.FinishBuild()
 	task = <-builds
-	assert.Equal(t, Task{Label: target3.Label}, task)
+	assert.Equal(t, Task{Target: target3}, task)
 }
 
 func addTarget(state *BuildState, name string, labels ...string) {

--- a/src/exec/exec_test.go
+++ b/src/exec/exec_test.go
@@ -34,7 +34,7 @@ func TestPrepareRuntimeDir(t *testing.T) {
 	if err := build.StoreTargetMetadata(target, &core.BuildMetadata{}); err != nil {
 		panic(err)
 	}
-	build.Build(state, target.Label, false)
+	build.Build(state, target, false)
 
 	err := core.PrepareRuntimeDir(state, target, "plz-out/exec/pkg")
 	assert.Nil(t, err)

--- a/src/parse/parse_step_test.go
+++ b/src/parse/parse_step_test.go
@@ -155,7 +155,7 @@ func getAllPending(state *core.BuildState) ([]string, []string) {
 				builds = nil
 				break
 			}
-			pendingBuilds = append(pendingBuilds, t.Label.String())
+			pendingBuilds = append(pendingBuilds, t.Target.Label.String())
 		}
 	}
 	return pendingParses, pendingBuilds

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -33,9 +33,7 @@ var numUploadFailures int64
 const maxUploadFailures int64 = 10
 
 // Test runs the tests for a single target.
-func Test(state *core.BuildState, label core.BuildLabel, remote bool, run int) {
-	target := state.Graph.TargetOrDie(label)
-
+func Test(state *core.BuildState, target *core.BuildTarget, remote bool, run int) {
 	// Defer this so that no matter what happens in this test run, we always call target.CompleteRun
 	defer func() {
 		runsAllCompleted := target.CompleteRun(state)
@@ -53,7 +51,7 @@ func Test(state *core.BuildState, label core.BuildLabel, remote bool, run int) {
 	}()
 
 	state.LogBuildResult(target, core.TargetTesting, "Testing...")
-	test(state.ForTarget(target), label, target, remote, run)
+	test(state.ForTarget(target), target.Label, target, remote, run)
 }
 
 func test(state *core.BuildState, label core.BuildLabel, target *core.BuildTarget, runRemotely bool, run int) {


### PR DESCRIPTION
Some cleanup post #2816 . Mostly this is sticking the target directly on the Task struct rather than a label which immediately gets looked up again later on. Also pulls out a regex compile so we don't do it for every log line.