### PR TITLE
Remove chmod of junit_runner.jar

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,6 @@ for OUTPUT in $OUTPUTS; do
     chmod 0775 "$TARGET"
 done
 ln -sf "${DEST}/please" "${DEST}/plz"
-chmod 0664 "${DEST}/junit_runner.jar"
 
 echo "Please installed into $DEST"
 


### PR DESCRIPTION
This is broken if you do it from scratch, because we don't install that file any more.