### PR TITLE
Fix language server crash when trying to format malformed content

### DIFF
--- a/tools/build_langserver/lsp/lsp.go
+++ b/tools/build_langserver/lsp/lsp.go
@@ -61,7 +61,18 @@ func NewHandler() *Handler {
 // Handle implements the jsonrpc2.Handler interface
 func (h *Handler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
 	if resp, err := h.handle(req.Method, req.Params); err != nil {
-		if err := conn.ReplyWithError(ctx, req.ID, err.(*jsonrpc2.Error)); err != nil {
+		// check if the error is a jsonrpc error
+		jsonerr, ok := err.(*jsonrpc2.Error)
+
+		if !ok {
+			// if it's not a jsonrpc error then create a CodeInternalError
+			jsonerr = &jsonrpc2.Error{
+				Code:    jsonrpc2.CodeInternalError,
+				Message: fmt.Sprintf("%s", err),
+			}
+		}
+
+		if err := conn.ReplyWithError(ctx, req.ID, jsonerr); err != nil {
 			log.Error("Failed to send error response: %s", err)
 		}
 	} else if resp != nil {


### PR DESCRIPTION
This PR attempts to fix a crash that happens when trying to format a BUILD file that is malformed. The lsp `Handle` function assumes that any error it encounters is already a `jsonrpc2.Error` but it can be a `ParseError` (and presumably other errors as well). In those cases this fix casts other error types to an internal jsonrpc2 error.

Note: I'm not sure how to test this change, it doesn't look like the `Handle` function is actually tested anywhere. The best I could think of doing it adding a test to show that the result of the formatting call is a `ParseError` type, not a `jsonrpc2.Error`.