### PR TITLE
`format`: support function parameter aliases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/ProtonMail/go-crypto v0.0.0-20210920135941-2c5829bbf927
 	github.com/alessio/shellescape v1.4.1
-	github.com/bazelbuild/buildtools v0.0.0-20210920153738-d6daef01a1a2
+	github.com/bazelbuild/buildtools v0.0.0-20230510134650-37bd1811516d
 	github.com/bazelbuild/remote-apis v0.0.0-20210718193713-0ecef08215cf
 	github.com/bazelbuild/remote-apis-sdks v0.0.0-20221114180157-e62cf9b8696a
 	github.com/cespare/xxhash/v2 v2.1.2

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.17.6 h1:VQFOLQVL3BrKM/NLO/7FiS4vcp5b
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/bazelbuild/buildtools v0.0.0-20210920153738-d6daef01a1a2 h1:hWvEw/36XcpZzKZB2LBYhKSGt72ETiIhudjxd637+4w=
 github.com/bazelbuild/buildtools v0.0.0-20210920153738-d6daef01a1a2/go.mod h1:689QdV3hBP7Vo9dJMmzhoYIyo/9iMhEmHkJcnaPRCbo=
+github.com/bazelbuild/buildtools v0.0.0-20230510134650-37bd1811516d h1:Fl1FfItZp34QIQmmDTbZXHB5XA6JfbNNfH7tRRGWvQo=
+github.com/bazelbuild/buildtools v0.0.0-20230510134650-37bd1811516d/go.mod h1:689QdV3hBP7Vo9dJMmzhoYIyo/9iMhEmHkJcnaPRCbo=
 github.com/bazelbuild/remote-apis v0.0.0-20210718193713-0ecef08215cf h1:DjbO/OLNTvELsPJRy5qU/aIsozQxBQVek+vTO49ybus=
 github.com/bazelbuild/remote-apis v0.0.0-20210718193713-0ecef08215cf/go.mod h1:ry8Y6CkQqCVcYsjPOlLXDX2iRVjOnjogdNwhvHmRcz8=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20221114180157-e62cf9b8696a h1:zIP0R2m8O2VgQlDlMYM0jGmJ+BPx4FQ6+ETRERaLMkM=

--- a/src/format/test_data/after.build
+++ b/src/format/test_data/after.build
@@ -1,3 +1,30 @@
+def no_type(arg):
+    pass
+
+def one_type(arg:str):
+    pass
+
+def multiple_types(arg:int|str):
+    pass
+
+def one_type_default(arg:str=10):
+    pass
+
+def multiple_types_default(arg:int|str=10):
+    pass
+
+def one_alias(arg:int|str&oldarg):
+    pass
+
+def multiple_aliases(arg:int|str&oldarg&oldarg2):
+    pass
+
+def one_alias_with_default(arg:int|str&oldarg=10):
+    pass
+
+def multiple_aliases_with_default(arg:int|str&oldarg&oldarg2=10):
+    pass
+
 go_library(
     name = f"{name}_lib",
     srcs = glob(["*.go"]),

--- a/src/format/test_data/before.build
+++ b/src/format/test_data/before.build
@@ -1,3 +1,30 @@
+def no_type(arg):
+    pass
+
+def one_type(arg: str):
+    pass
+
+def multiple_types(arg: int | str):
+    pass
+
+def one_type_default(arg: str = 10):
+    pass
+
+def multiple_types_default(arg: int | str = 10):
+    pass
+
+def one_alias(arg: int | str & oldarg):
+    pass
+
+def multiple_aliases(arg: int | str & oldarg & oldarg2):
+    pass
+
+def one_alias_with_default(arg: int | str & oldarg = 10):
+    pass
+
+def multiple_aliases_with_default(arg: int | str & oldarg & oldarg2 = 10):
+    pass
+
 go_library(
 deps = ["//src/core"],
 name=f'{name}_lib',

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -17,7 +17,7 @@ go_toolchain(
 go_mod_download(
     name = "build_tools_dl",
     module = "github.com/peterebden/buildtools",
-    version = "ce40803f44fb09c5cf60b5554fe5819d02df23fc",
+    version = "1bf812c34357cd58ee72892491ddb20b3cab4fce",
 )
 
 go_repo(


### PR DESCRIPTION
Please's build language permits function parameters to have aliases, which are specified after any type but before any default value, using the `&` operator:

```
def fn(name:str&altname="value"):
    # ...
```

This syntax is supported in our Please-compatible buildtools fork as of commit 1bf812c (https://github.com/peterebden/buildtools/pull/5). Bump to this version so that `plz format` supports this syntax and outputs BUILD files with function parameter aliases formatted according to Please's whitespace conventions.