### PR TITLE
Fix tool invocations for remote execution

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1655,7 +1655,7 @@ func (target *BuildTarget) toolPath(abs bool, namedOutput string) string {
 			if abs {
 				ret[i] = filepath.Join(RepoRoot, target.OutDir(), o)
 			} else {
-				ret[i] = filepath.Join(target.Label.PackageName, o)
+				ret[i] = filepath.Join(target.PackageDir(), o)
 			}
 		}
 		return strings.Join(ret, " ")


### PR DESCRIPTION
I'm getting an action that fails to find its tool, because the file in the tree honours the subrepo package root thing from #2605 but the environment variables for them don't. This comes up with `go_repo` when you try to use tools from them (e.g. as `protoc-gen-go` does).

This seems like it should be uncontroversial. Cue failing tests...