### PR TITLE
Display update fixes

### DIFF
--- a/src/cli/logging.go
+++ b/src/cli/logging.go
@@ -222,7 +222,10 @@ func (backend *LogBackend) SetPassthrough(passthrough bool, interactiveRows int,
 }
 
 func (backend *LogBackend) recalcWindowSize() {
-	rows, cols, _ := WindowSize()
+	rows, cols, err := WindowSize()
+	if err != nil {
+		log.Debug("Failed to recalculate window size: %s", err)
+	}
 	backend.mutex.Lock()
 	defer backend.mutex.Unlock()
 	backend.rows = rows - 4 // Give a little space at the edge for any off-by-ones

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -46,6 +46,7 @@ func MonitorState(state *core.BuildState, plainOutput, detailedTests, streamTest
 	defer t.Stop()
 	results := state.Results()
 	bt := newBuildingTargets(state, plainOutput)
+	displayer.Update(bt.Targets())
 loop:
 	for {
 		select {

--- a/test/BUILD
+++ b/test/BUILD
@@ -136,7 +136,7 @@ filegroup(
 # Simulates a code generating rule to test the require / provide mechanism.
 plz_e2e_test(
     name = "require_provide_test",
-    cmd = "plz build //test/moar:require_provide_check -v 2 -p",
+    cmd = "plz build //test/moar:require_provide_check -v 1 -p",
     expected_output = "require_provide_test.txt",
 )
 


### PR DESCRIPTION
I'm trying to track a weird heisenbug where sometimes I don't get any shell output for a build.
It appears the issue is that `cols` is zero so it ends up filtering out everything that isn't an ANSI escape code. I can't see how this is occurring though since it looks like we should fall back to 80 even on an error, and now it's decided to stop happening.

Putting this stuff in so if I see it again I might get a useful log. Also chucked in one initial display update because tickers don't tick until their duration elapses once, so this makes it feel more immediate.