### PR TITLE
Fix formatting for timed out message

### DIFF
--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -355,7 +355,7 @@ func testResultMessage(results *core.TestSuite, showDuration bool) string {
 		msg += fmt.Sprintf(", ${BOLD_MAGENTA}%s${RESET}", pluralise(results.FlakyPasses(), "flake", "flakes"))
 	}
 	if results.TimedOut {
-		msg += ", ${RED_ON_WHITE}TIMED OUT${RESET}"
+		msg += ", ${WHITE_ON_RED}TIMED OUT${RESET}"
 	}
 	if results.Cached {
 		msg += " ${GREEN}[cached]${RESET}"


### PR DESCRIPTION
This colour doesn't exist. Elsewhere we log it like this so I'm changing it here. 