### PR TITLE
Strip >= from the PLZ_VERSION variable

### DIFF
--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -82,6 +82,9 @@ func newConfig(state *core.BuildState) *pyConfig {
 	base["BUILD_CONFIG"] = pyString(state.Config.Build.Config)
 	base["DEBUG_PORT"] = pyInt(state.DebugPort)
 
+	// >= is legal at the start of the plz version but it shouldn't appear to the BUILD file.
+	base["PLZ_VERSION"] = pyString(strings.TrimPrefix(state.Config.Please.Version.String(), ">="))
+
 	return &pyConfig{base: &pyConfigBase{dict: base}}
 }
 


### PR DESCRIPTION
I don't think this is supposed to appear in the config variable (it seems nasty for the BUILD files to have to be aware this might be there).

I'm also not sure if the behaviour is correct (that you get the one from the config rather than the _actual_ version) but just handling this for now.