### PR TITLE
`new_http_archive`: add `patches` files as sources to extraction target

### DIFF
--- a/rules/subrepo_rules.build_defs
+++ b/rules/subrepo_rules.build_defs
@@ -130,6 +130,7 @@ def new_http_archive(name:str, urls:list, build_file:str=None, build_file_conten
         name = name,
         srcs = {
             'remote': [remote_rule],
+            'patches': patches,
             'build': [build_file],
         },
         tools = [CONFIG.ARCAT_TOOL],


### PR DESCRIPTION
Currently, any attempt to use the `patches` parameter on subrepo rules fails because the patch files referenced in the command aren't visible as sources to the target that extracts the subrepo archive. Add them so that the generated `patch` commands succeed.