### PR TITLE
`format`: avoid unneeded parentheses around `in`/`not in` expressions

### DIFF
--- a/src/format/test_data/after.build
+++ b/src/format/test_data/after.build
@@ -1,3 +1,5 @@
+x = y is not None
+
 def no_type(arg):
     pass
 

--- a/src/format/test_data/before.build
+++ b/src/format/test_data/before.build
@@ -1,3 +1,5 @@
+x = y is not None
+
 def no_type(arg):
     pass
 

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -21,8 +21,8 @@ go_stdlib(
 
 go_mod_download(
     name = "build_tools_dl",
-    module = "github.com/peterebden/buildtools",
-    version = "1bf812c34357cd58ee72892491ddb20b3cab4fce",
+    module = "github.com/please-build/buildtools",
+    version = "24cce64e067d6147dcfff2a7059fa00c28537597",
 )
 
 go_repo(


### PR DESCRIPTION
Bump `github.com/please-build/buildtools` to 24cce64 to resolve a bug that results in `plz format` adding unnecessary parentheses around `in` and `not in` binary expressions when they are used on the right-hand side of assignment, `if`-`else` and `and`/`or` expressions - see https://github.com/please-build/buildtools/pull/6.

Fixes #2869.