### PR TITLE
Add Filter and Map builtin functions

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -165,6 +165,16 @@
     <li>
       <span>
         <code class="code"
+          ><span class="fn-name">map</span><span class="fn-p">(</span
+          ><span class="fn-arg">mapper</span>, <span class="fn-arg">seq</span
+          ><span class="fn-p">)</span></code
+        >
+        - returns a copy of the given list with the items transformed using function.
+      </span>
+    </li>
+    <li>
+      <span>
+        <code class="code"
           ><span class="fn-name">package_name</span><span class="fn-p">(</span
           ><span class="fn-arg"></span><span class="fn-p">)</span></code
         >

--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -155,6 +155,16 @@
     <li>
       <span>
         <code class="code"
+          ><span class="fn-name">filter</span><span class="fn-p">(</span
+          ><span class="fn-arg">filter</span>, <span class="fn-arg">seq</span
+          ><span class="fn-p">)</span></code
+        >
+        - returns a copy of the given list with the items filtered using function.
+      </span>
+    </li>
+    <li>
+      <span>
+        <code class="code"
           ><span class="fn-name">package_name</span><span class="fn-p">(</span
           ><span class="fn-arg"></span><span class="fn-p">)</span></code
         >

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -91,6 +91,9 @@ def min(seq:list, key:function=None):
 def max(seq:list, key:function=None):
     pass
 
+def filter(filter:function, seq:list):
+    pass
+
 def bool(b) -> bool:
     pass
 def int(s:str) -> int:

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -94,6 +94,9 @@ def max(seq:list, key:function=None):
 def filter(filter:function, seq:list):
     pass
 
+def map(mapper:function, seq:list):
+    pass
+
 def bool(b) -> bool:
     pass
 def int(s:str) -> int:

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -37,6 +37,7 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "sorted", sorted)
 	setNativeCode(s, "reversed", reversed)
 	setNativeCode(s, "filter", filter)
+	setNativeCode(s, "map", mapFunc)
 	setNativeCode(s, "isinstance", isinstance)
 	setNativeCode(s, "range", pyRange)
 	setNativeCode(s, "enumerate", enumerate)
@@ -717,6 +718,24 @@ func filter(s *scope, args []pyObject) pyObject {
 		if f.Call(s, c).IsTruthy() {
 			ret = append(ret, li)
 		}
+	}
+	return ret
+}
+
+func mapFunc(s *scope, args []pyObject) pyObject {
+	mapper, isFunc := args[0].(*pyFunc)
+	l, isList := args[1].(pyList)
+	s.Assert(isFunc, "Argument mapper must be callable, not %s", args[0].Type())
+	s.Assert(isList, "Argument seq must be a list, not %s", args[1].Type())
+
+	var ret pyList
+	for _, li := range l {
+		c := &Call{
+			Arguments: []CallArgument{{
+				Value: Expression{Optimised: &OptimisedExpression{Constant: li}},
+			}},
+		}
+		ret = append(ret, mapper.Call(s, c))
 	}
 	return ret
 }

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -36,6 +36,7 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "package", pkg, false, kwargs)
 	setNativeCode(s, "sorted", sorted)
 	setNativeCode(s, "reversed", reversed)
+	setNativeCode(s, "filter", filter)
 	setNativeCode(s, "isinstance", isinstance)
 	setNativeCode(s, "range", pyRange)
 	setNativeCode(s, "enumerate", enumerate)
@@ -698,6 +699,26 @@ func reversed(s *scope, args []pyObject) pyObject {
 		l[i], l[j] = l[j], l[i]
 	}
 	return l
+}
+
+func filter(s *scope, args []pyObject) pyObject {
+	f, isFunc := args[0].(*pyFunc)
+	l, isList := args[1].(pyList)
+	s.Assert(isFunc, "Argument filter must be callable, not %s", args[0].Type())
+	s.Assert(isList, "Argument seq must be a list, not %s", args[1].Type())
+
+	var ret pyList
+	for _, li := range l {
+		c := &Call{
+			Arguments: []CallArgument{{
+				Value: Expression{Optimised: &OptimisedExpression{Constant: li}},
+			}},
+		}
+		if f.Call(s, c).IsTruthy() {
+			ret = append(ret, li)
+		}
+	}
+	return ret
 }
 
 func joinPath(s *scope, args []pyObject) pyObject {

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -173,6 +173,14 @@ func TestReversed(t *testing.T) {
 	assert.Equal(t, pyList{pyInt(4), pyInt(3), pyInt(2), pyInt(1)}, s.Lookup("r3"))
 }
 
+func TestFilter(t *testing.T) {
+	s, err := parseFile("src/parse/asp/test_data/interpreter/filter.build")
+	require.NoError(t, err)
+	assert.Equal(t, pyList{pyInt(1), pyInt(2), pyInt(3)}, s.Lookup("f1"))
+	assert.Equal(t, pyList{pyInt(0), pyInt(2)}, s.Lookup("f2"))
+	assert.Equal(t, pyList{pyInt(5), pyInt(5)}, s.Lookup("f3"))
+}
+
 func TestInterpreterUnpacking(t *testing.T) {
 	s, err := parseFile("src/parse/asp/test_data/interpreter/unpacking.build")
 	require.NoError(t, err)

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -181,6 +181,13 @@ func TestFilter(t *testing.T) {
 	assert.Equal(t, pyList{pyInt(5), pyInt(5)}, s.Lookup("f3"))
 }
 
+func TestMap(t *testing.T) {
+	s, err := parseFile("src/parse/asp/test_data/interpreter/map.build")
+	require.NoError(t, err)
+	assert.Equal(t, pyList{pyInt(0), pyInt(1), pyInt(2), pyInt(3)}, s.Lookup("m1"))
+	assert.Equal(t, pyList{pyInt(1), pyInt(2), pyInt(3), pyInt(4)}, s.Lookup("m2"))
+}
+
 func TestInterpreterUnpacking(t *testing.T) {
 	s, err := parseFile("src/parse/asp/test_data/interpreter/unpacking.build")
 	require.NoError(t, err)

--- a/src/parse/asp/test_data/interpreter/filter.build
+++ b/src/parse/asp/test_data/interpreter/filter.build
@@ -1,0 +1,9 @@
+# identity
+f1 = filter(lambda x: x, [0, 1, 2, 3])
+
+# odd numbers
+f2 = filter(lambda x: (x % 2) == 0, [0, 1, 2, 3])
+
+# context
+need = 5
+f3 = filter(lambda x: x == need, [0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 5, 4, 3, 2, 1, 0])

--- a/src/parse/asp/test_data/interpreter/map.build
+++ b/src/parse/asp/test_data/interpreter/map.build
@@ -1,0 +1,5 @@
+# identity
+m1 = map(lambda x: x, [0, 1, 2, 3])
+
+# add 1
+m2 = map(lambda x: x + 1, [0, 1, 2, 3])


### PR DESCRIPTION
```
filter(filter, seq)
```
returns a copy of the given list with the items filtered using function

```
map(mapper, seq)
```
returns a copy of the given list with the items transformed using function