### PR TITLE
`format`: split out test cases into separate files

### DIFF
--- a/src/format/fmt_test.go
+++ b/src/format/fmt_test.go
@@ -20,28 +20,24 @@ func TestFormat(t *testing.T) {
 	for _, file := range files {
 		if test, isBefore := strings.CutSuffix(file.Name(), ".before.build"); isBefore {
 			t.Run(test, func(t *testing.T) {
-				formatTestCase(t, test)
+				before := filepath.Join(testDir, test + ".before.build")
+				after := filepath.Join(testDir, test + ".after.build")
+
+				changed, err := Format(core.DefaultConfiguration(), []string{before}, false, true)
+				assert.NoError(t, err)
+				assert.True(t, changed)
+
+				// N.B. this rewrites the file; be careful if you're adding more tests here.
+				changed, err = Format(core.DefaultConfiguration(), []string{before}, true, false)
+				assert.NoError(t, err)
+				assert.True(t, changed)
+
+				beforeContents, err := os.ReadFile(before)
+				require.NoError(t, err)
+				afterContents, err := os.ReadFile(after)
+				require.NoError(t, err)
+				assert.Equal(t, beforeContents, afterContents)
 			})
 		}
 	}
-}
-
-func formatTestCase(t *testing.T, test string) {
-	before := filepath.Join(testDir, test + ".before.build")
-	after := filepath.Join(testDir, test + ".after.build")
-
-	changed, err := Format(core.DefaultConfiguration(), []string{before}, false, true)
-	assert.NoError(t, err)
-	assert.True(t, changed)
-
-	// N.B. this rewrites the file; be careful if you're adding more tests here.
-	changed, err = Format(core.DefaultConfiguration(), []string{before}, true, false)
-	assert.NoError(t, err)
-	assert.True(t, changed)
-
-	beforeContents, err := os.ReadFile(before)
-	require.NoError(t, err)
-	afterContents, err := os.ReadFile(after)
-	require.NoError(t, err)
-	assert.Equal(t, beforeContents, afterContents)
 }

--- a/src/format/fmt_test.go
+++ b/src/format/fmt_test.go
@@ -2,6 +2,8 @@ package format
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,9 +12,23 @@ import (
 	"github.com/thought-machine/please/src/core"
 )
 
+const testDir = "src/format/test_data"
+
 func TestFormat(t *testing.T) {
-	const before = "src/format/test_data/before.build"
-	const after = "src/format/test_data/after.build"
+	files, err := os.ReadDir(testDir)
+	assert.NoError(t, err)
+	for _, file := range files {
+		if test, isBefore := strings.CutSuffix(file.Name(), ".before.build"); isBefore {
+			t.Run(test, func(t *testing.T) {
+				formatTestCase(t, test)
+			})
+		}
+	}
+}
+
+func formatTestCase(t *testing.T, test string) {
+	before := filepath.Join(testDir, test + ".before.build")
+	after := filepath.Join(testDir, test + ".after.build")
 
 	changed, err := Format(core.DefaultConfiguration(), []string{before}, false, true)
 	assert.NoError(t, err)

--- a/src/format/fmt_test.go
+++ b/src/format/fmt_test.go
@@ -20,8 +20,8 @@ func TestFormat(t *testing.T) {
 	for _, file := range files {
 		if test, isBefore := strings.CutSuffix(file.Name(), ".before.build"); isBefore {
 			t.Run(test, func(t *testing.T) {
-				before := filepath.Join(testDir, test + ".before.build")
-				after := filepath.Join(testDir, test + ".after.build")
+				before := filepath.Join(testDir, test+".before.build")
+				after := filepath.Join(testDir, test+".after.build")
 
 				changed, err := Format(core.DefaultConfiguration(), []string{before}, false, true)
 				assert.NoError(t, err)

--- a/src/format/test_data/build_target.after.build
+++ b/src/format/test_data/build_target.after.build
@@ -1,0 +1,6 @@
+go_library(
+    name = f"{name}_lib",
+    srcs = glob(["*.go"]),
+    visibility = ["PUBLIC"],
+    deps = ["//src/core"],
+)

--- a/src/format/test_data/build_target.before.build
+++ b/src/format/test_data/build_target.before.build
@@ -1,0 +1,6 @@
+go_library(
+deps = ["//src/core"],
+name=f'{name}_lib',
+visibility =["PUBLIC"],
+srcs =glob(["*.go"]),
+)

--- a/src/format/test_data/function_types_aliases.after.build
+++ b/src/format/test_data/function_types_aliases.after.build
@@ -1,5 +1,3 @@
-x = y is not None
-
 def no_type(arg):
     pass
 
@@ -26,10 +24,3 @@ def one_alias_with_default(arg:int|str&oldarg=10):
 
 def multiple_aliases_with_default(arg:int|str&oldarg&oldarg2=10):
     pass
-
-go_library(
-    name = f"{name}_lib",
-    srcs = glob(["*.go"]),
-    visibility = ["PUBLIC"],
-    deps = ["//src/core"],
-)

--- a/src/format/test_data/function_types_aliases.before.build
+++ b/src/format/test_data/function_types_aliases.before.build
@@ -1,5 +1,3 @@
-x = y is not None
-
 def no_type(arg):
     pass
 
@@ -26,10 +24,3 @@ def one_alias_with_default(arg: int | str & oldarg = 10):
 
 def multiple_aliases_with_default(arg: int | str & oldarg & oldarg2 = 10):
     pass
-
-go_library(
-deps = ["//src/core"],
-name=f'{name}_lib',
-visibility =["PUBLIC"],
-srcs =glob(["*.go"]),
-)

--- a/src/format/test_data/is_precedence.after.build
+++ b/src/format/test_data/is_precedence.after.build
@@ -1,0 +1,1 @@
+x = (y is not None)

--- a/src/format/test_data/is_precedence.before.build
+++ b/src/format/test_data/is_precedence.before.build
@@ -1,0 +1,1 @@
+x = ((y is not None))


### PR DESCRIPTION
This will make the purpose of each test clearer, make adding new test cases simpler, and make regressions easier to spot in failing test output.