### PR TITLE
Regression test for arch-specific config loading not working with preloaded subincludes

### DIFF
--- a/test/plugins/BUILD
+++ b/test/plugins/BUILD
@@ -10,7 +10,7 @@ genrule(
     cmd = "mv $SRCS_PLUGIN foo_plugin && mv $SRCS_TOOL foo_plugin/tools && tar -czf $OUT foo_plugin",
 )
 
-def plugin_e2e_test(name, plz_command, expected_output=None, expected_failure=False, expect_output_contains=None):
+def plugin_e2e_test(name, plz_command, expected_output=None, expected_failure=False, expect_output_contains=None, repo="test_repo"):
     return please_repo_e2e_test(
         name = name,
         data = {
@@ -21,7 +21,7 @@ def plugin_e2e_test(name, plz_command, expected_output=None, expected_failure=Fa
         expected_failure = expected_failure,
         expected_output = expected_output,
         plz_command = plz_command.replace("plz ", "plz -o buildconfig.nested-subrepo:$TMP_DIR/$DATA_NESTED_SUBREPO -o please.pluginrepo:file://$TMP_DIR/$DATA_PLUGIN "),
-        repo = "test_repo",
+        repo = repo,
     )
 
 plugin_e2e_test(
@@ -125,4 +125,12 @@ plugin_e2e_test(
         "plz-out/gen/foo_bar66/fooc.txt": "bar66",
     },
     plz_command = "plz build -o plugin.foo.modulepath:something --arch foo_bar66 //:output_fooc",
+)
+
+# Currently preloading breaks arch-specific config loading.
+# Once we have a fix, we should remove the 'not' from 'if not CONFIG.FOO.BOOL_TEST:' in test/plugins/preload/BUILD_FILE
+plugin_e2e_test(
+    name = "arch_with_preload_test",
+    plz_command = "plz build --arch freebsd_amd64 //:output_fooc",
+    repo = "preload",
 )

--- a/test/plugins/preload/.plzconfig
+++ b/test/plugins/preload/.plzconfig
@@ -1,0 +1,11 @@
+[parse]
+preloadsubincludes = ///foo//build_defs:foolang
+
+[Plugin "foo"]
+Target = //plugins:foo
+FoocTool = @foo//tools:fooc
+bartool = bar
+CompileFlag = -sha256
+BoolTest = True
+IntTest = 15
+ModulePath = modulepath

--- a/test/plugins/preload/.plzconfig_freebsd_amd64
+++ b/test/plugins/preload/.plzconfig_freebsd_amd64
@@ -1,0 +1,2 @@
+[Plugin "foo"]
+BoolTest = False

--- a/test/plugins/preload/BUILD_FILE
+++ b/test/plugins/preload/BUILD_FILE
@@ -1,0 +1,8 @@
+if not CONFIG.FOO.BOOL_TEST:
+    fail("BoolTest should be falsy")
+
+genrule(
+    name = "output_fooc",
+    cmd = f"echo {CONFIG.FOO.FOOC_TOOL} > $OUT",
+    outs = ["fooc.txt"],
+)

--- a/test/plugins/preload/plugins/BUILD_FILE
+++ b/test/plugins/preload/plugins/BUILD_FILE
@@ -1,0 +1,4 @@
+plugin_repo(
+    name = "foo",
+    revision = "v1.0.0",
+)


### PR DESCRIPTION
Fix isn't in yet, this just reproduces the issue. When we land the fix we should swap the condition around at the top of `test/plugins/preload/BUILD_FILE`