### PR TITLE
Wait for non pkg local targets in getX builtins

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1463,7 +1463,6 @@ loop:
 				cyclestr += "[" + k.String() + "]{" + dstr + "}\n"
 			}
 			log.Fatalf("Dependencies cycle detected:\n%s", cyclestr)
-			panic("Fatal failed")
 		}
 	case ptask := <-state.waitTargetCycleDetectorRm:
 		if !ptask.Mode.IsForInformation() {

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1463,6 +1463,7 @@ loop:
 				cyclestr += "[" + k.String() + "]{" + dstr + "}\n"
 			}
 			log.Fatalf("Dependencies cycle detected:\n%s", cyclestr)
+			panic("Fatal failed")
 		}
 	case ptask := <-state.waitTargetCycleDetectorRm:
 		if !ptask.Mode.IsForInformation() {

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -233,6 +233,11 @@ type BuildState struct {
 	// they're encountered.
 	EnableBreakpoints bool
 
+	// WaitTargetCycleDetector keep a registry of waiter and waitee and check there is no cycle
+	waitTargetCycleDetector    map[BuildLabel][]BuildLabel
+	waitTargetCycleDetectorAdd chan ParseTask
+	waitTargetCycleDetectorRm  chan ParseTask
+
 	// initOnce is used to control loading the subrepo .plzconfig
 	initOnce *sync.Once
 
@@ -871,7 +876,9 @@ func (state *BuildState) waitForBuiltTarget(l, dependent BuildLabel, mode ParseM
 	// okay, we need to register and wait for this guy.
 	if ch, inserted := state.progress.pendingTargets.AddOrGet(l, make(chan struct{})); !inserted {
 		// Something's already registered for this, get on the train
+		state.waitTargetCycleDetectorAdd <- ParseTask{Label: l, Dependent: dependent, Mode: mode}
 		<-ch
+		state.waitTargetCycleDetectorRm <- ParseTask{Label: l, Dependent: dependent, Mode: mode}
 		return state.Graph.Target(l)
 	}
 	if err := state.queueTarget(l, dependent, mode.IsForSubinclude(), mode); err != nil {
@@ -1390,8 +1397,11 @@ func NewBuildState(config *Configuration) *BuildState {
 			internalResults: make(chan *BuildResult, 1000),
 			cycleDetector:   cycleDetector{graph: graph},
 		},
-		initOnce:            new(sync.Once),
-		preloadDownloadOnce: new(sync.Once),
+		waitTargetCycleDetectorAdd: make(chan ParseTask, 1000),
+		waitTargetCycleDetectorRm:  make(chan ParseTask, 1000),
+		waitTargetCycleDetector:    make(map[BuildLabel][]BuildLabel),
+		initOnce:                   new(sync.Once),
+		preloadDownloadOnce:        new(sync.Once),
 	}
 
 	state.PathHasher = state.Hasher(config.Build.HashFunction)
@@ -1401,7 +1411,79 @@ func NewBuildState(config *Configuration) *BuildState {
 		state.experimentalLabels = append(state.experimentalLabels, BuildLabel{PackageName: exp, Name: "..."})
 	}
 	go state.forwardResults()
+	go state.waitTargetCycleDetectorFunc()
 	return state
+}
+
+func isMapCycle(m *map[BuildLabel][]BuildLabel, start BuildLabel, current *BuildLabel) bool {
+	if current != nil && *current == start {
+		return true
+	}
+	if current == nil {
+		current = &start
+	}
+	childs, ok := (*m)[*current]
+	if !ok {
+		return false
+	}
+	for _, child := range childs {
+		if isMapCycle(m, start, &child) {
+			return true
+		}
+	}
+	return false
+}
+
+func (state *BuildState) waitTargetCycleDetectorFunc() {
+loop:
+	select {
+	case ptask := <-state.waitTargetCycleDetectorAdd:
+		if !ptask.Mode.IsForInformation() {
+			// ignore
+			goto loop
+		}
+		ptask.Dependent.Name = ""
+		ptask.Label.Name = ""
+		state.waitTargetCycleDetector[ptask.Dependent] = append(
+			state.waitTargetCycleDetector[ptask.Dependent],
+			ptask.Label)
+		if isMapCycle(&state.waitTargetCycleDetector, ptask.Dependent, nil) {
+			cyclestr := ""
+			for k, v := range state.waitTargetCycleDetector {
+				dstr := ""
+				first := true
+				for _, s := range v {
+					if first {
+						dstr += s.String()
+						first = false
+					} else {
+						dstr += ", " + s.String()
+					}
+				}
+				cyclestr += "[" + k.String() + "]{" + dstr + "}\n"
+			}
+			log.Fatalf("Dependencies cycle detected:\n%s", cyclestr)
+		}
+	case ptask := <-state.waitTargetCycleDetectorRm:
+		if !ptask.Mode.IsForInformation() {
+			// ignore
+			goto loop
+		}
+		ptask.Dependent.Name = ""
+		ptask.Label.Name = ""
+		childs, ok := state.waitTargetCycleDetector[ptask.Dependent]
+		if ok {
+			for i := range childs {
+				if childs[i] == ptask.Label {
+					state.waitTargetCycleDetector[ptask.Dependent] = append(state.waitTargetCycleDetector[ptask.Dependent][:i], state.waitTargetCycleDetector[ptask.Dependent][i+1:]...)
+				}
+			}
+			if len(state.waitTargetCycleDetector[ptask.Dependent]) == 0 {
+				delete(state.waitTargetCycleDetector, ptask.Dependent)
+			}
+		}
+	}
+	goto loop
 }
 
 // NewDefaultBuildState creates a BuildState for the default configuration.

--- a/test/build_defs/test.build_defs
+++ b/test/build_defs/test.build_defs
@@ -11,6 +11,7 @@ def please_repo_e2e_test(
         expect_output_contains: dict = {},
         expect_output_doesnt_contain: dict = {},
         labels: list = [],
+        timeout: int = 0,
 ):
     plz_command = plz_command.replace("plz ", "$TOOLS_PLEASE ")
     if expected_failure:
@@ -48,6 +49,7 @@ def please_repo_e2e_test(
         env = {
             "PLZ_CONFIG_PROFILE": "e2e",
         },
+        timeout = timeout,
         no_test_output = True,
         labels = labels + ["plz_e2e_test", "e2e"],
         sandbox = False,

--- a/test/targetmeta/BUILD
+++ b/test/targetmeta/BUILD
@@ -52,3 +52,14 @@ please_repo_e2e_test(
     expected_failure = True,
     repo = "error/non_visible_target",
 )
+
+please_repo_e2e_test(
+    name = "targetmeta_dep_cycle",
+    plz_command = "plz build",
+    expect_output_contains = {
+        "plz-out/log/build.log": "Dependencies cycle detected"
+    },
+    expected_failure = True,
+    timeout = 10,
+    repo = "error/dep_cycle",
+)

--- a/test/targetmeta/BUILD
+++ b/test/targetmeta/BUILD
@@ -1,0 +1,54 @@
+subinclude("//test/build_defs")
+
+
+success_out = '{"1": [//test/sub1:sub1|1], "2": [//test/sub1:sub1|2], "3": [//test/sub2:sub2|3], "4": [//test/sub2:sub2|4]}'
+please_repo_e2e_test(
+    name = "targetmeta_success",
+    plz_command = "plz build //test:success",
+    expected_output = { "plz-out/gen/test/success": success_out },
+    repo = "test_repo",
+)
+
+please_repo_e2e_test(
+    name = "targetmeta_unknown_target",
+    plz_command = "plz build",
+    expect_output_contains = {
+        "plz-out/log/build.log": "depends on //inexistent_pkg:inexistent_pkg, but the directory inexistent_pkg doesn't exist"
+    },
+    expected_failure = True,
+    repo = "error/unknown_target",
+)
+
+please_repo_e2e_test(
+    name = "targetmeta_unknown_local_target",
+    plz_command = "plz build",
+    expect_output_contains = {
+        "plz-out/log/build.log": "CRITICAL: Target //:local not found in build graph"
+    },
+    expected_failure = True,
+    repo = "error/unknown_local_target",
+)
+
+
+# This test can output one of two line depending on the order files are finished parsing
+out1 = "Parsed build file extern/BUILD_FILE but it doesn't contain target b"
+out2 = "CRITICAL: Target //extern:b (referenced by //:all) doesn't exist"
+log_file = "plz-out/log/build.log"
+test_cmd = f'_STR="$(cat {log_file})" _SUBSTR1="{out1}" _SUBSTR2="{out2}"'
+test_cmd += ' && if [ "${_STR##*$_SUBSTR1*}" ] && [ "${_STR##*$_SUBSTR2*}" ]; then echo "$_STR"; exit 1; fi'
+
+please_repo_e2e_test(
+    name = "targetmeta_unknown_extern_target",
+    plz_command = f"plz build; [ ! $? -eq 0 ] && {test_cmd}",
+    repo = "error/unknown_extern_target",
+)
+
+please_repo_e2e_test(
+    name = "targetmeta_non_visible_target",
+    plz_command = "plz build",
+    expect_output_contains = {
+        "plz-out/log/build.log": "Target //extern:a isn't visible to"
+    },
+    expected_failure = True,
+    repo = "error/non_visible_target",
+)

--- a/test/targetmeta/error/dep_cycle/.plzconfig
+++ b/test/targetmeta/error/dep_cycle/.plzconfig
@@ -1,0 +1,2 @@
+[Parse]
+BuildFileName = BUILD_FILE

--- a/test/targetmeta/error/dep_cycle/BUILD_FILE
+++ b/test/targetmeta/error/dep_cycle/BUILD_FILE
@@ -1,0 +1,9 @@
+t = get_outs(f"@//c")
+
+text_file(
+    name = "top",
+    visibility = ["PUBLIC"],
+    content = t,
+)
+
+

--- a/test/targetmeta/error/dep_cycle/a/BUILD_FILE
+++ b/test/targetmeta/error/dep_cycle/a/BUILD_FILE
@@ -1,0 +1,7 @@
+t = get_outs(f"@//b")
+
+text_file(
+    name = package_name(),
+    visibility = ["PUBLIC"],
+    content = t,
+)

--- a/test/targetmeta/error/dep_cycle/b/BUILD_FILE
+++ b/test/targetmeta/error/dep_cycle/b/BUILD_FILE
@@ -1,0 +1,7 @@
+t = get_outs(f"@//c")
+
+text_file(
+    name = package_name(),
+    visibility = ["PUBLIC"],
+    content = t,
+)

--- a/test/targetmeta/error/dep_cycle/c/BUILD_FILE
+++ b/test/targetmeta/error/dep_cycle/c/BUILD_FILE
@@ -1,0 +1,7 @@
+t = get_outs(f"@//d")
+
+text_file(
+    name = package_name(),
+    visibility = ["PUBLIC"],
+    content = t,
+)

--- a/test/targetmeta/error/dep_cycle/d/BUILD_FILE
+++ b/test/targetmeta/error/dep_cycle/d/BUILD_FILE
@@ -1,0 +1,7 @@
+t = get_outs(f"@//e")
+
+text_file(
+    name = package_name(),
+    visibility = ["PUBLIC"],
+    content = t,
+)

--- a/test/targetmeta/error/dep_cycle/e/BUILD_FILE
+++ b/test/targetmeta/error/dep_cycle/e/BUILD_FILE
@@ -1,0 +1,7 @@
+t = get_outs(f"@//f")
+
+text_file(
+    name = package_name(),
+    visibility = ["PUBLIC"],
+    content = t,
+)

--- a/test/targetmeta/error/dep_cycle/f/BUILD_FILE
+++ b/test/targetmeta/error/dep_cycle/f/BUILD_FILE
@@ -1,0 +1,7 @@
+t = get_outs(f"@//a")
+
+text_file(
+    name = package_name(),
+    visibility = ["PUBLIC"],
+    content = t,
+)

--- a/test/targetmeta/error/non_visible_target/.plzconfig
+++ b/test/targetmeta/error/non_visible_target/.plzconfig
@@ -1,0 +1,2 @@
+[Parse]
+BuildFileName = BUILD_FILE

--- a/test/targetmeta/error/non_visible_target/BUILD_FILE
+++ b/test/targetmeta/error/non_visible_target/BUILD_FILE
@@ -1,0 +1,3 @@
+
+
+t = get_outs(f"@//extern:a")

--- a/test/targetmeta/error/non_visible_target/extern/BUILD_FILE
+++ b/test/targetmeta/error/non_visible_target/extern/BUILD_FILE
@@ -1,0 +1,4 @@
+text_file(
+    name = "a",
+    content = "aaaaaaaaaaa",
+)

--- a/test/targetmeta/error/unknown_extern_target/.plzconfig
+++ b/test/targetmeta/error/unknown_extern_target/.plzconfig
@@ -1,0 +1,2 @@
+[Parse]
+BuildFileName = BUILD_FILE

--- a/test/targetmeta/error/unknown_extern_target/BUILD_FILE
+++ b/test/targetmeta/error/unknown_extern_target/BUILD_FILE
@@ -1,0 +1,3 @@
+
+
+t = get_outs(f"@//extern:b")

--- a/test/targetmeta/error/unknown_extern_target/extern/BUILD_FILE
+++ b/test/targetmeta/error/unknown_extern_target/extern/BUILD_FILE
@@ -1,0 +1,5 @@
+text_file(
+    name = "a",
+    visibility = ["PUBLIC"],
+    content = "aaaaaaaaaaa",
+)

--- a/test/targetmeta/error/unknown_local_target/.plzconfig
+++ b/test/targetmeta/error/unknown_local_target/.plzconfig
@@ -1,0 +1,2 @@
+[Parse]
+BuildFileName = BUILD_FILE

--- a/test/targetmeta/error/unknown_local_target/BUILD_FILE
+++ b/test/targetmeta/error/unknown_local_target/BUILD_FILE
@@ -1,0 +1,8 @@
+
+
+t = get_outs(f"@//:local")
+
+
+genrule(
+    name = "local",
+)

--- a/test/targetmeta/error/unknown_target/.plzconfig
+++ b/test/targetmeta/error/unknown_target/.plzconfig
@@ -1,0 +1,2 @@
+[Parse]
+BuildFileName = BUILD_FILE

--- a/test/targetmeta/error/unknown_target/BUILD_FILE
+++ b/test/targetmeta/error/unknown_target/BUILD_FILE
@@ -1,0 +1,3 @@
+
+
+t = get_outs(f"@//inexistent_pkg")

--- a/test/targetmeta/test_repo/.plzconfig
+++ b/test/targetmeta/test_repo/.plzconfig
@@ -1,0 +1,2 @@
+[Parse]
+BuildFileName = BUILD_FILE

--- a/test/targetmeta/test_repo/test/BUILD_FILE
+++ b/test/targetmeta/test_repo/test/BUILD_FILE
@@ -1,0 +1,21 @@
+def subtargets(target:str) -> dict:
+    return { k: [ f'{target}|{k}' ] for k in get_named_outs(target).keys() }
+
+here = get_base_path()
+
+sub1targets = subtargets(f"@//{here}/sub1")
+sub2targets = subtargets(f"@//{here}/sub2")
+
+tg = filegroup(
+    name = "targetmeta_combined",
+    srcs = sub1targets | sub2targets
+)
+
+text_file(
+    name = "success",
+    content = str(get_named_outs(tg)),
+)
+
+# should instantly fail
+# t = get_outs(f"@//{here}:ssss")
+# t = get_outs(f"@//{here}/sub1:nope")

--- a/test/targetmeta/test_repo/test/sub1/BUILD_FILE
+++ b/test/targetmeta/test_repo/test/sub1/BUILD_FILE
@@ -1,0 +1,14 @@
+filegroup(
+    name = basename(package_name()),
+    visibility = ["//test:all", "//test/sub2:all"],
+    srcs = {
+        "1": [text_file(
+            name = "a",
+            content = "aaaaaaaaaaa",
+        )],
+        "2": [text_file(
+            name = "b",
+            content = "bbbbbbbbbb",
+        )],
+    }
+)

--- a/test/targetmeta/test_repo/test/sub2/BUILD_FILE
+++ b/test/targetmeta/test_repo/test/sub2/BUILD_FILE
@@ -1,0 +1,19 @@
+sub1 = dirname(get_base_path()) + "/sub1"
+
+sub1keys = get_named_outs(f"@//{sub1}").keys()
+idx = len(sub1keys)
+
+filegroup(
+    name = basename(package_name()),
+    visibility = ['PUBLIC'],
+    srcs = {
+        str(idx + 1): [text_file(
+            name = "c",
+            content = "ccccccccccc",
+        )],
+        str(idx + 2): [text_file(
+            name = "d",
+            content = "dddddddd",
+        )],
+    }
+)


### PR DESCRIPTION
Use WaitForBuiltTarget with `get*` (get_outs, get_licenses, get_labels, ...) allows querying non-local targets metadata.

It can be useful to be able to re-export filegroups inside another, but it is tedious if you need to repeat the keys. With these changes, one can write something like this:

```
filegroup(
    name = 'in_pkg_b',
    visibility = ['PUBLIC'],
    srcs = {
        'X': [...]
        'y': [...]
    }
)
---------------
filegroup(
    name = 'in_pkg_a',
    visibility = ['PUBLIC'],
    srcs = {
        'A': [...]
    } | {
        f'B_{k}': [ f'//b:in_pkg_b|{k}' ] for k in get_named_outs('//b:in_pkg_b').keys()
    }
)
```

Also it makes possible the following syntax:
```
def dictioniryze(target:str) -> dict:
    return { k: [ f'{target}|{k}' ] for k in get_named_outs(target).keys() }

a = dictioniryze('//a:in_pkg_a')

genrule(
    name = 'build',
    srcs = {
        'A': a.A,
        'B1': B.X,
        'B2': B.y,
    }
)

```

The Pr is separated into two commits:
- 61b839 - main changes, make add*, get* and set* use `getTarget()` to resolve targets, increasing consistency between these functions. `getTarget()` will `WaitForBuiltTarget` on targets not local to the current package.
- 6f084d - Implement a basic cycle detector with a e2e test for the case the user creates a cycle of dependencies, someone more experienced with please codebase could probably implement this better than me.