### PR TITLE
Acquire target lock on pkg local srcs when download filegroups for rex

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -419,6 +419,8 @@ func (c *Client) Download(target *core.BuildTarget) error {
 		file := core.AcquireExclusiveFileLock(target.BuildLockFile())
 		defer core.ReleaseFileLock(file)
 
+		// This is a bit of a grungy hack to avoid clobbering outputs.
+		// See https://github.com/thought-machine/please/issues/2886
 		if target.IsFilegroup {
 			for _, t := range target.AllSources() {
 				if l, ok := t.Label(); ok {


### PR DESCRIPTION
This is a bit grungy so we may want to solve this more elegantly. Essentially we hit issues when:

1) we're using remote execution
2) We have a filegroup that defines a package local target in its sources list
3) Both these targets should be downloaded 
4) There are multiple instances of Please downloading outputs. 

Normally we grab the target lock when downloading outputs to avoid multiple Please instances clobbering outputs in plz-out. If we have 2 targets that output the same file, we can hit issues as we now have two lock files for the same output. For this reason, this is prohibited, however we have exemptions for filegroups as we build them through a totally different mechanism locally. This isn't quite the case for remote execution where we upload the action result and download the action outputs again. 

There's a separate bug in v17.2.x where we mark all the transitive deps of a target for pre-load. We download the outputs of a target if we think it's needed for a subinclude, and we consider any target needed for preloading to also be needed for subincludes. We have issues in core3 where we have go binaries that are used to generate stuff when subincluding:

This means we have:
1) //third_party/go:_hcl#a_rule that outputs plz-out/gen/third_party/go/pkg/linux_amd64/github.com/hashicorp/hcl/json/...
2) //third_party/go:hcl that exports the a_rule and other targets in the same package
3) These are needed for a subinclude as they are a dep of some target that generates a list of valid environment names. 

If two please instances decide to download these outputs, then the two please instances end up clobbering eachothers outputs in plz-out. We also end up re-downloading on subsequent runs because //third_party/go:hcl overrides the xattrs from //third_party/go:_hcl#a_rule, so when we check the xattrs on the next please run, they're incorrect. 

This is likely the same issues we've been seeing with plugins where we're missing certain files from the subrepo as two please instances download the subrepo targets.  