### PR TITLE
Don't download transitive deps of subincludes during rex

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -38,7 +38,7 @@ func (m ParseMode) IsPreload() bool {
 }
 
 func (m ParseMode) IsForSubinclude() bool {
-	return m&ParseModeForSubinclude != 0 || m&ParseModeForPreload != 0
+	return m&ParseModeForSubinclude != 0
 }
 
 // startTime is as close as we can conveniently get to process start time.
@@ -908,10 +908,10 @@ func (state *BuildState) AddTarget(pkg *Package, target *BuildTarget) {
 // ShouldDownload returns true if the given target should be downloaded during remote execution.
 func (state *BuildState) ShouldDownload(target *BuildTarget) bool {
 	// Need to download the target if it was originally requested (and the user didn't pass --nodownload).
-	downloadOriginalTarget := state.OutputDownload == OriginalOutputDownload && state.IsOriginalTarget(target)
+	downloadOriginalTarget := state.OutputDownload == OriginalOutputDownload && state.IsOriginalTarget(target) && !state.NeedTests
 	downloadTransitiveTarget := state.OutputDownload == TransitiveOutputDownload
 	downloadLinkableTarget := state.Config.Build.DownloadLinkable && target.HasLinks(state)
-	return target.neededForSubinclude.Value() || (downloadOriginalTarget && !state.NeedTests) || downloadTransitiveTarget || downloadLinkableTarget
+	return (downloadOriginalTarget && !state.NeedTests) || downloadTransitiveTarget || downloadLinkableTarget
 }
 
 // ShouldRebuild returns true if we should force a rebuild of this target (i.e. the user


### PR DESCRIPTION
We ensure they're downloaded in the `subincludeTarget()` function in the builtins after building the subinclude. We don't need to download them during the build itself. We queue up transitive subincludes of preload targets with "ParseModForPreload"  which was causing us to download them. 