### PR TITLE
Fix query somepath when it encounters a cycle

### DIFF
--- a/src/query/somepath.go
+++ b/src/query/somepath.go
@@ -85,6 +85,7 @@ func somePath(graph *core.BuildGraph, hidden bool, target1, target2 *core.BuildT
 	} else if _, present := seen[target1.Label]; present {
 		return nil
 	}
+	seen[target1.Label] = struct{}{}
 	for _, dep := range target1.DeclaredDependencies() {
 		if t := graph.Target(dep); t != nil {
 			if _, present := except[t.Label]; present {
@@ -97,7 +98,6 @@ func somePath(graph *core.BuildGraph, hidden bool, target1, target2 *core.BuildT
 			}
 		}
 	}
-	seen[target1.Label] = struct{}{}
 	return nil
 }
 


### PR DESCRIPTION
There will of course be other problems, but `query somepath` is failing with a stack overflow because it can infinitely recurse into a cyclic graph. This prevents that from happening (which will hopefully help me debug what is actually going wrong in this case).