### PR TITLE
Fix text_file strip

### DIFF
--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -508,7 +508,7 @@ def text_file(name:str, content:str, strip:bool=False, hashes:list=None, data:li
 
     if strip:
         content = '\n'.join(
-            [ line.lstrip(' \t') for line in content.removeprefix('\n').split('\n') ]
+            [ line.lstrip(' ') for line in content.removeprefix('\n').split('\n') ]
         )
 
     return build_rule(

--- a/test/build_defs/test_file_content.sh
+++ b/test/build_defs/test_file_content.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 file=$1
 
@@ -7,10 +7,16 @@ if ! test -f "$file"; then
   exit 1
 fi
 
-CONTENT=$(cat "$file")
+CONTENT=$(<"$file")
 shift 1
+CHECK=$(< <(printf '%s\n' "$@"))
 
-if [ "$CONTENT" != "$@" ]; then
-  echo "$file" doesnt contain "$@", it contains "$CONTENT"
+if [[ "$CONTENT" != "$CHECK" ]]; then
+  printf '%s\n%s\n%s\n%s\n%s\n' \
+    "${file} doesnt contain" \
+    "${CHECK}" \
+    "---- it contains ----" \
+    "${CONTENT}" \
+    "---- EOF ----"
   exit 1
 fi

--- a/test/text_file/BUILD
+++ b/test/text_file/BUILD
@@ -11,6 +11,8 @@ text_file(
         This is a multi lines file,
         use strip option to remove first empty newline
         and all empty spaces on the left of the text.
+        t - t should not be stripped
+        \ - nor backslash
     """,
     strip = True,
 )
@@ -39,7 +41,9 @@ gentest(
         $TOOL $(location :multilines_file) \
             'This is a multi lines file,' \
             'use strip option to remove first empty newline' \
-            'and all empty spaces on the left of the text.'
+            'and all empty spaces on the left of the text.' \
+            't - t should not be stripped' \
+            '\ - nor backslash'
     """,
     test_tools = ["//test/build_defs:content_checker"],
 )


### PR DESCRIPTION
Please doesn't really support tabs,
the strip command ended up removing t and \ from lines beginnning with them.
test_file_content.sh didn't correctly checked multilines.

Everything should be good with these changes