### PR TITLE
Add stacktrace builtin

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -263,6 +263,16 @@
     <li>
       <span>
         <code class="code"
+          ><span class="fn-name">stacktrace</span
+          ><span class="fn-p">()</span></code
+        >
+        - return a list of dict containing filename, package_name, subrepo and function
+        leading to the current scope where stacktrace was called.
+      </span>
+    </li>
+    <li>
+      <span>
+        <code class="code"
           ><span class="fn-name">json</span><span class="fn-p">(</span
           ><span class="fn-arg">x</span><span class="fn-p">)</span></code
         >

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -281,6 +281,10 @@ def breakpoint():
     """Breaks into an interactive debugging session."""
     pass
 
+def stacktrace():
+    """Returns a stacktrace."""
+    pass
+
 def is_semver(s:str) -> bool:
     """Returns true if the given string is a semantic version number (either with or without
     a leading v), or false if not.

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -70,6 +70,7 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "set_command", setCommand)
 	setNativeCode(s, "json", valueAsJSON)
 	setNativeCode(s, "breakpoint", breakpoint)
+	setNativeCode(s, "stacktrace", stacktrace)
 	setNativeCode(s, "is_semver", isSemver)
 	setNativeCode(s, "semver_check", semverCheck)
 	setNativeCode(s, "looks_like_build_label", looksLikeBuildLabel)
@@ -1387,6 +1388,25 @@ func breakpoint(s *scope, args []pyObject) pyObject {
 	}
 	fmt.Printf("Debugger exited, continuing...\n")
 	return None
+}
+
+// stacktrace returns a list of dict containing filename, package_name, subrepo and function
+// leading to the current scope where stacktrace was called
+func stacktrace(s *scope, args []pyObject) pyObject {
+	ret := make(pyList, 0)
+	for scp := s; scp != nil; scp = scp.caller {
+		if scp.function != nil {
+			trace := make(pyDict, 0)
+			trace["filename"] = pyString(scp.filename)
+			if scp.pkg != nil {
+				trace["subrepo"] = pyString(scp.pkg.SubrepoName)
+				trace["package"] = pyString(scp.pkg.Name)
+			}
+			trace["function"] = pyString(scp.function.name)
+			ret = append(ret, trace)
+		}
+	}
+	return ret
 }
 
 func isSemver(s *scope, args []pyObject) pyObject {

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -277,11 +277,13 @@ type parseTarget struct {
 type scope struct {
 	interpreter     *interpreter
 	filename        string
+	function        *pyFunc
 	state           *core.BuildState
 	pkg             *core.Package
 	subincludeLabel *core.BuildLabel
 	parsingFor      *parseTarget
 	parent          *scope
+	caller          *scope
 	locals          pyDict
 	config          *pyConfig
 	globber         *fs.Globber
@@ -369,13 +371,19 @@ func (s *scope) NewPackagedScope(pkg *core.Package, mode core.ParseMode, hint in
 }
 
 func (s *scope) newScope(pkg *core.Package, mode core.ParseMode, filename string, hint int) *scope {
+	return s.newFunctionScope(pkg, mode, filename, nil, s, hint)
+}
+
+func (s *scope) newFunctionScope(pkg *core.Package, mode core.ParseMode, filename string, function *pyFunc, caller *scope, hint int) *scope {
 	s2 := &scope{
 		filename:    filename,
+		function:    function,
 		interpreter: s.interpreter,
 		state:       s.state,
 		pkg:         pkg,
 		parsingFor:  s.parsingFor,
 		parent:      s,
+		caller:      caller,
 		locals:      make(pyDict, hint),
 		config:      s.config,
 		Callback:    s.Callback,

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -637,7 +637,7 @@ func (f *pyFunc) Call(s *scope, c *Call) pyObject {
 		}
 		return f.callNative(s, c)
 	}
-	s2 := f.scope.newScope(s.pkg, s.mode, f.scope.filename, len(f.args)+1)
+	s2 := f.scope.newFunctionScope(s.pkg, s.mode, f.scope.filename, f, s, len(f.args)+1)
 	s2.config = s.config
 	s2.Set("CONFIG", s.config) // This needs to be copied across too :(
 	s2.Callback = s.Callback

--- a/test/stacktrace/BUILD
+++ b/test/stacktrace/BUILD
@@ -1,0 +1,54 @@
+
+
+expect = [
+    {
+        "filename": "test/stacktrace/BUILD",
+        "subrepo": "",
+        "package": "test/stacktrace",
+        "function": "<lambda>"
+    },
+    {
+        "filename": "test/stacktrace/BUILD",
+        "subrepo": "",
+        "package": "test/stacktrace",
+        "function": "c"
+    },
+    {
+        "filename": "test/stacktrace/BUILD",
+        "subrepo": "",
+        "package": "test/stacktrace",
+        "function": "b"
+    },
+    {
+        "filename": "test/stacktrace/BUILD",
+        "subrepo": "",
+        "package": "test/stacktrace",
+        "function": "a"
+    },
+]
+
+
+def d(res):
+    return res
+
+def c():
+    x = lambda: stacktrace()
+    return d(x())
+
+def b():
+    return c()
+
+def a():
+    return b()
+
+trace = a()
+
+if len(trace) != len(expect):
+    fail(f"trace doesnt have expected lenght\n{expect}\n{trace}")
+
+for i in range(len(expect)):
+    if trace[i] != expect[i]:
+        fail(f"trace is different than expected\n{expect}\n{trace}")
+
+
+


### PR DESCRIPTION
return a list of dict containing filename, package_name, subrepo and function leading to the current scope where stacktrace was called

This useful when using `breakpoint()` to have a stacktrace. 
Also it can be useful to tag current function name to a build_rule