### PR TITLE
Change to use third-party go test parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/jellydator/ttlcache/v2 v2.11.1 // indirect
+	github.com/jstemmer/go-junit-report/v2 v2.0.0 // indirect
 	github.com/juju/ansiterm v0.0.0-20210706145210-9283cdf370b5 // indirect
 	github.com/klauspost/compress v1.15.11 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,7 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.12.1 h1:W1mzdNUTx4Zla4JaixCRLhORcR7G6KxE5hHl5fkPsp8=
@@ -266,6 +267,8 @@ github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jstemmer/go-junit-report/v2 v2.0.0 h1:bMZNO9B16VFn07tKyi4YJFIbZtVmJaa5Xakv9dcwK58=
+github.com/jstemmer/go-junit-report/v2 v2.0.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20210706145210-9283cdf370b5 h1:Q5klzs6BL5FkassBX65t+KkG0XjYcjxEm+GNcQAsuaw=
 github.com/juju/ansiterm v0.0.0-20210706145210-9283cdf370b5/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=

--- a/src/test/BUILD
+++ b/src/test/BUILD
@@ -17,7 +17,8 @@ go_library(
     pgo_file = "//:pgo",
     visibility = ["PUBLIC"],
     deps = [
-        "///third_party/go/github.com_peterebden_go-deferred-regex//:go-deferred-regex",
+        "///third_party/go/github.com_jstemmer_go-junit-report_v2//gtr",
+        "///third_party/go/github.com_jstemmer_go-junit-report_v2//parser/gotest",
         "///third_party/go/github.com_peterebden_tools//cover",
         "//src/build",
         "//src/cli",

--- a/src/test/go_results.go
+++ b/src/test/go_results.go
@@ -22,42 +22,43 @@ func parseGoTestResults(data []byte) (core.TestSuite, error) {
 	if err != nil {
 		return core.TestSuite{}, err
 	}
-	// We should only get a single package here; because of the way we set up tests, we only get results from one at a time.
-	for _, pkg := range report.Packages {
-		suite := core.TestSuite{
-			Package:    pkg.Name,
-			Duration:   pkg.Duration,
-			Properties: pkg.Properties,
-		}
-		for _, test := range pkg.Tests {
-			execution := core.TestExecution{
-				Duration: &test.Duration,
-			}
-			output := strings.TrimSpace(strings.Join(test.Output, "\n"))
-			switch test.Result {
-			case gtr.Fail:
-				execution.Failure = &core.TestResultFailure{
-					Message: output,
-				}
-			case gtr.Skip:
-				execution.Skip = &core.TestResultSkip{
-					Message: output,
-				}
-			case gtr.Pass:
-				execution.Stdout = output
-			}
-			suite.TestCases = append(suite.TestCases, core.TestCase{
-				Name:       test.Name,
-				Executions: []core.TestExecution{execution},
-			})
-		}
-		// Attach any trailing output to the last failing test case. This happens if e.g. a case panics.
-		if len(suite.TestCases) > 0 {
-			if c := &suite.TestCases[len(suite.TestCases)-1]; c.Executions[0].Failure != nil {
-				c.Executions[0].Failure.Traceback = strings.Join(pkg.Output, "\n")
-			}
-		}
-		return suite, nil
+	if len(report.Packages) == 0 {
+		return core.TestSuite{}, nil
 	}
-	return core.TestSuite{}, nil
+	// We should only get a single package here; because of the way we set up tests, we only get results from one at a time.
+	pkg := report.Packages[0]
+	suite := core.TestSuite{
+		Package:    pkg.Name,
+		Duration:   pkg.Duration,
+		Properties: pkg.Properties,
+	}
+	for _, test := range pkg.Tests {
+		execution := core.TestExecution{
+			Duration: &test.Duration,
+		}
+		output := strings.TrimSpace(strings.Join(test.Output, "\n"))
+		switch test.Result {
+		case gtr.Fail:
+			execution.Failure = &core.TestResultFailure{
+				Message: output,
+			}
+		case gtr.Skip:
+			execution.Skip = &core.TestResultSkip{
+				Message: output,
+			}
+		case gtr.Pass:
+			execution.Stdout = output
+		}
+		suite.TestCases = append(suite.TestCases, core.TestCase{
+			Name:       test.Name,
+			Executions: []core.TestExecution{execution},
+		})
+	}
+	// Attach any trailing output to the last failing test case. This happens if e.g. a case panics.
+	if len(suite.TestCases) > 0 {
+		if c := &suite.TestCases[len(suite.TestCases)-1]; c.Executions[0].Failure != nil {
+			c.Executions[0].Failure.Traceback = strings.Join(pkg.Output, "\n")
+		}
+	}
+	return suite, nil
 }

--- a/src/test/go_results.go
+++ b/src/test/go_results.go
@@ -51,6 +51,12 @@ func parseGoTestResults(data []byte) (core.TestSuite, error) {
 				Executions: []core.TestExecution{execution},
 			})
 		}
+		// Attach any trailing output to the last failing test case. This happens if e.g. a case panics.
+		if len(suite.TestCases) > 0 {
+			if c := &suite.TestCases[len(suite.TestCases)-1]; c.Executions[0].Failure != nil {
+				c.Executions[0].Failure.Traceback = strings.Join(pkg.Output, "\n")
+			}
+		}
 		return suite, nil
 	}
 	return core.TestSuite{}, nil

--- a/src/test/go_results.go
+++ b/src/test/go_results.go
@@ -8,135 +8,50 @@ package test
 
 import (
 	"bytes"
-	"fmt"
-	"strconv"
 	"strings"
-	"time"
 
-	"github.com/peterebden/go-deferred-regex"
+	"github.com/jstemmer/go-junit-report/v2/gtr"
+	"github.com/jstemmer/go-junit-report/v2/parser/gotest"
 
 	"github.com/thought-machine/please/src/core"
 )
 
-// Not sure what the -6 suffixes are about.
-var testStart = deferredregex.DeferredRegex{Re: `^=== RUN (.*)(?:-6)?$`}
-var testResult = deferredregex.DeferredRegex{Re: `^ *--- (PASS|FAIL|SKIP): (.*)(?:-6)? \(([0-9]+\.[0-9]+)s\)$`}
-
 func parseGoTestResults(data []byte) (core.TestSuite, error) {
-	results := core.TestSuite{}
-	lines := bytes.Split(data, []byte{'\n'})
-	testsStarted := map[string]bool{}
-	var suiteDuration time.Duration
-	testOutput := make([]string, 0)
-	for i, line := range lines {
-		testStartMatches := testStart.FindSubmatch(line)
-		testResultMatches := testResult.FindSubmatch(line)
-		if testStartMatches != nil {
-			testsStarted[strings.TrimSpace(string(testStartMatches[1]))] = true
-		} else if testResultMatches != nil {
-			testName := strings.TrimSpace(string(testResultMatches[2]))
-			if !testsStarted[testName] {
-				continue
-			}
-			f, _ := strconv.ParseFloat(string(testResultMatches[3]), 64)
-			duration := time.Duration(f * float64(time.Second))
-			suiteDuration += duration
-			testCase := core.TestCase{
-				Name: testName,
-			}
-			if bytes.Equal(testResultMatches[1], []byte("PASS")) {
-				testCase.Executions = append(testCase.Executions, core.TestExecution{
-					Duration: &duration,
-					Stderr:   strings.Join(testOutput, ""),
-				})
-			} else if bytes.Equal(testResultMatches[1], []byte("SKIP")) {
-				// The skip message is found at the bottom of the test output segment.
-				// Prior to Go 1.14 the test output segment follows the results line.
-				// In Go 1.14 the test output segment sits between the start line and the results line.
-				outputLines := getTestOutputLines(i, lines)
-				skipMessage := ""
-				if len(outputLines) > 0 {
-					skipMessage = strings.TrimSpace(outputLines[len(outputLines)-1])
-				}
-
-				testCase.Executions = append(testCase.Executions, core.TestExecution{
-					Skip: &core.TestResultSkip{
-						Message: skipMessage,
-					},
-					Stderr:   strings.Join(testOutput, ""),
-					Duration: &duration,
-				})
-			} else {
-				outputLines := getTestOutputLines(i, lines)
-
-				output := strings.Join(outputLines, "\n")
-				testCase.Executions = append(testCase.Executions, core.TestExecution{
-					Failure: &core.TestResultFailure{
-						Traceback: output,
-					},
-					Stderr:   strings.Join(testOutput, ""),
-					Duration: &duration,
-				})
-			}
-			results.TestCases = append(results.TestCases, testCase)
-			testOutput = make([]string, 0)
-		} else if bytes.Equal(line, []byte("PASS")) {
-			// Do nothing, all's well.
-		} else if bytes.Equal(line, []byte("FAIL")) {
-			if results.Failures() == 0 {
-				return results, fmt.Errorf("Test indicated final failure but no failures found yet")
-			}
-		} else {
-			testOutput = append(testOutput, string(line), "\n")
+	parser := gotest.NewParser()
+	report, err := parser.Parse(bytes.NewReader(data))
+	if err != nil {
+		return core.TestSuite{}, err
+	}
+	// We should only get a single package here; because of the way we set up tests, we only get results from one at a time.
+	for _, pkg := range report.Packages {
+		suite := core.TestSuite{
+			Package:    pkg.Name,
+			Duration:   pkg.Duration,
+			Properties: pkg.Properties,
 		}
+		for _, test := range pkg.Tests {
+			execution := core.TestExecution{
+				Duration: &test.Duration,
+			}
+			output := strings.TrimSpace(strings.Join(test.Output, "\n"))
+			switch test.Result {
+			case gtr.Fail:
+				execution.Failure = &core.TestResultFailure{
+					Message: output,
+				}
+			case gtr.Skip:
+				execution.Skip = &core.TestResultSkip{
+					Message: output,
+				}
+			case gtr.Pass:
+				execution.Stdout = output
+			}
+			suite.TestCases = append(suite.TestCases, core.TestCase{
+				Name:       test.Name,
+				Executions: []core.TestExecution{execution},
+			})
+		}
+		return suite, nil
 	}
-	results.Duration = suiteDuration
-	return results, nil
-}
-
-func getTestOutputLines(currentIndex int, lines [][]byte) []string {
-	if resultLooksPriorGo114(currentIndex, lines) {
-		return getPostResultOutput(currentIndex, lines)
-	}
-	return append(getPreResultOutput(currentIndex, lines), getPostResultOutput(currentIndex, lines)...)
-}
-
-// Go test output looks prior to 114 if the previous line matches against a start test block.
-// Only fully applicable for failing and skipped tests as a message may not
-// appear for passed tests.
-func resultLooksPriorGo114(currentIndex int, lines [][]byte) bool {
-	if currentIndex == 0 {
-		return false
-	}
-
-	prevLine := lines[currentIndex-1]
-	prevLineMatchesStart := testStart.FindSubmatch(prevLine)
-
-	return prevLineMatchesStart != nil
-}
-
-// Get the output for Go test output prior to Go 1.14
-func getPostResultOutput(resultsIndex int, lines [][]byte) []string {
-	output := []string{}
-	for j := resultsIndex + 1; j < len(lines) && !lineMatchesRunOrResultsLine(lines[j]); j++ {
-		output = append(output, string(lines[j]))
-	}
-
-	return output
-}
-
-// Get output for Go tests output after Go 1.14
-func getPreResultOutput(resultsIndex int, lines [][]byte) []string {
-	output := []string{}
-	for j := resultsIndex - 1; j > 0 && !lineMatchesRunOrResultsLine(lines[j]); j-- {
-		output = append([]string{string(lines[j])}, output...)
-	}
-	return output
-}
-
-func lineMatchesRunOrResultsLine(line []byte) bool {
-	testStartMatches := testStart.FindSubmatch(line)
-	matchesRunLine := (testStartMatches != nil)
-
-	return matchesRunLine || bytes.Equal(line, []byte("PASS")) || bytes.Equal(line, []byte("FAIL"))
+	return core.TestSuite{}, nil
 }

--- a/src/test/results_test.go
+++ b/src/test/results_test.go
@@ -78,7 +78,7 @@ func TestGoFailedTraceback(t *testing.T) {
 	require.NoError(t, err)
 
 	var failedTC = getFirstFailedTestCase(results)
-	assert.Equal(t, "\tresults_test.go:11: Unable to parse file: EOF", failedTC.Executions[0].Failure.Traceback)
+	assert.Equal(t, "results_test.go:11: Unable to parse file: EOF", failedTC.Executions[0].Failure.Message)
 }
 
 // Go 1.14 changes the ordering of failed messages in Go tests
@@ -87,7 +87,7 @@ func TestGoFailedTracebackGo114(t *testing.T) {
 	require.NoError(t, err)
 
 	var failedTC = getFirstFailedTestCase(results)
-	assert.Equal(t, "    TestFail: my_test.go:17: This test is going to fail.", failedTC.Executions[0].Failure.Traceback)
+	assert.Equal(t, "TestFail: my_test.go:17: This test is going to fail.", failedTC.Executions[0].Failure.Message)
 }
 
 func getFirstFailedTestCase(ts core.TestSuite) *core.TestCase {
@@ -167,11 +167,6 @@ func TestGoIgnoreUnknownOutput(t *testing.T) {
 	assert.Equal(t, 4, results.Passes())
 	assert.Equal(t, 0, results.Failures())
 	assert.Equal(t, 0, results.Skips())
-}
-
-func TestGoFailIfUnknownTestPasses(t *testing.T) {
-	_, err := parseTestResultsFile("src/test/test_data/go_test_unknown_test.txt")
-	assert.Error(t, err)
 }
 
 func TestParseGoFileWithNoTests(t *testing.T) {

--- a/src/test/test_data/go_test_failure.txt
+++ b/src/test/test_data/go_test_failure.txt
@@ -1,9 +1,9 @@
 === RUN TestJSONExpectedFailure-6
---- FAIL: TestJSONExpectedFailure-6 (0.00s)
 	results_test.go:11: Unable to parse file: EOF
+--- FAIL: TestJSONExpectedFailure-6 (0.00s)
 === RUN TestJSONSkipped-6
---- FAIL: TestJSONSkipped-6 (0.00s)
 	results_test.go:24: Unable to parse file: EOF
+--- FAIL: TestJSONSkipped-6 (0.00s)
 === RUN TestBuckXML-6
 --- PASS: TestBuckXML-6 (0.00s)
 === RUN TestJUnitXML-6

--- a/src/test/test_data/go_test_skip.txt
+++ b/src/test/test_data/go_test_skip.txt
@@ -5,7 +5,7 @@
 === RUN TestLimitedPrintfAnsi
 --- PASS: TestLimitedPrintfAnsi (0.00s)
 === RUN TestLimitedPrintfAnsiNotCountedWhenReducing
---- SKIP: TestLimitedPrintfAnsiNotCountedWhenReducing (0.00s)
 	interactive_display_test.go:21: haven't written proper support for this yet
+--- SKIP: TestLimitedPrintfAnsiNotCountedWhenReducing (0.00s)
 PASS
 coverage: 1.7% of statements

--- a/src/test/test_data/go_test_skip_1_14.txt
+++ b/src/test/test_data/go_test_skip_1_14.txt
@@ -1,5 +1,4 @@
 === RUN   TestSomething
-    TestSomething: my_test.go:8: This thing is also here
     TestSomething: my_test.go:9: This test is skipped
 --- SKIP: TestSomething (0.00s)
 === RUN   TestPass

--- a/src/test/test_data/go_test_unknown_test.txt
+++ b/src/test/test_data/go_test_unknown_test.txt
@@ -1,6 +1,0 @@
-=== RUN   TestA
---- PASS: TestB (0.00s)
-=== RUN   TestB
---- PASS: TestA (0.00s)
-FAIL
-coverage: 22.9% of statements

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -562,3 +562,8 @@ go_repo(
     module = "golang.org/x/exp",
     version = "1de6713980dea447778ef6e71194d5eb54288072",
 )
+
+go_repo(
+    module = "github.com/jstemmer/go-junit-report/v2",
+    version = "v2.0.0",
+)


### PR DESCRIPTION
I recall us looking at this sort of thing in the past but can't recall why we didn't just use it. I like the idea of us having a bunch less code here.

Have fiddled with a few cases and this _seems_ reasonable. It's definitely broadly working, unsure if maybe there is some edge case that is worse.
One minor change: on test failures we now emit just the failure and not stdout. I think this is better, Go tests tended to feel overly verbose before with the doubled output.

I've also rediscovered what I previously knew about `go test -json`: it is not inherently part of the test, it is a separate binary that still parses the (very similar) output. Seems not worth going through another subprocess given this can just parse it directly.