### PR TITLE
Update golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.18'
+          go-version: '^1.21'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.51.2
+          version: v1.54.2
           args: src/... tools/...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,10 @@ issues:
     - exitAfterDefer # Potentially useful but not in any cases it fires right now.
     - receiver-naming # Think this is confused about generics
     - error-strings
+    - unused-parameter # Potentially useful but we have quite a few cases to fix
+    - empty-block # generally not useful
+    - redefines-builtin-id
+    - superfluous-else
   exclude-rules:
     - path: _test\.go
       linters:
@@ -34,7 +38,6 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
-    - deadcode
     - dogsled
     - dupl
     - exportloopref
@@ -43,19 +46,16 @@ linters:
     - gofmt
     - gosimple
     - govet
-    - ifshort
     - ineffassign
     - misspell
     - nilerr
     - prealloc
     - revive
     - staticcheck
-    - structcheck
     - tenv
     - thelper
     - unconvert
     - unused
-    - varcheck
     - wastedassign
     - whitespace
 


### PR DESCRIPTION
Disables some deprecated linters & a few warnings that we generally aren't actioning (and probably not really intending to).