### PR TITLE
Fix visibility check on subrepos

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -62,7 +62,7 @@ plugins = {
     "go": "v1.8.2",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
-    "go-proto": "v0.2.0",
+    "go-proto": "v0.2.1",
     "python-proto": "v0.1.0",
     "proto": "v0.2.1",
 }

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.4.1",
     "java": "v0.3.0",
-    "go": "v1.8.1",
+    "go": "v1.8.2",
     "cc": "v0.3.2",
     "shell": "v0.2.0",
     "go-proto": "v0.2.0",

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -60,7 +60,7 @@ plugins = {
     "python": "v1.4.1",
     "java": "v0.3.0",
     "go": "v1.8.2",
-    "cc": "v0.3.2",
+    "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.2.0",
     "python-proto": "v0.1.0",

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -269,6 +269,9 @@ func (label BuildLabel) IsPseudoTarget() bool {
 
 // Includes returns true if label includes the other label (//pkg:target1 is covered by //pkg:all etc).
 func (label BuildLabel) Includes(that BuildLabel) bool {
+	if label.Subrepo != that.Subrepo && label.Subrepo != "" {
+		return false
+	}
 	if (label.PackageName == "" && label.IsAllSubpackages()) ||
 		that.PackageName == label.PackageName ||
 		strings.HasPrefix(that.PackageName, label.PackageName+"/") {

--- a/src/core/build_label_test.go
+++ b/src/core/build_label_test.go
@@ -51,6 +51,14 @@ func TestIncludesSubpackages(t *testing.T) {
 	assert.True(t, label1.Includes(label2))
 }
 
+func TestIncludesSubrepo(t *testing.T) {
+	label1 := BuildLabel{Subrepo: "plz", PackageName: "src/core", Name: "..."}
+	label2 := BuildLabel{Subrepo: "plz", PackageName: "src/core", Name: "core_test"}
+	label3 := BuildLabel{Subrepo: "go", PackageName: "src/core", Name: "core_test"}
+	assert.True(t, label1.Includes(label2))
+	assert.False(t, label1.Includes(label3))
+}
+
 func TestLabelParent(t *testing.T) {
 	label := BuildLabel{PackageName: "src/core", Name: "core"}
 	assert.Equal(t, label, label.Parent())


### PR DESCRIPTION
Looks like this never got added when we added the subrepo concept.

This is of course fixing a bug so we can call it not a breaking change, but it probably will break things out there that are incorrect. Arguably it may be safer to do this at a major version.