### PR TITLE
Make provides add dependencies too

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1175,7 +1175,9 @@ func (target *BuildTarget) AddProvide(language string, label BuildLabel) {
 	} else {
 		target.Provides[language] = label
 	}
-	target.AddDependency(label)
+	if label != target.Label {
+		target.AddDependency(label)
+	}
 }
 
 // ProvideFor returns the build label that we'd provide for the given target.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1175,6 +1175,7 @@ func (target *BuildTarget) AddProvide(language string, label BuildLabel) {
 	} else {
 		target.Provides[language] = label
 	}
+	target.AddDependency(label)
 }
 
 // ProvideFor returns the build label that we'd provide for the given target.


### PR DESCRIPTION
Relevant: https://github.com/please-build/go-rules/pull/162

It seems that if you don't do this, there is no direct dependency, and you can wind up with weird "should be built by now" errors. You are of course _meant_ to ensure there's at least an indirect one but it's not clear to me that there's any reason for us not to just add this.