### PR TITLE
plz run parallel/sequential accepts inline args

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -57,7 +57,7 @@ genrule(
 
 # Plugin versions to pull the docs from
 plugins = {
-    "python": "v1.4.1",
+    "python": "v1.5.0",
     "java": "v0.3.0",
     "go": "v1.9.1",
     "cc": "v0.4.0",

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.4.1",
     "java": "v0.3.0",
-    "go": "v1.9.0",
+    "go": "v1.9.1",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.2.1",

--- a/src/please.go
+++ b/src/please.go
@@ -602,6 +602,7 @@ var buildFunctions = map[string]func() int{
 				dir = getAbsolutePath(opts.Run.WD, originalWorkingDirectory)
 			}
 			output := opts.Run.Parallel.Output
+			args = append(args, opts.Run.Sequential.Args.AsStrings()...)
 			os.Exit(run.Parallel(context.Background(), state, annotated, args, opts.Run.Parallel.NumTasks, output, opts.Run.Remote, opts.Run.Env, opts.Run.Parallel.Detach, opts.Run.InTempDir, dir))
 		}
 		return 1
@@ -618,6 +619,7 @@ var buildFunctions = map[string]func() int{
 				log.Warningf("--quiet has been deprecated in favour of --output=quiet and will be removed in v17.")
 				output = process.Quiet
 			}
+			args = append(args, opts.Run.Sequential.Args.AsStrings()...)
 			os.Exit(run.Sequential(state, annotated, args, output, opts.Run.Remote, opts.Run.Env, opts.Run.InTempDir, dir))
 		}
 		return 1

--- a/src/please.go
+++ b/src/please.go
@@ -1434,14 +1434,6 @@ func initBuild(args []string) string {
 	return command
 }
 
-func unannotateLabels(als []core.AnnotatedOutputLabel) []core.BuildLabel {
-	labels := make([]core.BuildLabel, len(als))
-	for i, al := range als {
-		labels[i] = al.BuildLabel
-	}
-	return labels
-}
-
 func writeGoTraceFile() {
 	if err := runtime.StartTrace(); err != nil {
 		log.Fatalf("failed to start trace: %v", err)

--- a/src/please.go
+++ b/src/please.go
@@ -1209,7 +1209,15 @@ type TargetsOrArgs []TargetOrArg
 func (l TargetsOrArgs) Separate() (annotated []core.AnnotatedOutputLabel, unannotated []core.BuildLabel, args []string) {
 	for _, arg := range l {
 		if l, _ := arg.label.Label(); l.IsEmpty() {
-			args = append(args, arg.arg)
+			if arg.arg == "-" {
+				labels := plz.ReadAndParseStdinLabels()
+				unannotated = append(unannotated, labels...)
+				for _, label := range labels {
+					annotated = append(annotated, core.AnnotatedOutputLabel{BuildLabel: label})
+				}
+			} else {
+				args = append(args, arg.arg)
+			}
 		} else {
 			annotated = append(annotated, arg.label)
 			unannotated = append(unannotated, arg.label.BuildLabel)

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -239,12 +239,19 @@ func ReadStdinLabels(labels []core.BuildLabel) []core.BuildLabel {
 	ret := []core.BuildLabel{}
 	for _, l := range labels {
 		if l == core.BuildLabelStdin {
-			for s := range flags.ReadStdin() {
-				ret = append(ret, core.ParseBuildLabels([]string{s})...)
-			}
+			ret = append(ret, ReadAndParseStdinLabels()...)
 		} else {
 			ret = append(ret, l)
 		}
+	}
+	return ret
+}
+
+// ReadAndParseStdinLabels unconditionally reads stdin and parses it into build labels.
+func ReadAndParseStdinLabels() []core.BuildLabel {
+	ret := []core.BuildLabel{}
+	for s := range flags.ReadStdin() {
+		ret = append(ret, core.ParseBuildLabels([]string{s})...)
 	}
 	return ret
 }


### PR DESCRIPTION
Decided I hate the current nested flag approach. This leverages the same approach as `exec`. Before:
```
$ plz run sequential //src:please //src:please -- --version
Build stopped after 30ms. 1 target failed:
    //--version:--version
Can't build //--version:--version; the directory --version doesn't exist
$ plz run sequential //src:please //src:please -a="--version"
Please version 17.3.1
Please version 17.3.1
```
After:
```
$ plz run //src:please -- --version
Please version 17.3.1
$ plz run parallel //src:please //src:please -- --version
Please version 17.3.1
Please version 17.3.1
$ plz run sequential //src:please //src:please -- --version
Please version 17.3.1
Please version 17.3.1
```
I think this is a lot more generally sane & consistent with other commands.