### PR TITLE
Fix reduce builtin

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -186,11 +186,11 @@
       <span>
         <code class="code"
           ><span class="fn-name">reduce</span><span class="fn-p">(</span
-          ><span class="fn-arg">function</span>, <span class="fn-arg">seq</span
+          ><span class="fn-arg">reducer</span>, <span class="fn-arg">seq</span
           >, <span class="fn-arg">initializer=None</span
           ><span class="fn-p">)</span></code
         >
-        - apply function of two arguments cumulatively to the items of seq from left to right reducing to a single value returning that value. eg. reduce(lambda x, y: x+y, [0, 1, 2, 3]) would return (((0+1)+2)+3)=6. If initializer is present it is placed before the first item in the sequence.
+        - returns a single value by applying function cumulatively to the list items, from left to right.
       </span>
     </li>
     <li>

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -99,7 +99,7 @@ def filter(filter:function, seq:list):
 def map(mapper:function, seq:list):
     pass
 
-def reduce(function:function, seq:list, initializer=None):
+def reduce(reducer:function, seq:list, initializer=None):
     pass
 
 def bool(b) -> bool:

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -751,32 +751,29 @@ func mapFunc(s *scope, args []pyObject) pyObject {
 }
 
 func reduce(s *scope, args []pyObject) pyObject {
-	function, isFunc := args[0].(*pyFunc)
+	reducer, isFunc := args[0].(*pyFunc)
 	l, isList := args[1].(pyList)
-	init := args[2]
-	s.Assert(isFunc, "Argument function must be callable, not %s", args[0].Type())
+	s.Assert(isFunc, "Argument reducer must be callable, not %s", args[0].Type())
 	s.Assert(isList, "Argument seq must be a list, not %s", args[1].Type())
 
-	ret := init
-	start := 0
-	if init == None {
-		start = 1
-		if len(l) > 0 {
-			ret = l[0]
-		}
-		if len(l) <= 1 {
-			return ret
-		}
+	if len(l) == 0 {
+		return args[2]
 	}
-	for _, li := range l[start:] {
+
+	var ret pyObject
+	if ret = args[2]; ret == None {
+		ret, l = l[0], l[1:]
+	}
+
+	for _, li := range l {
 		c := &Call{
 			Arguments: []CallArgument{{
-				Value: Expression{Optimised: &OptimisedExpression{Constant: li}},
-			}, {
 				Value: Expression{Optimised: &OptimisedExpression{Constant: ret}},
+			}, {
+				Value: Expression{Optimised: &OptimisedExpression{Constant: li}},
 			}},
 		}
-		ret = function.Call(s, c)
+		ret = reducer.Call(s, c)
 	}
 	return ret
 }

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -205,6 +205,7 @@ func TestReduce(t *testing.T) {
 	assert.Equal(t, pyInt(5), s.Lookup("r5"))
 	assert.Equal(t, pyInt(6), s.Lookup("r6"))
 	assert.Equal(t, pyInt(7), s.Lookup("r7"))
+	assert.EqualValues(t, "abcde", s.Lookup("r8"))
 }
 
 func TestInterpreterUnpacking(t *testing.T) {

--- a/src/parse/asp/test_data/interpreter/reduce.build
+++ b/src/parse/asp/test_data/interpreter/reduce.build
@@ -3,7 +3,7 @@ r1 = reduce(lambda x, y: x + y, [0, 1, 2, 3])
 
 # with init
 r2 = reduce(
-    function=lambda x, y: x + y,
+    reducer=lambda x, y: x + y,
     seq=[0, 1, 2, 3],
     initializer=10,
 )
@@ -15,3 +15,6 @@ r4 = reduce(lambda x, y: x + y, [])
 r5 = reduce(lambda x, y: x + y, [], initializer=5)
 r6 = reduce(lambda x, y: x + y, [1], initializer=5)
 r7 = reduce(lambda x, y: x + y, [7])
+
+# string (non-commutative) 
+r8 = reduce(lambda x, y: ''.join((x, y)), ["a", "b", "c", "d", "e"])


### PR DESCRIPTION
#2880 introduced a buggy reduce builtin which operates on the given list from right to left. So this:
```
reduce(lambda x, y: ''.join((x, y)), ["a", "b", "c", "d", "e"])
```
incorrectly returns "edcba" instead of "abcde".

The proposed patches hopefully solve this bug.