### PR TITLE
Use errgroup limiter where appropriate

### DIFF
--- a/src/format/fmt.go
+++ b/src/format/fmt.go
@@ -41,12 +41,10 @@ func Format(config *core.Configuration, filenames []string, rewrite, quiet bool)
 func formatAll(filenames <-chan string, parallelism int, rewrite, quiet bool) (bool, error) {
 	var changed int64
 	var g errgroup.Group
-	limiter := make(chan struct{}, parallelism)
+        g.SetLimit(parallelism)
 	for filename := range filenames {
 		filename := filename
 		g.Go(func() error {
-			limiter <- struct{}{}
-			defer func() { <-limiter }()
 			c, err := format(filename, rewrite, quiet)
 			if c {
 				atomic.AddInt64(&changed, 1)

--- a/src/format/fmt.go
+++ b/src/format/fmt.go
@@ -41,7 +41,7 @@ func Format(config *core.Configuration, filenames []string, rewrite, quiet bool)
 func formatAll(filenames <-chan string, parallelism int, rewrite, quiet bool) (bool, error) {
 	var changed int64
 	var g errgroup.Group
-        g.SetLimit(parallelism)
+	g.SetLimit(parallelism)
 	for filename := range filenames {
 		filename := filename
 		g.Go(func() error {

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -39,7 +39,7 @@ func Parallel(ctx context.Context, state *core.BuildState, labels []core.Annotat
 	prepareRun()
 
 	var g errgroup.Group
-        g.SetLimit(numTasks)
+	g.SetLimit(numTasks)
 	for _, label := range labels {
 		label := label // capture locally
 		g.Go(func() error {

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -38,14 +38,11 @@ func Run(state *core.BuildState, label core.AnnotatedOutputLabel, args []string,
 func Parallel(ctx context.Context, state *core.BuildState, labels []core.AnnotatedOutputLabel, args []string, numTasks int, outputMode process.OutputMode, remote, env, detach, inTmp bool, dir string) int {
 	prepareRun()
 
-	limiter := make(chan struct{}, numTasks)
 	var g errgroup.Group
+        g.SetLimit(numTasks)
 	for _, label := range labels {
 		label := label // capture locally
 		g.Go(func() error {
-			limiter <- struct{}{}
-			defer func() { <-limiter }()
-
 			err := runWithOutput(ctx, state, label, args, outputMode, remote, env, detach, inTmp, dir)
 			if err != nil && ctx.Err() == nil {
 				log.Error("Command failed: %s", err)


### PR DESCRIPTION
errgroup now has one (well it has for a while), use that where possible