### PR TITLE
Don't use the bootstrap version of please_go

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,13 +1,12 @@
 [parse]
 BlacklistDirs = tree ; The performance test repo
 preloadsubincludes = ///go//build_defs:go
-preloadsubincludes = ///cc//build_defs:cc 
+preloadsubincludes = ///cc//build_defs:cc
 preloadsubincludes = ///python//build_defs:python
 preloadsubincludes = ///shell//build_defs:shell
 
 [Plugin "go"]
 Target = //plugins:go
-pleasegotool = ///go//tools/please_go:bootstrap
 importpath = github.com/thought-machine/please
 gotool = //third_party/go:toolchain|go
 FeatureFlags = go_get


### PR DESCRIPTION
I'm not sure what the reason for this was? If it's to fix the circular dependency on bringing up a new architecture, I think we could fix that another way; it seems it'd be nice not to add its bootstrap process to plz when there are compiled binaries available.