### PR TITLE
Add all commit date formats to supported git_show() format verbs

### DIFF
--- a/src/parse/asp/exec.go
+++ b/src/parse/asp/exec.go
@@ -263,7 +263,11 @@ func execGitShow(s *scope, args []pyObject) pyObject {
 	case "%cn": // committer name
 	case "%ce": // committer email
 	case "%ct": // committer date, UNIX timestamp
-	case "%D": // ref names without the " (", ")" wrapping.
+	case "%ci": // committer date, ISO8601-like format
+	case "%cI": // committer date, strict ISO8601
+	case "%cs": // committer date, short format (YYYY-MM-DD)
+	case "%ch": // committer date, human style
+	case "%D": // ref names without the " (", ")" wrapping
 	case "%e": // encoding
 	case "%s": // subject
 	case "%f": // sanitized subject line, suitable for a filename


### PR DESCRIPTION
This is a proposal to add the five `%cX` date formats to `please git-show()` supported verbs. The rationale is simple:

Right now, with no builtin support for dates, the only available verb, `%ct` (UNIX timestamp) is almost useless unless you precisely need it. With the proposed changes, one could freely use any date format including the ones that are humanely readable. 

PS. It is also funny that in `execGitShow()` [heading comment](https://github.com/thought-machine/please/blob/6cc3d7689ad78c667618b5ca9d089630864cd140/src/parse/asp/exec.go#L247-L253), the explanation uses `%ci` which is *not* supported by the code and would be if the PR was accepted.