### PR TITLE
Revert "Make provides add dependencies too (#2915)"

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1175,9 +1175,6 @@ func (target *BuildTarget) AddProvide(language string, label BuildLabel) {
 	} else {
 		target.Provides[language] = label
 	}
-	if label != target.Label {
-		target.AddDependency(label)
-	}
 }
 
 // ProvideFor returns the build label that we'd provide for the given target.


### PR DESCRIPTION
This reverts commit cf51ad003d63d4e287aeeff51b9ca716ecf6736e.

Apparently something's going wrong internally. I don't have time to investigate any further so just rolling this back.