### PR TITLE
Avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/src/fs/glob.go
+++ b/src/fs/glob.go
@@ -26,7 +26,7 @@ type regexGlob struct {
 }
 
 func (r regexGlob) Match(name string) (bool, error) {
-	return r.regex.Match([]byte(name)), nil
+	return r.regex.MatchString(name), nil
 }
 
 // This converts the string pattern into a matcher. A matcher can either be one of our homebrew compiled regexs that


### PR DESCRIPTION
We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` when matching string to avoid unnecessary `[]byte` conversions and reduce allocations. A one-line change for free performance improvement.

Example benchmark:

```go
var globRegex = regexp.MustCompile("foo.*")

func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := globRegex.Match([]byte("foo bar baz")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := globRegex.MatchString("foo bar baz"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/thought-machine/please/src/fs
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 3749234	       326.8 ns/op	      16 B/op	       1 allocs/op
BenchmarkMatchString-16    	 8119546	       154.9 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/thought-machine/please/src/fs	2.968s
```