### PR TITLE
Convert cmap shards to an rwmutex

### DIFF
--- a/src/cmap/BUILD
+++ b/src/cmap/BUILD
@@ -19,6 +19,7 @@ go_test(
         ":cmap",
         "///third_party/go/github.com_cespare_xxhash_v2//:v2",
         "///third_party/go/github.com_stretchr_testify//assert",
+        "///third_party/go/golang.org_x_sync//errgroup",
     ],
 )
 
@@ -28,6 +29,7 @@ go_benchmark(
     deps = [
         ":cmap",
         "///third_party/go/github.com_stretchr_testify//assert",
+        "///third_party/go/golang.org_x_sync//errgroup",
     ],
 )
 

--- a/src/cmap/cmap.go
+++ b/src/cmap/cmap.go
@@ -101,7 +101,7 @@ type awaitableValue[V any] struct {
 // A shard is one of the individual shards of a map.
 type shard[K comparable, V any] struct {
 	m map[K]awaitableValue[V]
-	l sync.Mutex
+	l sync.RWMutex
 }
 
 // Set is the equivalent of `map[key] = val`.
@@ -136,6 +136,13 @@ func (s *shard[K, V]) Set(key K, val V, overwrite bool) (V, bool) {
 // Exactly one of the target or channel will be returned.
 // The third value is true if it is the first call that is waiting on this value.
 func (s *shard[K, V]) Get(key K) (val V, wait <-chan struct{}, first bool) {
+	s.l.RLock()
+	if v, ok := s.m[key]; ok {
+		s.l.RUnlock()
+		return v.Val, v.Wait, false
+	}
+	s.l.RUnlock()
+
 	s.l.Lock()
 	defer s.l.Unlock()
 	if v, ok := s.m[key]; ok {
@@ -150,8 +157,8 @@ func (s *shard[K, V]) Get(key K) (val V, wait <-chan struct{}, first bool) {
 
 // Values returns a copy of all the targets currently in the map.
 func (s *shard[K, V]) Values() []V {
-	s.l.Lock()
-	defer s.l.Unlock()
+	s.l.RLock()
+	defer s.l.RUnlock()
 	ret := make([]V, 0, len(s.m))
 	for _, v := range s.m {
 		if v.Wait == nil {


### PR DESCRIPTION
Was noodling around with the mutex profiler post #2942 (which it pinpointed pretty well, at least when invoked in the right way) and found it pointing surprisingly hard at cmap, which I'd less expected given we have a fair number of shards. Turns out that it hotspots quite a bit - it seems a bit less evenly distributed than I would have thought, but think the main issue is that some targets are just accessed way more (because very many things depend on them). Also turns out our access pattern is very read-heavy; there are ~2 orders of magnitude more reads than writes. It's a bit fiddly since we also technically write on the read path to add the wait channel, but there are far more read accesses that access an existing element than ones that don't.

This converts the mutex to an RWMutex; it slightly trades off the 'get a non existing item' path (which now needs an extra map lookup) for optimising the 'get an existing item' path to be able to happen in parallel. This drops it right out of the contention profile, and the new benchmark is more than twice as good:
```
BenchmarkMapInsertsAndGets-12    	      40	  25356774 ns/op
```
vs.
```
BenchmarkMapInsertsAndGets-12    	     120	  10297239 ns/op
```
Theoretically we could do slightly better if we had an upgradeable RWMutex (i.e. a path where, we can go from holding the read lock to holding the write lock without unlocking) but I don't think Go's can support that as is (it seems very hard; Boost has something that seems to do it but I'm not really across how it actually works without deadlocking).

I also looked at using `sync.Map` but it dies in `Set` when not overwriting and it closes the channel twice (because two things simultaneously retrieve the previous value). I haven't figured out a good way around that but it does seem faster.