### PR TITLE
Wildcard regex matching for includes

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -1082,10 +1083,12 @@ func match(pattern, s string) bool {
 	if pattern == s {
 		return true
 	}
-	if strings.HasSuffix(pattern, "*") && strings.HasPrefix(s, pattern[:len(pattern)-1]) {
-		return true
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		log.Warning("Error compiling pattern %s: %v", pattern, err)
+		return false
 	}
-	return false
+	return re.MatchString(s)
 }
 
 // PrefixedLabels returns all labels of this target with the given prefix.

--- a/test/include/BUILD
+++ b/test/include/BUILD
@@ -10,13 +10,13 @@ please_repo_e2e_test(
 # Test that we can include targets using a wildcard
 please_repo_e2e_test(
     name = "include_contains_wildcard_test",
-    plz_command = "numtargets=$(plz query alltargets //:all --include 'f*' | wc -l) && if [[ $numtargets -ne 1 ]]; then echo \"Expected 1 target. Got $numtargets\" && exit 1; fi",
+    plz_command = "numtargets=$(plz query alltargets //:all --include 'f.*' | wc -l) && if [[ $numtargets -ne 1 ]]; then echo \"Expected 1 target. Got $numtargets\" && exit 1; fi",
     repo = "test_repo",
 )
 
 # Test that we can exclude targets using a wildcard
 please_repo_e2e_test(
     name = "exclude_contains_wildcard_test",
-    plz_command = "numtargets=$(plz query alltargets //:all --exclude 'ba*' | wc -l) && if [[ $numtargets -ne 1 ]]; then echo \"Expected 1 target. Got $numtargets\" && exit 1; fi",
+    plz_command = "numtargets=$(plz query alltargets //:all --exclude '.*r' | wc -l) && if [[ $numtargets -ne 1 ]]; then echo \"Expected 1 target. Got $numtargets\" && exit 1; fi",
     repo = "test_repo",
 )

--- a/test/include/BUILD
+++ b/test/include/BUILD
@@ -10,13 +10,13 @@ please_repo_e2e_test(
 # Test that we can include targets using a wildcard
 please_repo_e2e_test(
     name = "include_contains_wildcard_test",
-    plz_command = "numtargets=$(plz query alltargets //:all --include 'f.*' | wc -l) && if [[ $numtargets -ne 1 ]]; then echo \"Expected 1 target. Got $numtargets\" && exit 1; fi",
+    plz_command = "numtargets=$(plz query alltargets //:all --include '^f.*' | wc -l) && if [[ $numtargets -ne 1 ]]; then echo \"Expected 1 target. Got $numtargets\" && exit 1; fi",
     repo = "test_repo",
 )
 
 # Test that we can exclude targets using a wildcard
 please_repo_e2e_test(
     name = "exclude_contains_wildcard_test",
-    plz_command = "numtargets=$(plz query alltargets //:all --exclude '.*r' | wc -l) && if [[ $numtargets -ne 1 ]]; then echo \"Expected 1 target. Got $numtargets\" && exit 1; fi",
+    plz_command = "numtargets=$(plz query alltargets //:all --exclude '.*r$' | wc -l) && if [[ $numtargets -ne 1 ]]; then echo \"Expected 1 target. Got $numtargets\" && exit 1; fi",
     repo = "test_repo",
 )


### PR DESCRIPTION
This adds regex-based wildcard matching to the 'include' flag, so that labels can be matched more flexibly. 

Unfortunately, this adds a little breaking change as matching on just `*` will no longer work as before. We could either add a hack to this version so that a single * at the end of the pattern matches like it did before, or we should really wait until the next major release :( 