### PR TITLE
Make config loading use a virtual filesystem

### DIFF
--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -6,7 +6,6 @@ package build_test
 import (
 	"fmt"
 	"io"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,7 +22,7 @@ const size = 1000
 var state *core.BuildState
 
 func TestBuildLotsOfTargets(t *testing.T) {
-	config, _ := core.ReadConfigFiles(os.DirFS("."), nil, nil)
+	config, _ := core.ReadConfigFiles(core.HostFS(), nil, nil)
 	config.Please.NumThreads = 10
 	state = core.NewBuildState(config)
 	state.Parser = &fakeParser{

--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -6,6 +6,7 @@ package build_test
 import (
 	"fmt"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,7 @@ const size = 1000
 var state *core.BuildState
 
 func TestBuildLotsOfTargets(t *testing.T) {
-	config, _ := core.ReadConfigFiles(nil, nil)
+	config, _ := core.ReadConfigFiles(os.DirFS("."), nil, nil)
 	config.Please.NumThreads = 10
 	state = core.NewBuildState(config)
 	state.Parser = &fakeParser{

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -519,7 +519,7 @@ func TestSha1SingleHash(t *testing.T) {
 }
 
 func newStateWithHashCheckers(label, hashFunction string, hashCheckers ...string) (*core.BuildState, *core.BuildTarget) {
-	config, _ := core.ReadConfigFiles(os.DirFS("."), nil, nil)
+	config, _ := core.ReadConfigFiles(core.HostFS(), nil, nil)
 	if hashFunction != "" {
 		config.Build.HashFunction = hashFunction
 	}
@@ -538,7 +538,7 @@ func newStateWithHashCheckers(label, hashFunction string, hashCheckers ...string
 }
 
 func newStateWithHashFunc(label, hashFunc string) (*core.BuildState, *core.BuildTarget) {
-	config, _ := core.ReadConfigFiles(os.DirFS("."), nil, nil)
+	config, _ := core.ReadConfigFiles(core.HostFS(), nil, nil)
 	config.Build.HashFunction = hashFunc
 	state := core.NewBuildState(config)
 	state.Config.Parse.BuildFileName = []string{"BUILD_FILE"}
@@ -552,7 +552,7 @@ func newStateWithHashFunc(label, hashFunc string) (*core.BuildState, *core.Build
 }
 
 func newState(label string) (*core.BuildState, *core.BuildTarget) {
-	config, _ := core.ReadConfigFiles(os.DirFS("."), nil, nil)
+	config, _ := core.ReadConfigFiles(core.HostFS(), nil, nil)
 	state := core.NewBuildState(config)
 	state.Config.Parse.BuildFileName = []string{"BUILD_FILE"}
 	target := core.NewBuildTarget(core.ParseBuildLabel(label, ""))

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -519,7 +519,7 @@ func TestSha1SingleHash(t *testing.T) {
 }
 
 func newStateWithHashCheckers(label, hashFunction string, hashCheckers ...string) (*core.BuildState, *core.BuildTarget) {
-	config, _ := core.ReadConfigFiles(nil, nil)
+	config, _ := core.ReadConfigFiles(os.DirFS("."), nil, nil)
 	if hashFunction != "" {
 		config.Build.HashFunction = hashFunction
 	}
@@ -538,7 +538,7 @@ func newStateWithHashCheckers(label, hashFunction string, hashCheckers ...string
 }
 
 func newStateWithHashFunc(label, hashFunc string) (*core.BuildState, *core.BuildTarget) {
-	config, _ := core.ReadConfigFiles(nil, nil)
+	config, _ := core.ReadConfigFiles(os.DirFS("."), nil, nil)
 	config.Build.HashFunction = hashFunc
 	state := core.NewBuildState(config)
 	state.Config.Parse.BuildFileName = []string{"BUILD_FILE"}
@@ -552,7 +552,7 @@ func newStateWithHashFunc(label, hashFunc string) (*core.BuildState, *core.Build
 }
 
 func newState(label string) (*core.BuildState, *core.BuildTarget) {
-	config, _ := core.ReadConfigFiles(nil, nil)
+	config, _ := core.ReadConfigFiles(os.DirFS("."), nil, nil)
 	state := core.NewBuildState(config)
 	state.Config.Parse.BuildFileName = []string{"BUILD_FILE"}
 	target := core.NewBuildTarget(core.ParseBuildLabel(label, ""))

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -15,11 +15,9 @@ import (
 	"github.com/thought-machine/please/src/cli"
 )
 
-var wdFS = os.DirFS(".")
-
 func TestPlzConfigWorking(t *testing.T) {
 	RepoRoot = "/repo/root"
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/working.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/working.plzconfig"}, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "pexmabob", config.Python.PexTool)
@@ -33,12 +31,12 @@ func TestPlzConfigWorking(t *testing.T) {
 }
 
 func TestPlzConfigFailing(t *testing.T) {
-	_, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/failing.plzconfig"}, nil)
+	_, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/failing.plzconfig"}, nil)
 	assert.Error(t, err)
 }
 
 func TestPlzConfigProfile(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/working.plzconfig"}, []string{"dev"})
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/working.plzconfig"}, []string{"dev"})
 	assert.NoError(t, err)
 	assert.Equal(t, "pexmabob", config.Python.PexTool)
 	assert.Equal(t, "/opt/java/bin/javac", config.Java.JavacTool)
@@ -48,7 +46,7 @@ func TestPlzConfigProfile(t *testing.T) {
 }
 
 func TestMultiplePlzConfigFiles(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, []string{
+	config, err := ReadConfigFiles(HostFS(), []string{
 		"src/core/test_data/working.plzconfig",
 		"src/core/test_data/failing.plzconfig",
 	}, nil)
@@ -58,7 +56,7 @@ func TestMultiplePlzConfigFiles(t *testing.T) {
 }
 
 func TestConfigSlicesOverwrite(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/slices.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/slices.plzconfig"}, nil)
 	assert.NoError(t, err)
 	// This should be completely overwritten by the config file
 	assert.Equal(t, []string{"/sbin"}, config.Build.Path)
@@ -177,29 +175,29 @@ func TestPleaseTildeLocationOverride(t *testing.T) {
 }
 
 func TestReadSemver(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/version_good.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/version_good.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 2, config.Please.Version.Major)
 	assert.EqualValues(t, 3, config.Please.Version.Minor)
 	assert.EqualValues(t, 4, config.Please.Version.Patch)
-	_, err = ReadConfigFiles(wdFS, []string{"src/core/test_data/version_bad.plzconfig"}, nil)
+	_, err = ReadConfigFiles(HostFS(), []string{"src/core/test_data/version_bad.plzconfig"}, nil)
 	assert.Error(t, err)
 }
 
 func TestReadDurations(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/duration_good.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/duration_good.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 500*time.Millisecond, config.Build.Timeout)
 	assert.EqualValues(t, 5*time.Second, config.Test.Timeout)
-	_, err = ReadConfigFiles(wdFS, []string{"src/core/test_data/duration_bad.plzconfig"}, nil)
+	_, err = ReadConfigFiles(HostFS(), []string{"src/core/test_data/duration_bad.plzconfig"}, nil)
 	assert.Error(t, err)
 }
 
 func TestReadByteSizes(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/bytesize_good.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/bytesize_good.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 500*1000*1000, config.Cache.DirCacheHighWaterMark)
-	_, err = ReadConfigFiles(wdFS, []string{"src/core/test_data/bytesize_bad.plzconfig"}, nil)
+	_, err = ReadConfigFiles(HostFS(), []string{"src/core/test_data/bytesize_bad.plzconfig"}, nil)
 	assert.Error(t, err)
 }
 
@@ -212,29 +210,29 @@ func TestCompletions(t *testing.T) {
 }
 
 func TestConfigVerifiesOptions(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/testrunner_good.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/testrunner_good.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "pytest", config.Python.TestRunner)
-	_, err = ReadConfigFiles(wdFS, []string{"src/core/test_data/testrunner_bad.plzconfig"}, nil)
+	_, err = ReadConfigFiles(HostFS(), []string{"src/core/test_data/testrunner_bad.plzconfig"}, nil)
 	assert.Error(t, err)
 }
 
 func TestDefaultHashCheckers(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, nil, nil)
+	config, err := ReadConfigFiles(HostFS(), nil, nil)
 
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"sha1", "sha256", "blake3"}, config.Build.HashCheckers)
 }
 
 func TestHashCheckersConfig(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/hashcheckers.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/hashcheckers.plzconfig"}, nil)
 
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"blake3"}, config.Build.HashCheckers)
 }
 
 func TestOverrideHashCheckersConfig(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/hashcheckers.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/hashcheckers.plzconfig"}, nil)
 	assert.NoError(t, err)
 
 	err = config.ApplyOverrides(map[string]string{"build.hashcheckers": "sha256"})
@@ -243,7 +241,7 @@ func TestOverrideHashCheckersConfig(t *testing.T) {
 }
 
 func TestOverrideHashCheckersNoConfig(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, nil, nil)
+	config, err := ReadConfigFiles(HostFS(), nil, nil)
 	assert.NoError(t, err)
 
 	err = config.ApplyOverrides(map[string]string{"build.hashcheckers": "sha1,blake3"})
@@ -252,7 +250,7 @@ func TestOverrideHashCheckersNoConfig(t *testing.T) {
 }
 
 func TestUnknownHashChecker(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, nil, nil)
+	config, err := ReadConfigFiles(HostFS(), nil, nil)
 	assert.NoError(t, err)
 
 	err = config.ApplyOverrides(map[string]string{"build.hashcheckers": "fake-algo"})
@@ -260,7 +258,7 @@ func TestUnknownHashChecker(t *testing.T) {
 }
 
 func TestBuildEnvSection(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/buildenv.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/buildenv.plzconfig"}, nil)
 	assert.NoError(t, err)
 	expected := []string{
 		"BAR_BAR=first",
@@ -273,7 +271,7 @@ func TestBuildEnvSection(t *testing.T) {
 func TestPassEnv(t *testing.T) {
 	t.Setenv("FOO", "first")
 	t.Setenv("BAR", "second")
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/passenv.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/passenv.plzconfig"}, nil)
 	assert.NoError(t, err)
 	expected := []string{
 		"BAR=second",
@@ -286,7 +284,7 @@ func TestPassEnv(t *testing.T) {
 func TestPassUnsafeEnv(t *testing.T) {
 	t.Setenv("FOO", "first")
 	t.Setenv("BAR", "second")
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/passunsafeenv.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/passunsafeenv.plzconfig"}, nil)
 	assert.NoError(t, err)
 	expected := []string{
 		"BAR=second",
@@ -303,7 +301,7 @@ func TestPassUnsafeEnvExcludedFromHash(t *testing.T) {
 	err = os.Unsetenv("BAR")
 	require.NoError(t, err)
 
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/passunsafeenv.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/passunsafeenv.plzconfig"}, nil)
 	require.NoError(t, err)
 
 	expected := config.Hash()
@@ -315,7 +313,7 @@ func TestPassUnsafeEnvExcludedFromHash(t *testing.T) {
 }
 
 func TestBuildPathWithPathEnv(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/passenv.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/passenv.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, config.Build.Path, strings.Split(os.Getenv("PATH"), ":"))
 }
@@ -350,7 +348,7 @@ func TestUpdateArgsWithQuotedAliases(t *testing.T) {
 }
 
 func TestParseNewFormatAliases(t *testing.T) {
-	c, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/alias.plzconfig"}, nil)
+	c, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/alias.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(c.Alias))
 	a := c.Alias["auth"]
@@ -360,7 +358,7 @@ func TestParseNewFormatAliases(t *testing.T) {
 }
 
 func TestAttachAliasFlags(t *testing.T) {
-	c, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/alias.plzconfig"}, nil)
+	c, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/alias.plzconfig"}, nil)
 	assert.NoError(t, err)
 	t.Setenv("GO_FLAGS_COMPLETION", "1")
 	p := flags.NewParser(&struct{}{}, 0)
@@ -396,7 +394,7 @@ func TestAttachAliasFlags(t *testing.T) {
 }
 
 func TestPrintAliases(t *testing.T) {
-	c, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/alias.plzconfig"}, nil)
+	c, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/alias.plzconfig"}, nil)
 	assert.NoError(t, err)
 	var buf bytes.Buffer
 	c.PrintAliases(&buf)
@@ -438,7 +436,7 @@ func TestEnsurePleaseLocation(t *testing.T) {
 }
 
 func TestPluginConfig(t *testing.T) {
-	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/plugin.plzconfig"}, nil)
+	config, err := ReadConfigFiles(HostFS(), []string{"src/core/test_data/plugin.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"fooc"}, config.Plugin["foo"].ExtraValues["fooctool"])
 }

--- a/src/core/config_test.go
+++ b/src/core/config_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/thought-machine/please/src/cli"
 )
 
+var wdFS = os.DirFS(".")
+
 func TestPlzConfigWorking(t *testing.T) {
 	RepoRoot = "/repo/root"
-	config, err := ReadConfigFiles([]string{"src/core/test_data/working.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/working.plzconfig"}, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "pexmabob", config.Python.PexTool)
@@ -31,12 +33,12 @@ func TestPlzConfigWorking(t *testing.T) {
 }
 
 func TestPlzConfigFailing(t *testing.T) {
-	_, err := ReadConfigFiles([]string{"src/core/test_data/failing.plzconfig"}, nil)
+	_, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/failing.plzconfig"}, nil)
 	assert.Error(t, err)
 }
 
 func TestPlzConfigProfile(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/working.plzconfig"}, []string{"dev"})
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/working.plzconfig"}, []string{"dev"})
 	assert.NoError(t, err)
 	assert.Equal(t, "pexmabob", config.Python.PexTool)
 	assert.Equal(t, "/opt/java/bin/javac", config.Java.JavacTool)
@@ -46,7 +48,7 @@ func TestPlzConfigProfile(t *testing.T) {
 }
 
 func TestMultiplePlzConfigFiles(t *testing.T) {
-	config, err := ReadConfigFiles([]string{
+	config, err := ReadConfigFiles(wdFS, []string{
 		"src/core/test_data/working.plzconfig",
 		"src/core/test_data/failing.plzconfig",
 	}, nil)
@@ -56,7 +58,7 @@ func TestMultiplePlzConfigFiles(t *testing.T) {
 }
 
 func TestConfigSlicesOverwrite(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/slices.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/slices.plzconfig"}, nil)
 	assert.NoError(t, err)
 	// This should be completely overwritten by the config file
 	assert.Equal(t, []string{"/sbin"}, config.Build.Path)
@@ -175,29 +177,29 @@ func TestPleaseTildeLocationOverride(t *testing.T) {
 }
 
 func TestReadSemver(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/version_good.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/version_good.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 2, config.Please.Version.Major)
 	assert.EqualValues(t, 3, config.Please.Version.Minor)
 	assert.EqualValues(t, 4, config.Please.Version.Patch)
-	_, err = ReadConfigFiles([]string{"src/core/test_data/version_bad.plzconfig"}, nil)
+	_, err = ReadConfigFiles(wdFS, []string{"src/core/test_data/version_bad.plzconfig"}, nil)
 	assert.Error(t, err)
 }
 
 func TestReadDurations(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/duration_good.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/duration_good.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 500*time.Millisecond, config.Build.Timeout)
 	assert.EqualValues(t, 5*time.Second, config.Test.Timeout)
-	_, err = ReadConfigFiles([]string{"src/core/test_data/duration_bad.plzconfig"}, nil)
+	_, err = ReadConfigFiles(wdFS, []string{"src/core/test_data/duration_bad.plzconfig"}, nil)
 	assert.Error(t, err)
 }
 
 func TestReadByteSizes(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/bytesize_good.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/bytesize_good.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 500*1000*1000, config.Cache.DirCacheHighWaterMark)
-	_, err = ReadConfigFiles([]string{"src/core/test_data/bytesize_bad.plzconfig"}, nil)
+	_, err = ReadConfigFiles(wdFS, []string{"src/core/test_data/bytesize_bad.plzconfig"}, nil)
 	assert.Error(t, err)
 }
 
@@ -210,29 +212,29 @@ func TestCompletions(t *testing.T) {
 }
 
 func TestConfigVerifiesOptions(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/testrunner_good.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/testrunner_good.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "pytest", config.Python.TestRunner)
-	_, err = ReadConfigFiles([]string{"src/core/test_data/testrunner_bad.plzconfig"}, nil)
+	_, err = ReadConfigFiles(wdFS, []string{"src/core/test_data/testrunner_bad.plzconfig"}, nil)
 	assert.Error(t, err)
 }
 
 func TestDefaultHashCheckers(t *testing.T) {
-	config, err := ReadConfigFiles(nil, nil)
+	config, err := ReadConfigFiles(wdFS, nil, nil)
 
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"sha1", "sha256", "blake3"}, config.Build.HashCheckers)
 }
 
 func TestHashCheckersConfig(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/hashcheckers.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/hashcheckers.plzconfig"}, nil)
 
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"blake3"}, config.Build.HashCheckers)
 }
 
 func TestOverrideHashCheckersConfig(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/hashcheckers.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/hashcheckers.plzconfig"}, nil)
 	assert.NoError(t, err)
 
 	err = config.ApplyOverrides(map[string]string{"build.hashcheckers": "sha256"})
@@ -241,7 +243,7 @@ func TestOverrideHashCheckersConfig(t *testing.T) {
 }
 
 func TestOverrideHashCheckersNoConfig(t *testing.T) {
-	config, err := ReadConfigFiles(nil, nil)
+	config, err := ReadConfigFiles(wdFS, nil, nil)
 	assert.NoError(t, err)
 
 	err = config.ApplyOverrides(map[string]string{"build.hashcheckers": "sha1,blake3"})
@@ -250,7 +252,7 @@ func TestOverrideHashCheckersNoConfig(t *testing.T) {
 }
 
 func TestUnknownHashChecker(t *testing.T) {
-	config, err := ReadConfigFiles(nil, nil)
+	config, err := ReadConfigFiles(wdFS, nil, nil)
 	assert.NoError(t, err)
 
 	err = config.ApplyOverrides(map[string]string{"build.hashcheckers": "fake-algo"})
@@ -258,7 +260,7 @@ func TestUnknownHashChecker(t *testing.T) {
 }
 
 func TestBuildEnvSection(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/buildenv.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/buildenv.plzconfig"}, nil)
 	assert.NoError(t, err)
 	expected := []string{
 		"BAR_BAR=first",
@@ -271,7 +273,7 @@ func TestBuildEnvSection(t *testing.T) {
 func TestPassEnv(t *testing.T) {
 	t.Setenv("FOO", "first")
 	t.Setenv("BAR", "second")
-	config, err := ReadConfigFiles([]string{"src/core/test_data/passenv.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/passenv.plzconfig"}, nil)
 	assert.NoError(t, err)
 	expected := []string{
 		"BAR=second",
@@ -284,7 +286,7 @@ func TestPassEnv(t *testing.T) {
 func TestPassUnsafeEnv(t *testing.T) {
 	t.Setenv("FOO", "first")
 	t.Setenv("BAR", "second")
-	config, err := ReadConfigFiles([]string{"src/core/test_data/passunsafeenv.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/passunsafeenv.plzconfig"}, nil)
 	assert.NoError(t, err)
 	expected := []string{
 		"BAR=second",
@@ -301,7 +303,7 @@ func TestPassUnsafeEnvExcludedFromHash(t *testing.T) {
 	err = os.Unsetenv("BAR")
 	require.NoError(t, err)
 
-	config, err := ReadConfigFiles([]string{"src/core/test_data/passunsafeenv.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/passunsafeenv.plzconfig"}, nil)
 	require.NoError(t, err)
 
 	expected := config.Hash()
@@ -313,7 +315,7 @@ func TestPassUnsafeEnvExcludedFromHash(t *testing.T) {
 }
 
 func TestBuildPathWithPathEnv(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/passenv.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/passenv.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, config.Build.Path, strings.Split(os.Getenv("PATH"), ":"))
 }
@@ -348,7 +350,7 @@ func TestUpdateArgsWithQuotedAliases(t *testing.T) {
 }
 
 func TestParseNewFormatAliases(t *testing.T) {
-	c, err := ReadConfigFiles([]string{"src/core/test_data/alias.plzconfig"}, nil)
+	c, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/alias.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(c.Alias))
 	a := c.Alias["auth"]
@@ -358,7 +360,7 @@ func TestParseNewFormatAliases(t *testing.T) {
 }
 
 func TestAttachAliasFlags(t *testing.T) {
-	c, err := ReadConfigFiles([]string{"src/core/test_data/alias.plzconfig"}, nil)
+	c, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/alias.plzconfig"}, nil)
 	assert.NoError(t, err)
 	t.Setenv("GO_FLAGS_COMPLETION", "1")
 	p := flags.NewParser(&struct{}{}, 0)
@@ -394,7 +396,7 @@ func TestAttachAliasFlags(t *testing.T) {
 }
 
 func TestPrintAliases(t *testing.T) {
-	c, err := ReadConfigFiles([]string{"src/core/test_data/alias.plzconfig"}, nil)
+	c, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/alias.plzconfig"}, nil)
 	assert.NoError(t, err)
 	var buf bytes.Buffer
 	c.PrintAliases(&buf)
@@ -436,7 +438,7 @@ func TestEnsurePleaseLocation(t *testing.T) {
 }
 
 func TestPluginConfig(t *testing.T) {
-	config, err := ReadConfigFiles([]string{"src/core/test_data/plugin.plzconfig"}, nil)
+	config, err := ReadConfigFiles(wdFS, []string{"src/core/test_data/plugin.plzconfig"}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"fooc"}, config.Plugin["foo"].ExtraValues["fooctool"])
 }

--- a/src/core/stamp_test.go
+++ b/src/core/stamp_test.go
@@ -10,7 +10,7 @@ func TestStampFile(t *testing.T) {
 	config := DefaultConfiguration()
 	config.Licences.Accept = []string{"bsd-2-clause"}
 	t1 := NewBuildTarget(ParseBuildLabel("//src/core:core", ""))
-	t2 := NewBuildTarget(ParseBuildLabel("//src/fs:fs", ""))
+	t2 := NewBuildTarget(ParseBuildLabel("//src/wdFS:wdFS", ""))
 	t3 := NewBuildTarget(ParseBuildLabel("//third_party/go:errors", ""))
 	t1.AddLabel("go")
 	t3.AddLabel("go_get:github.com/pkg/errors")
@@ -28,7 +28,7 @@ func TestStampFile(t *testing.T) {
         "go"
       ]
     },
-    "//src/fs:fs": {},
+    "//src/wdFS:wdFS": {},
     "//third_party/go:errors": {
       "labels": [
         "go_get:github.com/pkg/errors"

--- a/src/core/stamp_test.go
+++ b/src/core/stamp_test.go
@@ -10,7 +10,7 @@ func TestStampFile(t *testing.T) {
 	config := DefaultConfiguration()
 	config.Licences.Accept = []string{"bsd-2-clause"}
 	t1 := NewBuildTarget(ParseBuildLabel("//src/core:core", ""))
-	t2 := NewBuildTarget(ParseBuildLabel("//src/wdFS:wdFS", ""))
+	t2 := NewBuildTarget(ParseBuildLabel("//src/fs:fs", ""))
 	t3 := NewBuildTarget(ParseBuildLabel("//third_party/go:errors", ""))
 	t1.AddLabel("go")
 	t3.AddLabel("go_get:github.com/pkg/errors")
@@ -28,7 +28,7 @@ func TestStampFile(t *testing.T) {
         "go"
       ]
     },
-    "//src/wdFS:wdFS": {},
+    "//src/fs:fs": {},
     "//third_party/go:errors": {
       "labels": [
         "go_get:github.com/pkg/errors"

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1192,12 +1192,12 @@ func (state *BuildState) ForArch(arch cli.Arch) *BuildState {
 	configPath := ".plzconfig_" + arch.String()
 
 	config := state.Config.copyConfig()
-	if err := readConfigFile(config, configPath, false); err != nil {
+	if err := readConfigFile(HostFS(), config, configPath, false); err != nil {
 		log.Fatalf("%v", err)
 	}
 
 	repoConfig := state.Config.copyConfig()
-	if err := readConfigFile(repoConfig, configPath, false); err != nil {
+	if err := readConfigFile(HostFS(), repoConfig, configPath, false); err != nil {
 		log.Fatalf("%v", err)
 	}
 

--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -77,7 +77,7 @@ func (s *Subrepo) Dir(dir string) string {
 
 func readConfigFilesInto(repoConfig *Configuration, files []string) error {
 	for _, file := range files {
-		err := readConfigFile(repoConfig, file, true)
+		err := readConfigFile(HostFS(), repoConfig, file, true)
 		if err != nil {
 			return err
 		}

--- a/src/help/completion.go
+++ b/src/help/completion.go
@@ -18,7 +18,7 @@ func (topic *Topic) UnmarshalFlag(value string) error {
 
 // Complete implements the flags.Completer interface, which is used for shell completion.
 func (topic Topic) Complete(match string) []flags.Completion {
-	config, err := core.ReadDefaultConfigFiles(nil)
+	config, err := core.ReadDefaultConfigFiles(core.HostFS(), nil)
 	if err != nil {
 		config = core.DefaultConfiguration()
 	}

--- a/src/help/help.go
+++ b/src/help/help.go
@@ -27,7 +27,7 @@ const maxSuggestionDistance = 4
 // Help prints help on a particular topic.
 // It returns true if the topic is known or false if it isn't.
 func Help(topic string) bool {
-	config, err := core.ReadDefaultConfigFiles(nil)
+	config, err := core.ReadDefaultConfigFiles(core.HostFS(), nil)
 	if err != nil {
 		// Don't bother the user if we can't load config files or whatever - just do our best.
 		config = core.DefaultConfiguration()

--- a/src/help/rules.go
+++ b/src/help/rules.go
@@ -41,7 +41,7 @@ func PrintRuleArgs(files cli.StdinStrings) {
 func newState() *core.BuildState {
 	// If we're in a repo, we might be able to read some stuff from there.
 	if core.FindRepoRoot() {
-		if config, err := core.ReadDefaultConfigFiles(nil); err == nil {
+		if config, err := core.ReadDefaultConfigFiles(core.HostFS(), nil); err == nil {
 			return core.NewBuildState(config)
 		}
 	}

--- a/src/parse/asp/main/main.go
+++ b/src/parse/asp/main/main.go
@@ -203,7 +203,7 @@ func main() {
 	config := core.DefaultConfiguration()
 	if !opts.NoConfig {
 		var err error
-		config, err = core.ReadConfigFiles([]string{filepath.Join(core.MustFindRepoRoot(), core.ConfigFileName)}, nil)
+		config, err = core.ReadConfigFiles(core.HostFS(), []string{filepath.Join(core.MustFindRepoRoot(), core.ConfigFileName)}, nil)
 		if err != nil {
 			log.Fatalf("%s", err)
 		}

--- a/src/please.go
+++ b/src/please.go
@@ -1013,7 +1013,7 @@ var buildFunctions = map[string]func() int{
 // Check if tool is given as label or path and then run
 func runTool(_tool tool.Tool) int {
 	c := core.DefaultConfiguration()
-	if cfg, err := core.ReadDefaultConfigFiles(opts.BuildFlags.Profile); err == nil {
+	if cfg, err := core.ReadDefaultConfigFiles(core.HostFS(), opts.BuildFlags.Profile); err == nil {
 		c = cfg
 	}
 	t, _ := tool.MatchingTool(c, string(_tool))
@@ -1257,7 +1257,7 @@ func (l TargetsOrArgs) SeparateUnannotated() ([]core.BuildLabel, []string) {
 
 // readConfig reads the initial configuration files
 func readConfig() *core.Configuration {
-	cfg, err := core.ReadDefaultConfigFiles(opts.BuildFlags.Profile)
+	cfg, err := core.ReadDefaultConfigFiles(core.HostFS(), opts.BuildFlags.Profile)
 	if err != nil {
 		log.Fatalf("Error reading config file: %s", err)
 	} else if err := cfg.ApplyOverrides(opts.BuildFlags.Option); err != nil {

--- a/src/tool/tool_test.go
+++ b/src/tool/tool_test.go
@@ -1,6 +1,7 @@
 package tool
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +10,7 @@ import (
 )
 
 func TestMatchingTools(t *testing.T) {
-	c, err := core.ReadConfigFiles(nil, nil)
+	c, err := core.ReadConfigFiles(os.DirFS("."), nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"langserver": "//_please:build_langserver"}, matchingTools(c, "la"))
 	assert.Equal(t, map[string]string{"langserver": "//_please:build_langserver"}, matchingTools(c, "lang"))
@@ -19,7 +20,7 @@ func TestMatchingTools(t *testing.T) {
 }
 
 func TestAllToolNames(t *testing.T) {
-	c, err := core.ReadConfigFiles(nil, nil)
+	c, err := core.ReadConfigFiles(os.DirFS("."), nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"javacworker"}, allToolNames(c, "ja"))
 }

--- a/src/tool/tool_test.go
+++ b/src/tool/tool_test.go
@@ -1,7 +1,6 @@
 package tool
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +9,7 @@ import (
 )
 
 func TestMatchingTools(t *testing.T) {
-	c, err := core.ReadConfigFiles(os.DirFS("."), nil, nil)
+	c, err := core.ReadConfigFiles(core.HostFS(), nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"langserver": "//_please:build_langserver"}, matchingTools(c, "la"))
 	assert.Equal(t, map[string]string{"langserver": "//_please:build_langserver"}, matchingTools(c, "lang"))
@@ -20,7 +19,7 @@ func TestMatchingTools(t *testing.T) {
 }
 
 func TestAllToolNames(t *testing.T) {
-	c, err := core.ReadConfigFiles(os.DirFS("."), nil, nil)
+	c, err := core.ReadConfigFiles(core.HostFS(), nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"javacworker"}, allToolNames(c, "ja"))
 }

--- a/tools/build_langserver/lsp/lsp.go
+++ b/tools/build_langserver/lsp/lsp.go
@@ -187,7 +187,7 @@ func (h *Handler) initialize(params *lsp.InitializeParams) (*lsp.InitializeResul
 	if err := os.Chdir(h.root); err != nil {
 		return nil, err
 	}
-	config, err := core.ReadDefaultConfigFiles(nil)
+	config, err := core.ReadDefaultConfigFiles(core.HostFS(), nil)
 	if err != nil {
 		log.Error("Error reading configuration: %s", err)
 		config = core.DefaultConfiguration()

--- a/tools/please_shim/main.go
+++ b/tools/please_shim/main.go
@@ -104,7 +104,7 @@ func findRootAndReadConfigFilesOnly() *core.Configuration {
 		core.RepoRoot = abs
 	} else if !core.FindRepoRoot() {
 		log.Debug("Trying to find the default repo root on global config files")
-		if err := core.ReadDefaultGlobalConfigFilesOnly(config); err != nil {
+		if err := core.ReadDefaultGlobalConfigFilesOnly(core.HostFS(), config); err != nil {
 			log.Fatalf("Error reading default global config file: %s", err)
 		}
 		// We are done here. There's no default repo root and we've read all
@@ -116,7 +116,7 @@ func findRootAndReadConfigFilesOnly() *core.Configuration {
 	}
 
 	// At this point the repo root is known so read its config files.
-	if err := core.ReadDefaultConfigFilesOnly(config, opts.BuildFlags.Profile); err != nil {
+	if err := core.ReadDefaultConfigFilesOnly(core.HostFS(), config, opts.BuildFlags.Profile); err != nil {
 		log.Fatalf("Error reading config file: %s", err)
 	}
 
@@ -165,7 +165,7 @@ func maybeUpdatePlease(state state, isUpdateCommand bool) {
 	core.PleaseVersion = strings.TrimPrefix(strings.TrimSpace(string(out)), "Please version ")
 
 	// Read and load the configuration as it would have been done by the main binary.
-	cfg, err := core.ReadDefaultConfigFiles(opts.BuildFlags.Profile)
+	cfg, err := core.ReadDefaultConfigFiles(core.HostFS(), opts.BuildFlags.Profile)
 	if err != nil {
 		log.Fatalf("Error reading config file: %s", err)
 	} else if err := cfg.ApplyOverrides(opts.BuildFlags.Option); err != nil {


### PR DESCRIPTION
This will be useful later on when we allow subrepos to have a filesystem based on the REAPI. We can plug in the remote FS in here so we can resolve config files without downloading the subrepo sources. 