### PR TITLE
Implement iofs.StatFS for the CAS FS

### DIFF
--- a/src/remote/fs/info.go
+++ b/src/remote/fs/info.go
@@ -10,16 +10,55 @@ import (
 
 // info represents information about a file/directory
 type info struct {
-	name     string
-	isDir    bool
-	size     int64
-	modTime  time.Time
-	mode     os.FileMode
-	typeMode os.FileMode
+	name    string
+	size    int64
+	modTime time.Time
+	mode    os.FileMode
+}
+
+func newFileInfo(f *pb.FileNode) *info {
+	i := info{
+		size: f.Digest.SizeBytes,
+		name: f.Name,
+	}
+	return i.withProperties(f.NodeProperties)
+}
+func newDirInfo(name string, dir *pb.Directory) *info {
+	i := &info{
+		name: name,
+		mode: os.ModeDir,
+	}
+	return i.withProperties(dir.NodeProperties)
+}
+
+func newSymlinkInfo(node *pb.SymlinkNode) *info {
+	i := &info{
+		name: node.Name,
+		mode: os.ModeSymlink,
+	}
+	return i.withProperties(node.NodeProperties)
+}
+
+// withProperties safely sets the node info if it's available.
+func (i *info) withProperties(nodeProperties *pb.NodeProperties) *info {
+	if nodeProperties == nil {
+		return i
+	}
+
+	if nodeProperties.UnixMode != nil {
+		// This should in theory have the type mode set already but we bitwise or here to to make sure this is preserved
+		// from the constructors above in case the remote doesn't set this.
+		i.mode = i.mode | os.FileMode(nodeProperties.UnixMode.Value)
+	}
+
+	if nodeProperties.Mtime != nil {
+		i.modTime = nodeProperties.Mtime.AsTime()
+	}
+	return i
 }
 
 func (i *info) Type() iofs.FileMode {
-	return i.typeMode
+	return i.mode.Type()
 }
 
 func (i *info) Info() (iofs.FileInfo, error) {
@@ -43,25 +82,9 @@ func (i *info) ModTime() time.Time {
 }
 
 func (i *info) IsDir() bool {
-	return i.isDir
+	return i.mode.IsDir()
 }
 
 func (i *info) Sys() any {
 	return nil
-}
-
-// withProperties safely sets the node info if it's available.
-func (i *info) withProperties(nodeProperties *pb.NodeProperties) *info {
-	if nodeProperties == nil {
-		return i
-	}
-
-	if nodeProperties.UnixMode != nil {
-		i.mode = os.FileMode(nodeProperties.UnixMode.Value)
-	}
-
-	if nodeProperties.Mtime != nil {
-		i.modTime = nodeProperties.Mtime.AsTime()
-	}
-	return i
 }

--- a/src/remote/fs/info.go
+++ b/src/remote/fs/info.go
@@ -48,7 +48,7 @@ func (i *info) withProperties(nodeProperties *pb.NodeProperties) *info {
 	if nodeProperties.UnixMode != nil {
 		// This should in theory have the type mode set already but we bitwise or here to to make sure this is preserved
 		// from the constructors above in case the remote doesn't set this.
-		i.mode = i.mode | os.FileMode(nodeProperties.UnixMode.Value)
+		i.mode |= os.FileMode(nodeProperties.UnixMode.Value)
 	}
 
 	if nodeProperties.Mtime != nil {


### PR DESCRIPTION
Without this, `iofs.Stat()` will open the file, which results in us downloading it from the CAS. This PR implements this interface which meas we can check if a file exists purely from the directory metadata in the Tree proto. It also fixes a couple issues with the unix mode bits, where we were not including the type bits correctly. 