### PR TITLE
Fix plz exec/run sequential/parallel to treat the first arg as a target always

### DIFF
--- a/test/plz_run/BUILD
+++ b/test/plz_run/BUILD
@@ -129,3 +129,21 @@ please_repo_e2e_test(
     plz_command = "plz run parallel //src:arg_printer wibble wobble > args.txt",
     repo = "test_repo",
 )
+
+please_repo_e2e_test(
+    name = "test_args_sequential_no_slashes",
+    expected_output = {
+        "args.txt": "wibble wobble",
+    },
+    plz_command = "plz run sequential src:arg_printer wibble wobble > args.txt",
+    repo = "test_repo",
+)
+
+please_repo_e2e_test(
+    name = "test_args_parallel_no_slashes",
+    expected_output = {
+        "args.txt": "wibble wobble",
+    },
+    plz_command = "plz run parallel src:arg_printer wibble wobble > args.txt",
+    repo = "test_repo",
+)


### PR DESCRIPTION
This means that it will still work when using the non-canonical target form without the leading `//` . 

These won't work if passed subsequently though, e.g. `plz run parallel a/b c/d` runs target `//a/b:b` with the argument `c/d`; there isn't much we can do there (but the caller can easily spell it `//c/d` if that is what they want)