### PR TITLE
Don't double up on the subrepo arch when parsing labels from subrepos

### DIFF
--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -314,7 +314,7 @@ func (s *scope) parseLabelInPackage(label string, pkg *core.Package) core.BuildL
 			subrepo = ""
 		} else if s.state.CurrentSubrepo == "" && subrepo == s.state.Config.PluginDefinition.Name {
 			subrepo = ""
-		} else {
+		} else if pkg.Subrepo == nil || subrepo != pkg.Subrepo.Arch.String() {
 			subrepo = pkg.SubrepoArchName(subrepo)
 		}
 		return core.BuildLabel{PackageName: p, Name: name, Subrepo: subrepo}


### PR DESCRIPTION
If we had `///darwin_amd64//foo/bar` from within `///subrepo_darwin_amd64//...`, we would double up with `///darwin_amd64_darwin_amd64//foo/bar`, which isn't right. 