### PR TITLE
Don't promise to parse the package in the pre/post build function

### DIFF
--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -90,7 +90,6 @@ func (p *aspParser) RegisterPreload(label core.BuildLabel) error {
 // runBuildFunction runs either the pre- or post-build function.
 func (p *aspParser) runBuildFunction(state *core.BuildState, target *core.BuildTarget, callbackType string, f func() error) error {
 	state.LogBuildResult(target, core.PackageParsing, fmt.Sprintf("Running %s-build function for %s", callbackType, target.Label))
-	state.SyncParsePackage(target.Label)
 	if err := f(); err != nil {
 		state.LogBuildError(target.Label, core.ParseFailed, err, "Failed %s-build function for %s", callbackType, target.Label)
 		return err


### PR DESCRIPTION
When this function returns nil, we add a sync channel to the package waits, and the caller is expected to close that (via a call to LogParseResult()). Subsequent calls to this function will hang until we do. I don't think this ever parses the package. It must be parsed by now if we have the resolved target, so I don't think this call ever did anything. 