### PR TITLE
Add `add_entry_point` and `get_entry_points` built-in functions

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -258,6 +258,10 @@ def get_outs(target:str):
     pass
 def get_named_outs(target:str) -> dict:
     pass
+def add_entry_point(target:str, name:str, out:str):
+    pass
+def get_entry_points(target:str) -> dict:
+    pass
 def add_licence(target:str, licence:str):
     pass
 def get_licences(target:str):

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1710,6 +1710,25 @@ func (target *BuildTarget) AddNamedOutput(name, output string) {
 	target.namedOutputs[name] = target.insert(target.namedOutputs[name], output)
 }
 
+// AddEntryPoint adds a new entry point to the target. It panics if the given entry
+// point name is disallowed in the context of this build target, or if an entry point
+// with the same name already exists.
+func (target *BuildTarget) AddEntryPoint(name, output string) {
+	if target.EntryPoints == nil {
+		target.EntryPoints = make(map[string]string)
+	}
+	if target.NamedOutputs(name) != nil {
+		panic(fmt.Sprintf("%v already has a named output named %v; entry points may not have the same name as a named output"))
+	}
+	if target.IsFilegroup && target.NamedSources[name] != nil {
+		panic(fmt.Sprintf("%v already has a named source named %v; entry points may not have the same name as a named source on a filegroup"))
+	}
+	if _, exists := target.EntryPoints[name]; exists {
+		panic(fmt.Sprintf("%v already has an entry point named %v", target.Label, name))
+	}
+	target.EntryPoints[name] = output
+}
+
 // insert adds a string into a slice if it's not already there. Sorted order is maintained.
 func (target *BuildTarget) insert(sl []string, s string) []string {
 	if s == "" {

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1718,10 +1718,10 @@ func (target *BuildTarget) AddEntryPoint(name, output string) {
 		target.EntryPoints = make(map[string]string)
 	}
 	if target.NamedOutputs(name) != nil {
-		panic(fmt.Sprintf("%v already has a named output named %v; entry points may not have the same name as a named output"))
+		panic(fmt.Sprintf("%v already has a named output named %v; entry points may not have the same name as a named output", target.Label))
 	}
 	if target.IsFilegroup && target.NamedSources[name] != nil {
-		panic(fmt.Sprintf("%v already has a named source named %v; entry points may not have the same name as a named source on a filegroup"))
+		panic(fmt.Sprintf("%v already has a named source named %v; entry points may not have the same name as a named source on a filegroup", target.Label))
 	}
 	if _, exists := target.EntryPoints[name]; exists {
 		panic(fmt.Sprintf("%v already has an entry point named %v", target.Label, name))

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1718,10 +1718,10 @@ func (target *BuildTarget) AddEntryPoint(name, output string) {
 		target.EntryPoints = make(map[string]string)
 	}
 	if target.NamedOutputs(name) != nil {
-		panic(fmt.Sprintf("%v already has a named output named %v; entry points may not have the same name as a named output", target.Label))
+		panic(fmt.Sprintf("%v already has a named output named %v; entry points may not have the same name as a named output", target.Label, name))
 	}
 	if target.IsFilegroup && target.NamedSources[name] != nil {
-		panic(fmt.Sprintf("%v already has a named source named %v; entry points may not have the same name as a named source on a filegroup", target.Label))
+		panic(fmt.Sprintf("%v already has a named source named %v; entry points may not have the same name as a named source on a filegroup", target.Label, name))
 	}
 	if _, exists := target.EntryPoints[name]; exists {
 		panic(fmt.Sprintf("%v already has an entry point named %v", target.Label, name))

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -67,6 +67,8 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "add_out", addOut)
 	setNativeCode(s, "get_outs", getOuts)
 	setNativeCode(s, "get_named_outs", getNamedOuts)
+	setNativeCode(s, "add_entry_point", addEntryPoint)
+	setNativeCode(s, "get_entry_points", getEntryPoints)
 	setNativeCode(s, "add_licence", addLicence)
 	setNativeCode(s, "get_licences", getLicences)
 	setNativeCode(s, "get_command", getCommand)
@@ -1184,6 +1186,32 @@ func getNamedOuts(s *scope, args []pyObject) pyObject {
 			list[i] = pyString(out)
 		}
 		ret[k] = list
+	}
+	return ret
+}
+
+// addEntryPoint adds an entry point to a target.
+func addEntryPoint(s *scope, args []pyObject) pyObject {
+	target := getTargetPost(s, string(args[0].(pyString)))
+	name := string(args[1].(pyString))
+	output := string(args[2].(pyString))
+	target.AddEntryPoint(name, output)
+	return None
+}
+
+// getEntryPoints returns a dict containing the given target's entry points.
+func getEntryPoints(s *scope, args []pyObject) pyObject {
+	var target *core.BuildTarget
+	if name := args[0].String(); core.LooksLikeABuildLabel(name) {
+		label := core.ParseBuildLabel(name, s.pkg.Name)
+		target = s.state.Graph.TargetOrDie(label)
+	} else {
+		target = getTargetPost(s, name)
+	}
+
+	ret := make(pyDict, len(target.EntryPoints))
+	for name, output := range target.EntryPoints {
+		ret[name] = pyString(output)
 	}
 	return ret
 }

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -306,18 +306,11 @@ func addEntryPoints(s *scope, arg pyObject, target *core.BuildTarget) {
 	entryPointsPy, ok := asDict(arg)
 	s.Assert(ok, "entry_points must be a dict")
 
-	entryPoints := make(map[string]string, len(entryPointsPy))
 	for name, entryPointPy := range entryPointsPy {
 		entryPoint, ok := entryPointPy.(pyString)
 		s.Assert(ok, "Values of entry_points must be strings, found %v at key %v", entryPointPy.Type(), name)
-		s.Assert(target.NamedOutputs(entryPoint.String()) == nil, "Entry points can't have the same name as a named output")
-		if target.IsFilegroup {
-			s.Assert(target.NamedSources[entryPoint.String()] == nil, "Entry points can't have the same name as a named source on a filegroup")
-		}
-		entryPoints[name] = string(entryPoint)
+		target.AddEntryPoint(name, string(entryPoint))
 	}
-
-	target.EntryPoints = entryPoints
 }
 
 // addEnv adds entry points to a target

--- a/test/get_entry_points/BUILD
+++ b/test/get_entry_points/BUILD
@@ -1,0 +1,31 @@
+none = genrule(
+    name = "none",
+    outs = ["x"],
+    cmd = "echo x > $OUTS",
+)
+
+one = genrule(
+    name = "one",
+    outs = {
+        "y": ["y"],
+        "z": ["z"],
+    },
+    cmd = "for i in $OUTS; do echo x > $i; done",
+    entry_points = {
+        "ep": "y",
+    },
+)
+
+def assert_dict(l1, l2):
+    if l1 != l2:
+        fail(f"{l1} != {l2}")
+
+assert_dict(
+    {},
+    get_entry_points(none),
+)
+
+assert_dict(
+    {"ep": "y"},
+    get_entry_points(one),
+)


### PR DESCRIPTION
`get_entry_points` enables the entry points for a build target to be looked up dynamically. `add_entry_point` enables entry points to be defined on build targets dynamically, e.g. in post-build functions.