### PR TITLE
Set release headers

### DIFF
--- a/tools/misc/gen_release.py
+++ b/tools/misc/gen_release.py
@@ -43,8 +43,9 @@ class ReleaseGen:
         self.session.verify = '/etc/ssl/certs/ca-certificates.crt'
         if not dry_run:
             self.session.headers.update({
-                'Accept': 'application/vnd.github.v3+json',
-                'Authorization': 'token ' + github_token,
+                'Accept': 'application/vnd.github+json',
+                'Authorization': 'Bearer ' + github_token,
+                'X-GitHub-Api-Version': '2022-11-28',
             })
         self.version = self.read_file('VERSION').strip()
         self.version_name = 'Version ' + self.version


### PR DESCRIPTION
This appears to be what the heads here are meant to be:
https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release