### PR TITLE
Redo the stats handler for remote execution

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.5.0",
     "java": "v0.4.0",
-    "go": "v1.11.5",
+    "go": "v1.12.1",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -157,9 +157,8 @@ func New(state *core.BuildState) *Client {
 		fileMetadataCache: filemetadata.NewNoopCache(),
 		shellPath:         state.Config.Remote.Shell,
 		buildID:           state.Config.Remote.BuildID,
+		stats:             newStatsHandler(),
 	}
-
-	c.stats = newStatsHandler(c)
 	go c.CheckInitialised() // Kick off init now, but we don't have to wait for it.
 	return c
 }

--- a/src/remote/stats.go
+++ b/src/remote/stats.go
@@ -15,9 +15,9 @@ const updateFrequency = 1 * time.Second
 // instantaneous performance.
 type statsHandler struct {
 	client            *Client
-	in, out           atomic.Int64
-	rateIn, rateOut atomic.Int64
-	totalIn, totalOut atomic.Int64
+	in, out           atomic.Int64 // aggregated for the current second
+	rateIn, rateOut   atomic.Int64 // the stats for the previous second (which gets displayed)
+	totalIn, totalOut atomic.Int64 // aggregated total for all time
 }
 
 func newStatsHandler(c *Client) *statsHandler {

--- a/src/remote/stats.go
+++ b/src/remote/stats.go
@@ -14,14 +14,13 @@ const updateFrequency = 1 * time.Second
 // A statsHandler is an implementation of a grpc stats.Handler that calculates an estimate of
 // instantaneous performance.
 type statsHandler struct {
-	client            *Client
 	in, out           atomic.Int64 // aggregated for the current second
 	rateIn, rateOut   atomic.Int64 // the stats for the previous second (which gets displayed)
 	totalIn, totalOut atomic.Int64 // aggregated total for all time
 }
 
-func newStatsHandler(c *Client) *statsHandler {
-	h := &statsHandler{client: c}
+func newStatsHandler() *statsHandler {
+	h := &statsHandler{}
 	go h.update()
 	return h
 }
@@ -55,7 +54,7 @@ func (h *statsHandler) DataRate() (int, int, int, int) {
 	return int(h.rateIn.Load()), int(h.rateOut.Load()), int(h.totalIn.Load()), int(h.totalOut.Load())
 }
 
-// update runs continually, updating the aggregated stats on the Client instance.
+// update runs continually, updating the aggregated stats on the handler.
 func (h *statsHandler) update() {
 	for range time.NewTicker(updateFrequency).C {
 		in := h.in.Swap(0)


### PR DESCRIPTION
This is much simpler; we don't need to keep around varying-length slices of observed RPCs, we just aggregate on a per-second basis (which is nicer in the display; it feels far too 'jittery' to have it updating at the display update rate). Bonus: we lose the mutex in favour of atomics.

I think this will do a bit better in some cases; I've seen it previously sit around at some arbitrary number when not much is happening (e.g. you're waiting on one long-running Execute RPC) where it seems like it should have dropped to zero.