### PR TITLE
Handle .out temp output suffix for remote execution

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -395,7 +395,7 @@ func (c *Client) buildMetadata(target *core.BuildTarget, ar *pb.ActionResult, ne
 		}
 		metadata.Stderr = b
 	}
-	outputs, err := c.outputTree(ar)
+	outputs, err := c.outputTree(target, ar)
 	if err != nil {
 		return nil, err
 	}
@@ -527,7 +527,7 @@ func (c *Client) uploadLocalTarget(target *core.BuildTarget) error {
 	if err := c.uploadIfMissing(context.Background(), entries); err != nil {
 		return err
 	}
-	outs, err := c.outputTree(ar)
+	outs, err := c.outputTree(target, ar)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Targets like `///third_party/go/github.com_grpc-ecosystem_grpc-gateway_v2//protoc-gen-grpc-gateway` add the temp output suffix to the rule to avoid collisions with the directory i.e. the output for the `go_binary()` is `protoc-gen-grpc-gateway.out` rather than `protoc-gen-grpc-gateway`. This means that when we try and use this output, we get errors like so:

```
go_repo(
    module = "github.com/grpc-ecosystem/grpc-gateway/v2",
    version = "v2.18.1"
)

filegroup(
    name = "test",
    srcs = ["///third_party/go/github.com_grpc-ecosystem_grpc-gateway_v2//protoc-gen-grpc-gateway"],
)
```
```
➜  please git:(master) ✗ plz build --profile localremote //third_party/go:test
Build stopped after 80ms. 1 target failed:
    //third_party/go:test
Missing output from filegroup: protoc-gen-grpc-gateway
```

The issue is that we don't translate this back to the real path anywhere for remote execution. This code adds the translation into the code that generates the output tree from the action result. 