### PR TITLE
Add a `--json` flag to `plz query outputs`

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -392,7 +392,7 @@ var opts struct {
 			} `positional-args:"true" required:"true"`
 		} `command:"input" alias:"inputs" description:"Prints all transitive inputs of a target."`
 		Output struct {
-			JSON       bool     `long:"json" description:"Print the outputs as a json map from target to lists of output files, rather than a flat list of files"`
+			JSON bool `long:"json" description:"Print the outputs as a json map from target to lists of output files, rather than a flat list of files"`
 			Args struct {
 				Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to display outputs for" required:"true"`
 			} `positional-args:"true" required:"true"`

--- a/src/please.go
+++ b/src/please.go
@@ -392,6 +392,7 @@ var opts struct {
 			} `positional-args:"true" required:"true"`
 		} `command:"input" alias:"inputs" description:"Prints all transitive inputs of a target."`
 		Output struct {
+			JSON       bool     `long:"json" description:"Print the outputs as a json map from target to lists of output files, rather than a flat list of files"`
 			Args struct {
 				Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to display outputs for" required:"true"`
 			} `positional-args:"true" required:"true"`
@@ -806,7 +807,7 @@ var buildFunctions = map[string]func() int{
 	},
 	"query.output": func() int {
 		return runQuery(true, opts.Query.Output.Args.Targets, func(state *core.BuildState) {
-			query.TargetOutputs(state.Graph, state.ExpandOriginalLabels())
+			query.TargetOutputs(state.Graph, state.ExpandOriginalLabels(), opts.Query.Output.JSON)
 		})
 	},
 	"query.completions": func() int {

--- a/src/query/outputs.go
+++ b/src/query/outputs.go
@@ -35,11 +35,9 @@ func targetOutputsJSON(graph *core.BuildGraph, labels []core.BuildLabel) {
 			data[label.String()] = append(data[label.String()], filepath.Join(target.OutDir(), out))
 		}
 	}
-	bs, err := json.Marshal(data)
-	if err != nil {
-		log.Fatalf("failed to marshal JSON: %v", err)
-	}
-	if _, err := os.Stdout.Write(bs); err != nil {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(data); err != nil {
 		log.Fatalf("failed to write JSON: %v", err)
 	}
 }

--- a/src/query/outputs.go
+++ b/src/query/outputs.go
@@ -1,18 +1,45 @@
 package query
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/thought-machine/please/src/core"
 )
 
 // TargetOutputs prints all output files for a set of targets.
-func TargetOutputs(graph *core.BuildGraph, labels []core.BuildLabel) {
+func TargetOutputs(graph *core.BuildGraph, labels []core.BuildLabel, useJSON bool) {
+	if useJSON {
+		targetOutputsJSON(graph, labels)
+	} else {
+		targetOutputsFlat(graph, labels)
+	}
+}
+
+func targetOutputsFlat(graph *core.BuildGraph, labels []core.BuildLabel) {
 	for _, label := range labels {
 		target := graph.TargetOrDie(label)
 		for _, out := range target.Outputs() {
 			fmt.Printf("%s\n", filepath.Join(target.OutDir(), out))
 		}
+	}
+}
+
+func targetOutputsJSON(graph *core.BuildGraph, labels []core.BuildLabel) {
+	data := map[string][]string{}
+	for _, label := range labels {
+		target := graph.TargetOrDie(label)
+		for _, out := range target.Outputs() {
+			data[label.String()] = append(data[label.String()], filepath.Join(target.OutDir(), out))
+		}
+	}
+	bs, err := json.Marshal(data)
+	if err != nil {
+		log.Fatalf("failed to marshal JSON: %v", err)
+	}
+	if _, err := os.Stdout.Write(bs); err != nil {
+		log.Fatalf("failed to write JSON: %v", err)
 	}
 }


### PR DESCRIPTION
Produces a map from target name to an array of output files.

Tested using `plz-out/bin/src/please query outputs --json //src:please`