### PR TITLE
Simplify subincludes during reformat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
    build-linux:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20230903
+       - image: thoughtmachine/please_ubuntu:20240103
      resource_class: large
      environment:
        PLZ_ARGS: "-p --profile ci"
@@ -91,7 +91,7 @@ jobs:
    build-linux-alt:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu_alt:20230903
+       - image: thoughtmachine/please_ubuntu_alt:20240103
      resource_class: large
      environment:
        PLZ_ARGS: "-p -c cover --profile ci-alt"
@@ -176,7 +176,7 @@ jobs:
    build-linux-arm64:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20230903
+       - image: thoughtmachine/please_ubuntu:20240103
      resource_class: large
      steps:
        - checkout
@@ -207,9 +207,9 @@ jobs:
       steps:
        - checkout
        - restore_cache:
-           key: go-mod-darwin-v6-{{ checksum "bootstrap.sh" }}
+           key: go-mod-darwin-v7-{{ checksum "bootstrap.sh" }}
        - restore_cache:
-           key: go-darwin-go119-v1-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-go121-v1-{{ checksum "third_party/go/BUILD" }}
        - restore_cache:
            key: python-darwin-v3-{{ checksum "third_party/python/BUILD" }}
        - run:
@@ -232,11 +232,11 @@ jobs:
        - store_artifacts:
            path: /tmp/artifacts
        - save_cache:
-           key: go-mod-darwin-v6-{{ checksum "go.mod" }}
+           key: go-mod-darwin-v7-{{ checksum "go.mod" }}
            paths:
              - "~/go/pkg/mod"
        - save_cache:
-           key: go-darwin-go119-v1-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-go121-v1-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
        - save_cache:
            key: python-darwin-v3-{{ checksum "third_party/python/BUILD" }}
@@ -245,7 +245,7 @@ jobs:
    test-rex:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20230903
+       - image: thoughtmachine/please_ubuntu:20240103
      resource_class: xlarge
      steps:
        - checkout
@@ -262,7 +262,7 @@ jobs:
    test-http-cache:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20230903
+       - image: thoughtmachine/please_ubuntu:20240103
      resource_class: large
      steps:
        - checkout
@@ -305,7 +305,7 @@ jobs:
    # Runs a benchmarking test and records some performance results.
    perf-test:
      docker:
-       - image: thoughtmachine/please_ubuntu:20230903
+       - image: thoughtmachine/please_ubuntu:20240103
      resource_class: xlarge  # Want to run these tests with a significant amount of parallelism
      steps:
        - checkout

--- a/.circleci/setup_osx.sh
+++ b/.circleci/setup_osx.sh
@@ -4,7 +4,7 @@ set -eu
 
 # /usr/local/go might get cached.
 if [ ! -d "/usr/local/go" ]; then
-    curl -fsSL https://dl.google.com/go/go1.19.darwin-amd64.tar.gz | sudo tar -xz -C /usr/local
+    curl -fsSL https://dl.google.com/go/go1.21.5.darwin-amd64.tar.gz | sudo tar -xz -C /usr/local
 fi
 sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
 

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ To build Please yourself, run `./bootstrap.sh` in the repo root.
 This will bootstrap a minimal version of Please using Go and then
 rebuild it using itself.
 
-You'll need to have Go 1.18+ installed to build Please although once
-built it can target any version from 1.8+ onwards.
+You'll need to have Go 1.21+ installed to build Please although once
+built it can target any recent version (we think back to about 1.8ish).
 
 Optional dependencies for various tests include Python, Java, clang,
 gold and docker - none of those are required to build components so

--- a/src/format/fmt.go
+++ b/src/format/fmt.go
@@ -7,6 +7,7 @@ package format
 import (
 	"bytes"
 	"os"
+	"slices"
 	"sync/atomic"
 
 	"github.com/bazelbuild/buildtools/build"
@@ -65,6 +66,7 @@ func format(filename string, rewrite, quiet bool) (bool, error) {
 	if err != nil {
 		return true, err
 	}
+	simplify(f)
 	after := build.Format(f)
 	if bytes.Equal(before, after) {
 		log.Debug("%s is already in canonical format", filename)
@@ -82,4 +84,33 @@ func format(filename string, rewrite, quiet bool) (bool, error) {
 		return true, err
 	}
 	return true, fs.WriteFile(bytes.NewReader(after), filename, info.Mode())
+}
+
+// simplify runs a series of syntactical simplifications on the given file contents.
+func simplify(f *build.File) {
+	for i := len(f.Stmt)-2; i >= 0; i-- {
+		if call := subinclude(f.Stmt[i]); call != nil {
+			if next := subinclude(f.Stmt[i+1]); next != nil {
+				call.List = append(call.List, next.List...)
+				f.Stmt = slices.Delete(f.Stmt, i+1, i+2)
+				call.ForceCompact = true
+				call.ForceMultiLine = false
+			}
+		}
+	}
+}
+
+// subinclude returns the call expression for a subinclude call, or nil if it's not valid
+func subinclude(expr build.Expr) *build.CallExpr {
+	if call, ok := expr.(*build.CallExpr); ok {
+		if x, ok := call.X.(*build.Ident); ok && x.Name == "subinclude" {
+			for _, arg := range call.List {
+				if _, ok := arg.(*build.StringExpr); !ok {
+					return nil
+				}
+			}
+			return call
+		}
+	}
+	return nil
 }

--- a/src/format/fmt.go
+++ b/src/format/fmt.go
@@ -88,7 +88,7 @@ func format(filename string, rewrite, quiet bool) (bool, error) {
 
 // simplify runs a series of syntactical simplifications on the given file contents.
 func simplify(f *build.File) {
-	for i := len(f.Stmt)-2; i >= 0; i-- {
+	for i := len(f.Stmt) - 2; i >= 0; i-- {
 		if call := subinclude(f.Stmt[i]); call != nil {
 			if next := subinclude(f.Stmt[i+1]); next != nil {
 				call.List = append(call.List, next.List...)

--- a/src/format/fmt_test.go
+++ b/src/format/fmt_test.go
@@ -36,7 +36,7 @@ func TestFormat(t *testing.T) {
 				require.NoError(t, err)
 				afterContents, err := os.ReadFile(after)
 				require.NoError(t, err)
-				assert.Equal(t, beforeContents, afterContents)
+				assert.Equal(t, string(afterContents), string(beforeContents))
 			})
 		}
 	}

--- a/src/format/test_data/subincludes.after.build
+++ b/src/format/test_data/subincludes.after.build
@@ -1,0 +1,6 @@
+subinclude("//build_defs:go", "///python//build_defs:python", "///cc//build_defs:cc", "//build_defs:test")
+
+python_library(
+    name = "lib",
+    srcs = glob(["*.py"]),
+)

--- a/src/format/test_data/subincludes.before.build
+++ b/src/format/test_data/subincludes.before.build
@@ -1,0 +1,10 @@
+subinclude("//build_defs:go")
+
+subinclude("///python//build_defs:python")
+
+subinclude("///cc//build_defs:cc", "//build_defs:test")
+
+python_library(
+    name = "lib",
+    srcs = glob(["*.py"]),
+)

--- a/src/parse/asp/BUILD
+++ b/src/parse/asp/BUILD
@@ -23,7 +23,6 @@ go_library(
         "///third_party/go/github.com_Masterminds_semver_v3//:v3",
         "///third_party/go/github.com_manifoldco_promptui//:promptui",
         "///third_party/go/github.com_please-build_gcfg//types",
-        "///third_party/go/golang.org_x_exp//slices",
         "//rules",
         "//src/cli",
         "//src/cli/logging",

--- a/src/parse/asp/file_position.go
+++ b/src/parse/asp/file_position.go
@@ -3,8 +3,7 @@ package asp
 import (
 	"fmt"
 	"os"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // A FilePosition is the more user-friendly equivalent to the Position type.

--- a/tools/images/ubuntu/Dockerfile
+++ b/tools/images/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 MAINTAINER peter.ebden@gmail.com
 
 
@@ -15,7 +15,7 @@ RUN truncate -s0 /tmp/preseed.cfg; \
     apt-get clean
 
 # Go - we want a specific package version here.
-RUN curl -fsSL https://dl.google.com/go/go1.21.0.linux-amd64.tar.gz | tar -xzC /usr/local
+RUN curl -fsSL https://dl.google.com/go/go1.21.5.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Locale

--- a/tools/images/ubuntu_alt/Dockerfile
+++ b/tools/images/ubuntu_alt/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get clean
 
 # Go
-RUN curl -fsSL https://dl.google.com/go/go1.20.7.linux-amd64.tar.gz | tar -xzC /usr/local
+RUN curl -fsSL https://dl.google.com/go/go1.21.5.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Locale


### PR DESCRIPTION
This rewrites repeated calls to `subinclude` into one. See example in test_data.

Have run internally and am happy with the results (although other unrelated fmt issues have arisen...)