### PR TITLE
Support Python-style 0oXXX octal integers

### DIFF
--- a/src/parse/asp/lexer.go
+++ b/src/parse/asp/lexer.go
@@ -224,7 +224,14 @@ func (l *lex) nextToken() Token {
 			return Token{Type: EOL, Pos: pos}
 		}
 		return l.nextToken()
-	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+	case '0':
+		if l.bytes[l.pos] == 'o' {
+			l.pos++
+			l.col++
+			return l.consumeInteger(next, pos)
+		}
+		fallthrough
+	case '1', '2', '3', '4', '5', '6', '7', '8', '9':
 		return l.consumeInteger(next, pos)
 	case '"', '\'':
 		// String literal, consume to end.

--- a/src/parse/asp/lexer_test.go
+++ b/src/parse/asp/lexer_test.go
@@ -348,3 +348,9 @@ func TestCRLF(t *testing.T) {
 	assertNextToken(t, l, ')', ")", 2, 12, 23)
 	assertNextToken(t, l, EOL, "", 2, 14, 25)
 }
+
+func TestOctal(t *testing.T) {
+	l := newLexer(strings.NewReader("0o604 0604"))
+	assertNextToken(t, l, Int, "0604", 1, 1, 1)
+	assertNextToken(t, l, Int, "0604", 1, 7, 7)
+}


### PR DESCRIPTION
This is relevant because the autoformatter likes to rewrite to this style, which is then unparseable. It's also less ambiguous although I'm not particularly up for trying to stop supporting 0XXX any time soon.