### PR TITLE
Log value of gauge metrics too

### DIFF
--- a/src/metrics/prometheus.go
+++ b/src/metrics/prometheus.go
@@ -27,6 +27,8 @@ func Push(config *core.Configuration) {
 			for _, metric := range fam.Metric {
 				if metric.Counter != nil {
 					log.Debug("Metric recorded: %s: %0.0f", *fam.Name, *metric.Counter.Value)
+				} else if metric.Gauge != nil {
+					log.Debug("Metric recorded: %s: %0.0f", *fam.Name, *metric.Gauge.Value)
 				}
 			}
 		}


### PR DESCRIPTION
Initially this only did counters because I was only thinking of our first-party metrics. The `go_memstats` ones are useful too though and the gauges probably more interesting there (e.g. `go_memstats_alloc_bytes` may be more relevant than just `go_memstats_alloc_bytes_total`).