### PR TITLE
Add version tag to build metadata

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -241,6 +241,10 @@ type BuildTarget struct {
 	ShowProgress atomicBool `name:"progress"`
 }
 
+// ExpectedBuildMetadataVersionTag is the version tag that the current Please version expects. If this doesn't match
+// the VersionTag of the BuildMetadata object, then Please will not use the cached target metadata.
+var ExpectedBuildMetadataVersionTag = 1
+
 // BuildMetadata is temporary metadata that's stored around a build target - we don't
 // generally persist it indefinitely.
 type BuildMetadata struct {
@@ -260,6 +264,10 @@ type BuildMetadata struct {
 	Test bool
 	// True if the results were retrieved from a cache, false if we ran the full build action.
 	Cached bool
+	// VersionTag is an integer representing the version of this cache object. This is used to invalidate the local
+	// action result cache in the event that the cache has been poisoned due to a bug. If this doesn't match the
+	// expected version above, Please will not use this cached metadata.
+	VersionTag int
 }
 
 // A PreBuildFunction is a type that allows hooking a pre-build callback.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -242,7 +242,9 @@ type BuildTarget struct {
 }
 
 // ExpectedBuildMetadataVersionTag is the version tag that the current Please version expects. If this doesn't match
-// the VersionTag of the BuildMetadata object, then Please will not use the cached target metadata.
+// the VersionTag of the BuildMetadata object, then Please will not use the cached target metadata. Changing this value
+// will invalidate the local action metadata cache, which can be useful if it has been poisoned by a bug in a
+// previous version of Please.
 var ExpectedBuildMetadataVersionTag = 1
 
 // BuildMetadata is temporary metadata that's stored around a build target - we don't
@@ -264,8 +266,7 @@ type BuildMetadata struct {
 	Test bool
 	// True if the results were retrieved from a cache, false if we ran the full build action.
 	Cached bool
-	// VersionTag is an integer representing the version of this cache object. This is used to invalidate the local
-	// action result cache in the event that the cache has been poisoned due to a bug. If this doesn't match the
+	// VersionTag is an integer representing the version of this cache object. If this doesn't match the
 	// expected version above, Please will not use this cached metadata.
 	VersionTag int
 }

--- a/src/remote/build_metadata_store.go
+++ b/src/remote/build_metadata_store.go
@@ -61,6 +61,8 @@ func (d *directoryMetadataStore) clean() {
 }
 
 func (d *directoryMetadataStore) storeMetadata(key string, md *core.BuildMetadata) error {
+	md.VersionTag = core.ExpectedBuildMetadataVersionTag
+
 	prefix := key[:2]
 	dir := filepath.Join(d.directory, d.instance, prefix)
 	if err := os.MkdirAll(dir, fs.DirPermissions); err != nil {
@@ -89,6 +91,10 @@ func (d *directoryMetadataStore) retrieveMetadata(key string) (*core.BuildMetada
 	}
 
 	if d.hasExpired(md) {
+		return nil, nil
+	}
+	// If the cached version metadata doesn't match the expected version, then we should not use this metadata file
+	if md.VersionTag != core.ExpectedBuildMetadataVersionTag {
 		return nil, nil
 	}
 	return md, nil


### PR DESCRIPTION
In 17.4.2 we introduced a fix to the action result output processing which meant that we handle the `.out` suffix correctly for remote execution. This is cached on the target metadata though, so users have to clear out this local action result cache. This PR introduced a crude mechanism for Please to do this.