### PR TITLE
plz update --noverify skips hash verification

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -259,7 +259,7 @@ var opts struct {
 
 	Update struct {
 		Force            bool        `long:"force" description:"Forces a re-download of the new version."`
-		NoVerify         bool        `long:"noverify" description:"Skips signature verification of downloaded version"`
+		NoVerify         bool        `long:"noverify" description:"Skips signature and hash verification of downloaded version"`
 		Latest           bool        `long:"latest" description:"Update to latest available version (overrides config)."`
 		LatestPrerelease bool        `long:"latest_prerelease" description:"Update to latest available prerelease version (overrides config)."`
 		Version          cli.Version `long:"version" description:"Updates to a particular version (overrides config)."`

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -191,7 +191,7 @@ func downloadAndLinkPlease(config *core.Configuration, verify bool, progress boo
 	if !core.PathExists(newPlease) {
 		downloadPlease(config, verify, progress)
 	}
-	if !verifyNewPlease(newPlease, config.Please.Version.VersionString()) {
+	if verify && !verifyNewPlease(newPlease, config.Please.Version.VersionString()) {
 		cleanDir(filepath.Join(config.Please.Location, config.Please.Version.VersionString()))
 		log.Fatalf("Not continuing.")
 	}
@@ -234,7 +234,7 @@ func downloadPlease(config *core.Configuration, verify bool, progress bool) {
 	defer mustClose(pleaseReadCloser)
 	var pleaseReader io.Reader = bufio.NewReader(pleaseReadCloser)
 
-	if len(config.Please.VersionChecksum) > 0 {
+	if verify && len(config.Please.VersionChecksum) > 0 {
 		pleaseReader = mustVerifyHash(pleaseReader, config.Please.VersionChecksum)
 	}
 

--- a/src/update/update_test.go
+++ b/src/update/update_test.go
@@ -139,7 +139,7 @@ func TestDownloadAndLinkPlease(t *testing.T) {
 
 func TestDownloadAndLinkPleaseBadVersion(t *testing.T) {
 	c := makeConfig("downloadandlink")
-	assert.Panics(t, func() { downloadAndLinkPlease(c, false, true) })
+	assert.Panics(t, func() { downloadAndLinkPlease(c, true, true) })
 	// Should have deleted the thing it downloaded.
 	assert.False(t, core.PathExists(filepath.Join(c.Please.Location, c.Please.Version.String())))
 }


### PR DESCRIPTION
Previously it just skipped signature verification, which is what it said, but that's rarely useful; conversely, in a repo with hashes configured, it's not really possible to update please to an arbitrary version sensibly (i.e. `plz update --version 17.4.2` will error if the repo is currently configured for 17.4.1).

Arguably `--version` could imply this (almost any time I use it this is what I want), but I don't think it's a good idea for that flag to silently turn off verification.