### PR TITLE
Update the macos executors on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,13 +124,13 @@ jobs:
    build-darwin-arm64:
      working_directory: ~/please
      macos:
-       xcode: "13.4.1"
+       xcode: "15.2.0"
      steps:
        - checkout
        - attach_workspace:
            at: /tmp/workspace
        - restore_cache:
-           key: go-darwin-arm64-v4-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-arm64-v5-{{ checksum "third_party/go/BUILD" }}
        - run:
            name: Extract plz
            command: tar -xzf /tmp/workspace/darwin_amd64/please_*.tar.gz
@@ -144,7 +144,7 @@ jobs:
        - store_artifacts:
            path: plz-out/log
        - save_cache:
-           key: go-darwin-arm64-v4-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-arm64-v5-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
 
    build-freebsd:
@@ -201,17 +201,17 @@ jobs:
            paths: [ ".plz-cache/third_party/go" ]
    build-darwin:
       macos:
-        xcode: "13.4.1"
+        xcode: "15.2.0"
       environment:
         PLZ_ARGS: "-p --profile ci --exclude pip --exclude embed"
       steps:
        - checkout
        - restore_cache:
-           key: go-mod-darwin-v7-{{ checksum "bootstrap.sh" }}
+           key: go-mod-darwin-v8-{{ checksum "bootstrap.sh" }}
        - restore_cache:
-           key: go-darwin-go121-v1-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-go121-v2-{{ checksum "third_party/go/BUILD" }}
        - restore_cache:
-           key: python-darwin-v3-{{ checksum "third_party/python/BUILD" }}
+           key: python-darwin-v4-{{ checksum "third_party/python/BUILD" }}
        - run:
            name: Install deps
            command: ./.circleci/setup_osx.sh
@@ -232,14 +232,13 @@ jobs:
        - store_artifacts:
            path: /tmp/artifacts
        - save_cache:
-           key: go-mod-darwin-v7-{{ checksum "go.mod" }}
-           paths:
-             - "~/go/pkg/mod"
+           key: go-mod-darwin-v8-{{ checksum "go.mod" }}
+           paths: [ "~/go/pkg/mod" ]
        - save_cache:
-           key: go-darwin-go121-v1-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-go121-v2-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
        - save_cache:
-           key: python-darwin-v3-{{ checksum "third_party/python/BUILD" }}
+           key: python-darwin-v4-{{ checksum "third_party/python/BUILD" }}
            paths: [ ".plz-cache/third_party/python" ]
 
    test-rex:


### PR DESCRIPTION
I think 13.x is getting towards EOL.

I have a vague memory there was some issue with 14 but just gonna try this and see what happens.