### PR TITLE
Add an environment variable containing the test run

### DIFF
--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -162,7 +162,7 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string, run
 		// We shouldn't really have specific things like this here, but it really is just easier to set it.
 		"GTEST_OUTPUT=xml:"+resultsFile,
 		"PEX_NOCACHE=true",
-		"_TEST_RUN="+base64.RawStdEncoding.EncodeToString(hash[:12]),
+		"_TEST_ID="+base64.RawStdEncoding.EncodeToString(hash[:12]),
 	)
 	if state.NeedCoverage && !target.HasAnyLabel(state.Config.Test.DisableCoverage) {
 		env = append(env,

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -145,7 +145,7 @@ func withUserProvidedEnv(target *BuildTarget, env BuildEnv) BuildEnv {
 }
 
 // TestEnvironment creates the environment variables for a test.
-func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) BuildEnv {
+func TestEnvironment(state *BuildState, target *BuildTarget, testDir string, run int) BuildEnv {
 	env := RuntimeEnvironment(state, target, filepath.IsAbs(testDir), true)
 	resultsFile := filepath.Join(testDir, TestResultsFile)
 
@@ -159,6 +159,7 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string) Bui
 		// We shouldn't really have specific things like this here, but it really is just easier to set it.
 		"GTEST_OUTPUT=xml:"+resultsFile,
 		"PEX_NOCACHE=true",
+		fmt.Sprintf("TEST_RUN=%d", run),
 	)
 	if state.NeedCoverage && !target.HasAnyLabel(state.Config.Test.DisableCoverage) {
 		env = append(env,

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -159,7 +159,7 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string, run
 		// We shouldn't really have specific things like this here, but it really is just easier to set it.
 		"GTEST_OUTPUT=xml:"+resultsFile,
 		"PEX_NOCACHE=true",
-		fmt.Sprintf("TEST_RUN=%d", run),
+		fmt.Sprintf("_TEST_RUN=%d", run),
 	)
 	if state.NeedCoverage && !target.HasAnyLabel(state.Config.Test.DisableCoverage) {
 		env = append(env,

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -11,6 +11,7 @@ import (
 	iofs "io/fs"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -556,6 +557,10 @@ func (state *BuildState) ArchSubrepoInitialised(subrepoLabel BuildLabel) {
 
 // LogTestRunning logs a target while its tests are running.
 func (state *BuildState) LogTestRunning(target *BuildTarget, run int, status BuildResultStatus, message string) {
+	// Annotate the message with the run number if appropriate.
+	if state.NumTestRuns > 1 {
+		message = strings.TrimSuffix(message, "...") + fmt.Sprintf(" (run %d of %d)...", run, state.NumTestRuns)
+	}
 	state.logResult(&BuildResult{
 		Label:       target.Label,
 		target:      target,

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -427,7 +427,7 @@ func printTempDirs(state *core.BuildState, duration time.Duration, shell, shellR
 		if state.NeedTests {
 			cmd = target.GetTestCommand(state)
 			dir = filepath.Join(core.RepoRoot, target.TestDir(1))
-			env = core.TestEnvironment(state, target, dir)
+			env = core.TestEnvironment(state, target, dir, 1)
 			shouldSandbox = target.Test.Sandbox
 			if len(state.TestArgs) > 0 {
 				env = append(env, "TESTS="+strings.Join(state.TestArgs, " "))

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -373,7 +373,7 @@ func (c *Client) Run(target *core.BuildTarget) error {
 	if err := c.CheckInitialised(); err != nil {
 		return err
 	}
-	cmd, digest, err := c.uploadAction(target, false, true)
+	cmd, digest, err := c.uploadAction(target, false, true, 0)
 	if err != nil {
 		return err
 	}
@@ -389,7 +389,7 @@ func (c *Client) build(target *core.BuildTarget) (*core.BuildMetadata, *pb.Actio
 	// This implements the rules of stamp whereby we don't force rebuilds every time e.g. the SCM revision changes.
 	var unstampedDigest *pb.Digest
 	if target.Stamp {
-		command, digest, err := c.buildAction(target, false, false)
+		command, digest, err := c.buildAction(target, false, false, 0)
 		if err != nil {
 			return nil, nil, nil, err
 		} else if metadata, ar := c.maybeRetrieveResults(target, command, digest, false, needStdout, 0); metadata != nil {
@@ -398,7 +398,7 @@ func (c *Client) build(target *core.BuildTarget) (*core.BuildMetadata, *pb.Actio
 		}
 		unstampedDigest = digest
 	}
-	command, stampedDigest, err := c.buildAction(target, false, true)
+	command, stampedDigest, err := c.buildAction(target, false, true, 0)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -550,7 +550,7 @@ func (c *Client) Test(target *core.BuildTarget, run int) (metadata *core.BuildMe
 	if err := c.CheckInitialised(); err != nil {
 		return nil, err
 	}
-	command, digest, err := c.buildAction(target, true, false)
+	command, digest, err := c.buildAction(target, true, false, run)
 	if err != nil {
 		return nil, err
 	}
@@ -620,7 +620,7 @@ func (c *Client) execute(target *core.BuildTarget, command *pb.Command, digest *
 		}
 	}
 	// We didn't actually upload the inputs before, so we must do so now.
-	command, digest, err := c.uploadAction(target, isTest, false)
+	command, digest, err := c.uploadAction(target, isTest, false, 0)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to upload build action: %s", err)
 	}

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -204,13 +204,13 @@ func test(state *core.BuildState, label core.BuildLabel, target *core.BuildTarge
 		}
 	} else if state.TestSequentially {
 		for run := 1; run <= int(state.NumTestRuns); run++ {
-			state.LogTestRunning(target, run, core.TargetTesting, getRunStatus(run, int(state.NumTestRuns)))
+			state.LogTestRunning(target, run, core.TargetTesting, "Testing...")
 			var results core.TestSuite
 			results, coverage = doTest(state, target, runRemotely, 1) // Sequential tests re-use run 1's test dir
 			target.AddTestResults(results)
 		}
 	} else {
-		state.LogTestRunning(target, run, core.TargetTesting, getRunStatus(run, int(state.NumTestRuns)))
+		state.LogTestRunning(target, run, core.TargetTesting, "Testing...")
 		var results core.TestSuite
 		results, coverage = doTest(state, target, runRemotely, run)
 		target.AddTestResults(results)
@@ -273,13 +273,6 @@ func getFlakeStatus(flake int, flakes int) string {
 		return "Testing..."
 	}
 	return fmt.Sprintf("Testing (flake %d of %d)...", flake, flakes)
-}
-
-func getRunStatus(run int, numRuns int) string {
-	if numRuns == 1 {
-		return "Testing..."
-	}
-	return fmt.Sprintf("Testing (run %d of %d)...", run, numRuns)
 }
 
 func logTargetResults(state *core.BuildState, target *core.BuildTarget, coverage *core.TestCoverage, run int) {

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -338,7 +338,7 @@ func pluralise(word string, quantity int) string {
 // testCommandAndEnv returns the test command & environment for a target.
 func testCommandAndEnv(state *core.BuildState, target *core.BuildTarget, run int) (string, core.BuildEnv, error) {
 	replacedCmd, err := core.ReplaceTestSequences(state, target, target.GetTestCommand(state))
-	env := core.TestEnvironment(state, target, filepath.Join(core.RepoRoot, target.TestDir(run)))
+	env := core.TestEnvironment(state, target, filepath.Join(core.RepoRoot, target.TestDir(run)), run)
 	if len(state.TestArgs) > 0 {
 		replacedCmd += " " + strings.Join(state.TestArgs, " ")
 	}


### PR DESCRIPTION
I don't completely like that they can theoretically now take action based on this, but I think it's a fairly practical way of deduplicating them on the remote execution side.
Arguably there are more elegant ways of tackling that but this will work right now and won't require the backend to be able to separate multiple concurrent executions of the same action.

We could also only do this for remote execution, but I think it's a bad idea to start adding differences between the two (in some ways they already are but c'est la vie)