### PR TITLE
Implement iteration as a more generic concept

### DIFF
--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -41,7 +41,7 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "map", mapFunc)
 	setNativeCode(s, "reduce", reduce)
 	setNativeCode(s, "isinstance", isinstance)
-	setNativeCode(s, "range", pyRange)
+	setNativeCode(s, "range", pyRangeFunc)
 	setNativeCode(s, "enumerate", enumerate)
 	setNativeCode(s, "zip", zip, varargs)
 	setNativeCode(s, "any", anyFunc)
@@ -869,7 +869,7 @@ func canonicalise(s *scope, args []pyObject) pyObject {
 	return pyString(label.String())
 }
 
-func pyRange(s *scope, args []pyObject) pyObject {
+func pyRangeFunc(s *scope, args []pyObject) pyObject {
 	start := args[0].(pyInt)
 	stop, isInt := args[1].(pyInt)
 	step := args[2].(pyInt)
@@ -878,11 +878,11 @@ func pyRange(s *scope, args []pyObject) pyObject {
 		stop = start
 		start = 0
 	}
-	ret := make(pyList, 0, stop-start)
-	for i := start; i < stop; i += step {
-		ret = append(ret, i)
+	return &pyRange{
+		Start: start,
+		Stop:  stop,
+		Step:  step,
 	}
-	return ret
 }
 
 func enumerate(s *scope, args []pyObject) pyObject {

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -32,6 +32,15 @@ type freezable interface {
 	Freeze() pyObject
 }
 
+// An iterable represents an object that can be iterated (the y in `for x in y`).
+// Not all pyObjects implement this.
+type iterable interface {
+	pyObject
+	// This isn't super generic but it works fine for all cases we have right now.
+	Len() int
+	Item(index int) pyObject
+}
+
 type pyBool bool
 
 // True and False are the singletons representing those values.
@@ -399,6 +408,16 @@ func (l pyList) Repeat(n pyInt) pyList {
 		ret = append(ret, l...)
 	}
 	return ret
+}
+
+// Len returns the length of this list, implementing iterable.
+func (l pyList) Len() int {
+	return len(l)
+}
+
+// Item returns the i'th item of this list, implementing iterable.
+func (l pyList) Item(i int) pyObject {
+	return l[i]
 }
 
 // A pyFrozenList implements an immutable list.

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -962,3 +962,47 @@ func (c *pyFrozenConfig) Property(scope *scope, name string) pyObject {
 	}
 	return c.pyConfig.Property(scope, name)
 }
+
+// A pyRange implements the result of a range() call
+type pyRange struct {
+	Start, Stop, Step pyInt
+}
+
+func (r *pyRange) String() string {
+	return fmt.Sprintf("range(%d, %d, %d)", r.Start, r.Stop, r.Step)
+}
+
+func (r *pyRange) Type() string {
+	return "range"
+}
+
+func (r *pyRange) IsTruthy() bool {
+	return true
+}
+
+func (r *pyRange) Property(scope *scope, name string) pyObject {
+	panic("range object has no property " + name)
+}
+
+func (r *pyRange) Operator(operator Operator, operand pyObject) pyObject {
+	if l, ok := operand.(pyList); ok {
+		ret := make(pyList, 0, r.Len()+len(l))
+		for i := r.Start; i < r.Stop; i += r.Step {
+			ret = append(ret, i)
+		}
+		return append(ret, l...)
+	}
+	panic(fmt.Sprintf("operator %s not implemented on type range", operator))
+}
+
+func (r *pyRange) IndexAssign(index, value pyObject) {
+	panic("range type is not indexable")
+}
+
+func (r *pyRange) Len() int {
+	return int((r.Stop - r.Start) / r.Step)
+}
+
+func (r *pyRange) Item(index int) pyObject {
+	return r.Start + pyInt(index)*r.Step
+}


### PR DESCRIPTION
Rather than coercing everything to a list, this allows iterating compliant objects on the fly.
Spotted that we allocate a surprising amount to `range()` calls which this effectively just stops (because now it just creates a single range object which lazily emits integers).

Seeing some local improvement in memory allocation; not a huge amount to the maxrss (because these are nearly always throwaway) but it seems slightly better overall (insofar as one can measure given how noisy it is).