### PR TITLE
Make Optimised field private

### DIFF
--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -736,7 +736,7 @@ func filter(s *scope, args []pyObject) pyObject {
 	for _, li := range l {
 		c := &Call{
 			Arguments: []CallArgument{{
-				Value: Expression{Optimised: &OptimisedExpression{Constant: li}},
+				Value: Expression{optimised: &OptimisedExpression{Constant: li}},
 			}},
 		}
 		if f.Call(s, c).IsTruthy() {
@@ -756,7 +756,7 @@ func mapFunc(s *scope, args []pyObject) pyObject {
 	for _, li := range l {
 		c := &Call{
 			Arguments: []CallArgument{{
-				Value: Expression{Optimised: &OptimisedExpression{Constant: li}},
+				Value: Expression{optimised: &OptimisedExpression{Constant: li}},
 			}},
 		}
 		ret = append(ret, mapper.Call(s, c))
@@ -782,9 +782,9 @@ func reduce(s *scope, args []pyObject) pyObject {
 	for _, li := range l {
 		c := &Call{
 			Arguments: []CallArgument{{
-				Value: Expression{Optimised: &OptimisedExpression{Constant: ret}},
+				Value: Expression{optimised: &OptimisedExpression{Constant: ret}},
 			}, {
-				Value: Expression{Optimised: &OptimisedExpression{Constant: li}},
+				Value: Expression{optimised: &OptimisedExpression{Constant: li}},
 			}},
 		}
 		ret = reducer.Call(s, c)
@@ -939,7 +939,7 @@ func extreme(s *scope, args []pyObject, cmp Operator) pyObject {
 		if key != nil {
 			c := &Call{
 				Arguments: []CallArgument{{
-					Value: Expression{Optimised: &OptimisedExpression{Constant: li}},
+					Value: Expression{optimised: &OptimisedExpression{Constant: li}},
 				}},
 			}
 			cli = key.Call(s, c)

--- a/src/parse/asp/grammar.go
+++ b/src/parse/asp/grammar.go
@@ -96,14 +96,13 @@ type Argument struct {
 // An Expression is a generalised Python expression, i.e. anything that can appear where an
 // expression is allowed (including the extra parts like inline if-then-else, operators, etc).
 type Expression struct {
-	Pos     Position
-	EndPos  Position
-	UnaryOp *UnaryOp
-	Val     *ValueExpression
-	Op      []OpExpression
-	If      *InlineIf
-	// For internal optimisation - do not use outside this package.
-	Optimised *OptimisedExpression
+	Pos       Position
+	EndPos    Position
+	UnaryOp   *UnaryOp
+	Val       *ValueExpression
+	Op        []OpExpression
+	If        *InlineIf
+	optimised *OptimisedExpression
 }
 
 // An OptimisedExpression contains information to optimise certain aspects of execution of

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -302,7 +302,7 @@ func TestInterpreterOptimiseConfig(t *testing.T) {
 	assert.NotNil(t, statements[0].Ident)
 	assert.NotNil(t, statements[0].Ident.Action)
 	assert.NotNil(t, statements[0].Ident.Action.Assign)
-	assert.Equal(t, "GO_TOOL", statements[0].Ident.Action.Assign.Optimised.Config)
+	assert.Equal(t, "GO_TOOL", statements[0].Ident.Action.Assign.optimised.Config)
 	assert.EqualValues(t, "go", s.Lookup("x"))
 }
 
@@ -436,8 +436,8 @@ func TestFStringOptimisation(t *testing.T) {
 	// Check that it's been optimised to something
 	assign := stmts[0].Ident.Action.Assign
 	assert.Nil(t, assign.Val)
-	assert.NotNil(t, assign.Optimised.Constant)
-	assert.EqualValues(t, "test", assign.Optimised.Constant)
+	assert.NotNil(t, assign.optimised.Constant)
+	assert.EqualValues(t, "test", assign.optimised.Constant)
 }
 
 func TestFormat(t *testing.T) {

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -644,7 +644,7 @@ func (f *pyFunc) Call(s *scope, c *Call) pyObject {
 	args := c.Arguments
 	if f.self != nil {
 		args = append([]CallArgument{{
-			Value: Expression{Optimised: &OptimisedExpression{Constant: f.self}},
+			Value: Expression{optimised: &OptimisedExpression{Constant: f.self}},
 		}}, args...)
 	}
 	for i, a := range args {


### PR DESCRIPTION
Was public because once upon a time we used to serialise the ASTs. That doesn't happen any more so this can be actually private.