### PR TITLE
use parser.open rather than os.open when we encounter an error interpreting during parse

### DIFF
--- a/src/parse/asp/parser.go
+++ b/src/parse/asp/parser.go
@@ -83,7 +83,7 @@ func (p *Parser) ParseFile(pkg *core.Package, label, dependent *core.BuildLabel,
 	}
 	_, err = p.interpreter.interpretAll(pkg, label, dependent, mode, statements)
 	if err != nil {
-		f, _ := os.Open(filename)
+		f, _ := p.open(fs, filename)
 		p.annotate(err, f)
 	}
 	return err


### PR DESCRIPTION
Previously we were calling os.Open which could fail if the build file doesn't exist. Instead use the remote fs by calling parser.open instead.

this was causing
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4f1140]

goroutine 9094 [running]:
os.(*File).Name(0xfade40?)
	os/file.go:56
github.com/thought-machine/please/src/parse/asp.NameOfReader(...)
	src/parse/asp/lexer.go:50
github.com/thought-machine/please/src/parse/asp.(*errorStack).AddReader(0xc00366f3b0, {0xfb3f28?, 0x0})
	src/parse/asp/errors.go:225 +0x1b4
github.com/thought-machine/please/src/parse/asp.AddReader(...)
	src/parse/asp/errors.go:79
github.com/thought-machine/please/src/parse/asp.(*Parser).annotate(0xc0000b84f8, {0xfafa00?, 0xc00366f3b0}, {0xfb3f28?, 0x0?})
	src/parse/asp/parser.go:174 +0x65
github.com/thought-machine/please/src/parse/asp.(*Parser).ParseFile(0xc0000b84f8, 0xc007298700, 0xc013805b00, 0xc013805b30, 0x1, {0xfae920, 0xc0053b6dc0}, {0xc019f99640, 0x1d})
	src/parse/asp/parser.go:87 +0x4b8
github.com/thought-machine/please/src/parse.(*aspParser).ParseFile(0xc00d3d2af8?, 0x0?, 0xfae920?, 0xc0053b6dc0?, 0xe3?, {0xfae920?, 0xc0053b6dc0?}, {0xc019f99640?, 0xc000b83df0?})
	src/parse/init.go:60 +0x2e
github.com/thought-machine/please/src/parse.parsePackage(0xc000dc8f00, {{0xc003e503e3, 0x17}, {0xc003e503ec, 0xe}, {0xc0007a3920, 0x25}}, {{0xc00028d7e8, 0x0}, {0xc004b0ce81, ...}, ...}, ...)
	src/parse/parse_step.go:192 +0x4be
github.com/thought-machine/please/src/parse.parse(0xc000462000?, {{0xc003e503e3, 0x17}, {0xc003e503ec, 0xe}, {0xc0007a3920, 0x25}}, {{0xc00028d7e8, 0x0}, {0xc004b0ce81, ...}, ...}, ...)
	src/parse/parse_step.go:82 +0x7f2
github.com/thought-machine/please/src/parse.Parse(...)
	src/parse/parse_step.go:35
github.com/thought-machine/please/src/plz.Run.func1.1({{{0xc003e503e3, 0x17}, {0xc003e503ec, 0xe}, {0xc0007a3920, 0x25}}, {{0xc00028d7e8, 0x0}, {0xc004b0ce81, 0x8}, ...}, ...})
	src/plz/plz.go:54 +0xb7
created by github.com/thought-machine/please/src/plz.Run.func1 in goroutine 66
	src/plz/plz.go:53 +0xb8
```