### PR TITLE
Remove `github.com/peterebden/buildtools` as a dependency

### DIFF
--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -162,11 +162,6 @@ go_repo(
 )
 
 go_repo(
-    module = "github.com/peterebden/buildtools",
-    version = "f7a36c689cc9e038956d51005332c67ade7aa9c6",
-)
-
-go_repo(
     module = "google.golang.org/genproto",
     version = "v0.0.0-20221206210731-b1a01be3a5f6",
 )


### PR DESCRIPTION
Looks like this isn't used any more (everything ought to be using `github.com/please-build/buildtools` by now).