### PR TITLE
`format`: only sort `tag` parameter below `name` for built-in rules

### DIFF
--- a/src/format/test_data/param_sort_order_tag.after.build
+++ b/src/format/test_data/param_sort_order_tag.after.build
@@ -1,6 +1,26 @@
+build_rule(
+    name = "a",
+    # This should sort below "name" (build_rule is a Please built-in):
+    tag = "a_tag",
+    srcs = ["a.txt"],
+    outs = ["a.out"],
+    cmd = "cp $SRCS $OUTS",
+    visibility = ["PUBLIC"],
+)
+
 filegroup(
-    name = "name",
-    tag = "tag",
+    name = "b",
+    # This should sort below "name" (build_rule is a Please built-in):
+    tag = "b_tag",
     srcs = ["x.txt"],
+    visibility = ["PUBLIC"],
+)
+
+docker_mirror(
+    name = "c",
+    digest = "sha256:5d37aaee1673c45dba5ed666ae167ed3e5010ec1b5a20ee782197b66092749a0",
+    src_image = "registry.example/images/c",
+    # This should sort normally (docker_mirror isn't a Please built-in):
+    tag = "1.0.0",
     visibility = ["PUBLIC"],
 )

--- a/src/format/test_data/param_sort_order_tag.before.build
+++ b/src/format/test_data/param_sort_order_tag.before.build
@@ -1,6 +1,26 @@
+build_rule(
+    name = "a",
+    srcs = ["a.txt"],
+    outs = ["a.out"],
+    cmd = "cp $SRCS $OUTS",
+    # This should sort below "name" (build_rule is a Please built-in):
+    tag = "a_tag",
+    visibility = ["PUBLIC"],
+)
+
 filegroup(
-    name = "name",
+    name = "b",
     srcs = ["x.txt"],
-    tag = "tag",
+    # This should sort below "name" (build_rule is a Please built-in):
+    tag = "b_tag",
+    visibility = ["PUBLIC"],
+)
+
+docker_mirror(
+    name = "c",
+    digest = "sha256:5d37aaee1673c45dba5ed666ae167ed3e5010ec1b5a20ee782197b66092749a0",
+    src_image = "registry.example/images/c",
+    # This should sort normally (docker_mirror isn't a Please built-in):
+    tag = "1.0.0",
     visibility = ["PUBLIC"],
 )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -21,7 +21,7 @@ go_stdlib(
 
 go_repo(
     module = "github.com/please-build/buildtools",
-    version = "746673d48318e5a6eb8cf3946d7f08586d85bf37",
+    version = "77ffe55926d9e60171a92243fae5c7244a60e758",
 )
 
 go_repo(


### PR DESCRIPTION
Turns out `tag` is quite a common parameter name for custom build rules. We only want it to sort below `name` in cases where the parameter's value is actually part of the target name, i.e. for the Please built-ins `build_rule` and `filegroup`. In all other cases, it should sort alphabetically with the unprioritised parameters.