### PR TITLE
Improve performance on clean builds

### DIFF
--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -266,7 +266,9 @@ func (c *Client) retrieveLocalResults(target *core.BuildTarget, digest *pb.Diges
 		if err != nil {
 			log.Warningf("Failed to retrieve stored metadata for target %s, %v", target.Label, err)
 		}
-		if metadata != nil && len(metadata.RemoteAction) > 0 {
+		// Empty filegroups have empty action results
+		isEmptyFilegroup := target.IsFilegroup && len(target.AllSources()) == 0
+		if metadata != nil && (len(metadata.RemoteAction) > 0 || isEmptyFilegroup) {
 			ar := &pb.ActionResult{}
 			outputs := &pb.Tree{}
 			if err := proto.Unmarshal(metadata.RemoteAction, ar); err != nil {


### PR DESCRIPTION
```
➜  src git:(puku-sync) ✗ time ~/please/plz-out/bin/src/please --noupdate build --nodownload //third_party/go:alertmanager 
16:41:06.928 WARNING: Downgrading to Please version 17.5.0 skipped (current version: 17.6.0)
Build finished; total time 890ms, incrementality 100.0%.
~/please/plz-out/bin/src/please --noupdate build --nodownload   4.43s user 0.97s system 511% cpu 1.058 total
➜  src git:(puku-sync) ✗ time plz --noupdate build --nodownload //third_party/go:alertmanager 
Build finished; total time 6.18s, incrementality 100.0%.
plz --noupdate build --nodownload //third_party/go:alertmanager  38.98s user 2.54s system 651% cpu 6.370 total
```

Turns out there were 2 big perf hits:
1) We weren't using the locally cached action results for filegroups because the remote action metadata was missing
2) We were reconstructing the remote FS from the tree proto on every re-use which is kinda expensive. 