### PR TITLE
Recognise `range` type in `isinstance`

### DIFF
--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -457,6 +457,8 @@ func isType(obj pyObject, name string) bool {
 		return name == "int"
 	case pyString:
 		return name == "str"
+	case *pyRange:
+		return name == "range"
 	case pyList:
 		return name == "list"
 	case pyDict:

--- a/test/pytype/BUILD
+++ b/test/pytype/BUILD
@@ -6,6 +6,8 @@ v_int = 5
 
 v_str = "hello"
 
+v_range = range(1, 6)
+
 v_list = [
     0,
     1,
@@ -27,6 +29,7 @@ all_type = [
     bool,
     int,
     str,
+    range,
     list,
     dict,
     callable,
@@ -48,6 +51,10 @@ matrix = [
     [
         v_str,
         str,
+    ],
+    [
+        v_range,
+        range,
     ],
     [
         v_list,


### PR DESCRIPTION
`range` is a type of its own as of #3024, but `isinstance` doesn't know about it, so it's impossible to do type comparisons on `range` objects.

Fixes #3039.