### PR TITLE
Remove mention of `--nocache` flag

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -832,12 +832,6 @@
     If it's given targets to clean, it will need to perform a parse to work out
     what to clean, and will not return until those targets have been cleaned.
   </p>
-
-  <p>
-    The <code class="code">--nocache</code> flag works like all other commands
-    here, but bears mentioning since it will prevent artifacts from being
-    removed from the cache (by default they're cleaned from there too).
-  </p>
 </section>
 
 <section class="mt4">


### PR DESCRIPTION
Remove the mention of the `--nocache` in the `plz clean` docs because the flag no longer exists.

The `--nocache` flag was removed in v16: https://github.com/thought-machine/please/blob/11052fd323e5a765fbda5e15e44c7d3fcab5f86d/ChangeLog#L776