### PR TITLE
Add a --ignore_unknown flag to query whatinputs

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -403,9 +403,10 @@ var opts struct {
 			} `positional-args:"true"`
 		} `command:"graph" description:"Prints a representation of the build graph."`
 		WhatInputs struct {
-			Hidden    bool `long:"hidden" short:"h" description:"Output internal / hidden targets too."`
-			EchoFiles bool `long:"echo_files" description:"Echo the file for which the printed output is responsible."`
-			Args      struct {
+			Hidden        bool `long:"hidden" short:"h" description:"Output internal / hidden targets too."`
+			EchoFiles     bool `long:"echo_files" description:"Echo the file for which the printed output is responsible."`
+			IgnoreUnknown bool `long:"ignore_unknown" description:"Ignore any files that are not inputs to existing build targets"`
+			Args          struct {
 				Files cli.StdinStrings `positional-arg-name:"files" description:"Files to query as sources to targets" required:"true"`
 			} `positional-args:"true" required:"true"`
 		} `command:"whatinputs" description:"Prints out target(s) with provided file(s) as inputs"`
@@ -883,7 +884,7 @@ var buildFunctions = map[string]func() int{
 			labels = append(labels, core.FindOwningPackage(state, file))
 		}
 		return runQuery(true, labels, func(state *core.BuildState) {
-			query.WhatInputs(state.Graph, files, opts.Query.WhatInputs.Hidden, opts.Query.WhatInputs.EchoFiles)
+			query.WhatInputs(state.Graph, files, opts.Query.WhatInputs.Hidden, opts.Query.WhatInputs.EchoFiles, opts.Query.WhatInputs.IgnoreUnknown)
 		})
 	},
 	"query.whatoutputs": func() int {

--- a/src/query/whatinputs.go
+++ b/src/query/whatinputs.go
@@ -10,7 +10,7 @@ import (
 // WhatInputs prints the targets with the provided files as sources
 // The targets are printed in the same order as the provided files, separated by a newline
 // Use printFiles to additionally echo the files themselves (i.e. print <file> <target>)
-func WhatInputs(graph *core.BuildGraph, files []string, hidden, printFiles bool) {
+func WhatInputs(graph *core.BuildGraph, files []string, hidden, printFiles, ignoreUnknown bool) {
 	targets := graph.AllTargets()
 
 	for _, file := range files {
@@ -21,7 +21,7 @@ func WhatInputs(graph *core.BuildGraph, files []string, hidden, printFiles bool)
 				}
 				fmt.Printf("%s\n", label)
 			}
-		} else {
+		} else if !ignoreUnknown {
 			log.Fatalf("%s is not a source to any current target", file)
 		}
 	}


### PR DESCRIPTION
Can be useful to have a whole lot of files where you don't want to try to filter them yourself.
Motivating example is the Go package driver when given `/...`, it doesn't know what is owned and what's not but is happy to ask Please to answer it (in my current case, there are some example files and whatnot which happen not to be owned)