### PR TITLE
Make the subrepo targets output into plz-out/gen based on their pkg dir

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -407,11 +407,11 @@ func (target *BuildTarget) BuildLockFile() string {
 // //mickey/donald:goofy -> plz-out/gen/mickey/donald (or plz-out/bin if it's a binary)
 func (target *BuildTarget) OutDir() string {
 	if target.IsSubrepo {
-		return filepath.Join(SubrepoDir, target.Label.Subrepo, target.Label.PackageName)
+		return filepath.Join(SubrepoDir, target.PackageDir())
 	} else if target.IsBinary {
-		return filepath.Join(BinDir, target.Label.Subrepo, target.Label.PackageName)
+		return filepath.Join(BinDir, target.PackageDir())
 	}
-	return filepath.Join(GenDir, target.Label.Subrepo, target.Label.PackageName)
+	return filepath.Join(GenDir, target.PackageDir())
 }
 
 // ExecDir returns the exec directory for this target, e.g.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -406,12 +406,16 @@ func (target *BuildTarget) BuildLockFile() string {
 // OutDir returns the output directory for this target, eg.
 // //mickey/donald:goofy -> plz-out/gen/mickey/donald (or plz-out/bin if it's a binary)
 func (target *BuildTarget) OutDir() string {
-	if target.IsSubrepo {
-		return filepath.Join(SubrepoDir, target.PackageDir())
-	} else if target.IsBinary {
-		return filepath.Join(BinDir, target.PackageDir())
+	subrepoNamespace := target.Label.Subrepo // Use the subrepo name unless the package root has been provided for us
+	if target.Subrepo != nil && target.Subrepo.PackageRoot != "" {
+		subrepoNamespace = target.Subrepo.PackageRoot
 	}
-	return filepath.Join(GenDir, target.PackageDir())
+	if target.IsSubrepo {
+		return filepath.Join(SubrepoDir, subrepoNamespace, target.Label.PackageName)
+	} else if target.IsBinary {
+		return filepath.Join(BinDir, subrepoNamespace, target.Label.PackageName)
+	}
+	return filepath.Join(GenDir, subrepoNamespace, target.Label.PackageName)
 }
 
 // ExecDir returns the exec directory for this target, e.g.

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1385,6 +1385,8 @@ func subrepo(s *scope, args []pyObject) pyObject {
 	sr := core.NewSubrepo(state, s.pkg.SubrepoArchName(subrepoName), root, target, arch, isCrossCompile)
 	if args[PackageRootIdx].IsTruthy() {
 		sr.PackageRoot = args[PackageRootIdx].String()
+	} else {
+		sr.PackageRoot = sr.Name
 	}
 
 	// Typically this would be deferred until we have built the subrepo target and have its config available. As we

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1385,8 +1385,6 @@ func subrepo(s *scope, args []pyObject) pyObject {
 	sr := core.NewSubrepo(state, s.pkg.SubrepoArchName(subrepoName), root, target, arch, isCrossCompile)
 	if args[PackageRootIdx].IsTruthy() {
 		sr.PackageRoot = args[PackageRootIdx].String()
-	} else {
-		sr.PackageRoot = sr.Name
 	}
 
 	// Typically this would be deferred until we have built the subrepo target and have its config available. As we


### PR DESCRIPTION
This was a bit weird. We have the package root set, but it had no bearing on where we stash this guy in `plz-out`. Before and after: 
```
➜  please git:(subrepo-target-out-dir) ✗ plz build ///third_party/go/github.com_stretchr_testify//assert 
Build finished; total time 480ms, incrementality 80.0%. Outputs:
///third_party/go/github.com_stretchr_testify//assert:assert:
  plz-out/gen/third_party/go/github.com_stretchr_testify/assert/assert.a

➜  please git:(subrepo-target-out-dir) ✗ plz plz build ///third_party/go/github.com_stretchr_testify//assert
Build finished; total time 670ms, incrementality 44.2%. Outputs:
///third_party/go/github.com_stretchr_testify//assert:assert:
  plz-out/gen/pkg/linux_amd64/github.com/stretchr/testify/assert/assert.a
```

This has no real functional effect, but seems like it might be the right thing to do. 