### PR TITLE
Improve somepath --hidden behaviour

### DIFF
--- a/src/query/somepath.go
+++ b/src/query/somepath.go
@@ -11,7 +11,6 @@ import (
 func SomePath(graph *core.BuildGraph, from, to, except []core.BuildLabel, showHidden bool) error {
 	s := somepath{
 		graph:  graph,
-		hidden: showHidden,
 		except: make(map[core.BuildLabel]struct{}, len(except)),
 		memo:   map[core.BuildLabel]map[core.BuildLabel]struct{}{},
 	}
@@ -52,7 +51,6 @@ func expandAllTargets(graph *core.BuildGraph, labels []core.BuildLabel) []core.B
 
 type somepath struct {
 	graph  *core.BuildGraph
-	hidden bool
 	memo   map[core.BuildLabel]map[core.BuildLabel]struct{}
 	except map[core.BuildLabel]struct{}
 }
@@ -71,13 +69,13 @@ func (s *somepath) somePath(target1, target2 core.BuildLabel) []core.BuildLabel 
 		m = map[core.BuildLabel]struct{}{}
 		s.memo[target2] = m
 	}
-	return somePath(s.graph, s.hidden, s.graph.TargetOrDie(target1), s.graph.TargetOrDie(target2), m, s.except)
+	return somePath(s.graph, s.graph.TargetOrDie(target1), s.graph.TargetOrDie(target2), m, s.except)
 }
 
-func somePath(graph *core.BuildGraph, hidden bool, target1, target2 *core.BuildTarget, seen, except map[core.BuildLabel]struct{}) []core.BuildLabel {
+func somePath(graph *core.BuildGraph, target1, target2 *core.BuildTarget, seen, except map[core.BuildLabel]struct{}) []core.BuildLabel {
 	if target1.Label == target2.Label {
 		return []core.BuildLabel{target1.Label}
-	} else if !hidden && target1.Parent(graph) == target2 {
+	} else if target1.Parent(graph) == target2 {
 		// If there's some path to the parent of the named target, count that. This is usually what you want e.g. in the
 		// case of protos where the named target is just a filegroup that isn't actually depended on after the
 		// require/provide is resolved.
@@ -92,7 +90,7 @@ func somePath(graph *core.BuildGraph, hidden bool, target1, target2 *core.BuildT
 				continue
 			}
 			for _, l := range t.ProvideFor(target1) {
-				if path := somePath(graph, hidden, graph.TargetOrDie(l), target2, seen, except); len(path) != 0 {
+				if path := somePath(graph, graph.TargetOrDie(l), target2, seen, except); len(path) != 0 {
 					return append([]core.BuildLabel{target1.Label}, path...)
 				}
 			}


### PR DESCRIPTION
Found an unintuitive case where `plz query somepath` finds a path but `plz query somepath --hidden` doesn't (and the non-hidden version didn't really explain to me what was going on). This was somewhat intentional (with `--hidden` you were supposed to specify the exact coordinates at either end) but it was surprising and I think probably unhelpful.

This simplifies things quite a bit so it always constructs a path of potentially hidden targets then collapses them out afterwards if appropriate.

Technically it's a slight change of behaviour but I think it's just better this way.