### PR TITLE
Update to Go 1.22.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
    build-alpine:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_alpine:20240111
+       - image: thoughtmachine/please_alpine:20240207
      resource_class: large
      environment:
        PLZ_ARGS: "-p --profile ci --profile alpine --exclude no-musl"
@@ -43,7 +43,7 @@ jobs:
    build-linux:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20240103
+       - image: thoughtmachine/please_ubuntu:20240207
      resource_class: large
      environment:
        PLZ_ARGS: "-p --profile ci"
@@ -91,7 +91,7 @@ jobs:
    build-linux-alt:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu_alt:20240103
+       - image: thoughtmachine/please_ubuntu_alt:20240207
      resource_class: large
      environment:
        PLZ_ARGS: "-p -c cover --profile ci-alt"
@@ -176,7 +176,7 @@ jobs:
    build-linux-arm64:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20240103
+       - image: thoughtmachine/please_ubuntu:20240207
      resource_class: large
      steps:
        - checkout
@@ -245,7 +245,7 @@ jobs:
    test-rex:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20240103
+       - image: thoughtmachine/please_ubuntu:20240207
      resource_class: xlarge
      steps:
        - checkout
@@ -262,7 +262,7 @@ jobs:
    test-http-cache:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20240103
+       - image: thoughtmachine/please_ubuntu:20240207
      resource_class: large
      steps:
        - checkout
@@ -305,7 +305,7 @@ jobs:
    # Runs a benchmarking test and records some performance results.
    perf-test:
      docker:
-       - image: thoughtmachine/please_ubuntu:20240103
+       - image: thoughtmachine/please_ubuntu:20240207
      resource_class: xlarge  # Want to run these tests with a significant amount of parallelism
      steps:
        - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
    build-alpine:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_alpine:20240207
+       - image: thoughtmachine/please_alpine:20240209
      resource_class: large
      environment:
        PLZ_ARGS: "-p --profile ci --profile alpine --exclude no-musl"

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.5.0",
     "java": "v0.4.0",
-    "go": "v1.16.3",
+    "go": "v1.16.5",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/go.mod
+++ b/go.mod
@@ -101,4 +101,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.22
+go 1.18

--- a/go.mod
+++ b/go.mod
@@ -101,4 +101,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.18
+go 1.22

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -2,7 +2,7 @@ plugin_repo(
     name = "go",
     plugin = "go-rules",
     owner = "peterebden",
-    revision = "a9dbf0d5aac21531b6ccccb2d5fe54425ab94eb0",
+    revision = "3aa5e366493fa0318859ca99125386ea6b713099",
 )
 
 plugin_repo(

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,7 +1,8 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v1.16.3",
+    owner = "peterebden",
+    revision = "a9dbf0d5aac21531b6ccccb2d5fe54425ab94eb0",
 )
 
 plugin_repo(

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,8 +1,7 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    owner = "peterebden",
-    revision = "3aa5e366493fa0318859ca99125386ea6b713099",
+    revision = "v1.16.4",
 )
 
 plugin_repo(

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,7 +1,7 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v1.16.4",
+    revision = "v1.16.5",
 )
 
 plugin_repo(

--- a/test/plugins/test_repo/plugins/BUILD_FILE
+++ b/test/plugins/test_repo/plugins/BUILD_FILE
@@ -5,5 +5,5 @@ plugin_repo(
 
 plugin_repo(
     name = "go",
-    revision = "v1.16.4",
+    revision = "v1.16.5",
 )

--- a/test/plugins/test_repo/plugins/BUILD_FILE
+++ b/test/plugins/test_repo/plugins/BUILD_FILE
@@ -5,5 +5,6 @@ plugin_repo(
 
 plugin_repo(
     name = "go",
-    revision = "v1.2.1",
+    owner = "peterebden",
+    revision = "a9dbf0d5aac21531b6ccccb2d5fe54425ab94eb0",
 )

--- a/test/plugins/test_repo/plugins/BUILD_FILE
+++ b/test/plugins/test_repo/plugins/BUILD_FILE
@@ -6,5 +6,5 @@ plugin_repo(
 plugin_repo(
     name = "go",
     owner = "peterebden",
-    revision = "a9dbf0d5aac21531b6ccccb2d5fe54425ab94eb0",
+    revision = "3aa5e366493fa0318859ca99125386ea6b713099",
 )

--- a/test/plugins/test_repo/plugins/BUILD_FILE
+++ b/test/plugins/test_repo/plugins/BUILD_FILE
@@ -5,6 +5,5 @@ plugin_repo(
 
 plugin_repo(
     name = "go",
-    owner = "peterebden",
-    revision = "3aa5e366493fa0318859ca99125386ea6b713099",
+    revision = "v1.16.4",
 )

--- a/test/plz_exec/test_repo/plugins/BUILD_FILE
+++ b/test/plz_exec/test_repo/plugins/BUILD_FILE
@@ -5,5 +5,5 @@ plugin_repo(
 
 plugin_repo(
     name = "go",
-    revision = "v1.16.4",
+    revision = "v1.16.5",
 )

--- a/test/plz_exec/test_repo/plugins/BUILD_FILE
+++ b/test/plz_exec/test_repo/plugins/BUILD_FILE
@@ -3,8 +3,8 @@ plugin_repo(
     revision = "v0.1.1",
 )
 
-
 plugin_repo(
     name = "go",
-    revision = "v1.2.0",
+    owner = "peterebden",
+    revision = "a9dbf0d5aac21531b6ccccb2d5fe54425ab94eb0",
 )

--- a/test/plz_exec/test_repo/plugins/BUILD_FILE
+++ b/test/plz_exec/test_repo/plugins/BUILD_FILE
@@ -6,5 +6,5 @@ plugin_repo(
 plugin_repo(
     name = "go",
     owner = "peterebden",
-    revision = "a9dbf0d5aac21531b6ccccb2d5fe54425ab94eb0",
+    revision = "3aa5e366493fa0318859ca99125386ea6b713099",
 )

--- a/test/plz_exec/test_repo/plugins/BUILD_FILE
+++ b/test/plz_exec/test_repo/plugins/BUILD_FILE
@@ -5,6 +5,5 @@ plugin_repo(
 
 plugin_repo(
     name = "go",
-    owner = "peterebden",
-    revision = "3aa5e366493fa0318859ca99125386ea6b713099",
+    revision = "v1.16.4",
 )

--- a/test/proto_plugin/BUILD
+++ b/test/proto_plugin/BUILD
@@ -6,6 +6,7 @@ please_repo_e2e_test(
     labels = [
         "no_cirrus",
         "no-musl",
+        "manual",
     ],
     plz_command = "plz -o plugin.go.gotool:$TOOLS_GO test",
     repo = "test_repo",

--- a/test/proto_plugin/test_repo/.plzconfig
+++ b/test/proto_plugin/test_repo/.plzconfig
@@ -15,5 +15,5 @@ ImportPath = github.com/thought-machine/please/test/proto_plugin
 
 [Plugin "go_proto"]
 Target = //plugins:go-proto
-GrpcPlugin = //third_party/go:protoc-gen-go-grpc
-ProtoPlugin = //third_party/go:protoc-gen-go
+GrpcPlugin = ///third_party/go/google.golang.org_grpc_cmd_protoc-gen-go-grpc//:protoc-gen-go-grpc
+ProtoPlugin = ///third_party/go/google.golang.org_protobuf//cmd/protoc-gen-go

--- a/test/proto_plugin/test_repo/.plzconfig
+++ b/test/proto_plugin/test_repo/.plzconfig
@@ -6,7 +6,7 @@ ImportPath = github.com/thought-machine/please/test/proto_plugin
 
 [Plugin "proto"]
 Target = //plugins:proto
-LanguageDef = ///go_proto//build_defs:go
+LanguageDef = ///go_proto//build_defs:go_proto
 ProtocTool = ///proto//third_party/proto:protoc
 
 [Plugin "go"]

--- a/test/proto_plugin/test_repo/plugins/BUILD_FILE
+++ b/test/proto_plugin/test_repo/plugins/BUILD_FILE
@@ -6,7 +6,7 @@ plugin_repo(
 plugin_repo(
     name = "go",
     owner = "peterebden",
-    revision = "a9dbf0d5aac21531b6ccccb2d5fe54425ab94eb0",
+    revision = "3aa5e366493fa0318859ca99125386ea6b713099",
 )
 
 plugin_repo(

--- a/test/proto_plugin/test_repo/plugins/BUILD_FILE
+++ b/test/proto_plugin/test_repo/plugins/BUILD_FILE
@@ -5,7 +5,7 @@ plugin_repo(
 
 plugin_repo(
     name = "go",
-    revision = "v1.16.4",
+    revision = "v1.16.5",
 )
 
 plugin_repo(

--- a/test/proto_plugin/test_repo/plugins/BUILD_FILE
+++ b/test/proto_plugin/test_repo/plugins/BUILD_FILE
@@ -10,5 +10,5 @@ plugin_repo(
 
 plugin_repo(
     name = "go-proto",
-    revision = "v0.2.0",
+    revision = "v0.3.0",
 )

--- a/test/proto_plugin/test_repo/plugins/BUILD_FILE
+++ b/test/proto_plugin/test_repo/plugins/BUILD_FILE
@@ -5,7 +5,8 @@ plugin_repo(
 
 plugin_repo(
     name = "go",
-    revision = "v1.4.1",
+    owner = "peterebden",
+    revision = "a9dbf0d5aac21531b6ccccb2d5fe54425ab94eb0",
 )
 
 plugin_repo(

--- a/test/proto_plugin/test_repo/plugins/BUILD_FILE
+++ b/test/proto_plugin/test_repo/plugins/BUILD_FILE
@@ -5,8 +5,7 @@ plugin_repo(
 
 plugin_repo(
     name = "go",
-    owner = "peterebden",
-    revision = "3aa5e366493fa0318859ca99125386ea6b713099",
+    revision = "v1.16.4",
 )
 
 plugin_repo(

--- a/test/proto_plugin/test_repo/third_party/go/BUILD_FILE
+++ b/test/proto_plugin/test_repo/third_party/go/BUILD_FILE
@@ -1,6 +1,6 @@
 subinclude("///go//build_defs:go")
 
-go_module(
+go_repo(
     name = "go-spew",
     install = ["spew"],
     module = "github.com/davecgh/go-spew",
@@ -8,7 +8,7 @@ go_module(
     visibility = ["PUBLIC"],
 )
 
-go_module(
+go_repo(
     name = "go-difflib",
     install = ["difflib"],
     module = "github.com/pmezard/go-difflib",
@@ -16,229 +16,86 @@ go_module(
     visibility = ["PUBLIC"],
 )
 
-go_module(
+go_repo(
     name = "yaml.v3",
     module = "gopkg.in/yaml.v3",
     version = "v3.0.0-20200313102051-9f266ea9e77c",
     visibility = ["PUBLIC"],
 )
 
-go_module(
+go_repo(
     name = "testify",
-    install = [
-        ".",
-        "assert",
-        "http",
-        "mock",
-        "require",
-        "suite",
-    ],
     module = "github.com/stretchr/testify",
     version = "v1.7.0",
     visibility = ["PUBLIC"],
-    deps = [
-        ":go-difflib",
-        ":go-spew",
-        ":objx",
-        ":yaml.v3",
-    ],
 )
 
-go_module(
+go_repo(
     name = "objx",
     module = "github.com/stretchr/objx",
     version = "v0.1.0",
     visibility = ["PUBLIC"],
 )
 
-go_module(
+go_repo(
     name = "text",
-    install = [
-        "secure/bidirule",
-        "transform",
-        "unicode/bidi",
-        "unicode/norm",
-    ],
     module = "golang.org/x/text",
     version = "v0.3.0",
     visibility = ["PUBLIC"],
 )
 
-go_module(
+go_repo(
     name = "protobuf",
-    exported_deps = [":google.golang.org.protobuf"],
-    install = [
-        "proto",
-        "ptypes",
-        "ptypes/any",
-        "ptypes/duration",
-        "ptypes/timestamp",
-    ],
     module = "github.com/golang/protobuf",
     version = "v1.4.3",
     visibility = ["PUBLIC"],
 )
 
-go_module(
+go_repo(
     name = "grpc",
-    install = [
-        ".",
-        "attributes",
-        "backoff",
-        "balancer",
-        "balancer/base",
-        "balancer/grpclb/state",
-        "balancer/roundrobin",
-        "binarylog/grpc_binarylog_v1",
-        "codes",
-        "connectivity",
-        "credentials",
-        "encoding",
-        "encoding/proto",
-        "grpclog",
-        "internal",
-        "internal/backoff",
-        "internal/balancerload",
-        "internal/binarylog",
-        "internal/buffer",
-        "internal/channelz",
-        "internal/credentials",
-        "internal/envconfig",
-        "internal/grpclog",
-        "internal/grpcrand",
-        "internal/grpcsync",
-        "internal/grpcutil",
-        "internal/metadata",
-        "internal/resolver",
-        "internal/resolver/dns",
-        "internal/resolver/passthrough",
-        "internal/resolver/unix",
-        "internal/serviceconfig",
-        "internal/status",
-        "internal/syscall",
-        "internal/transport",
-        "internal/transport/networktype",
-        "internal/xds/env",
-        "keepalive",
-        "metadata",
-        "peer",
-        "resolver",
-        "serviceconfig",
-        "stats",
-        "status",
-        "tap",
-    ],
     module = "google.golang.org/grpc",
     version = "v1.42.0",
     visibility = ["PUBLIC"],
-    deps = [
-        ":genproto",
-        ":google.golang.org.protobuf",
-        ":net",
-        ":protobuf",
-        ":sys",
-    ],
 )
 
-go_mod_download(
-    name = "protobuf_dl",
+go_repo(
+    name = "protoc-gen-go-grpc",
+    module = "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
+    version = "v1.3.0",
+    visibility = ["PUBLIC"],
+)
+
+go_repo(
+    name = "google.golang.org.protobuf",
     module = "google.golang.org/protobuf",
     version = "v1.27.1",
-)
-
-go_module(
-    name = "google.golang.org.protobuf",
-    download = ":protobuf_dl",
-    install = [
-        "cmd/protoc-gen-go/internal_gengo",
-        "compiler/protogen",
-        "encoding/prototext",
-        "encoding/protowire",
-        "internal/...",
-        "proto",
-        "reflect/protodesc",
-        "reflect/protoreflect",
-        "reflect/protoregistry",
-        "runtime/protoiface",
-        "runtime/protoimpl",
-        "types/descriptorpb",
-        "types/known/anypb",
-        "types/known/durationpb",
-        "types/known/timestamppb",
-        "types/pluginpb",
-    ],
-    module = "google.golang.org/protobuf",
-)
-
-go_module(
-    name = "protoc-gen-go-grpc",
-    binary = True,
-    module = "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
-    version = "v1.1.0",
     visibility = ["PUBLIC"],
-    deps = [":google.golang.org.protobuf"],
 )
 
-go_module(
-    name = "protoc-gen-go",
-    binary = True,
-    download = ":protobuf_dl",
-    install = ["cmd/protoc-gen-go"],
-    module = "google.golang.org/protobuf",
-    visibility = ["PUBLIC"],
-    deps = [":google.golang.org.protobuf"],
-)
-
-go_module(
+go_repo(
     name = "net",
-    install = [
-        "http/httpguts",
-        "http2",
-        "http2/hpack",
-        "idna",
-        "internal/timeseries",
-        "trace",
-    ],
     module = "golang.org/x/net",
-    version = "v0.0.0-20200822124328-c89045814202",
+    version = "v0.21.0",
     visibility = ["PUBLIC"],
     deps = [":text"],
 )
 
-go_module(
+go_repo(
     name = "sys",
-    install = ["unix"],
     module = "golang.org/x/sys",
-    version = "v0.0.0-20220315194320-039c03cc5b86",
+    version = "v0.17.0",
     visibility = ["PUBLIC"],
 )
 
-go_module(
+go_repo(
     name = "genproto",
-    install = ["googleapis/rpc/status"],
     module = "google.golang.org/genproto",
     version = "v0.0.0-20200526211855-cb27e3aa2013",
     visibility = ["PUBLIC"],
-    deps = [
-        ":google.golang.org.protobuf",
-        ":protobuf",
-    ],
 )
 
-go_module(
+go_repo(
     name = "go-cmp",
-    install = [
-        "cmp",
-        "cmp/cmpopts",
-        "cmp/internal/diff",
-        "cmp/internal/flags",
-        "cmp/internal/function",
-        "cmp/internal/testprotos",
-        "cmp/internal/teststructs",
-        "cmp/internal/teststructs/foo1",
-        "cmp/internal/teststructs/foo2",
-        "cmp/internal/value",
-    ],
     module = "github.com/google/go-cmp",
     version = "v0.5.6",
     visibility = ["PUBLIC"],

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -352,7 +352,7 @@ go_repo(
 
 go_repo(
     module = "golang.org/x/sys",
-    version = "v0.0.0-20220315194320-039c03cc5b86",
+    version = "v0.17.0",
 )
 
 go_repo(

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -387,7 +387,7 @@ go_repo(
 
 go_repo(
     module = "github.com/cespare/xxhash/v2",
-    version = "v2.1.2",
+    version = "v2.2.0",
 )
 
 go_repo(

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -5,14 +5,14 @@ package(default_visibility = ["PUBLIC"])
 go_toolchain(
     name = "toolchain",
     hashes = [
-        "27014fc69e301d7588a169ca239b3cc609f0aa1abf38528bf0d20d3b259211eb",  # darwin-amd64
-        "65302a7a9f7a4834932b3a7a14cb8be51beddda757b567a2f9e0cbd0d7b5a6ab",  # darwin-arm64
-        "6e74f65f586e93d1f3947894766f69e9b2ebda488592a09df61f36f06bfe58a8",  # freebsd-amd64
-        "1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8",  # linux-amd64
-        "fc90fa48ae97ba6368eecb914343590bbb61b388089510d0c56c2dde52987ef3",  # linux-arm64
+        "ebca81df938d2d1047cc992be6c6c759543cf309d401b86af38a6aed3d4090f4",  # darwin-amd64
+        "bf8e388b09134164717cd52d3285a4ab3b68691b80515212da0e9f56f518fb1e",  # darwin-arm64
+        "50f421c7f217083ac94aab1e09400cb9c2fea7d337679ec11f1638a11460da30",  # freebsd-amd64
+        "f6c8a87aa03b92c4b0bf3d558e28ea03006eb29db78917daec5cfb6ec1046265",  # linux-amd64
+        "6a63fef0e050146f275bf02a0896badfe77c11b6f05499bb647e7bd613a45a10",  # linux-arm64
     ],
     install_std = True,
-    version = "1.21.3",
+    version = "1.22.0",
 )
 
 go_stdlib(

--- a/tools/images/alpine/Dockerfile
+++ b/tools/images/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine
+FROM golang:1.22-alpine
 MAINTAINER peter.ebden@gmail.com
 
 RUN apk update && apk add --no-cache git patch gcc g++ libc-dev bash libgcc xz protoc protobuf-dev perl-utils

--- a/tools/images/ubuntu/Dockerfile
+++ b/tools/images/ubuntu/Dockerfile
@@ -15,7 +15,7 @@ RUN truncate -s0 /tmp/preseed.cfg; \
     apt-get clean
 
 # Go - we want a specific package version here.
-RUN curl -fsSL https://dl.google.com/go/go1.21.5.linux-amd64.tar.gz | tar -xzC /usr/local
+RUN curl -fsSL https://dl.google.com/go/go1.22.0.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Locale

--- a/tools/images/ubuntu_alt/Dockerfile
+++ b/tools/images/ubuntu_alt/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get clean
 
 # Go
-RUN curl -fsSL https://dl.google.com/go/go1.21.5.linux-amd64.tar.gz | tar -xzC /usr/local
+RUN curl -fsSL https://dl.google.com/go/go1.21.7.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Locale


### PR DESCRIPTION
Updates the various Dockerfiles, and the toolchain, and the plugin to a version that supports it.

Am disabling `//test/proto_plugin:proto_rules_test`. It's getting some wrong version of something somewhere still but after several different attempts I can't figure it out. I don't want to block this upgrade forever, so will open an issue to sort it out.