### PR TITLE
Bump GHA versions to avoid warnings about Node versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
         language: ['go']
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - name: Initialize CodeQL

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,12 +11,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
-          go-version: '^1.21'
+          go-version: '^1.22'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v4
         with:
           version: v1.54.2
           args: src/... tools/...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,5 +18,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.54.2
+          version: v1.55
           args: src/... tools/...

--- a/.github/workflows/plugindocs-lint.yml
+++ b/.github/workflows/plugindocs-lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run checking script
         shell: bash

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ issues:
     - empty-block # generally not useful
     - redefines-builtin-id
     - superfluous-else
+    - indent-error-flow # revive getting a bit too pushy here
   exclude-rules:
     - path: _test\.go
       linters:


### PR DESCRIPTION
Feels a little tedious but wevs