### PR TITLE
Linter updates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,6 @@ linters:
     - bidichk
     - bodyclose
     - containedctx
-    - contextcheck
     - dogsled
     - dupl
     - exportloopref

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,7 @@ linters:
     - ineffassign
     - misspell
     - nilerr
+    - perfsprint
     - prealloc
     - revive
     - staticcheck
@@ -78,3 +79,6 @@ linters-settings:
       - standard # Captures all standard packages if they do not match another section.
       - default # Contains all imports that could not be matched to another section type.
       - prefix(github.com/thought-machine/please)
+
+  perfsprint:
+    errorf: false # sometimes it's easier not to import another package

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,9 +37,12 @@ issues:
 linters:
   disable-all: true
   enable:
+    - asasalint
     - asciicheck
     - bidichk
     - bodyclose
+    - containedctx
+    - contextcheck
     - dogsled
     - dupl
     - exportloopref
@@ -51,6 +54,7 @@ linters:
     - ineffassign
     - misspell
     - nilerr
+    - nosprintfhostport
     - perfsprint
     - prealloc
     - revive
@@ -61,10 +65,6 @@ linters:
     - unused
     - wastedassign
     - whitespace
-
-    # To consider enabling in future (once we fix errors etc):
-    # - errcheck
-    # - scopelint
 
 linters-settings:
   govet:

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -1136,7 +1136,7 @@ func fetchOneRemoteFile(state *core.BuildState, target *core.BuildTarget, url st
 // setHeaders sets up all the headers we should send on remote_file() requests, including User-Agent and any user
 // defined ones.
 func setHeaders(req *http.Request, target *core.BuildTarget, env core.BuildEnv) error {
-	req.Header.Set("User-Agent", fmt.Sprintf("please.build/%s", core.PleaseVersion))
+	req.Header.Set("User-Agent", "please.build/"+core.PleaseVersion)
 
 	param := func(str string) (string, string) {
 		if !strings.HasPrefix(str, "remote_file:") {

--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -7,7 +7,6 @@
 package build
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -127,7 +126,7 @@ func TestAllTestFieldsArePresentAndAccountedFor(t *testing.T) {
 	val := reflect.ValueOf(fields)
 	typ := val.Elem().Type()
 	for i := 0; i < typ.NumField(); i++ {
-		if field := typ.Field(i); !KnownFields[fmt.Sprintf("Test.%s", field.Name)] {
+		if field := typ.Field(i); !KnownFields["Test."+field.Name] {
 			t.Errorf("Unaccounted field in RuleHash: Test.%s", field.Name)
 		}
 	}
@@ -138,7 +137,7 @@ func TestAllDebugFieldsArePresentAndAccountedFor(t *testing.T) {
 	val := reflect.ValueOf(fields)
 	typ := val.Elem().Type()
 	for i := 0; i < typ.NumField(); i++ {
-		if field := typ.Field(i); !KnownFields[fmt.Sprintf("Debug.%s", field.Name)] {
+		if field := typ.Field(i); !KnownFields["Debug."+field.Name] {
 			t.Errorf("Unaccounted field in RuleHash: Debug.%s", field.Name)
 		}
 	}

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -394,7 +394,7 @@ func TestToolPathWithEntryPoint(t *testing.T) {
 	wd, _ := os.Getwd()
 	RepoRoot = wd
 	root := wd + "/plz-out/gen/src/core"
-	assert.Equal(t, fmt.Sprintf("%s/file1.go", root), target.toolPath(true, "f1"))
+	assert.Equal(t, root+"/file1.go", target.toolPath(true, "f1"))
 	assert.Equal(t, "src/core/file1.go", target.toolPath(false, "f1"))
 }
 

--- a/src/fs/hash.go
+++ b/src/fs/hash.go
@@ -37,7 +37,7 @@ type pendingHash struct {
 func NewPathHasher(root string, useXattrs bool, hash func() hash.Hash, algo string) *PathHasher {
 	var hashSuffix string
 	if algo != "sha1" {
-		hashSuffix = fmt.Sprintf("_%s", algo)
+		hashSuffix = "_" + algo
 	}
 	return &PathHasher{
 		new:       hash,

--- a/src/help/config.go
+++ b/src/help/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/peterebden/go-deferred-regex"
@@ -37,13 +38,13 @@ func ExampleValue(f reflect.Value, name string, t reflect.Type, example, options
 		return "10ms | 20s | 5m"
 	} else if t.Kind() == reflect.Int || t.Kind() == reflect.Int64 {
 		if f.Int() != 0 {
-			return fmt.Sprintf("%d", f.Int())
+			return strconv.FormatInt(f.Int(), 10)
 		}
 		return "42"
 	} else if t.Name() == "ByteSize" {
 		return "5K | 10MB | 20GiB"
 	} else if t.Kind() == reflect.Uint64 {
-		return fmt.Sprintf("%d", f.Uint())
+		return strconv.FormatUint(f.Uint(), 10)
 	} else if t.Name() == "BuildLabel" {
 		return "//src/core:core"
 	} else if t.Name() == "Arch" {

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -277,7 +277,7 @@ func showExecutionOutput(execution core.TestExecution) {
 
 func formatTestCase(result core.TestCase, name string, detailed bool) string {
 	if len(result.Executions) == 0 {
-		return fmt.Sprintf("%s (No results)", formatTestName(result, name))
+		return formatTestName(result, name) + " (No results)"
 	}
 	var outcome core.TestExecution
 	if len(result.Executions) > 1 && result.Success() != nil {
@@ -317,16 +317,16 @@ func formatTestExecution(execution core.TestExecution, detailed bool) string {
 		return "${BOLD_CYAN}ERROR${RESET}"
 	}
 	if execution.Failure != nil {
-		return fmt.Sprintf("${BOLD_RED}FAIL${RESET} %s", maybeToString(execution.Duration))
+		return "${BOLD_RED}FAIL${RESET} " + maybeToString(execution.Duration)
 	}
 	if execution.Skip != nil {
 		if detailed {
-			return fmt.Sprintf("${BOLD_YELLOW}SKIP\n        Reason:${RESET} %s", execution.Skip.Message)
+			return "${BOLD_YELLOW}SKIP\n        Reason:${RESET} " + execution.Skip.Message
 		}
 		// Not usually interesting to have a duration when we did no work.
 		return "${BOLD_YELLOW}SKIP${RESET}"
 	}
-	return fmt.Sprintf("${BOLD_GREEN}PASS${RESET} %s", maybeToString(execution.Duration))
+	return "${BOLD_GREEN}PASS${RESET} " + maybeToString(execution.Duration)
 }
 
 func maybeToString(duration *time.Duration) string {
@@ -338,7 +338,7 @@ func maybeToString(duration *time.Duration) string {
 
 // Produces a string describing the results of one test (or a single aggregation).
 func testResultMessage(results *core.TestSuite, showDuration bool) string {
-	msg := fmt.Sprintf("%s run", pluralise(results.Tests(), "test", "tests"))
+	msg := pluralise(results.Tests(), "test", "tests") + " run"
 	if showDuration && results.Duration >= 0.0 {
 		msg += fmt.Sprintf(" in ${BOLD_WHITE}%s${RESET}", results.Duration.Round(testDurationGranularity))
 	}
@@ -494,7 +494,7 @@ func printFailedBuildResults(failedTargets []core.BuildLabel, failedTargetMap ma
 // in at least this one place.
 func pluralise(num int, singular, plural string) string {
 	if num == 1 {
-		return fmt.Sprintf("1 %s", singular)
+		return "1 " + singular
 	}
 	return fmt.Sprintf("%d %s", num, plural)
 }

--- a/src/output/trace.go
+++ b/src/output/trace.go
@@ -83,7 +83,7 @@ func (tw *traceWriter) writeEvent(threadID int, result *core.BuildResult, phase 
 	entry.Tid = fmt.Sprintf("Builder %d", threadID)
 	entry.Args.Description = result.Description
 	if result.Err != nil {
-		entry.Args.Err = fmt.Sprintf("%s", result.Err)
+		entry.Args.Err = result.Err.Error()
 		entry.Cname = "terrible"
 	} else if entry.Cat == "Test" {
 		entry.Cname = "good"

--- a/src/query/print.go
+++ b/src/query/print.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -368,9 +369,9 @@ func (p *printer) genericPrint(v reflect.Value) (string, bool) {
 	case reflect.Bool:
 		return "True", v.Bool()
 	case reflect.Int, reflect.Int32:
-		return fmt.Sprintf("%d", v.Int()), true
+		return strconv.FormatInt(v.Int(), 10), true
 	case reflect.Uint8, reflect.Uint16:
-		return fmt.Sprintf("%d", v.Uint()), true
+		return strconv.FormatUint(v.Uint(), 10), true
 	case reflect.Struct, reflect.Interface:
 		if stringer, ok := v.Interface().(fmt.Stringer); ok {
 			return p.quote(stringer.String()), true

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -128,7 +128,7 @@ type actionDigestMap struct {
 func (m *actionDigestMap) Get(label core.BuildLabel) *pb.Digest {
 	d, ok := m.m.Load(label)
 	if !ok {
-		panic(fmt.Sprintf("could not find action digest for label: %s", label.String()))
+		panic("could not find action digest for label: " + label.String())
 	}
 	return d.(*pb.Digest)
 }

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -120,10 +120,10 @@ func printMilestoneMessage(pleaseVersion string) {
 		padLen := len(line) + (targetWidth-len(line))/2
 
 		// Prints the string ensuring it's the target width
-		fmtString := "|%-" + fmt.Sprint(targetWidth) + "s|\n"
+		fmtString := "|%-" + strconv.Itoa(targetWidth) + "s|\n"
 
 		// Left pad the string so it's center aligned
-		paddedString := fmt.Sprintf("%"+fmt.Sprint(padLen)+"s", line)
+		paddedString := fmt.Sprintf("%"+strconv.Itoa(padLen)+"s", line)
 
 		fmt.Fprintf(os.Stderr, fmtString, paddedString)
 	}

--- a/tools/build_langserver/lsp/lsp.go
+++ b/tools/build_langserver/lsp/lsp.go
@@ -69,7 +69,7 @@ func (h *Handler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2
 			// if it's not a jsonrpc error then create a CodeInternalError
 			jsonerr = &jsonrpc2.Error{
 				Code:    jsonrpc2.CodeInternalError,
-				Message: fmt.Sprintf("%s", err),
+				Message: err.Error(),
 			}
 		}
 


### PR DESCRIPTION
Found some new toys in golangci.

Most changes are coming from `perfsprint` which suggests using more efficient alternatives to `fmt.Sprintf`. Mostly they're not in critical places but it seems like good practice.