### PR TITLE
Allow type list for subinclude parameter

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -67,7 +67,7 @@ def lower(self:str) -> str:
 def fail(msg:str):
     pass
 
-def subinclude(target:str):
+def subinclude(target:str|list):
     pass
 def load(target:str, names:str=None):
     pass


### PR DESCRIPTION
Missing addition to allow to pass list in subinclude parameter

Relate to #2990