### PR TITLE
Make sure gcloud is actually on the path in the please_ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
    build-linux:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20240216
+       - image: thoughtmachine/please_ubuntu:20240227
      resource_class: large
      environment:
        PLZ_ARGS: "-p --profile ci"
@@ -176,7 +176,7 @@ jobs:
    build-linux-arm64:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20240216
+       - image: thoughtmachine/please_ubuntu:20240227
      resource_class: large
      steps:
        - checkout
@@ -245,7 +245,7 @@ jobs:
    test-rex:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20240216
+       - image: thoughtmachine/please_ubuntu:20240227
      resource_class: xlarge
      steps:
        - checkout
@@ -262,7 +262,7 @@ jobs:
    test-http-cache:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20240216
+       - image: thoughtmachine/please_ubuntu:20240227
      resource_class: large
      steps:
        - checkout
@@ -278,7 +278,7 @@ jobs:
    # Releases to github and homebrew
    release:
      docker:
-       - image: thoughtmachine/please_ubuntu:20240216
+       - image: thoughtmachine/please_ubuntu:20240227
      environment:
        GOOGLE_APPLICATION_CREDENTIALS=/tmp/service_account.json
      steps:
@@ -293,7 +293,7 @@ jobs:
    # Releases the docs and the binaries to gs for please.build and get.please.build
    release-gs:
      docker:
-       - image: thoughtmachine/please_ubuntu:20240216
+       - image: thoughtmachine/please_ubuntu:20240227
      environment:
        GOOGLE_APPLICATION_CREDENTIALS=/tmp/service_account.json
      steps:
@@ -305,7 +305,7 @@ jobs:
    # Runs a benchmarking test and records some performance results.
    perf-test:
      docker:
-       - image: thoughtmachine/please_ubuntu:20240216
+       - image: thoughtmachine/please_ubuntu:20240227
      environment:
        GOOGLE_APPLICATION_CREDENTIALS=/tmp/service_account.json
      resource_class: xlarge  # Want to run these tests with a significant amount of parallelism

--- a/tools/images/ubuntu/Dockerfile
+++ b/tools/images/ubuntu/Dockerfile
@@ -29,6 +29,7 @@ RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tm
 RUN mkdir -p /usr/local/gcloud \
   && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
   && /usr/local/gcloud/google-cloud-sdk/install.sh
+ENV PATH /usr/local/gcloud/google-cloud-sdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Welcome message
 COPY /motd.txt /etc/motd


### PR DESCRIPTION
It looks like the install script offers to do some complicated .bashrc shenanigans, but probably doesn't within the build because it's noninteractive.

Just set the stupid PATH variable manually and hope the builds work again.