### PR TITLE
Update some third-party libs

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -10,6 +10,7 @@ Target = //plugins:go
 importpath = github.com/thought-machine/please
 gotool = //third_party/go:toolchain|go
 FeatureFlags = go_get
+modfile = //:go_mod
 
 [Plugin "cc"]
 target = //plugins:cc
@@ -89,4 +90,4 @@ accept = ISC
 accept = notice
 
 [remote]
-url = 
+url =

--- a/BUILD
+++ b/BUILD
@@ -44,3 +44,9 @@ filegroup(
     srcs = ["default.pgo"],
     visibility = ["//src/..."],
 )
+
+filegroup(
+    name = "go_mod",
+    srcs = ["go.mod"],
+    visibility = ["//third_party/go/..."],
+)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/djherbis/atime v1.1.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fsnotify/fsnotify v1.5.1
-	github.com/golang/protobuf v1.5.3
+	github.com/golang/protobuf v1.5.4
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
@@ -49,7 +49,7 @@ require (
 	golang.org/x/tools v0.18.0
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.56.3
-	google.golang.org/protobuf v1.30.0
+	google.golang.org/protobuf v1.33.0
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
 )
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.2
-	github.com/jstemmer/go-junit-report/v2 v2.0.0
+	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/karrick/godirwalk v1.16.1
 	github.com/manifoldco/promptui v0.8.0
 	github.com/peterebden/go-cli-init/v5 v5.2.0

--- a/go.mod
+++ b/go.mod
@@ -62,9 +62,9 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/go-ole/go-ole v1.2.5 // indirect
-	github.com/golang/glog v1.1.0 // indirect
+	github.com/golang/glog v1.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-containerregistry v0.12.1 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -790,6 +792,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/alexcesaro/statsd.v2 v2.0.0 h1:FXkZSCZIH17vLCO5sO2UucTHsH9pc+17F6pl3JVCwMc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQA
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
+github.com/golang/glog v1.2.0 h1:uCdmnmatrKCgMBlM4rMuJZWOkPDqdbZPnrMXDY4gI68=
+github.com/golang/glog v1.2.0/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -197,6 +199,7 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.12.1 h1:W1mzdNUTx4Zla4JaixCRLhORcR7G6KxE5hHl5fkPsp8=
 github.com/google/go-containerregistry v0.12.1/go.mod h1:sdIK+oHQO7B93xI8UweYdl887YhuIwg9vz8BSLH3+8k=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/go.sum
+++ b/go.sum
@@ -268,6 +268,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jstemmer/go-junit-report/v2 v2.0.0 h1:bMZNO9B16VFn07tKyi4YJFIbZtVmJaa5Xakv9dcwK58=
 github.com/jstemmer/go-junit-report/v2 v2.0.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
+github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
+github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20210706145210-9283cdf370b5 h1:Q5klzs6BL5FkassBX65t+KkG0XjYcjxEm+GNcQAsuaw=
 github.com/juju/ansiterm v0.0.0-20210706145210-9283cdf370b5/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,7 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.12.1 h1:W1mzdNUTx4Zla4JaixCRLhORcR7G6KxE5hHl5fkPsp8=
 github.com/google/go-containerregistry v0.12.1/go.mod h1:sdIK+oHQO7B93xI8UweYdl887YhuIwg9vz8BSLH3+8k=

--- a/src/format/test_data/param_sort_order_tag.after.build
+++ b/src/format/test_data/param_sort_order_tag.after.build
@@ -18,9 +18,8 @@ filegroup(
 
 docker_mirror(
     name = "c",
+    tag = "1.0.0",
     digest = "sha256:5d37aaee1673c45dba5ed666ae167ed3e5010ec1b5a20ee782197b66092749a0",
     src_image = "registry.example/images/c",
-    # This should sort normally (docker_mirror isn't a Please built-in):
-    tag = "1.0.0",
     visibility = ["PUBLIC"],
 )

--- a/src/format/test_data/param_sort_order_tag.before.build
+++ b/src/format/test_data/param_sort_order_tag.before.build
@@ -20,7 +20,6 @@ docker_mirror(
     name = "c",
     digest = "sha256:5d37aaee1673c45dba5ed666ae167ed3e5010ec1b5a20ee782197b66092749a0",
     src_image = "registry.example/images/c",
-    # This should sort normally (docker_mirror isn't a Please built-in):
     tag = "1.0.0",
     visibility = ["PUBLIC"],
 )

--- a/src/test/go_results.go
+++ b/src/test/go_results.go
@@ -30,7 +30,10 @@ func parseGoTestResults(data []byte) (core.TestSuite, error) {
 	suite := core.TestSuite{
 		Package:    pkg.Name,
 		Duration:   pkg.Duration,
-		Properties: pkg.Properties,
+		Properties: make(map[string]string, len(pkg.Properties)),
+	}
+	for _, prop := range pkg.Properties {
+		suite.Properties[prop.Name] = prop.Value
 	}
 	for _, test := range pkg.Tests {
 		execution := core.TestExecution{

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -21,7 +21,7 @@ go_stdlib(
 
 go_repo(
     module = "github.com/please-build/buildtools",
-    version = "77ffe55926d9e60171a92243fae5c7244a60e758",
+    version = "v0.0.0-20240110130546-746673d48318",
 )
 
 go_repo(
@@ -31,12 +31,12 @@ go_repo(
 
 go_repo(
     module = "golang.org/x/text",
-    version = "v0.3.7",
+    version = "v0.14.0",
 )
 
 go_repo(
     module = "golang.org/x/tools",
-    version = "v0.1.5",
+    version = "v0.18.0",
 )
 
 go_repo(
@@ -57,7 +57,7 @@ go_repo(
 
 go_repo(
     module = "github.com/shirou/gopsutil/v3",
-    version = "v3.22.6",
+    version = "v3.21.8",
 )
 
 go_repo(
@@ -77,7 +77,7 @@ go_repo(
 
 go_repo(
     module = "github.com/stretchr/testify",
-    version = "v1.8.4",
+    version = "v1.8.1",
 )
 
 go_repo(
@@ -87,12 +87,12 @@ go_repo(
 
 go_repo(
     module = "gopkg.in/yaml.v3",
-    version = "v3.0.0-20210107192922-496545a6307b",
+    version = "v3.0.1",
 )
 
 go_repo(
     module = "github.com/klauspost/compress",
-    version = "v1.13.6",
+    version = "v1.15.11",
 )
 
 go_repo(
@@ -102,22 +102,22 @@ go_repo(
 
 go_repo(
     module = "github.com/please-build/gcfg",
-    version = "9b4d14cddd6148920e11c8bb7ee19369473b1019",
+    version = "v1.6.1-0.20220308170049-10ea9d657afb",
 )
 
 go_repo(
     module = "github.com/ProtonMail/go-crypto",
-    version = "3900d675f39ba9686203d137886d74fad620ae87",
+    version = "v0.0.0-20210920135941-2c5829bbf927",
 )
 
 go_repo(
     module = "golang.org/x/net",
-    version = "v0.17.0",
+    version = "v0.21.0",
 )
 
 go_repo(
     module = "github.com/prometheus/client_model",
-    version = "v0.2.0",
+    version = "v0.3.0",
 )
 
 go_repo(
@@ -137,12 +137,12 @@ go_repo(
 
 go_repo(
     module = "github.com/theupdateframework/go-tuf",
-    version = "v0.5.1",
+    version = "v0.5.2-0.20220930112810-3890c1e7ace4",
 )
 
 go_repo(
     module = "golang.org/x/oauth2",
-    version = "v0.4.0",
+    version = "v0.7.0",
 )
 
 go_repo(
@@ -157,7 +157,7 @@ go_repo(
 
 go_repo(
     module = "google.golang.org/genproto",
-    version = "v0.0.0-20221206210731-b1a01be3a5f6",
+    version = "v0.0.0-20230410155749-daa745c078e1",
 )
 
 go_repo(
@@ -167,7 +167,7 @@ go_repo(
 
 go_repo(
     module = "github.com/hashicorp/go-retryablehttp",
-    version = "v0.7.0",
+    version = "v0.7.2",
 )
 
 go_repo(
@@ -192,12 +192,12 @@ go_repo(
 
 go_repo(
     module = "github.com/mattn/go-isatty",
-    version = "v0.0.14",
+    version = "v0.0.16",
 )
 
 go_repo(
     module = "github.com/google/go-containerregistry",
-    version = "v0.12.0",
+    version = "v0.12.1",
 )
 
 go_repo(
@@ -207,7 +207,7 @@ go_repo(
 
 go_repo(
     module = "github.com/prometheus/client_golang",
-    version = "v1.11.0",
+    version = "v1.13.0",
 )
 
 go_repo(
@@ -217,12 +217,12 @@ go_repo(
 
 go_repo(
     module = "golang.org/x/term",
-    version = "v0.0.0-20210615171337-6886f2dfbf5b",
+    version = "v0.17.0",
 )
 
 go_repo(
     module = "github.com/google/go-cmp",
-    version = "b1c9c4891a6525d98001fea424c8926c6d77bb56",
+    version = "v0.5.9",
 )
 
 go_repo(
@@ -257,12 +257,12 @@ go_repo(
 
 go_repo(
     module = "github.com/googleapis/gax-go/v2",
-    version = "v2.7.0",
+    version = "v2.7.1",
 )
 
 go_repo(
     module = "github.com/golang/groupcache",
-    version = "v0.0.0-20200121045136-8c9f03a8e57e",
+    version = "v0.0.0-20210331224755-41bb18bfe9da",
 )
 
 go_repo(
@@ -272,12 +272,12 @@ go_repo(
 
 go_repo(
     module = "github.com/golang/protobuf",
-    version = "v1.5.2",
+    version = "v1.5.3",
 )
 
 go_repo(
     module = "golang.org/x/sync",
-    version = "v0.1.0",
+    version = "v0.6.0",
 )
 
 go_repo(
@@ -292,7 +292,7 @@ go_repo(
 
 go_repo(
     module = "github.com/googleapis/enterprise-certificate-proxy",
-    version = "v0.2.0",
+    version = "v0.2.3",
 )
 
 go_repo(
@@ -312,7 +312,7 @@ go_repo(
 
 go_repo(
     module = "github.com/mattn/go-colorable",
-    version = "v0.1.8",
+    version = "v0.1.13",
 )
 
 go_repo(
@@ -342,7 +342,7 @@ go_repo(
         "github.com/mattn/go-colorable",
         "github.com/mattn/go-isatty",
     ],
-    version = "720a0952cc2ac777afc295d9861263e2a4cf96a1",
+    version = "v0.0.0-20210706145210-9283cdf370b5",
 )
 
 go_repo(
@@ -372,7 +372,7 @@ go_repo(
 
 go_repo(
     module = "google.golang.org/grpc",
-    version = "v1.51.0",
+    version = "v1.56.3",
 )
 
 go_repo(
@@ -397,7 +397,7 @@ go_repo(
 
 go_repo(
     module = "github.com/klauspost/cpuid/v2",
-    version = "v2.2.1",
+    version = "v2.0.12",
 )
 
 go_repo(
@@ -422,18 +422,18 @@ go_repo(
 
 go_repo(
     module = "golang.org/x/crypto",
-    version = "v0.17.0",
+    version = "v0.19.0",
 )
 
 go_repo(
     module = "google.golang.org/protobuf",
-    version = "v1.25.0",
+    version = "v1.30.0",
 )
 
 go_repo(
     module = "github.com/golang/glog",
     patch = ["glog_disable.patch"],
-    version = "v0.0.0-20160126235308-23def4e6c14b",
+    version = "v1.1.0",
 )
 
 go_repo(
@@ -443,12 +443,12 @@ go_repo(
 
 go_repo(
     module = "github.com/pkg/xattr",
-    version = "v0.4.3",
+    version = "v0.4.4",
 )
 
 go_repo(
     module = "cloud.google.com/go/iam",
-    version = "v0.8.0",
+    version = "v0.13.0",
 )
 
 go_repo(
@@ -469,17 +469,17 @@ go_repo(
 
 go_repo(
     module = "github.com/prometheus/common",
-    version = "v0.30.0",
+    version = "v0.37.0",
 )
 
 go_repo(
     module = "github.com/titanous/rocacheck",
-    version = "afe73141d399b0c79c3d6412d4bdcf4c672c496a",
+    version = "v0.0.0-20171023193734-afe73141d399",
 )
 
 go_repo(
     module = "google.golang.org/api",
-    version = "v0.106.0",
+    version = "v0.114.0",
 )
 
 go_repo(
@@ -494,17 +494,17 @@ go_repo(
 
 go_repo(
     module = "cloud.google.com/go/longrunning",
-    version = "v0.4.0",
+    version = "v0.4.1",
 )
 
 go_repo(
     module = "github.com/prometheus/procfs",
-    version = "v0.6.0",
+    version = "v0.8.0",
 )
 
 go_repo(
     module = "github.com/manifoldco/promptui",
-    version = "v0.7.0",
+    version = "v0.8.0",
 )
 
 go_repo(
@@ -514,12 +514,12 @@ go_repo(
 
 go_repo(
     module = "github.com/google/uuid",
-    version = "v1.1.2",
+    version = "v1.3.0",
 )
 
 go_repo(
     module = "github.com/letsencrypt/boulder",
-    version = "cfa524a7a139bd4cf21c4c09ab47b994a96fd11f",
+    version = "v0.0.0-20221109233200-85aa52084eaf",
 )
 
 go_repo(
@@ -529,7 +529,7 @@ go_repo(
 
 go_repo(
     module = "github.com/bazelbuild/remote-apis",
-    version = "3e816456ee28f01ab2e0abf72306c1f340c7b229",
+    version = "v0.0.0-20210718193713-0ecef08215cf",
 )
 
 go_repo(
@@ -539,7 +539,7 @@ go_repo(
 
 go_repo(
     module = "cloud.google.com/go/kms",
-    version = "v1.8.0",
+    version = "v1.10.1",
 )
 
 go_repo(
@@ -549,10 +549,33 @@ go_repo(
 
 go_repo(
     module = "golang.org/x/exp",
-    version = "1de6713980dea447778ef6e71194d5eb54288072",
+    version = "v0.0.0-20240213143201-ec583247a57a",
 )
 
 go_repo(
     module = "github.com/jstemmer/go-junit-report/v2",
-    version = "v2.0.0",
+    version = "v2.1.0",
+)
+
+go_repo(
+    module = "cloud.google.com/go/compute",
+    version = "v1.19.1",
+    licences = ["Apache-2.0"],
+)
+
+go_repo(
+    module = "github.com/StackExchange/wmi",
+    version = "v1.2.1",
+)
+
+go_repo(
+    module = "github.com/go-ole/go-ole",
+    version = "v1.2.5",
+    licences = ["MIT"],
+)
+
+go_repo(
+    module = "google.golang.org/appengine",
+    version = "v1.6.7",
+    licences = ["Apache-2.0"],
 )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -272,7 +272,7 @@ go_repo(
 
 go_repo(
     module = "github.com/golang/protobuf",
-    version = "v1.5.3",
+    version = "v1.5.4",
 )
 
 go_repo(
@@ -427,7 +427,7 @@ go_repo(
 
 go_repo(
     module = "google.golang.org/protobuf",
-    version = "v1.30.0",
+    version = "v1.33.0",
 )
 
 go_repo(

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -222,7 +222,7 @@ go_repo(
 
 go_repo(
     module = "github.com/google/go-cmp",
-    version = "v0.5.9",
+    version = "v0.6.0",
 )
 
 go_repo(
@@ -433,7 +433,7 @@ go_repo(
 go_repo(
     module = "github.com/golang/glog",
     patch = ["glog_disable.patch"],
-    version = "v1.1.0",
+    version = "v1.2.0",
 )
 
 go_repo(

--- a/third_party/go/glog_disable.patch
+++ b/third_party/go/glog_disable.patch
@@ -1,20 +1,20 @@
 diff --git a/glog.go b/glog.go
-index 54bd7af..fda9853 100644
+index 8c00e73..3b1d59c 100644
 --- a/glog.go
 +++ b/glog.go
-@@ -669,6 +669,7 @@ func (l *loggingT) printWithFileLine(s severity, file string, line int, alsoToSt
- 
- // output writes the data to the log files and releases the buffer.
- func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoToStderr bool) {
+@@ -209,6 +209,7 @@ func logf(depth int, severity logsink.Severity, verbose bool, stack stack, forma
+ // ctxlogf writes a log message for a log function call (or log function wrapper)
+ // at the given depth in the current goroutine's stack.
+ func ctxlogf(ctx context.Context, depth int, severity logsink.Severity, verbose bool, stack stack, format string, args ...any) {
 +	return
- 	l.mu.Lock()
- 	if l.traceLocation.isSet() {
- 		if l.traceLocation.match(file, line) {
-@@ -997,6 +998,7 @@ type Verbose bool
- // V is at least the value of -v, or of -vmodule for the source file containing the
+ 	now := timeNow()
+ 	_, file, line, ok := runtime.Caller(depth + 1)
+ 	if !ok {
+@@ -399,6 +400,7 @@ type Verbose bool
+ // V is at most the value of -v, or of -vmodule for the source file containing the
  // call, the V call will log.
  func V(level Level) Verbose {
 +	return Verbose(false)
- 	// This function tries hard to be cheap unless there's work to do.
- 	// The fast path is two atomic loads and compares.
+ 	return VDepth(1, level)
+ }
  


### PR DESCRIPTION
Couple of upgrades plus a `puku sync`.
Fixed `github.com/jstemmer/go-junit-report/v2` which has a breaking change in v2.1.0 :(