### PR TITLE
dont parse subrepo package again if the subrepo label subrepo is the same as the dependent subrepo

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.5.0",
     "java": "v0.4.0",
-    "go": "v1.16.8",
+    "go": "v1.16.9",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,7 +1,7 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v1.16.8",
+    revision = "v1.16.9",
 )
 
 plugin_repo(

--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -127,10 +127,12 @@ func checkSubrepo(state *core.BuildState, label, dependent core.BuildLabel, mode
 		return s, err
 	}
 
-	// They may have meant a subrepo that was defined in the dependent label's subrepo rather than the host repo
-	s, err = maybeParseSubrepoPackage(state, sl.PackageName, dependent.Subrepo, label, mode)
-	if err != nil || s != nil {
-		return s, err
+	if sl.Subrepo != dependent.Subrepo {
+		// They may have meant a subrepo that was defined in the dependent label's subrepo rather than the host repo
+		s, err = maybeParseSubrepoPackage(state, sl.PackageName, dependent.Subrepo, label, mode)
+		if err != nil || s != nil {
+			return s, err
+		}
 	}
 
 	return nil, fmt.Errorf("Subrepo %s is not defined (referenced by %s)", label.Subrepo, dependent)


### PR DESCRIPTION
Previously we were maybeParseSubrepoPackage for the host repo and if we don't find the subrepo we would check in the dependent label's subrepo. This is unnecessary if the dependent label's subrepo is the same as the host repo.

There is also a bug which this fixes where we indefinitely wait on parsing a subrepo if the subrepo doesn't exist. This change should just be an optimisation but it fixes the bug too.