### PR TITLE
Remove AddChildDirs calls

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -243,11 +243,6 @@ func (c *Client) uploadInputDir(ch chan<- *uploadinfo.Entry, target *core.BuildT
 					Name:   filepath.Base(d.Name),
 					Digest: d.Digest,
 				})
-				if target.IsFilegroup {
-					if err := c.addChildDirs(b, filepath.Join(pkgName, d.Name), d.Digest); err != nil {
-						return b, err
-					}
-				}
 			}
 			for _, s := range o.Symlinks {
 				d := b.Dir(filepath.Join(pkgName, filepath.Dir(s.Name)))
@@ -299,25 +294,6 @@ func (c *Client) uploadInputDir(ch chan<- *uploadinfo.Entry, target *core.BuildT
 		})
 	}
 	return b, nil
-}
-
-// addChildDirs adds a set of child directories to a builder.
-func (c *Client) addChildDirs(b *dirBuilder, name string, dg *pb.Digest) error {
-	dir, err := c.readDirectory(dg)
-	if err != nil {
-		return err
-	}
-	d := b.Dir(name)
-	d.Directories = append(d.Directories, dir.Directories...)
-	d.Files = append(d.Files, dir.Files...)
-	d.Symlinks = append(d.Symlinks, dir.Symlinks...)
-	d.NodeProperties = dir.NodeProperties
-	for _, subdir := range dir.Directories {
-		if err := c.addChildDirs(b, filepath.Join(name, subdir.Name), subdir.Digest); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // uploadInput finds and uploads a single input.

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -86,11 +86,6 @@ type Client struct {
 	// This map is of effective type `map[*core.BuildTarget]*pendingDownload`
 	downloads sync.Map
 
-	// Used to store directories output from actions.
-	//
-	// This map is of effective type `map[string]*pb.Directory`
-	directories sync.Map
-
 	// Server-sent cache properties
 	maxBlobBatchSize int64
 

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -39,18 +39,6 @@ var downloadErrors = metrics.NewCounter(
 	"Number of times the an error has been seen during a tree digest download",
 )
 
-var directoriesRetrieved = metrics.NewCounter(
-	"remote",
-	"dirs_retrieved_total",
-	"Number of directories retrieved from cache",
-)
-
-var directoriesDownloaded = metrics.NewCounter(
-	"remote",
-	"dirs_downloaded_total",
-	"Number of directories downloaded from remote",
-)
-
 // xattrName is the name we use to record attributes on files.
 const xattrName = "user.plz_hash_remote"
 
@@ -195,18 +183,6 @@ func (c *Client) setOutputDirectoryOuts(target *core.BuildTarget, actionResultFS
 		target.AddOutput(e.Name())
 	}
 	return nil
-}
-
-// readDirectory reads a Directory proto, possibly using a local cache, otherwise going to the remote
-func (c *Client) readDirectory(dg *pb.Digest) (*pb.Directory, error) {
-	if dir, present := c.directories.Load(dg.Hash); present {
-		directoriesRetrieved.Inc()
-		return dir.(*pb.Directory), nil
-	}
-	dir := &pb.Directory{}
-	_, err := c.client.ReadProto(context.Background(), digest.NewFromProtoUnvalidated(dg), dir)
-	directoriesDownloaded.Inc()
-	return dir, err
 }
 
 // maybeGetOutDir will get the output directory based on the directory provided. If there's no matching directory, this


### PR DESCRIPTION
I've been noodling around the remote execution bit and am not certain why we need this. I think maybe it's intended for uploading filegroup inputs but so far in (admittedly somewhat empirical) testing it doesn't seem to suffer without.

If it works, this would be a nice boost to the happy path where things don't need to rebuild.