### PR TITLE
Only download child dirs for filegroups where necessary

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -193,7 +193,7 @@ func (c *Client) uploadInputs(ch chan<- *uploadinfo.Entry, target *core.BuildTar
 	if target.IsRemoteFile {
 		return &pb.Directory{}, nil
 	}
-	b, err := c.uploadInputDir(ch, target, isTest)
+	b, err := c.uploadInputDir(ch, target, isTest, false)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (c *Client) uploadInputs(ch chan<- *uploadinfo.Entry, target *core.BuildTar
 
 // uploadInputDir uploads the inputs to the build rule. It returns an un-finalised directory builder representing the
 // directory structure of the input dir. The caller is expected to finalise this by calling Build().
-func (c *Client) uploadInputDir(ch chan<- *uploadinfo.Entry, target *core.BuildTarget, isTest bool) (*dirBuilder, error) {
+func (c *Client) uploadInputDir(ch chan<- *uploadinfo.Entry, target *core.BuildTarget, isTest, needChildDirs bool) (*dirBuilder, error) {
 	b := newDirBuilder(c)
 	for input := range c.state.IterInputs(target, isTest) {
 		if l, ok := input.Label(); ok {
@@ -243,7 +243,7 @@ func (c *Client) uploadInputDir(ch chan<- *uploadinfo.Entry, target *core.BuildT
 					Name:   filepath.Base(d.Name),
 					Digest: d.Digest,
 				})
-				if target.IsFilegroup {
+				if needChildDirs && target.IsFilegroup {
 					if err := c.addChildDirs(b, filepath.Join(pkgName, d.Name), d.Digest); err != nil {
 						return b, err
 					}

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -904,7 +904,7 @@ func (c *Client) fetchRemoteFile(target *core.BuildTarget, actionDigest *pb.Dige
 
 // buildFilegroup "builds" a single filegroup target.
 func (c *Client) buildFilegroup(target *core.BuildTarget, command *pb.Command, actionDigest *pb.Digest) (*core.BuildMetadata, *pb.ActionResult, error) {
-	if metadata, ar, err := c.buildFilegroupWithChildDirs(target, command, actionDigest, false); err == nil || (err != nil && !errors.Is(err, errMissingOutputFromFilegroup)) {
+	if metadata, ar, err := c.buildFilegroupWithChildDirs(target, command, actionDigest, false); err == nil || !errors.Is(err, errMissingOutputFromFilegroup) {
 		return metadata, ar, err
 	}
 	return c.buildFilegroupWithChildDirs(target, command, actionDigest, true)

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -6,6 +6,7 @@ package remote
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	iofs "io/fs"
 	"os"
@@ -53,6 +54,8 @@ var remoteCacheReadDuration = metrics.NewHistogram(
 	"Time taken to read the remote cache, in milliseconds",
 	metrics.ExponentialBuckets(0.1, 2, 12), // 12 buckets, starting at 0.1ms and doubling in width.
 )
+
+var errMissingOutputFromFilegroup = errors.New("Missing output from filegroup")
 
 // A Client is the interface to the remote API.
 //
@@ -901,7 +904,14 @@ func (c *Client) fetchRemoteFile(target *core.BuildTarget, actionDigest *pb.Dige
 
 // buildFilegroup "builds" a single filegroup target.
 func (c *Client) buildFilegroup(target *core.BuildTarget, command *pb.Command, actionDigest *pb.Digest) (*core.BuildMetadata, *pb.ActionResult, error) {
-	inputDir, err := c.uploadInputDir(nil, target, false) // We don't need to actually upload the inputs here, that is already done.
+	if metadata, ar, err := c.buildFilegroupWithChildDirs(target, command, actionDigest, false); err == nil || (err != nil && !errors.Is(err, errMissingOutputFromFilegroup)) {
+		return metadata, ar, err
+	}
+	return c.buildFilegroupWithChildDirs(target, command, actionDigest, true)
+}
+
+func (c *Client) buildFilegroupWithChildDirs(target *core.BuildTarget, command *pb.Command, actionDigest *pb.Digest, needChildDirs bool) (*core.BuildMetadata, *pb.ActionResult, error) {
+	inputDir, err := c.uploadInputDir(nil, target, false, needChildDirs) // We don't need to actually upload the inputs here, that is already done.
 	if err != nil {
 		return nil, nil, err
 	}
@@ -924,8 +934,8 @@ func (c *Client) buildFilegroup(target *core.BuildTarget, command *pb.Command, a
 					IsExecutable: f.IsExecutable,
 				})
 			} else {
-				// Of course, we should not get here (classic developer things...)
-				return fmt.Errorf("Missing output from filegroup: %s", out)
+				// This might happen with needChildDirs=false, it shouldn't happen otherwise.
+				return fmt.Errorf("%w: %s", errMissingOutputFromFilegroup, out)
 			}
 		}
 		return nil


### PR DESCRIPTION
More selective version of #3107 . It doesn't seem as clean but it deals with some edge cases where that did seem to be necessary.