### PR TITLE
Fix output for downloading test inputs

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.5.1",
     "java": "v0.4.0",
-    "go": "v1.16.10",
+    "go": "v1.17.2",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -127,6 +127,7 @@ func prepareOnly(state *core.BuildState, target *core.BuildTarget) error {
 	if state.RemoteClient != nil {
 		// Targets were built remotely so we can simply download the inputs and place them in the
 		// tmp/ folder and exit.
+		state.LogBuildResult(target, core.TargetBuilding, "Downloading inputs...")
 		if err := state.DownloadAllInputs(target, target.TmpDir(), false); err != nil {
 			return err
 		}

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1319,7 +1319,6 @@ func (state *BuildState) DownloadInputsIfNeeded(target *BuildTarget, runtime boo
 
 // DownloadAllInputs downloads all inputs (including sources) for the target. Assumes remote execution.
 func (state *BuildState) DownloadAllInputs(target *BuildTarget, targetDir string, isTest bool) error {
-	state.LogBuildResult(target, TargetBuilding, "Downloading inputs...")
 	return state.RemoteClient.DownloadInputs(target, targetDir, isTest)
 }
 

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -263,6 +263,7 @@ func prepareOnly(state *core.BuildState, label core.BuildLabel, target *core.Bui
 	if state.RemoteClient != nil {
 		// Targets were built remotely so we can simply download the inputs and place them in the
 		// tmp/ folder and exit.
+		state.LogTestRunning(target, runNumber, core.TargetTesting, "Downloading inputs...")
 		if err := state.DownloadAllInputs(target, target.TestDir(runNumber), true); err != nil {
 			state.LogBuildError(label, core.TargetTestFailed, err, "Failed to download test inputs")
 			return


### PR DESCRIPTION
This shows on the wrong line, alongside the previous update, because we weren't setting the run number correctly.