### PR TITLE
Fix an NPE when querying targets with the --arch flag

### DIFF
--- a/src/core/state.go
+++ b/src/core/state.go
@@ -975,6 +975,10 @@ func (state *BuildState) WaitForTargetAndEnsureDownload(l, dependent BuildLabel,
 // WaitForInitialTargetAndEnsureDownload is like WaitForTargetAndEnsureDownload but is used for
 // targets in the initial set.
 func (state *BuildState) WaitForInitialTargetAndEnsureDownload(l, dependent BuildLabel) *BuildTarget {
+	// This may have been an architecture label from the CLI
+	if state.WaitForBuiltTarget(l, dependent, ParseModeNormal) == nil {
+		return nil
+	}
 	return state.waitForTargetAndEnsureDownload(l, dependent, ParseModeNormal)
 }
 

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -165,14 +165,15 @@ func findOriginalTask(state *core.BuildState, target core.BuildLabel, addToList 
 		// walk the directory tree, so we have to make sure the subrepo exists first.
 		dir := target.PackageName
 		prefix := ""
-		if target.Subrepo != "" && target.Subrepo != arch.String() {
+		if target.Subrepo != "" {
 			subrepoLabel := target.SubrepoLabel(state)
-			state.WaitForInitialTargetAndEnsureDownload(subrepoLabel, target)
-			// Targets now get activated during parsing, so can be built before we finish parsing their package.
-			state.WaitForPackage(subrepoLabel, target, core.ParseModeNormal)
-			subrepo := state.Graph.SubrepoOrDie(target.Subrepo)
-			dir = subrepo.Dir(dir)
-			prefix = subrepo.Dir(prefix)
+			if state.WaitForInitialTargetAndEnsureDownload(subrepoLabel, target) != nil {
+				// Targets now get activated during parsing, so can be built before we finish parsing their package.
+				state.WaitForPackage(subrepoLabel, target, core.ParseModeNormal)
+				subrepo := state.Graph.SubrepoOrDie(target.Subrepo)
+				dir = subrepo.Dir(dir)
+				prefix = subrepo.Dir(prefix)
+			}
 		}
 		for filename := range FindAllBuildFiles(state.Config, dir, "") {
 			dirname, _ := filepath.Split(filename)

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -165,7 +165,7 @@ func findOriginalTask(state *core.BuildState, target core.BuildLabel, addToList 
 		// walk the directory tree, so we have to make sure the subrepo exists first.
 		dir := target.PackageName
 		prefix := ""
-		if target.Subrepo != "" {
+		if target.Subrepo != "" && target.Subrepo != arch.String() {
 			subrepoLabel := target.SubrepoLabel(state)
 			state.WaitForInitialTargetAndEnsureDownload(subrepoLabel, target)
 			// Targets now get activated during parsing, so can be built before we finish parsing their package.


### PR DESCRIPTION
Fixes #3087

this is a bit janky but fixes the issue. 

This happens because we try and build the subrepo label for the architecture, which doesn't actually exist. We then get an NPE. 