### PR TITLE
Intern small integers

### DIFF
--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -441,7 +441,7 @@ func ord(s *scope, args []pyObject) pyObject {
 	c, isStr := args[0].(pyString)
 	s.Assert(isStr, "Argument c must be a string, not %s", args[0].Type())
 	s.Assert(objLen(c) == 1, "Argument c must be a string containing a single Unicode character")
-	return newPyInt([]rune(c)[0])
+	return newPyInt(int([]rune(c)[0]))
 }
 
 func isinstance(s *scope, args []pyObject) pyObject {

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -417,15 +417,15 @@ func lenFunc(s *scope, args []pyObject) pyObject {
 func objLen(obj pyObject) pyInt {
 	switch t := obj.(type) {
 	case pyList:
-		return pyInt(len(t))
+		return newPyInt(len(t))
 	case pyFrozenList:
-		return pyInt(len(t.pyList))
+		return newPyInt(len(t.pyList))
 	case pyDict:
-		return pyInt(len(t))
+		return newPyInt(len(t))
 	case pyFrozenDict:
-		return pyInt(len(t.pyDict))
+		return newPyInt(len(t.pyDict))
 	case pyString:
-		return pyInt(len([]rune(t)))
+		return newPyInt(len([]rune(t)))
 	}
 	panic("object of type " + obj.Type() + " has no len()")
 }
@@ -441,7 +441,7 @@ func ord(s *scope, args []pyObject) pyObject {
 	c, isStr := args[0].(pyString)
 	s.Assert(isStr, "Argument c must be a string, not %s", args[0].Type())
 	s.Assert(objLen(c) == 1, "Argument c must be a string containing a single Unicode character")
-	return pyInt([]rune(c)[0])
+	return newPyInt([]rune(c)[0])
 }
 
 func isinstance(s *scope, args []pyObject) pyObject {
@@ -576,13 +576,13 @@ func strRemoveSuffix(s *scope, args []pyObject) pyObject {
 func strFind(s *scope, args []pyObject) pyObject {
 	self := args[0].(pyString)
 	needle := args[1].(pyString)
-	return pyInt(strings.Index(string(self), string(needle)))
+	return newPyInt(strings.Index(string(self), string(needle)))
 }
 
 func strRFind(s *scope, args []pyObject) pyObject {
 	self := args[0].(pyString)
 	needle := args[1].(pyString)
-	return pyInt(strings.LastIndex(string(self), string(needle)))
+	return newPyInt(strings.LastIndex(string(self), string(needle)))
 }
 
 func strFormat(s *scope, args []pyObject) pyObject {
@@ -599,7 +599,7 @@ func strFormat(s *scope, args []pyObject) pyObject {
 func strCount(s *scope, args []pyObject) pyObject {
 	self := string(args[0].(pyString))
 	needle := string(args[1].(pyString))
-	return pyInt(strings.Count(self, needle))
+	return newPyInt(strings.Count(self, needle))
 }
 
 func strUpper(s *scope, args []pyObject) pyObject {
@@ -619,7 +619,7 @@ func boolType(s *scope, args []pyObject) pyObject {
 func intType(s *scope, args []pyObject) pyObject {
 	i, err := strconv.Atoi(string(args[0].(pyString)))
 	s.Assert(err == nil, "%s", err)
-	return pyInt(i)
+	return newPyInt(i)
 }
 
 func strType(s *scope, args []pyObject) pyObject {
@@ -915,7 +915,7 @@ func enumerate(s *scope, args []pyObject) pyObject {
 	s.Assert(ok, "Argument to enumerate must be a list, not %s", args[0].Type())
 	ret := make(pyList, len(l))
 	for i, li := range l {
-		ret[i] = pyList{pyInt(i), li}
+		ret[i] = pyList{newPyInt(i), li}
 	}
 	return ret
 }

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -652,7 +652,7 @@ func (s *scope) interpretOp(obj pyObject, op OpExpression) pyObject {
 		// Negate is a unary operator so Expr will be nil
 		i, ok := obj.(pyInt)
 		s.Assert(ok, "Unary - can only be applied to an integer")
-		return pyInt(-int(i))
+		return newPyInt(-int(i))
 	default:
 		return obj.Operator(op.Op, s.interpretExpression(op.Expr))
 	}
@@ -745,7 +745,7 @@ func (s *scope) interpretValueExpressionPart(expr *ValueExpression) pyObject {
 	} else if expr.FString != nil {
 		return s.interpretFString(expr.FString)
 	} else if expr.IsInt {
-		return pyInt(expr.Int)
+		return newPyInt(expr.Int)
 	} else if expr.True {
 		return True
 	} else if expr.False {
@@ -809,10 +809,10 @@ func (s *scope) interpretSlice(obj pyObject, sl *Slice) pyObject {
 	start := s.interpretSliceExpression(obj, sl.Start, 0)
 	switch t := obj.(type) {
 	case pyList:
-		end := s.interpretSliceExpression(obj, sl.End, pyInt(len(t)))
+		end := s.interpretSliceExpression(obj, sl.End, newPyInt(len(t)))
 		return t[start:end]
 	case pyString:
-		end := s.interpretSliceExpression(obj, sl.End, pyInt(len(t)))
+		end := s.interpretSliceExpression(obj, sl.End, newPyInt(len(t)))
 		return t[start:end]
 	}
 	s.Error("Unsliceable type %s", obj.Type())

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -167,7 +167,6 @@ func newPyInt(i int) pyInt {
 	if i >= 0 && i < numInternedInts {
 		return internedInts[i]
 	}
-	log.Debug("pyInt %d", i)
 	return pyInt(i)
 }
 

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -153,6 +153,24 @@ func (s pySentinel) MarshalJSON() ([]byte, error) {
 
 type pyInt int
 
+const numInternedInts = 100
+
+var internedInts = [100]pyInt{
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+	26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+	50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75,
+	76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99,
+}
+
+// newPyInt converts an int to a pyInt
+func newPyInt(i int) pyInt {
+	if i >= 0 && i < numInternedInts {
+		return internedInts[i]
+	}
+	log.Debug("pyInt %d", i)
+	return pyInt(i)
+}
+
 // pyIndex converts an object that's being used as an index to an int.
 func pyIndex(obj, index pyObject, slice bool) pyInt {
 	i, ok := index.(pyInt)
@@ -975,7 +993,7 @@ func (r *pyRange) Len() int {
 }
 
 func (r *pyRange) Item(index int) pyObject {
-	return r.Start + pyInt(index)*r.Step
+	return r.Start + newPyInt(index)*r.Step
 }
 
 func (r *pyRange) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
This interns integers 1-100 so we don't have to allocate them (I think they will basically all have to be heap-allocated to be returned as a pyObject). I'm observing 95% reduction in the number of ints created.

Before:
```
INFO: Run 1 of 5
INFO: Complete in 9.11s, using 4885716 KB
INFO: Run 2 of 5
INFO: Complete in 9.02s, using 5183780 KB
INFO: Run 3 of 5
INFO: Complete in 8.94s, using 5070080 KB
INFO: Run 4 of 5
INFO: Complete in 9.36s, using 5716848 KB
INFO: Run 5 of 5
INFO: Complete in 8.80s, using 5744780 KB
INFO: Complete, median time: 9.02s, median mem: 5183780.00 KB
```
After:
```
INFO: Run 1 of 5
INFO: Complete in 8.66s, using 5006120 KB
INFO: Run 2 of 5
INFO: Complete in 8.97s, using 5740016 KB
INFO: Run 3 of 5
INFO: Complete in 8.58s, using 5076388 KB
INFO: Run 4 of 5
INFO: Complete in 8.35s, using 5111484 KB
INFO: Run 5 of 5
INFO: Complete in 8.68s, using 5671328 KB
INFO: Complete, median time: 8.66s, median mem: 5111484.00 KB
```

Looks like there'd be some benefit from picking up a few negative numbers too but I'm not sure it's worth the extra fiddling.