### PR TITLE
[XS] Fix syntax in basics doc

### DIFF
--- a/docs/basics.html
+++ b/docs/basics.html
@@ -134,7 +134,7 @@
 
     java_binary(
         name = 'my_binary',
-        main = 'Main.java',
+        main_class = 'Main.java',
         deps = [':my_library'],
     )
 

--- a/docs/basics.html
+++ b/docs/basics.html
@@ -134,7 +134,7 @@
 
     java_binary(
         name = 'my_binary',
-        main_class = 'Main.java',
+        main_class = 'com.example.Main',
         deps = [':my_library'],
     )
 


### PR DESCRIPTION
`java_binary`'s `main` arg should  be `main_class` per https://please.build/plugins.html#java; just `main` throws an error about an unknown argument.