### PR TITLE
Query commands take subrepos into account

### DIFF
--- a/src/gc/gc.go
+++ b/src/gc/gc.go
@@ -173,6 +173,9 @@ func addTarget(graph *core.BuildGraph, m targetMap, target *core.BuildTarget) {
 	for _, dep := range target.Dependencies() {
 		addTarget(graph, m, dep)
 	}
+	if target.Subrepo != nil && target.Subrepo.Target != nil {
+		addTarget(graph, m, target.Subrepo.Target)
+	}
 }
 
 // anyInclude returns true if any of the given labels include this one.

--- a/src/gc/gc.go
+++ b/src/gc/gc.go
@@ -205,6 +205,9 @@ func publicDependencies(graph *core.BuildGraph, target *core.BuildTarget) []*cor
 			}
 		}
 	}
+	if target.Subrepo != nil && target.Subrepo.Target != nil {
+		ret = append(ret, target.Subrepo.Target)
+	}
 	return ret
 }
 

--- a/src/parse/asp/util.go
+++ b/src/parse/asp/util.go
@@ -11,6 +11,9 @@ func FindTarget(statements []*Statement, name string) (target *Statement) {
 	WalkAST(statements, func(stmt *Statement) bool {
 		if arg := FindArgument(stmt, "name"); arg != nil && arg.Value.Val != nil && arg.Value.Val.String != "" && strings.Trim(arg.Value.Val.String, `"`) == name {
 			target = stmt
+		} else if arg := FindArgument(stmt, "module"); arg != nil && arg.Value.Val != nil && arg.Value.Val.String != "" && strings.ReplaceAll(strings.Trim(arg.Value.Val.String, `"`), "/", "_") == name {
+			// This is very specific to go_repo but that's widely used enough we're just going to suck it up
+			target = stmt
 		}
 		return false // FindArgument is recursive so we never need to visit more deeply.
 	})

--- a/src/query/deps.go
+++ b/src/query/deps.go
@@ -52,6 +52,9 @@ func printTarget(out io.Writer, state *core.BuildState, target *core.BuildTarget
 	for _, dep := range target.Dependencies() {
 		printTarget(out, state, dep, indent, done, hidden, currentLevel, targetLevel)
 	}
+	if target.Subrepo != nil && target.Subrepo.Target != nil {
+		printTarget(out, state, target.Subrepo.Target, indent, done, hidden, currentLevel, targetLevel)
+	}
 }
 
 func printTargetDot(out io.Writer, state *core.BuildState, target *core.BuildTarget, parent *core.BuildTarget, done map[core.BuildLabel]bool, hidden bool, currentLevel int, targetLevel int) {

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -120,6 +120,9 @@ func buildRevdeps(graph *core.BuildGraph) map[core.BuildLabel][]*core.BuildTarge
 				}
 			}
 		}
+		if t.Subrepo != nil && t.Subrepo.Target != nil {
+			revdeps[t.Subrepo.Target.Label] = append(revdeps[t.Subrepo.Target.Label], t)
+		}
 	}
 	return revdeps
 }

--- a/src/query/somepath.go
+++ b/src/query/somepath.go
@@ -104,5 +104,10 @@ func somePath(graph *core.BuildGraph, target1, target2 *core.BuildTarget, seen, 
 			}
 		}
 	}
+	if target1.Subrepo != nil && target1.Subrepo.Target != nil {
+		if path := somePath(graph, target1.Subrepo.Target, target2, seen, except); len(path) != 0 {
+			return append([]core.BuildLabel{target1.Label}, path...)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
e.g.
```
$ plz query revdeps //third_party/go:golang.org_x_text
<nothing>
```
but that doesn't seem a particularly intuitive or useful result; clearly it _is_ depended on (if you remove that thing, it doesn't build). now it shows:
```
$ plz plz query revdeps //third_party/go:golang.org_x_text
///third_party/go/golang.org_x_text//secure/bidirule:bidirule
///third_party/go/golang.org_x_text//transform:transform
///third_party/go/golang.org_x_text//unicode/bidi:bidi
///third_party/go/golang.org_x_text//unicode/norm:norm
```

I can't see a particularly sensible way of doing this systematically (I don't think targets should get explicit dependencies on them for this), so this just spot-fixes several of the query subcommands.