### PR TITLE
Cache subinclude ASTs per path only

### DIFF
--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -218,7 +218,6 @@ func (i *interpreter) Subinclude(pkgScope *scope, path string, label core.BuildL
 	}
 
 	// If we get here, it falls to us to parse this.
-	log.Debug("Subinclude %s", path)
 	stmts := i.parseSubinclude(path)
 
 	mode := pkgScope.mode
@@ -258,7 +257,6 @@ func (i *interpreter) parseSubinclude(path string) []*Statement {
 		<-wait
 		return i.asts.Get(path)
 	}
-	log.Debug("Parsing %s", path)
 	stmts, err := i.parser.parse(nil, path)
 	if err != nil {
 		panic(err) // We're already inside another interpreter, which will handle this for us.


### PR DESCRIPTION
Currently we re-parse all globally preloaded subincludes for every subrepo (this caught me by surprise a bit).
It's not trivial to avoid interpreting them for each one (although I do want us to do better there) but this is reasonably low-hanging fruit: we only need to parse them once each since the AST representation doesn't change.

I'm seeing nearly a 20% CPU drop for parsing an internal repo. Sadly, I don't think this is well exercised by the postmerge performance tests. (Maybe we should try to improve that...)