### PR TITLE
Put release-gs before release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ workflows:
       - build-darwin-arm64:
           requires:
             - build-darwin
-      - release:
+      - release-gs:
           requires:
             - build-alpine
             - build-freebsd
@@ -355,9 +355,9 @@ workflows:
           filters:
             branches:
               only: master
-      - release-gs:
+      - release:
           requires:
-            - release
+            release-gs
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ workflows:
               only: master
       - release:
           requires:
-            release-gs
+            - release-gs
           filters:
             branches:
               only: master


### PR DESCRIPTION
There's a period between the release being published to Github and the bucket getting updated when it's 'released' but you can't `plz update` to it.
This swaps them around so once the 'announcement' happens it's all ready to go.