### PR TITLE
Use local paths only for determining changes

### DIFF
--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -10,8 +10,6 @@ import (
 	"github.com/thought-machine/please/src/core"
 )
 
-var toolNotFoundHashValue = []byte{1}
-
 // DiffGraphs calculates the difference between two build graphs.
 // Note that this is not symmetric; targets that have been removed from 'before' do not appear
 // (because this is designed to be fed into 'plz test' and we can't test targets that no longer exist).

--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -117,14 +117,8 @@ func sourceHash(state *core.BuildState, target *core.BuildTarget) ([]byte, error
 }
 
 func toolPathHash(state *core.BuildState, tool core.BuildInput) (hash []byte) {
-	defer func() {
-		if r := recover(); r != nil {
-			hash = toolNotFoundHashValue
-		}
-	}()
-
 	h := sha1.New()
-	for _, path := range tool.FullPaths(state.Graph) {
+	for _, path := range tool.LocalPaths(state.Graph) {
 		h.Write([]byte(path))
 	}
 	return h.Sum(nil)


### PR DESCRIPTION
I think this is a better version of #3137 

 - If sources are local to the package, we don't need to compare their package part. 
 - If they're off the PATH, we don't need to worry about the PATH changing (that's handled elsewhere) so their name is enough
 - Build labels are excluded from this check in `sourceHash` anyway.

Hence this should be fine, and removes the possibility of them panicking.