### PR TITLE
Attempt to switch circleci to apple silicon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,30 +121,31 @@ jobs:
        - save_cache:
            key: python-linux-alt-v2-{{ checksum "third_party/python/BUILD" }}
            paths: [ ".plz-cache/third_party/python" ]
-   build-darwin-arm64:
+   build-darwin-amd64:
      working_directory: ~/please
      macos:
        xcode: "13.4.1"
+     resource_class: macos.m1.medium.gen1
      steps:
        - checkout
        - attach_workspace:
            at: /tmp/workspace
        - restore_cache:
-           key: go-darwin-arm64-v4-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-amd64-v4-{{ checksum "third_party/go/BUILD" }}
        - run:
            name: Extract plz
-           command: tar -xzf /tmp/workspace/darwin_amd64/please_*.tar.gz
+           command: tar -xzf /tmp/workspace/darwin_arm64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch darwin_arm64 -o plugin.go.cgoenabled:1 -o plugin.go.cctool:clang -o "plugin.go.cflags:-target arm64-apple-macos11" //package:release_files
+           command: ./please/please build -p --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:1 -o plugin.go.cctool:clang -o "plugin.go.cflags:-target amd64-apple-macos11" //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:
-             - darwin_arm64/*
+             - darwin_amd64/*
        - store_artifacts:
            path: plz-out/log
        - save_cache:
-           key: go-darwin-arm64-v4-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-amd64-v4-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
 
    build-freebsd:
@@ -202,16 +203,17 @@ jobs:
    build-darwin:
       macos:
         xcode: "13.4.1"
+      resource_class: macos.m1.medium.gen1
       environment:
         PLZ_ARGS: "-p --profile ci --exclude pip --exclude embed"
       steps:
        - checkout
        - restore_cache:
-           key: go-mod-darwin-v7-{{ checksum "bootstrap.sh" }}
+           key: go-mod-darwin-arm64-v7-{{ checksum "bootstrap.sh" }}
        - restore_cache:
-           key: go-darwin-go121-v1-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-arm64-go121-v1-{{ checksum "third_party/go/BUILD" }}
        - restore_cache:
-           key: python-darwin-v3-{{ checksum "third_party/python/BUILD" }}
+           key: python-darwin-arm64-v3-{{ checksum "third_party/python/BUILD" }}
        - run:
            name: Install deps
            command: ./.circleci/setup_osx.sh
@@ -228,18 +230,18 @@ jobs:
        - persist_to_workspace:
            root: plz-out/pkg
            paths:
-             - darwin_amd64/*
+             - darwin_arm64/*
        - store_artifacts:
            path: /tmp/artifacts
        - save_cache:
-           key: go-mod-darwin-v7-{{ checksum "go.mod" }}
+           key: go-mod-darwin-arm64-v7-{{ checksum "go.mod" }}
            paths:
              - "~/go/pkg/mod"
        - save_cache:
-           key: go-darwin-go121-v1-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-arm64-go121-v1-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
        - save_cache:
-           key: python-darwin-v3-{{ checksum "third_party/python/BUILD" }}
+           key: python-darwin-arm64-v3-{{ checksum "third_party/python/BUILD" }}
            paths: [ ".plz-cache/third_party/python" ]
 
    test-rex:
@@ -338,14 +340,14 @@ workflows:
       - build-linux-arm64:
           requires:
             - build-alpine
-      - build-darwin-arm64:
+      - build-darwin-amd64:
           requires:
             - build-darwin
       - release-gs:
           requires:
             - build-alpine
             - build-freebsd
-            - build-darwin-arm64
+            - build-darwin-amd64
             - build-linux-arm64
             - build-linux
             - build-linux-alt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
            command: tar -xzf /tmp/workspace/darwin_arm64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:1 -o plugin.go.cctool:clang -o "plugin.go.cflags:-triple x86-64-apple-darwin-macho" //package:release_files
+           command: ./please/please build -p --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:1 -o plugin.go.cctool:clang -o "plugin.go.cflags:-target x86-64-apple-darwin-macho" //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
            command: tar -xzf /tmp/workspace/darwin_arm64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:1 -o plugin.go.cctool:clang -o "plugin.go.cflags:-target amd64-apple-macos11" //package:release_files
+           command: ./please/please build -p --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:1 -o plugin.go.cctool:clang -o "plugin.go.cflags:-target x86-64-apple-macos11" //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,11 +133,14 @@ jobs:
        - restore_cache:
            key: go-darwin-amd64-v4-{{ checksum "third_party/go/BUILD" }}
        - run:
+           name: Install deps
+           command: ./.circleci/setup_osx.sh
+       - run:
            name: Extract plz
            command: tar -xzf /tmp/workspace/darwin_arm64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:1 -o plugin.go.cctool:clang -o "plugin.go.cflags:-target x86-64-apple-darwin-macho" //package:release_files
+           command: ./please/please build -p --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:1 -o plugin.go.cctool:clang -o "plugin.go.cflags:-target x86_64-apple-macos13" //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
            command: tar -xzf /tmp/workspace/darwin_arm64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:1 -o plugin.go.cctool:clang -o "plugin.go.cflags:-target x86-64-apple-macos11" //package:release_files
+           command: ./please/please build -p --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:1 -o plugin.go.cctool:clang -o "plugin.go.cflags:-triple x86-64-apple-darwin-macho" //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:

--- a/.circleci/setup_osx.sh
+++ b/.circleci/setup_osx.sh
@@ -4,12 +4,12 @@ set -eu
 
 # /usr/local/go might get cached.
 if [ ! -d "/usr/local/go" ]; then
-    curl -fsSL https://dl.google.com/go/go1.21.5.darwin-amd64.tar.gz | sudo tar -xz -C /usr/local
+    curl -fsSL https://dl.google.com/go/go1.21.5.darwin-arm64.tar.gz | sudo tar -xz -C /usr/local
 fi
 sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 # xz might also.
-if [ ! -f "/usr/local/bin/xz" ]; then
-    curl -fsSL https://get.please.build/third_party/binary/xz-5.2.4-darwin_amd64 -o /usr/local/bin/xz
-    chmod +x /usr/local/bin/xz
-fi
+# if [ ! -f "/usr/local/bin/xz" ]; then
+#     curl -fsSL https://get.please.build/third_party/binary/xz-5.2.4-darwin_amd64 -o /usr/local/bin/xz
+#     chmod +x /usr/local/bin/xz
+# fi

--- a/.circleci/setup_osx.sh
+++ b/.circleci/setup_osx.sh
@@ -11,5 +11,5 @@ sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
 # xz might also.
 if ! command -v xz &> /dev/null; then
     brew install xz
-    ln -s /opt/homebrew/bin/xz /usr/local/bin/xz
 fi
+sudo ln -s /opt/homebrew/bin/xz /usr/local/bin/xz

--- a/.circleci/setup_osx.sh
+++ b/.circleci/setup_osx.sh
@@ -9,7 +9,6 @@ fi
 sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 # xz might also.
-# if [ ! -f "/usr/local/bin/xz" ]; then
-#     curl -fsSL https://get.please.build/third_party/binary/xz-5.2.4-darwin_amd64 -o /usr/local/bin/xz
-#     chmod +x /usr/local/bin/xz
-# fi
+if ! command -v xz &> /dev/null; then
+    brew install xz
+fi

--- a/.circleci/setup_osx.sh
+++ b/.circleci/setup_osx.sh
@@ -11,4 +11,5 @@ sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
 # xz might also.
 if ! command -v xz &> /dev/null; then
     brew install xz
+    ln -s /opt/homebrew/bin/xz /usr/local/bin/xz
 fi

--- a/test/config_rules/BUILD
+++ b/test/config_rules/BUILD
@@ -3,7 +3,8 @@ python_test(
     name = "config_test",
     srcs = ["config_test.py"],
     flags = select({
-        "//test/config_rules/config:x86_64": "--arch=x86_64",
-        "//test/config_rules/config:x86": "--arch=x86",
+        "//test/config_rules/config:x86_64": "--word_size=64",
+        "//test/config_rules/config:arm64": "--word_size=64",
+        "//test/config_rules/config:x86": "--word_size=32",
     }),
 )

--- a/test/config_rules/config/BUILD
+++ b/test/config_rules/config/BUILD
@@ -9,3 +9,9 @@ config_setting(
     values = {"cpu": "x86"},
     visibility = ["//test/config_rules/..."],
 )
+
+config_setting(
+    name = "arm64",
+    values = {"cpu": "arm64"},
+    visibility = ["//test/config_rules/..."],
+)

--- a/test/config_rules/config_test.py
+++ b/test/config_rules/config_test.py
@@ -5,5 +5,5 @@ import unittest
 class ConfigTest(unittest.TestCase):
 
     def test_flag_matches(self):
-        """Test the flag matches as expected. It's always x86_64 because we don't build Please for x86."""
-        self.assertEqual('--arch=x86_64', sys.argv[-1])
+        """Test the flag matches as expected."""
+        self.assertEqual('--word_size=64', sys.argv[-1])

--- a/test/proto_plugin/test_repo/plugins/BUILD_FILE
+++ b/test/proto_plugin/test_repo/plugins/BUILD_FILE
@@ -1,6 +1,6 @@
 plugin_repo(
     name = "proto",
-    revision = "v0.2.1",
+    revision = "064ff35796b681b33a0667e85a5b1a1d54b64f64",
 )
 
 plugin_repo(


### PR DESCRIPTION
They are deprecating Intel executors (https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718)

This attempts to swap them around so the default build is on arm and the cross-compile to Intel. I guess at some point we will drop that cross-compile step.