### PR TITLE
Deduplicate env vars

### DIFF
--- a/src/core/build_env_test.go
+++ b/src/core/build_env_test.go
@@ -185,3 +185,18 @@ func TestExecEnvironmentDebugTestTarget(t *testing.T) {
 	assert.Contains(t, env, "OUT=out_file1")
 	assert.Contains(t, env, "TEST=out_file1")
 }
+
+func TestDeduplicateEnvVars(t *testing.T) {
+	state := NewDefaultBuildState()
+	state.NeedCoverage = true
+
+	target := NewBuildTarget(NewBuildLabel("pkg", "t"))
+	target.Test = new(TestFields)
+	target.AddOutput("out_file1")
+	target.AddDebugDatum(FileLabel{File: "data_file1", Package: "pkg"})
+	target.Env = map[string]string{"COVERAGE": "wibble"}
+
+	env := TestEnvironment(state, target, "/path/to/runtime/dir", 1)
+	assert.Contains(t, env, "COVERAGE=wibble")
+	assert.NotContains(t, env, "COVERAGE=true")
+}


### PR DESCRIPTION
Currently you can get into a weird situation if you duplicate an existing env var (say you try to set `COVERAGE` to something other than `true`) where it actually has multiple values for it, and it's a bit arbitrary which wins (locally the last one does, so the env var override, with remote execution they're alphabetised so it depends).

I actually think this would all be an awful lot nicer if `BuildEnv` was a `map[string]string` (the best data structure) and we turned it into the `KEY=VAL` slice when required, but I'm not sure I want to refactor that today.