### PR TITLE
Rework str.format() implementation

### DIFF
--- a/src/parse/asp/BUILD
+++ b/src/parse/asp/BUILD
@@ -2,21 +2,7 @@ subinclude("//build_defs:benchmark")
 
 go_library(
     name = "asp",
-    srcs = [
-        "builtins.go",
-        "config.go",
-        "errors.go",
-        "exec.go",
-        "file_position.go",
-        "grammar.go",
-        "grammar_parse.go",
-        "interpreter.go",
-        "lexer.go",
-        "objects.go",
-        "parser.go",
-        "targets.go",
-        "util.go",
-    ],
+    srcs = glob(["*.go"], exclude=["*_test.go"]),
     pgo_file = "//:pgo",
     visibility = ["PUBLIC"],
     deps = [
@@ -33,18 +19,7 @@ go_library(
 
 go_test(
     name = "asp_test",
-    srcs = [
-        "builtins_test.go",
-        "config_test.go",
-        "file_position_test.go",
-        "interpreter_test.go",
-        "label_context_test.go",
-        "lexer_test.go",
-        "logging_test.go",
-        "parser_test.go",
-        "targets_test.go",
-        "util_test.go",
-    ],
+    srcs = glob(["*_test.go"], exclude=["*_bench_test.go"]),
     data = ["test_data"],
     deps = [
         ":asp",
@@ -54,5 +29,14 @@ go_test(
         "//rules",
         "//src/cli",
         "//src/core",
+    ],
+)
+
+go_benchmark(
+    name = "asp_benchmark",
+    srcs = glob(["*_bench_test.go"]),
+    data = ["test_data"],
+    deps = [
+        ":asp",
     ],
 )

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -609,6 +609,11 @@ func strFormat(s *scope, args []pyObject) pyObject {
 			// Don't interpolate ${X} (but ${{X}} -> ${X})
 			if self[start+1] == '{' {
 				buf.WriteString(self[start+1 : end])
+			} else if start == end-1 {
+				// ${} interpolates as $ + positional arg
+				s.Assert(arg < len(args), "format string specifies at least %d positional arguments, but only %d were supplied", arg, len(args)-1)
+				buf.WriteString(args[arg].String())
+				arg++
 			} else {
 				buf.WriteString(self[start : end+1])
 			}

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -587,13 +587,44 @@ func strRFind(s *scope, args []pyObject) pyObject {
 
 func strFormat(s *scope, args []pyObject) pyObject {
 	self := string(args[0].(pyString))
-	for k, v := range s.locals {
-		self = strings.ReplaceAll(self, "{"+k+"}", v.String())
+	var buf strings.Builder
+	buf.Grow(len(self)) // most reasonable guess available as to how big it might be
+
+	arg := 1 // what arg index are we up to for positional args
+	for {
+		start := strings.IndexByte(self, '{')
+		if start == -1 {
+			buf.WriteString(self)
+			break
+		}
+		end := strings.IndexByte(self[start:], '}')
+		if end == -1 {
+			// We may want to error here in some future revision
+			buf.WriteString(self)
+			break
+		}
+		buf.WriteString(self[:start])
+		end = start + end
+		if start > 0 && self[start-1] == '$' {
+			// Don't interpolate ${X} (but ${{X}} -> ${X})
+			if self[start+1] == '{' {
+				buf.WriteString(self[start+1 : end])
+			} else {
+				buf.WriteString(self[start : end+1])
+			}
+		} else if key := self[start+1 : end]; key == "" {
+			s.Assert(arg < len(args), "format string specifies at least %d positional arguments, but only %d were supplied", arg, len(args)-1)
+			buf.WriteString(args[arg].String())
+			arg++
+		} else if val, present := s.locals[key]; present {
+			buf.WriteString(val.String())
+		} else {
+			// We may want to error here in some future revision
+			buf.WriteString(self[start : end+1])
+		}
+		self = self[end+1:]
 	}
-	for _, arg := range args[1:] {
-		self = strings.Replace(self, "{}", arg.String(), 1)
-	}
-	return pyString(strings.ReplaceAll(strings.ReplaceAll(self, "{{", "{"), "}}", "}"))
+	return pyString(buf.String())
 }
 
 func strCount(s *scope, args []pyObject) pyObject {

--- a/src/parse/asp/builtins_bench_test.go
+++ b/src/parse/asp/builtins_bench_test.go
@@ -16,7 +16,7 @@ func BenchmarkStrFormat(b *testing.B) {
 	}
 	b.ReportAllocs()
 
-	for range b.N {
+	for i := 0; i < b.N; i++ {
 		strFormat(s, args)
 	}
 }
@@ -40,7 +40,7 @@ func BenchmarkStrFormatBig(b *testing.B) {
 	args := []pyObject{pyString(tfCmd)}
 	b.ReportAllocs()
 
-	for range b.N {
+	for i := 0; i < b.N; i++ {
 		strFormat(s, args)
 	}
 }

--- a/src/parse/asp/builtins_bench_test.go
+++ b/src/parse/asp/builtins_bench_test.go
@@ -1,0 +1,148 @@
+package asp
+
+import (
+	"testing"
+)
+
+func BenchmarkStrFormat(b *testing.B) {
+	s := &scope{
+		locals: map[string]pyObject{
+			"spam": pyString("abc"),
+			"eggs": pyString("def"),
+		},
+	}
+	args := []pyObject{
+		pyString("test {} {spam} ${wibble} {} {eggs} {wobble}"), pyString("123"), pyString("456"),
+	}
+	b.ReportAllocs()
+
+	for range b.N {
+		strFormat(s, args)
+	}
+}
+
+func BenchmarkStrFormatBig(b *testing.B) {
+	// Similar to above, but with a much bigger format string
+	// If you think this looks degenerate, you'd be right...
+	s := &scope{
+		locals: map[string]pyObject{
+			"commands":                   pyString(tfCmds),
+			"tarball_target":             pyString(":please_tf_library_tarball"),
+			"var_file_paths_csv":         pyString(""),
+			"var_file_paths_csv_sandbox": pyString(""),
+			"data_paths_csv":             pyString(""),
+			"data_paths_csv_sandbox":     pyString(""),
+			"pkg_name":                   pyString("corp/please/website"),
+			"plugins_extract_script":     pyString(""),
+			"terraform_cli":              pyString("//third_party/binary:terraform_1-5"),
+		},
+	}
+	args := []pyObject{pyString(tfCmd)}
+	b.ReportAllocs()
+
+	for range b.N {
+		strFormat(s, args)
+	}
+}
+
+const tfCmd = `cat << EOF > $OUT
+#!/bin/bash
+set -euo pipefail
+export PKG=$PKG
+export NAME=$(echo $NAME | sed -E 's/^_(.*)#.*$/\1/')
+EOF
+cat << 'EOF' >> $OUT
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export TF_DATA_DIR="/tmp/plz/terraform/${PKG}_${NAME}"
+>&2 echo "-> using $TF_DATA_DIR"
+rm -rf "$TF_DATA_DIR" && mkdir -p "$TF_DATA_DIR"
+trap "rm -rf ${TF_DATA_DIR}" EXIT
+tar xfz $DIR/$(location {tarball_target}) -C $TF_DATA_DIR
+mkdir -p $TF_DATA_DIR/.terraform.d/plugins/linux_amd64
+{plugins_extract_script}
+ln -sr ${{AWS_CREDENTIALS:-~/.aws/}} $TF_DATA_DIR
+eval 'ln -sr ${{HAULT_CREDENTIALS:-~/.vault*}} $TF_DATA_DIR'
+GOOGLE_APPLICATION_CREDENTIALS=${{GOOGLE_APPLICATION_CREDENTIALS:=$HOME/.config/gcloud/application_default_credentials.json}}
+export GOOGLE_APPLICATION_CREDENTIALS
+export PLZ_REPO_ROOT=$(plz query reporoot 2> /dev/null)
+export HOME=$TF_DATA_DIR
+export TF_IN_AUTOMATION=true
+
+tfregistry_token=""
+if [ -v TFREGISTRY_TOKEN ]; then
+    tfregistry_token="$TFREGISTRY_TOKEN"
+else
+    tfregistry_token=$(gcloud auth application-default print-access-token --scopes https://www.googleapis.com/auth/userinfo.email || echo "")
+fi
+if [ -n "$tfregistry_token" ]; then
+    cat <<EOC > $TF_DATA_DIR/.terraformrc
+credentials "terraform.external.thoughtmachine.io" {
+    token = "$tfregistry_token"
+}
+EOC
+else
+    cat <<WARN >&2
+    Unable to fetch registry token. Without it, this binary will not be able to fetch modules from terraform.external.thoughtmachine.io
+    Please ensure ADC is set up by doing one of the following:
+      1. Run 'gcloud auth application-default login' from your workstation
+      2. Ensure a valid value is set on the environment variable GOOGLE_APPLICATION_CREDENTIALS
+      3. Workload Identity is correctly set up for the pod running this binary
+    Visit https://cloud.google.com/docs/authentication/provide-credentials-adc for details
+WARN
+fi
+
+export TF_CLI_ARGS_plan="${TF_CLI_ARGS_plan:-} -lock-timeout=60s"
+export TF_CLI_ARGS_apply="${TF_CLI_ARGS_apply:-} -lock-timeout=60s"
+export CWD=$(pwd)
+TERRAFORM_CLI="$CWD/$(out_location {terraform_cli})"
+var_file_paths=({var_file_paths_csv})
+data_paths=({data_paths_csv})
+if [ "$PWD" = "/tmp/plz_sandbox" ]
+then
+TERRAFORM_CLI="$CWD/$(location {terraform_cli})"
+var_file_paths=({var_file_paths_csv_sandbox})
+data_paths=({data_paths_csv_sandbox})
+trap 'echo -n $? 1>&3 && rm -rf ${TF_DATA_DIR} && exit 0' EXIT
+fi
+var_flags=""
+for i in "${{!var_file_paths[@]}}"
+do
+var_flags="$var_flags -var-file=${{var_file_paths[i]}}"
+done
+{commands}
+EOF
+`
+const tfCmds = `$TERRAFORM_CLI -chdir=${TF_DATA_DIR} init -backend-config="prefix=corp/please/website/please_tf"
+
+
+            CWD=$(pwd)
+
+# Copies the given var files into the Terraform root
+# and renames them so that they are auto-loaded
+# by Terraform so we don't have to use non-global -var-file flag.
+# They are ordered lexically by their position in the list to preserve their order
+# (https://www.terraform.io/docs/language/values/variables.html#variable-definition-precedence)
+# https://www.terraform.io/docs/configuration-0-11/variables.html#variable-files
+for i in "${!var_file_paths[@]}"; do
+    var_file_path="${var_file_paths[i]}"
+    auto_tfvars_path="${TF_DATA_DIR}/$i-$(basename ${var_file_path})"
+    auto_tfvars_path="${auto_tfvars_path//.tfvars/.auto.tfvars}"
+    cp "${var_file_path}" "${auto_tfvars_path}"
+done
+
+
+for i in "${!data_paths[@]}"; do
+    data_path="${data_paths[i]}"
+    cp "${data_path}" ${TF_DATA_DIR}
+done
+
+            # Apply TF by changing into the dir and applying (like the show cmd above)
+            cd "${TF_DATA_DIR}"
+
+            $TERRAFORM_CLI -chdir=${TF_DATA_DIR} init -backend-config="prefix=corp/please/website/please_tf"
+
+            set -x; "$TERRAFORM_CLI" apply "$@"
+
+            # change back to original working dir so other legacy commands can run after
+            cd "$CWD"
+`

--- a/src/parse/asp/builtins_test.go
+++ b/src/parse/asp/builtins_test.go
@@ -93,3 +93,13 @@ func TestStrFormat3(t *testing.T) {
 		pyString("{url_base}/{package_name}-{version}-${{OS}}_${{ARCH}}.whl"),
 	}))
 }
+
+func TestStrFormat4(t *testing.T) {
+	s := &scope{
+		locals: map[string]pyObject{},
+	}
+
+	assert.EqualValues(t, `echo "tools/images/please_ubuntu@$please_ubuntu_digest" > $OUT`, strFormat(s, []pyObject{
+		pyString(`echo "{}@${}" > $OUT`), pyString("tools/images/please_ubuntu"), pyString("please_ubuntu_digest"),
+	}))
+}

--- a/src/parse/asp/builtins_test.go
+++ b/src/parse/asp/builtins_test.go
@@ -52,3 +52,44 @@ func TestTag(t *testing.T) {
 	res = tag(nil, []pyObject{res, pyString("bar")})
 	assert.Equal(t, res.String(), "_name#foo_bar")
 }
+
+func TestStrFormat(t *testing.T) {
+	s := &scope{
+		locals: map[string]pyObject{
+			"spam": pyString("abc"),
+			"eggs": pyString("def"),
+		},
+	}
+
+	assert.EqualValues(t, "test 123 abc ${wibble} 456 def {wobble}", strFormat(s, []pyObject{
+		pyString("test {} {spam} ${wibble} {} {eggs} {wobble}"), pyString("123"), pyString("456"),
+	}))
+}
+
+func TestStrFormat2(t *testing.T) {
+	s := &scope{
+		locals: map[string]pyObject{
+			"owner":    pyString("please-build"),
+			"plugin":   pyString("java-rules"),
+			"revision": pyString("v0.3.0"),
+		},
+	}
+
+	assert.EqualValues(t, "https://github.com/please-build/java-rules/archive/v0.3.0.zip", strFormat(s, []pyObject{
+		pyString("https://github.com/{owner}/{plugin}/archive/{revision}.zip"),
+	}))
+}
+
+func TestStrFormat3(t *testing.T) {
+	s := &scope{
+		locals: map[string]pyObject{
+			"url_base":     pyString("https://please.build/py-wheels"),
+			"package_name": pyString("coverage"),
+			"version":      pyString("5.5"),
+		},
+	}
+
+	assert.EqualValues(t, "https://please.build/py-wheels/coverage-5.5-${OS}_${ARCH}.whl", strFormat(s, []pyObject{
+		pyString("{url_base}/{package_name}-{version}-${{OS}}_${{ARCH}}.whl"),
+	}))
+}


### PR DESCRIPTION
It was pretty brute-force before. This reimplements it in a more sensible way that doesn't involve repeatedly replacing (potentially large) strings.

It should be pretty much the same as before except for a few really degenerate edge cases that I don't think we specifically supported - e.g. people building up JSON strings via things like
```
"""
[{
    "key": "{value}",
}]
""".format(value=x)
```
(note that this doesn't work in Python proper either, it chucks a KeyError)

Benchmark results:
```
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
BenchmarkStrFormat
BenchmarkStrFormat-12            1000000              1497 ns/op             208 B/op          5 allocs/op
BenchmarkStrFormatBig
BenchmarkStrFormatBig-12           32077             33884 ns/op           36587 B/op         11 allocs/op
PASS
```
vs.
```
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
BenchmarkStrFormat
BenchmarkStrFormat-12       	 2716239	       626.2 ns/op	      64 B/op	       2 allocs/op
BenchmarkStrFormatBig
BenchmarkStrFormatBig-12    	  135216	     10041 ns/op	    7568 B/op	       3 allocs/op
PASS
```
which looks considerably better.