### PR TITLE
Allocate fewer dicts for builtins

### DIFF
--- a/src/parse/asp/parser.go
+++ b/src/parse/asp/parser.go
@@ -251,7 +251,7 @@ func (p *Parser) optimiseBuiltinCalls(stmts []*Statement) {
 			for _, arg := range stmt.FuncDef.Arguments {
 				if arg.Value != nil && arg.Value.Val.Dict != nil && arg.Value.Val.Dict.Comprehension == nil && len(arg.Value.Val.Dict.Items) == 0 {
 					arg.Value.optimised = &optimisedExpression{
-						Constant: pyDict{},
+						Constant: pyFrozenDict{},
 					}
 				}
 			}


### PR DESCRIPTION
Small optimisation: normally we don't treat dicts as constants because they have pointer semantics, so modifying them internally would reflect on other calls. In builtins, we know we don't do that, so we can optimise them in that way. Should save a bunch of allocations of empty dicts.

One day (probably once Go has `rangefunc`) we can replace dicts with an implementation that suits us a bit better, which would genericise this to any function argument.