### PR TITLE
Fix hang on preloading subincludes

### DIFF
--- a/src/parse/parse_step.go
+++ b/src/parse/parse_step.go
@@ -50,9 +50,7 @@ func parse(state *core.BuildState, label, dependent core.BuildLabel, mode core.P
 	// Ensure that all the preloaded targets are built before we sync the package parse. If we don't do this, we might
 	// take the package lock for a package involved in a subinclude, and end up in a deadlock
 	if !mode.IsPreload() {
-		if err := state.RegisterPreloads(); err != nil {
-			return err
-		}
+		state.MustRegisterPreloads()
 	}
 
 	// See if something else has parsed this package first.


### PR DESCRIPTION
Found a  case where it hangs forever.
 - I have subincludes `//a` and `//b`, both of which are preloaded.
 -  `//a` contains `subinclude("//b")`. 
 - `//b` contains a syntax error
We never exit from `RegisterPreloads`; the errgroup has the error from `//b` but is waiting for `//a` to complete, which it never does.

This fixes it by dying, although it's a bit brutal. It would of course be better to have `//a` receive the parse error too...