### PR TITLE
Propagate errors through map

### DIFF
--- a/src/cmap/BUILD
+++ b/src/cmap/BUILD
@@ -1,9 +1,6 @@
 go_library(
     name = "cmap",
-    srcs = [
-        "cmap.go",
-        "hash.go",
-    ],
+    srcs = glob(["*.go"], exclude=["*_test.go"]),
     pgo_file = "//:pgo",
     visibility = ["PUBLIC"],
     deps = ["///third_party/go/github.com_cespare_xxhash_v2//:v2"],
@@ -11,10 +8,7 @@ go_library(
 
 go_test(
     name = "cmap_test",
-    srcs = [
-        "cmap_test.go",
-        "hash_test.go",
-    ],
+    srcs = glob(["*_test.go"]),
     deps = [
         ":cmap",
         "///third_party/go/github.com_cespare_xxhash_v2//:v2",

--- a/src/cmap/cerrmap.go
+++ b/src/cmap/cerrmap.go
@@ -1,0 +1,60 @@
+package cmap
+
+// NewErrMap returns a map that extends Map with an error type, which callers can also wait on
+// and receive if something goes wrong.
+func NewErrMap[K comparable, V any](shardCount uint64, hasher func(K) uint64) *ErrMap[K, V] {
+	return &ErrMap[K, V]{
+		m: New[K, errV[V]](shardCount, hasher),
+	}
+}
+
+type errV[V any] struct {
+	Err error
+	Val V
+}
+
+// An ErrMap extends Map with returned errors as a first-class concept
+type ErrMap[K comparable, V any] struct {
+	m *Map[K, errV[V]]
+}
+
+// Add adds the new item to the map.
+// It returns true if the item was inserted, false if it already existed (in which case it won't be inserted)
+func (m *ErrMap[K, V]) Add(key K, val V) bool {
+	return m.m.Add(key, errV[V]{Val: val})
+}
+
+// AddOrGet either adds a new item (if the key doesn't exist) or gets the existing one.
+// It returns true if the item was inserted, false if it already existed (in which case it won't be inserted)
+func (m *ErrMap[K, V]) AddOrGet(key K, val V) (V, bool, error) {
+	v, present := m.m.AddOrGet(key, errV[V]{Val: val})
+	return v.Val, present, v.Err
+}
+
+// Set is the equivalent of `map[key] = val`.
+// It always overwrites any key that existed before.
+func (m *ErrMap[K, V]) Set(key K, val V) {
+	m.m.Set(key, errV[V]{Val: val})
+}
+
+// SetError overwrites the key with the given error.
+func (m *ErrMap[K, V]) SetError(key K, err error) {
+	m.m.Set(key, errV[V]{Err: err})
+}
+
+// Get returns the value corresponding to the given key, or its zero value if the key doesn't exist in the map.
+// If an error has been set for the key, that will be returned.
+func (m *ErrMap[K, V]) Get(key K) (V, error) {
+	v := m.m.Get(key)
+	return v.Val, v.Err
+}
+
+// GetOrWait returns the value or, if the key isn't present, a channel that it can be waited
+// on for. The caller will need to call Get again after the channel closes.
+// If the channel is non-nil, then val will exist in the map; otherwise it will have its zero value.
+// The third return value is true if this is the first call that is awaiting this key.
+// It's always false if the key exists.
+func (m *ErrMap[K, V]) GetOrWait(key K) (val V, wait <-chan struct{}, first bool, err error) {
+	v, wait, first := m.m.GetOrWait(key)
+	return v.Val, wait, first, v.Err
+}

--- a/src/cmap/cerrmap_test.go
+++ b/src/cmap/cerrmap_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestErrMap(t *testing.T) {
-	m := NewErrMap[int, int](DefaultShardCount, hashInts)
+	m := NewErrMap[int, int](DefaultShardCount, hashInts, nil)
 	assert.True(t, m.Add(5, 7))
 	assert.True(t, m.Add(7, 5))
 	err := fmt.Errorf("it broke")
@@ -21,18 +21,14 @@ func TestErrMap(t *testing.T) {
 }
 
 func TestErrWait(t *testing.T) {
-	m := NewErrMap[int, int](DefaultShardCount, hashInts)
-	v, ch, first, err := m.GetOrWait(5)
-	assert.Equal(t, 0, v) // Should be the zero value
-	assert.True(t, first) // We're the first to request it
+	m := NewErrMap[int, int](DefaultShardCount, hashInts, nil)
+	v, err := m.GetOrSet(5, func() (int, error) {
+		return 5, nil
+	})
+	assert.Equal(t, 5, v)
 	assert.NoError(t, err)
-	go func() {
-		m.SetError(5, fmt.Errorf("it broke"))
-	}()
-	<-ch
-	v, ch, first, err = m.GetOrWait(5)
-	assert.Equal(t, 0, v)
-	assert.Nil(t, ch)
-	assert.False(t, first)
+	_, err = m.GetOrSet(7, func() (int, error) {
+		return 0, fmt.Errorf("it broke")
+	})
 	assert.Error(t, err)
 }

--- a/src/cmap/cerrmap_test.go
+++ b/src/cmap/cerrmap_test.go
@@ -1,0 +1,38 @@
+package cmap
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrMap(t *testing.T) {
+	m := NewErrMap[int, int](DefaultShardCount, hashInts)
+	assert.True(t, m.Add(5, 7))
+	assert.True(t, m.Add(7, 5))
+	err := fmt.Errorf("it broke")
+	m.SetError(7, err)
+	v, err2 := m.Get(5)
+	assert.Equal(t, 7, v)
+	assert.NoError(t, err2)
+	_, err2 = m.Get(7)
+	assert.Equal(t, err, err2)
+}
+
+func TestErrWait(t *testing.T) {
+	m := NewErrMap[int, int](DefaultShardCount, hashInts)
+	v, ch, first, err := m.GetOrWait(5)
+	assert.Equal(t, 0, v) // Should be the zero value
+	assert.True(t, first) // We're the first to request it
+	assert.NoError(t, err)
+	go func() {
+		m.SetError(5, fmt.Errorf("it broke"))
+	}()
+	<-ch
+	v, ch, first, err = m.GetOrWait(5)
+	assert.Equal(t, 0, v)
+	assert.Nil(t, ch)
+	assert.False(t, first)
+	assert.Error(t, err)
+}

--- a/src/cmap/cmap.go
+++ b/src/cmap/cmap.go
@@ -66,8 +66,7 @@ func (m *Map[K, V]) Set(key K, val V) {
 	m.shards[m.hasher(key)&m.mask].Set(key, val, true)
 }
 
-// Get returns the value https://github.com/peterebden/please/pull/new/generic-cmap-4corresponding to the given key, or its zero value if
-// the key doesn't exist in the map.
+// Get returns the value corresponding to the given key, or its zero value if the key doesn't exist in the map.
 func (m *Map[K, V]) Get(key K) V {
 	v, _, _ := m.shards[m.hasher(key)&m.mask].Get(key)
 	return v

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -18,8 +18,8 @@ import (
 type interpreter struct {
 	scope       *scope
 	parser      *Parser
-	subincludes *cmap.Map[string, pyDict]
-	asts        *cmap.Map[string, []*Statement]
+	subincludes *cmap.ErrMap[string, pyDict]
+	asts        *cmap.ErrMap[string, []*Statement]
 
 	configs      map[*core.BuildState]*pyConfig
 	configsMutex sync.RWMutex
@@ -37,23 +37,19 @@ func newInterpreter(state *core.BuildState, p *Parser) *interpreter {
 		state:  state,
 		locals: map[string]pyObject{},
 	}
-	// If we're creating an interpreter for a subrepo, we should share the subinclude cache.
-	var subincludes *cmap.Map[string, pyDict]
-	var asts *cmap.Map[string, []*Statement]
-	if p.interpreter != nil {
-		subincludes = p.interpreter.subincludes
-		asts = p.interpreter.asts
-	} else {
-		subincludes = cmap.New[string, pyDict](cmap.SmallShardCount, cmap.XXHash)
-		asts = cmap.New[string, []*Statement](cmap.SmallShardCount, cmap.XXHash)
-	}
 	i := &interpreter{
-		scope:       s,
-		parser:      p,
-		subincludes: subincludes,
-		asts:        asts,
-		configs:     map[*core.BuildState]*pyConfig{},
-		limiter:     make(semaphore, state.Config.Parse.NumThreads),
+		scope:   s,
+		parser:  p,
+		configs: map[*core.BuildState]*pyConfig{},
+		limiter: make(semaphore, state.Config.Parse.NumThreads),
+	}
+	// If we're creating an interpreter for a subrepo, we should share the subinclude cache.
+	if p.interpreter != nil {
+		i.subincludes = p.interpreter.subincludes
+		i.asts = p.interpreter.asts
+	} else {
+		i.subincludes = cmap.NewErrMap[string, pyDict](cmap.SmallShardCount, cmap.XXHash)
+		i.asts = cmap.NewErrMap[string, []*Statement](cmap.SmallShardCount, cmap.XXHash)
 	}
 	s.interpreter = i
 	s.LoadSingletons(state)
@@ -207,18 +203,26 @@ func (i *interpreter) interpretStatements(s *scope, statements []*Statement) (re
 // Subinclude returns the global values corresponding to subincluding the given file.
 func (i *interpreter) Subinclude(pkgScope *scope, path string, label core.BuildLabel, preload bool) pyDict {
 	key := filepath.Join(path, pkgScope.state.CurrentSubrepo)
-	globals, wait, first := i.subincludes.GetOrWait(key)
-	if globals != nil {
+	globals, wait, first, err := i.subincludes.GetOrWait(key)
+	if err != nil {
+		pkgScope.Error("failed to subinclude %s: %s", label, err)
+	} else if globals != nil {
 		return globals
 	} else if !first {
 		i.limiter.Release()
 		defer i.limiter.Acquire()
 		<-wait
-		return i.subincludes.Get(key)
+		locals, err := i.subincludes.Get(key)
+		pkgScope.Assert(err == nil, "failed to subinclude %s: %s", label, err)
+		return locals
 	}
 
 	// If we get here, it falls to us to parse this.
-	stmts := i.parseSubinclude(path)
+	stmts, err := i.parseSubinclude(path)
+	if err != nil {
+		i.subincludes.SetError(key, err)
+		pkgScope.Error("failed to subinclude %s: %s", label, err)
+	}
 
 	mode := pkgScope.mode
 	if preload {
@@ -234,6 +238,7 @@ func (i *interpreter) Subinclude(pkgScope *scope, path string, label core.BuildL
 
 	if !mode.IsPreload() {
 		if err := i.preloadSubincludes(s); err != nil {
+			i.subincludes.SetError(key, err)
 			s.Error("failed: %v", err)
 		}
 	}
@@ -247,24 +252,27 @@ func (i *interpreter) Subinclude(pkgScope *scope, path string, label core.BuildL
 }
 
 // parseSubinclude parses a subinclude to an AST, caching it (globally)
-func (i *interpreter) parseSubinclude(path string) []*Statement {
-	stmts, wait, first := i.asts.GetOrWait(path)
-	if stmts != nil {
-		return stmts
+func (i *interpreter) parseSubinclude(path string) ([]*Statement, error) {
+	stmts, wait, first, err := i.asts.GetOrWait(path)
+	if err != nil {
+		return nil, err
+	} else if stmts != nil {
+		return stmts, nil
 	} else if !first {
 		i.limiter.Release()
 		defer i.limiter.Acquire()
 		<-wait
 		return i.asts.Get(path)
 	}
-	stmts, err := i.parser.parse(nil, path)
+	stmts, err = i.parser.parse(nil, path)
 	if err != nil {
-		panic(err) // We're already inside another interpreter, which will handle this for us.
+		i.asts.SetError(path, err)
+		return nil, err
 	}
 	stmts = i.parser.optimise(stmts)
 	i.optimiseExpressions(stmts)
 	i.asts.Set(path, stmts)
-	return stmts
+	return stmts, nil
 }
 
 // optimiseExpressions implements a peephole optimiser for expressions by precalculating constants


### PR DESCRIPTION
This is a nicer version of #3150; it should fix the same problem in a more principled way.

Repeating the context here:
 - I have subincludes `//a` and `//b`, both of which are preloaded.
 - `//a` contains `subinclude("//b")`.
 - `//b` contains a syntax error

We never exit from RegisterPreloads; the errgroup has the error from `//b` but is waiting for `//a` to complete, which it never does.

This fixes it by propagating the error through the map where the caller is waiting, so they can receive it too; it extends it from "get the thing or wait" to "get the thing or the error, or wait". I think this should be a more generic solution to this kind of thing overall.