### PR TITLE
De-loop type checking on function calls

### DIFF
--- a/src/parse/asp/grammar_parse.go
+++ b/src/parse/asp/grammar_parse.go
@@ -233,7 +233,7 @@ func (p *parser) parseFuncDef() *FuncDef {
 		p.next('-')
 		p.next('>')
 
-		tok := p.oneofval("bool", "str", "int", "list", "dict", "function", "config", "none")
+		tok := p.oneofval(knownTypeNames...)
 		fd.Return = tok.Value
 	}
 

--- a/src/parse/asp/grammar_parse.go
+++ b/src/parse/asp/grammar_parse.go
@@ -233,7 +233,7 @@ func (p *parser) parseFuncDef() *FuncDef {
 		p.next('-')
 		p.next('>')
 
-		tok := p.oneofval("bool", "str", "int", "list", "dict", "function", "config")
+		tok := p.oneofval("bool", "str", "int", "list", "dict", "function", "config", "none")
 		fd.Return = tok.Value
 	}
 

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -595,7 +595,7 @@ func newPyFunc(parentScope *scope, def *FuncDef) pyObject {
 		args:       make([]string, len(def.Arguments)),
 		argIndices: make(map[string]int, len(def.Arguments)),
 		constants:  make([]pyObject, len(def.Arguments)),
-		types:      make([][]string, len(def.Arguments)),
+		types:      make([]int16, len(def.Arguments)),
 		code:       def.Statements,
 		kwargsonly: def.KeywordsOnly,
 		returnType: def.Return,
@@ -1005,4 +1005,16 @@ func (r *pyRange) toList(extraCapacity int) pyList {
 		ret = append(ret, i)
 	}
 	return ret
+}
+
+// Known types, used for type signatures on function arguments
+// This doesn't have to be totally exhaustive, it's only the ones that can be declared in syntax.
+var knownTypeNames = []string{"bool", "str", "int", "list", "dict", "function", "config", "none"}
+
+var knownTypeValues = make(map[string]int{}, len(knownTypeNames))
+
+func init() {
+	for i, x := range knownTypeNames {
+		knownTypeValues[x] = i
+	}
 }


### PR DESCRIPTION
Rather than looping over a bunch of strings doing comparisons on them all, this optimises it by calculating a bitmask for types so in the happy path we're just doing a couple of int operations.

Hopefully we should see a small improvement on the ongoing CI perf tests.