### PR TITLE
Move optimiseBuiltinCalls out of ParseData

### DIFF
--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -102,6 +102,7 @@ func (i *interpreter) LoadBuiltins(filename string, contents []byte, statements 
 				stmt.FuncDef.IsBuiltin = true
 			}
 		}
+		i.parser.optimiseBuiltinCalls(stmts)
 		return i.loadBuiltinStatements(s, stmts, err)
 	}
 	stmts, err := i.parser.parse(nil, filename)

--- a/src/parse/asp/parser.go
+++ b/src/parse/asp/parser.go
@@ -156,9 +156,7 @@ func (p *Parser) open(fs iofs.FS, filename string) (io.ReadSeekCloser, error) {
 // The 'filename' argument is only used in case of errors so doesn't necessarily have to correspond to a real file.
 func (p *Parser) ParseData(data []byte, filename string) ([]*Statement, error) {
 	r := &namedReader{r: bytes.NewReader(data), name: filename}
-	stmts, err := p.parseAndHandleErrors(r)
-	p.optimiseBuiltinCalls(stmts)
-	return stmts, err
+	return p.parseAndHandleErrors(r)
 }
 
 // parseAndHandleErrors handles errors nicely if the given input fails to parse.


### PR DESCRIPTION
Make this more specific to the actual builtin loading; turns out the LSP code uses this too