### PR TITLE
Fix flaky LSP test

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -64,7 +64,7 @@ plugins = {
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",
     "python-proto": "v0.1.0",
-    "proto": "v0.2.1",
+    "proto": "v0.4.0",
 }
 
 plugin_targets = []

--- a/tools/build_langserver/lsp/lsp_test.go
+++ b/tools/build_langserver/lsp/lsp_test.go
@@ -629,12 +629,10 @@ func (h *Handler) CurrentContent(doc string) string {
 
 // WaitForPackage blocks until the given package has been parsed.
 func (h *Handler) WaitForPackage(pkg string) {
-	for result := range h.state.Results() {
-		if result.Status == core.PackageParsed && result.Label.PackageName == pkg {
-			return
-		} else if h.state.Graph.Package(pkg, "") != nil {
-			return
-		}
+	// this can only be described as 'grotty', but it is test code
+	h.state.Graph.WaitForTarget(core.BuildLabel{PackageName: pkg})
+	if h.state.Graph.Package(pkg, "") == nil {
+		log.Fatal("package %s doesn't exist", pkg)
 	}
 }
 

--- a/tools/build_langserver/lsp/lsp_test.go
+++ b/tools/build_langserver/lsp/lsp_test.go
@@ -632,7 +632,7 @@ func (h *Handler) WaitForPackage(pkg string) {
 	// this can only be described as 'grotty', but it is test code
 	h.state.Graph.WaitForTarget(core.BuildLabel{PackageName: pkg})
 	if h.state.Graph.Package(pkg, "") == nil {
-		log.Fatal("package %s doesn't exist", pkg)
+		log.Fatalf("package %s doesn't exist", pkg)
 	}
 }
 

--- a/tools/build_langserver/lsp/test_data/.plzconfig
+++ b/tools/build_langserver/lsp/test_data/.plzconfig
@@ -6,3 +6,7 @@ preloadsubincludes = ///go//build_defs:go
 
 [Plugin "go"]
 target = //plugins:go
+
+[remote]
+url =
+numexecutors = 0


### PR DESCRIPTION
It wants to consume the build event stream, but sometimes it's too slow and the whole thing has finished before it gets there, in which case there are no results for it and it hangs. This handles it a different way.
This feels not entirely beautiful but it really wants (another) rewrite to properly handle partial / incremental parsing.

Fixes #3065