### PR TITLE
Clean up BuildRuleArgOrder

### DIFF
--- a/src/build/build_step_stress_test.go
+++ b/src/build/build_step_stress_test.go
@@ -141,8 +141,3 @@ func (fake *fakeParser) RunPostBuildFunction(state *core.BuildState, target *cor
 	}
 	return nil
 }
-
-// BuildRuleArgOrder stub
-func (fake *fakeParser) BuildRuleArgOrder() map[string]int {
-	return map[string]int{}
-}

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -644,11 +644,6 @@ func (fake *fakeParser) RunPostBuildFunction(state *core.BuildState, target *cor
 	return target.PostBuildFunction.Call(target, output)
 }
 
-// BuildRuleArgOrder sub
-func (fake *fakeParser) BuildRuleArgOrder() map[string]int {
-	return map[string]int{}
-}
-
 type preBuildFunction func(*core.BuildTarget) error
 type postBuildFunction func(*core.BuildTarget, string) error
 

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -92,8 +92,6 @@ type Parser interface {
 	RunPreBuildFunction(state *BuildState, target *BuildTarget) error
 	// RunPostBuildFunction runs a post-build function for a target.
 	RunPostBuildFunction(state *BuildState, target *BuildTarget, output string) error
-	// BuildRuleArgOrder returns a map of the arguments to build rule and the order they appear in the source file
-	BuildRuleArgOrder() map[string]int
 	RegisterPreload(label BuildLabel) error
 }
 

--- a/src/parse/asp/parser.go
+++ b/src/parse/asp/parser.go
@@ -257,22 +257,6 @@ func (p *Parser) optimiseBuiltinCalls(stmts []*Statement) {
 	}
 }
 
-// BuildRuleArgOrder returns a map of the arguments to build rule and the order they appear in the source file
-func (p *Parser) BuildRuleArgOrder() map[string]int {
-	// Find the root scope to avoid cases where build_rule might've been overloaded
-	scope := p.interpreter.scope
-	for s := scope.parent; s != nil; s = s.parent {
-		scope = s
-	}
-	args := scope.locals["build_rule"].(*pyFunc).args
-	ret := make(map[string]int, len(args))
-
-	for order, name := range args {
-		ret[name] = order
-	}
-	return ret
-}
-
 // whitelistedKwargs returns true if the given built-in function name is allowed to
 // be called as non-kwargs.
 // TODO(peterebden): Come up with a syntax that exposes this directly in the file.

--- a/src/parse/init.go
+++ b/src/parse/init.go
@@ -78,11 +78,6 @@ func (p *aspParser) RunPostBuildFunction(state *core.BuildState, target *core.Bu
 	})
 }
 
-// BuildRuleArgOrder returns a map of the arguments to build rule and the order they appear in the source file
-func (p *aspParser) BuildRuleArgOrder() map[string]int {
-	return p.parser.BuildRuleArgOrder()
-}
-
 // RegisterPreload pre-registers a preload, forcing us to build any transitive preloads before we move on
 func (p *aspParser) RegisterPreload(label core.BuildLabel) error {
 	return p.parser.RegisterPreload(label)
@@ -117,4 +112,21 @@ func createBazelSubrepo(state *core.BuildState) {
 			log.Fatalf("%s", err)
 		}
 	}
+}
+
+// BuildRuleArgOrder returns a map of the arguments to build rule and the order they appear in the source file
+func BuildRuleArgOrder(state *core.BuildState) map[string]int {
+	p := asp.NewParser(state)
+	b, _ := rules.ReadAsset("builtins.build_defs")
+	stmts, _ := p.ParseData(b, "builtins.build_defs")
+	m := map[string]int{}
+	for _, stmt := range stmts {
+		if stmt.FuncDef != nil && stmt.FuncDef.Name == "build_rule" {
+			for i, arg := range stmt.FuncDef.Arguments {
+				m[arg.Name] = i
+			}
+			return m
+		}
+	}
+	return m
 }

--- a/src/query/BUILD
+++ b/src/query/BUILD
@@ -1,22 +1,6 @@
 go_library(
     name = "query",
-    srcs = [
-        "alltargets.go",
-        "changes.go",
-        "completions.go",
-        "config.go",
-        "deps.go",
-        "filter.go",
-        "graph.go",
-        "inputs.go",
-        "outputs.go",
-        "print.go",
-        "query_step.go",
-        "reverse_deps.go",
-        "somepath.go",
-        "whatinputs.go",
-        "whatoutputs.go",
-    ],
+    srcs = glob(["*.go"], exclude=["*_test.go"]),
     pgo_file = "//:pgo",
     visibility = ["PUBLIC"],
     deps = [
@@ -25,21 +9,14 @@ go_library(
         "//src/build",
         "//src/cli/logging",
         "//src/core",
+        "//src/parse",
         "//src/fs",
     ],
 )
 
 go_test(
     name = "query_test",
-    srcs = [
-        "changes_test.go",
-        "completions_test.go",
-        "graph_test.go",
-        "print_test.go",
-        "reverse_deps_test.go",
-        "whatinputs_test.go",
-        "whatoutputs_test.go",
-    ],
+    srcs = glob(["*_test.go"]),
     data = ["completions_test_repo"],
     deps = [
         ":query",

--- a/src/query/print.go
+++ b/src/query/print.go
@@ -12,12 +12,14 @@ import (
 	"time"
 
 	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/parse"
 )
 
 // Print produces a Python call which would (hopefully) regenerate the same build rule if run.
 // This is of course not ideal since they were almost certainly created as a java_library
 // or some similar wrapper rule, but we've lost that information by now.
 func Print(state *core.BuildState, targets []core.BuildLabel, fields, labels []string, omitHidden, outputJSON bool) {
+	order := parse.BuildRuleArgOrder(state)
 	graph := state.Graph
 	ts := map[string]map[string]interface{}{}
 	for _, target := range targets {
@@ -28,7 +30,7 @@ func Print(state *core.BuildState, targets []core.BuildLabel, fields, labels []s
 		t := graph.TargetOrDie(target)
 
 		if outputJSON {
-			ts[target.String()] = targetToValueMap(state.Parser.BuildRuleArgOrder(), fields, t)
+			ts[target.String()] = targetToValueMap(order, fields, t)
 			continue
 		}
 
@@ -46,9 +48,9 @@ func Print(state *core.BuildState, targets []core.BuildLabel, fields, labels []s
 			fmt.Fprintf(os.Stdout, "# %s:\n", target)
 		}
 		if len(fields) > 0 {
-			newPrinter(os.Stdout, t, 0, state.Parser.BuildRuleArgOrder()).PrintFields(fields)
+			newPrinter(os.Stdout, t, 0, order).PrintFields(fields)
 		} else {
-			newPrinter(os.Stdout, t, 0, state.Parser.BuildRuleArgOrder()).PrintTarget()
+			newPrinter(os.Stdout, t, 0, order).PrintTarget()
 		}
 	}
 

--- a/src/query/print_test.go
+++ b/src/query/print_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/thought-machine/please/src/parse"
 )
 
-var order = parse.InitParser(core.NewDefaultBuildState()).Parser.BuildRuleArgOrder()
+var order = parse.BuildRuleArgOrder(core.NewDefaultBuildState())
 
 func TestAllFieldsArePresentAndAccountedFor(t *testing.T) {
 	target := &core.BuildTarget{}


### PR DESCRIPTION
This takes it out of the main parser interface since we only need it in one place, and the existing parser isn't _that_ good at actually answering it (it's basically about the same amount of code to just parse `builtins.build_defs` on demand to find it)