### PR TITLE
Split out declared dependencies

### DIFF
--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -17,6 +17,7 @@ var KnownFields = map[string]bool{
 	// These fields are explicitly hashed.
 	"Label":                       true,
 	"dependencies":                true,
+	"declaredDeps":                true,
 	"Hashes":                      true,
 	"Sources":                     true,
 	"NamedSources":                true,

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -537,6 +537,7 @@ func (target *BuildTarget) resolveDependencies(graph *BuildGraph, callback func(
 	var g errgroup.Group
 	target.mutex.RLock()
 	for i := range target.dependencies {
+		i := i
 		dep := &target.dependencies[i] // avoid using a loop variable here as it mutates each iteration
 		if len(dep.deps) > 0 {
 			continue // already done

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -109,7 +109,7 @@ type BuildTarget struct {
 	// Maps the original declaration to whatever dependencies actually got attached,
 	// which may be more than one in some cases. Also contains info about exporting etc.
 	declaredDeps []BuildLabel `name:"deps"`
-	dependencies []depInfo
+	dependencies []depInfo    `print:"false"`
 	// List of build target patterns that can use this build target.
 	Visibility []BuildLabel
 	// Source files of this rule. Can refer to build rules themselves.

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -415,7 +415,7 @@ func TestDependencies(t *testing.T) {
 	target1 := makeTarget1("//src/core:target1", "")
 	target2 := makeTarget1("//src/core:target2", "", target1)
 	target3 := makeTarget1("//src/core:target3", "", target1, target2)
-	assert.Equal(t, []BuildLabel{}, target1.DeclaredDependencies())
+	assert.Equal(t, 0, len(target1.DeclaredDependencies()))
 	assert.Equal(t, []*BuildTarget{}, target1.Dependencies())
 	assert.Equal(t, []BuildLabel{target1.Label}, target2.DeclaredDependencies())
 	assert.Equal(t, []*BuildTarget{target1}, target2.Dependencies())
@@ -446,7 +446,7 @@ func TestDeclaredDependenciesStrict(t *testing.T) {
 func TestAddDependency(t *testing.T) {
 	target1 := makeTarget1("//src/core:target1", "")
 	target2 := makeTarget1("//src/core:target2", "")
-	assert.Equal(t, []BuildLabel{}, target2.DeclaredDependencies())
+	assert.Equal(t, 0, len(target2.DeclaredDependencies()))
 	assert.Equal(t, []BuildLabel{}, target2.ExportedDependencies())
 	target2.AddDependency(target1.Label)
 	assert.Equal(t, []BuildLabel{target1.Label}, target2.DeclaredDependencies())


### PR DESCRIPTION
More perf work. `BuildTarget.DeclaredDependencies()` shows up as 2-3% of CPU, which seems too much; this makes it inline to basically nothing.
Before:
```
INFO: Run 1 of 5
INFO: Complete in 27.83s, using 9933692 KB
INFO: Run 2 of 5
INFO: Complete in 24.55s, using 12287520 KB
INFO: Run 3 of 5
INFO: Complete in 23.06s, using 13040620 KB
INFO: Run 4 of 5
INFO: Complete in 23.29s, using 13311044 KB
INFO: Run 5 of 5
INFO: Complete in 23.23s, using 13587596 KB
INFO: Complete, median time: 23.29s, median mem: 13040620.00 KB
```
After:
```
INFO: Run 1 of 5
INFO: Complete in 22.96s, using 13285284 KB
INFO: Run 2 of 5
INFO: Complete in 22.80s, using 14015176 KB
INFO: Run 3 of 5
INFO: Complete in 21.29s, using 11657828 KB
INFO: Run 4 of 5
INFO: Complete in 20.67s, using 12313460 KB
INFO: Run 5 of 5
INFO: Complete in 21.76s, using 14261576 KB
INFO: Complete, median time: 21.76s, median mem: 13285284.00 KB
```