### PR TITLE
Don't install stdlib in go_toolchain

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.6.0",
     "java": "v0.4.0",
-    "go": "v1.17.2",
+    "go": "v1.17.3",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,8 +1,7 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    owner = "peterebden",
-    revision = "980af09adb9cffc6ede217741ad15c24cdde1671",
+    revision = "v1.17.3",
 )
 
 plugin_repo(

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,7 +1,8 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v1.16.9",
+    owner = "peterebden",
+    revision = "980af09adb9cffc6ede217741ad15c24cdde1671",
 )
 
 plugin_repo(

--- a/test/proto_plugin/test_repo/.plzconfig
+++ b/test/proto_plugin/test_repo/.plzconfig
@@ -12,6 +12,7 @@ ProtocTool = ///proto//third_party/proto:protoc
 [Plugin "go"]
 Target = //plugins:go
 ImportPath = github.com/thought-machine/please/test/proto_plugin
+stdlib = //third_party/go:std
 
 [Plugin "go_proto"]
 Target = //plugins:go-proto

--- a/test/proto_plugin/test_repo/third_party/go/BUILD_FILE
+++ b/test/proto_plugin/test_repo/third_party/go/BUILD_FILE
@@ -1,5 +1,9 @@
 subinclude("///go//build_defs:go")
 
+go_stdlib(
+    name = "std",
+)
+
 go_repo(
     name = "go-spew",
     install = ["spew"],

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -11,7 +11,7 @@ go_toolchain(
         "f6c8a87aa03b92c4b0bf3d558e28ea03006eb29db78917daec5cfb6ec1046265",  # linux-amd64
         "6a63fef0e050146f275bf02a0896badfe77c11b6f05499bb647e7bd613a45a10",  # linux-arm64
     ],
-    install_std = True,
+    install_std = False,
     version = "1.22.0",
 )
 


### PR DESCRIPTION
I'm seeing some nondeterminism in the tests where one of the cross-compile tests rebuilds the toolchain while other things are trying to use it. Not really sure how we haven't seen this before tbh, it feels like it must have been this way for a while.