### PR TITLE
Fix list concat overwriting

### DIFF
--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -686,3 +686,17 @@ func TestOperatorPrecedence(t *testing.T) {
 	assert.EqualValues(t, False, s.Lookup("m"))
 	assert.EqualValues(t, True, s.Lookup("n"))
 }
+
+func TestListConcatenation(t *testing.T) {
+	s, err := parseFile("src/parse/asp/test_data/interpreter/list_concat.build")
+	assert.NoError(t, err)
+	assert.EqualValues(t, pyList{
+		pyString("apple"),
+		pyString("banana"),
+		pyString("edamame"),
+		pyString("fennel"),
+		pyString("tuna"),
+		pyString("baked beans"),
+		pyString("haribo"),
+	}, s.Lookup("fruit_veg_canned_food_and_sweets"))
+}

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -3,6 +3,7 @@ package asp
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -363,7 +364,7 @@ func (l pyList) Operator(operator Operator, operand pyObject) pyObject {
 			}
 			panic("Cannot add list and " + operand.Type())
 		}
-		return append(l, l2...)
+		return slices.Clip(append(l, l2...))
 	case In, NotIn:
 		for _, item := range l {
 			if item == operand {
@@ -429,7 +430,7 @@ func (l pyList) Freeze() pyObject {
 
 // Repeat returns a copy of this list, repeated n times
 func (l pyList) Repeat(n pyInt) pyList {
-	var ret pyList
+	ret := make(pyList, 0, int(n)*len(l))
 	for i := 0; i < int(n); i++ {
 		ret = append(ret, l...)
 	}

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -360,7 +360,7 @@ func (l pyList) Operator(operator Operator, operand pyObject) pyObject {
 		l2, ok := operand.(pyList)
 		if !ok {
 			if l2, ok := operand.(pyFrozenList); ok {
-				return append(l, l2.pyList...)
+				return slices.Clip(append(l, l2.pyList...))
 			}
 			panic("Cannot add list and " + operand.Type())
 		}

--- a/src/parse/asp/test_data/interpreter/list_concat.build
+++ b/src/parse/asp/test_data/interpreter/list_concat.build
@@ -1,0 +1,22 @@
+fruit = [
+    "apple",
+    "banana",
+]
+
+fruit_and_veg = fruit + [
+    "edamame",
+    "fennel",
+]
+
+fruit_veg_and_canned_food = fruit_and_veg + [
+    "tuna",
+    "baked beans",
+]
+
+fruit_veg_canned_food_and_sweets = fruit_veg_and_canned_food + [
+    "haribo",
+]
+
+fruit_veg_canned_food_and_drinks = fruit_veg_and_canned_food + [
+    "matcha latte",
+]


### PR DESCRIPTION
Fixes #3166 

Looks like this is due to the slices overwriting since on append they both think they have extra capacity, but are in fact sharing it. A pure Go example: https://go.dev/play/p/pLl6MlMr3V4

This fixes this particular case; I don't think there are others at present, we seem to construct lists with capacity equal to their final size in other instances.