### PR TITLE
Added dependency check after post_build step.

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -78,7 +78,6 @@ func Build(state *core.BuildState, target *core.BuildTarget, remote bool) {
 	} else {
 		successfulLocalTargetBuildDuration.Observe(float64(time.Since(start).Milliseconds()))
 	}
-
 	// Mark the target as having finished building.
 	target.FinishBuild()
 	if target.IsTest() && state.NeedTests && state.IsOriginalTarget(target) {

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -677,6 +677,15 @@ func (target *BuildTarget) ExportedDependencies() []BuildLabel {
 	defer target.mutex.RUnlock()
 	ret := make(BuildLabels, 0, len(target.dependencies))
 	for _, info := range target.dependencies {
+
+		logString := ""
+		for i, dep := range info.deps {
+			logString += dep.Label.Name
+			if i+1 < len(info.deps) {
+				logString += ", "
+			}
+		}
+		log.Info("Exported deps call for target %s: %s , exported: %t", target.Label, logString, info.exported)
 		if info.exported {
 			ret = append(ret, *info.declared)
 		}
@@ -1651,6 +1660,15 @@ func (target *BuildTarget) AddMaybeExportedDependency(dep BuildLabel, exported, 
 		info.internal = info.internal && internal
 		info.data = false // It's not *only* data any more.
 	}
+}
+
+// RegisterDependencyTarget registers a build target to be used for a dependency label on the given target.
+func (target *BuildTarget) RegisterDependencyTarget(dep BuildLabel, deptarget *BuildTarget) {
+	info := target.dependencyInfo(dep)
+	if info == nil {
+		log.Fatalf("Target %s doesn't contain dependency %s.\n", target.Label, dep)
+	}
+	info.deps = append(info.deps, deptarget)
 }
 
 // IsTool returns true if the given build label is a tool used by this target.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -677,14 +677,6 @@ func (target *BuildTarget) ExportedDependencies() []BuildLabel {
 	defer target.mutex.RUnlock()
 	ret := make(BuildLabels, 0, len(target.dependencies))
 	for _, info := range target.dependencies {
-		logString := ""
-		for i, dep := range info.deps {
-			logString += dep.Label.Name
-			if i+1 < len(info.deps) {
-				logString += ", "
-			}
-		}
-		log.Info("Exported deps call for target %s: %s , exported: %t", target.Label, logString, info.exported)
 		if info.exported {
 			ret = append(ret, *info.declared)
 		}

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1666,8 +1666,9 @@ func (target *BuildTarget) RegisterDependencyTarget(dep BuildLabel, deptarget *B
 	info := target.dependencyInfo(dep)
 	if info == nil {
 		log.Fatalf("Target %s doesn't contain dependency %s.\n", target.Label, dep)
+	} else {
+		info.deps = append(info.deps, deptarget)
 	}
-	info.deps = append(info.deps, deptarget)
 }
 
 // IsTool returns true if the given build label is a tool used by this target.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -677,7 +677,6 @@ func (target *BuildTarget) ExportedDependencies() []BuildLabel {
 	defer target.mutex.RUnlock()
 	ret := make(BuildLabels, 0, len(target.dependencies))
 	for _, info := range target.dependencies {
-
 		logString := ""
 		for i, dep := range info.deps {
 			logString += dep.Label.Name

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1125,6 +1125,7 @@ func addDep(s *scope, args []pyObject) pyObject {
 	dep := s.parseLabelInPackage(string(args[1].(pyString)), s.pkg)
 	exported := args[2].IsTruthy()
 	target.AddMaybeExportedDependency(dep, exported, false, false)
+	target.RegisterDependencyTarget(dep, s.state.Graph.Target(dep))
 	// Queue this dependency if it'll be needed.
 	if target.State() > core.Inactive {
 		err := s.state.QueueTarget(dep, target.Label, false, core.ParseModeNormal)


### PR DESCRIPTION
Fixes the race condition for dependencies created within post_build steps #3168.

The issue is that a target will mark itself complete, even though the post_build step could have added additional dependencies to it. This meant that any dependents would start running, without waiting for the post_build dependencies to complete, resulting in a race.

The added code will now re-check all the dependencies of a target, after its post_build step has completed. This way, additional dependencies will properly get waited on, avoiding the race.

I would like to note, however, that the addition is essentially a copy of some code in [queueTargetAsync](https://github.com/thought-machine/please/blob/03ae086cd5c75bb1f42f7e823b9d61b81809a163/src/core/state.go#L1176), where the initial dependency checks occur. In this case, this is somewhat duplicating the dependency checks and also re-checking already resolved dependencies, even if a post_build step doesn't change the dependencies.