### PR TITLE
Report worker name from partial execution metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/ProtonMail/go-crypto v0.0.0-20210920135941-2c5829bbf927
 	github.com/alessio/shellescape v1.4.2
-	github.com/bazelbuild/remote-apis v0.0.0-20210718193713-0ecef08215cf
+	github.com/bazelbuild/remote-apis v0.0.0-20240409135018-1f36c310b28d
 	github.com/bazelbuild/remote-apis-sdks v0.0.0-20221114180157-e62cf9b8696a
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/coreos/go-semver v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4u
 github.com/alessio/shellescape v1.4.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/bazelbuild/remote-apis v0.0.0-20210718193713-0ecef08215cf h1:DjbO/OLNTvELsPJRy5qU/aIsozQxBQVek+vTO49ybus=
 github.com/bazelbuild/remote-apis v0.0.0-20210718193713-0ecef08215cf/go.mod h1:ry8Y6CkQqCVcYsjPOlLXDX2iRVjOnjogdNwhvHmRcz8=
+github.com/bazelbuild/remote-apis v0.0.0-20240409135018-1f36c310b28d h1:0aFLY/13huh7hMwsxXXf2etOuS4GrdTk37aJEXYEsic=
+github.com/bazelbuild/remote-apis v0.0.0-20240409135018-1f36c310b28d/go.mod h1:ry8Y6CkQqCVcYsjPOlLXDX2iRVjOnjogdNwhvHmRcz8=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20221114180157-e62cf9b8696a h1:zIP0R2m8O2VgQlDlMYM0jGmJ+BPx4FQ6+ETRERaLMkM=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20221114180157-e62cf9b8696a/go.mod h1:p6PH8Kyjfm/hhbwC8ymX8SarB7CQTUiW6J0T/zbEKj8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -430,10 +430,10 @@ func outputsForActionResult(ar *pb.ActionResult) map[string]bool {
 	}
 
 	// TODO(jpoole): remove these two after REAPI 2.1
-	for _, o := range ar.OutputFileSymlinks {
+	for _, o := range ar.OutputFileSymlinks { //nolint:staticcheck
 		ret[o.Path] = true
 	}
-	for _, o := range ar.OutputDirectorySymlinks {
+	for _, o := range ar.OutputDirectorySymlinks { //nolint:staticcheck
 		ret[o.Path] = true
 	}
 	return ret

--- a/src/remote/remote_test.go
+++ b/src/remote/remote_test.go
@@ -327,7 +327,7 @@ func TestTargetPlatform(t *testing.T) {
 				Value: "linux",
 			},
 		},
-	}, cmd.Platform)
+	}, cmd.Platform) //nolint:staticcheck
 
 	target.Labels = []string{"remote-platform-property:size=chomky"}
 	cmd, err = c.buildCommand(target, &pb.Directory{}, false, false, false, 0)
@@ -343,7 +343,7 @@ func TestTargetPlatform(t *testing.T) {
 				Value: "linux",
 			},
 		},
-	}, cmd.Platform)
+	}, cmd.Platform) //nolint:staticcheck
 }
 
 // Store is a small hack that stores a target's outputs for testing only.

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -138,7 +138,7 @@ func (c *Client) outputTree(target *core.BuildTarget, ar *pb.ActionResult) (*pb.
 		Root: &pb.Directory{
 			Files:       make([]*pb.FileNode, len(ar.OutputFiles)),
 			Directories: make([]*pb.DirectoryNode, 0, len(ar.OutputDirectories)),
-			Symlinks:    make([]*pb.SymlinkNode, len(ar.OutputFileSymlinks)+len(ar.OutputDirectorySymlinks)),
+			Symlinks:    make([]*pb.SymlinkNode, len(ar.OutputFileSymlinks)+len(ar.OutputDirectorySymlinks)), //nolint:staticcheck
 		},
 	}
 	// N.B. At this point the various things we stick into this Directory proto can be in
@@ -165,7 +165,7 @@ func (c *Client) outputTree(target *core.BuildTarget, ar *pb.ActionResult) (*pb.
 			Digest: c.digestMessage(tree.Root),
 		})
 	}
-	for i, s := range append(ar.OutputFileSymlinks, ar.OutputDirectorySymlinks...) {
+	for i, s := range append(ar.OutputFileSymlinks, ar.OutputDirectorySymlinks...) { //nolint:staticcheck
 		o.Root.Symlinks[i] = &pb.SymlinkNode{
 			Name:   target.GetRealOutput(s.Path),
 			Target: s.Target,
@@ -627,7 +627,7 @@ func (c *Client) dialOpts() ([]grpc.DialOption, error) {
 // The special-casing is important to make remote_file hash properly (also so you can
 // calculate it manually by sha256sum'ing the file).
 func (c *Client) outputHash(ar *pb.ActionResult) string {
-	if len(ar.OutputFiles) == 1 && len(ar.OutputDirectories) == 0 && len(ar.OutputFileSymlinks) == 0 && len(ar.OutputDirectorySymlinks) == 0 {
+	if len(ar.OutputFiles) == 1 && len(ar.OutputDirectories) == 0 && len(ar.OutputFileSymlinks) == 0 && len(ar.OutputDirectorySymlinks) == 0 { //nolint:staticcheck
 		return ar.OutputFiles[0].Digest.Hash
 	}
 	return c.digestMessage(ar).Hash

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -504,7 +504,7 @@ go_repo(
 
 go_repo(
     module = "github.com/bazelbuild/remote-apis",
-    version = "v0.0.0-20210718193713-0ecef08215cf",
+    version = "v0.0.0-20240409135018-1f36c310b28d",
 )
 
 go_repo(


### PR DESCRIPTION
Newer revisions of REAPI allow the server to report its metadata with updates. This grabs the worker field & reports it if populated.

I'm not sure if it might turn out to be a bit too noisy - I think it's probably interesting & potentially a useful debugging tool but it might be a little much CLI output.