### PR TITLE
Revert "log aquiring target lock (#3177)"

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -346,6 +346,7 @@ func (c *Client) Build(target *core.BuildTarget) (*core.BuildMetadata, error) {
 	c.setOutputsFromMetadata(target, metadata)
 
 	if c.state.ShouldDownload(target) {
+		c.state.LogBuildResult(target, core.TargetBuilding, "Downloading")
 		if err := c.Download(target); err != nil {
 			return metadata, err
 		}
@@ -359,7 +360,6 @@ func (c *Client) Build(target *core.BuildTarget) (*core.BuildMetadata, error) {
 
 // downloadData downloads all the runtime data for a target, recursively.
 func (c *Client) downloadData(target *core.BuildTarget) error {
-	c.state.LogBuildResult(target, core.TargetBuilding, "Downloading...")
 	var g errgroup.Group
 	for _, datum := range target.AllData() {
 		if l, ok := datum.Label(); ok {
@@ -433,7 +433,6 @@ func (c *Client) Download(target *core.BuildTarget) error {
 	if target.Local {
 		return nil // No download needed since this target was built locally
 	}
-	c.state.LogBuildResult(target, core.TargetBuilding, "Acquiring target lock...")
 	return c.download(target, func() error {
 		buildAction := c.unstampedBuildActionDigests.Get(target.Label)
 		file := core.AcquireExclusiveFileLock(target.BuildLockFile())
@@ -461,7 +460,6 @@ func (c *Client) Download(target *core.BuildTarget) error {
 		if ar == nil {
 			return fmt.Errorf("Failed to retrieve action result for %s", target)
 		}
-		c.state.LogBuildResult(target, core.TargetBuilding, "Downloading...")
 		return c.reallyDownload(target, buildAction, ar)
 	})
 }


### PR DESCRIPTION
This reverts commit 5b52e7bbfb7e750c3278f570354f90f500bfe389.

I see the motivation, but it results in some odd output where targets hang around in the output showing `Acquiring target lock...` indefinitely. This happens when it downloads after the action has completed building (notably for subincludes from `WaitForTargetAndEnsureDownload`), and nothing after that message ever logs a 'completed' status again for it.

I've fiddled a little to try to make it more selective but that doesn't seem to really do anything. 
Logging a completed status after we download breaks it (there is an assumption that targets only complete once, so doing it again leads to a rapid death due to `close of closed channel`).
I thought about trying to make the download happen before the action completes building, but there are subtle race conditions there (it might build once without needing download, then later we decide that we do need to download it).

Basically I'm not sure how to fix this right now. Maybe the logged build result shouldn't also do the status check, or it should be safe to do multiple times. Either seems likely to be a bigger piece of work though.