### PR TITLE
Add config value to make optional outputs required for remote execution

### DIFF
--- a/docs/config.html
+++ b/docs/config.html
@@ -1016,6 +1016,12 @@
     </li>
     <li>
       <div>
+        <h3 class="mt1 f6 lh-title" id="remote.optionaloutputsrequired">OptionalOutputsRequired <span class="normal">(bool)</span></h3>
+        <p>{{ index .ConfigHelpText "remote.optionaloutputsrequired" }}</p>
+      </div>
+    </li>
+    <li>
+      <div>
         <h3 class="mt1 f6 lh-title" id="remote.shell">Shell </h3>
         <p>{{ index .ConfigHelpText "remote.shell" }}</p>
       </div>

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -558,23 +558,23 @@ type Configuration struct {
 		ExcludeableTargets []BuildLabel `help:"If set, only targets that match these wildcards will be allowed to opt out of the sandbox"`
 	} `help:"A config section describing settings relating to sandboxing of build actions."`
 	Remote struct {
-		URL           string       `help:"URL for the remote server."`
-		CASURL        string       `help:"URL for the CAS service, if it is different to the main one."`
-		AssetURL      string       `help:"URL for the remote asset server, if it is different to the main one."`
-		NumExecutors  int          `help:"Maximum number of remote executors to use simultaneously."`
-		Instance      string       `help:"Remote instance name to request; depending on the server this may be required."`
-		Name          string       `help:"A name for this worker instance. This is attached to artifacts uploaded to remote storage." example:"agent-001"`
-		DisplayURL    string       `help:"A URL to browse the remote server with (e.g. using buildbarn-browser). Only used when printing hashes."`
-		TokenFile     string       `help:"A file containing a token that is attached to outgoing RPCs to authenticate them. This is somewhat bespoke; we are still investigating further options for authentication."`
-		Timeout       cli.Duration `help:"Timeout for connections made to the remote server."`
-		Secure        bool         `help:"Whether to use TLS for communication or not."`
-		VerifyOutputs bool         `help:"Whether to verify all outputs are present after a cached remote execution action. Depending on your server implementation, you may require this to ensure files are really present."`
-		UploadDirs    bool         `help:"Uploads individual directory blobs after build actions. This might not be necessary with some servers, but if you aren't sure, you should leave it on."`
-		OptionalOutputsRequired bool `help:"Requires that any optional outputs of build actions (optional test outputs, coverage when not opted out of) are produced. By default this is a non-fatal failure, but the actions may not cache remotely."`
-		Shell         string       `help:"Path to the shell to use to execute actions in. Default is 'bash' which will be looked up by the server."`
-		Platform      []string     `help:"Platform properties to request from remote workers, in the format key=value."`
-		CacheDuration cli.Duration `help:"Length of time before we re-check locally cached build actions. Default is unlimited."`
-		BuildID       string       `help:"ID of the build action that's being run, to attach to remote requests. If not set then one is automatically generated."`
+		URL                     string       `help:"URL for the remote server."`
+		CASURL                  string       `help:"URL for the CAS service, if it is different to the main one."`
+		AssetURL                string       `help:"URL for the remote asset server, if it is different to the main one."`
+		NumExecutors            int          `help:"Maximum number of remote executors to use simultaneously."`
+		Instance                string       `help:"Remote instance name to request; depending on the server this may be required."`
+		Name                    string       `help:"A name for this worker instance. This is attached to artifacts uploaded to remote storage." example:"agent-001"`
+		DisplayURL              string       `help:"A URL to browse the remote server with (e.g. using buildbarn-browser). Only used when printing hashes."`
+		TokenFile               string       `help:"A file containing a token that is attached to outgoing RPCs to authenticate them. This is somewhat bespoke; we are still investigating further options for authentication."`
+		Timeout                 cli.Duration `help:"Timeout for connections made to the remote server."`
+		Secure                  bool         `help:"Whether to use TLS for communication or not."`
+		VerifyOutputs           bool         `help:"Whether to verify all outputs are present after a cached remote execution action. Depending on your server implementation, you may require this to ensure files are really present."`
+		UploadDirs              bool         `help:"Uploads individual directory blobs after build actions. This might not be necessary with some servers, but if you aren't sure, you should leave it on."`
+		OptionalOutputsRequired bool         `help:"Requires that any optional outputs of build actions (optional test outputs, coverage when not opted out of) are produced. By default this is a non-fatal failure, but the actions may not cache remotely."`
+		Shell                   string       `help:"Path to the shell to use to execute actions in. Default is 'bash' which will be looked up by the server."`
+		Platform                []string     `help:"Platform properties to request from remote workers, in the format key=value."`
+		CacheDuration           cli.Duration `help:"Length of time before we re-check locally cached build actions. Default is unlimited."`
+		BuildID                 string       `help:"ID of the build action that's being run, to attach to remote requests. If not set then one is automatically generated."`
 	} `help:"Settings related to remote execution & caching using the Google remote execution APIs. This section is still experimental and subject to change."`
 	Size  map[string]*Size `help:"Named sizes of targets; these are the definitions of what can be passed to the 'size' argument."`
 	Cover struct {

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -570,6 +570,7 @@ type Configuration struct {
 		Secure        bool         `help:"Whether to use TLS for communication or not."`
 		VerifyOutputs bool         `help:"Whether to verify all outputs are present after a cached remote execution action. Depending on your server implementation, you may require this to ensure files are really present."`
 		UploadDirs    bool         `help:"Uploads individual directory blobs after build actions. This might not be necessary with some servers, but if you aren't sure, you should leave it on."`
+		OptionalOutputsRequired bool `help:"Requires that any optional outputs of build actions (optional test outputs, coverage when not opted out of) are produced. By default this is a non-fatal failure, but the actions may not cache remotely."`
 		Shell         string       `help:"Path to the shell to use to execute actions in. Default is 'bash' which will be looked up by the server."`
 		Platform      []string     `help:"Platform properties to request from remote workers, in the format key=value."`
 		CacheDuration cli.Duration `help:"Length of time before we re-check locally cached build actions. Default is unlimited."`

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -450,8 +450,8 @@ func (c *Client) verifyActionResult(target *core.BuildTarget, command *pb.Comman
 			return fmt.Errorf("Remote build action for %s failed to produce output %s%s", target, core.TestResultsFile, c.actionURL(actionDigest, true))
 		}
 		if c.state.Config.Remote.OptionalOutputsRequired {
-			if !target.Test.NoCoverage && !outs[core.TestCoverageFile] {
-				return fmt.Errorf("Remote build action for %s failed to produce output %s%s", target, core.TestCoverageFile, c.actionURL(actionDigest, true))
+			if !target.Test.NoCoverage && !outs[core.CoverageFile] {
+				return fmt.Errorf("Remote build action for %s failed to produce output %s%s", target, core.CoverageFile, c.actionURL(actionDigest, true))
 			}
 			for _, out := range target.Test.Outputs {
 				if !outs[out] {

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -446,8 +446,18 @@ func (c *Client) verifyActionResult(target *core.BuildTarget, command *pb.Comman
 	outs := outputsForActionResult(ar)
 	// Test outputs are optional
 	if isTest {
-		if !outs[core.TestResultsFile] && !target.Test.NoOutput {
+		if !target.Test.NoOutput && !outs[core.TestResultsFile] {
 			return fmt.Errorf("Remote build action for %s failed to produce output %s%s", target, core.TestResultsFile, c.actionURL(actionDigest, true))
+		}
+		if c.state.Config.Remote.OptionalOutputsRequired {
+			if !target.Test.NoCoverage && !outs[core.TestCoverageFile] {
+				return fmt.Errorf("Remote build action for %s failed to produce output %s%s", target, core.TestCoverageFile, c.actionURL(actionDigest, true))
+			}
+			for _, out := range target.Test.Outputs {
+				if !outs[out] {
+					return fmt.Errorf("Remote build action for %s failed to produce output %s%s", target, out, c.actionURL(actionDigest, true))
+				}
+			}
 		}
 	} else {
 		for _, out := range command.OutputPaths {

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -450,7 +450,7 @@ func (c *Client) verifyActionResult(target *core.BuildTarget, command *pb.Comman
 			return fmt.Errorf("Remote build action for %s failed to produce output %s%s", target, core.TestResultsFile, c.actionURL(actionDigest, true))
 		}
 		if c.state.Config.Remote.OptionalOutputsRequired {
-			if !target.Test.NoCoverage && !outs[core.CoverageFile] {
+			if target.NeedCoverage(c.state) && !outs[core.CoverageFile] {
 				return fmt.Errorf("Remote build action for %s failed to produce output %s%s", target, core.CoverageFile, c.actionURL(actionDigest, true))
 			}
 			for _, out := range target.Test.Outputs {


### PR DESCRIPTION
Over the past day or two, I've found a bunch of tests in our repo that don't cache properly because they don't produce all their outputs. This is really due to a mismatch between Please's semantics (that some test outputs are optional) and what REAPI is able to express. I'm fixing them as I can (#3188 is part of this) but it seems untenable in the long run since people can just break these again, and nothing tells them that anything is wrong.

This adds a config flag for remote execution to require optional test outputs to be present. I'll have to fix everything to be able to apply it, but once it's in, I'll at least know nobody will break it again the next time JS frameworks change.