### PR TITLE
Query changes blocks at subrepos

### DIFF
--- a/src/query/BUILD
+++ b/src/query/BUILD
@@ -25,6 +25,7 @@ go_test(
         ":query",
         "///third_party/go/github.com_stretchr_testify//assert",
         "///third_party/go/github.com_stretchr_testify//require",
+        "//src/cli",
         "//src/core",
         "//src/parse",
     ],

--- a/src/query/changes.go
+++ b/src/query/changes.go
@@ -68,7 +68,7 @@ func changedTargets(state *core.BuildState, files []string, changed map[*core.Bu
 	}
 
 	if level != 0 {
-		revdeps := FindRevdeps(state, labels, true, false, level)
+		revdeps := FindRevdeps(state, labels, true, false, includeSubrepos, level)
 		for dep := range revdeps {
 			if _, present := changed[dep]; !present {
 				labels = append(labels, dep.Label)

--- a/src/query/changes_test.go
+++ b/src/query/changes_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/cli"
 )
 
 func TestDiffGraphs(t *testing.T) {
@@ -77,6 +78,25 @@ func TestDiffGraphsIncludeTransitive(t *testing.T) {
 	assert.EqualValues(t, core.BuildLabels{t1.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, nil, -1, false))
 }
 
+func TestDiffGraphsVsSubrepos(t *testing.T) {
+	s1 := core.NewDefaultBuildState()
+	s2 := core.NewDefaultBuildState()
+	t1 := addTarget(s1, "//:modfile", nil, "go.mod")
+	t2 := addTarget(s1, "//third_party/go:mod", t1)
+	t3 := addTarget(s1, "///third_party/go/mod//:mod", nil)
+	t3.Subrepo = core.NewSubrepo(s1, "go_mod", "third_party/go", t2, cli.Arch{}, false)
+	addTarget(s1, "//src/core:core", t3)
+
+	t1 = addTarget(s2, "//:modfile", nil, "go.mod")
+	t2 = addTarget(s2, "//third_party/go:mod", t1)
+	t3 = addTarget(s2, "///third_party/go/mod//:mod", nil)
+	t3.Subrepo = core.NewSubrepo(s2, "go_mod", "third_party/go", t2, cli.Arch{}, false)
+	addTarget(s2, "//src/core:core", t3)
+
+	// t3 should not be changed here - its subrepo has but we should see that the targets generated in it are still identical
+	assert.EqualValues(t, []core.BuildLabel{t1.Label, t2.Label}, DiffGraphs(s1, s2, []string{"go.mod"}, -1, false))
+}
+
 func TestChangesIncludesDataDirs(t *testing.T) {
 	s := core.NewDefaultBuildState()
 	t1 := addTarget(s, "//src/core:core", nil, "src/core/core.go")
@@ -119,7 +139,7 @@ func addTarget(state *core.BuildState, label string, dep *core.BuildTarget, sour
 	}
 	pkg := state.Graph.PackageByLabel(t.Label)
 	if pkg == nil {
-		pkg = core.NewPackage(t.Label.PackageName)
+		pkg = core.NewPackageSubrepo(t.Label.PackageName, t.Label.Subrepo)
 		state.Graph.AddPackage(pkg)
 	}
 	pkg.AddTarget(t)

--- a/src/query/changes_test.go
+++ b/src/query/changes_test.go
@@ -114,6 +114,8 @@ func TestDiffGraphsStillChecksTargetsInSubrepos(t *testing.T) {
 
 	// t3 should now count as changed - it has a different source file - and that should propagate to t4
 	assert.EqualValues(t, []core.BuildLabel{t1.Label, t4.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, []string{"go.mod"}, -1, true))
+	// If includeSubrepos=false, t4 should still count as changed, although we won't see t3.
+	assert.EqualValues(t, []core.BuildLabel{t1.Label, t4.Label, t2.Label}, DiffGraphs(s1, s2, []string{"go.mod"}, -1, false))
 }
 
 func TestChangesIncludesDataDirs(t *testing.T) {

--- a/src/query/changes_test.go
+++ b/src/query/changes_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/core"
 )
 
 func TestDiffGraphs(t *testing.T) {
@@ -80,13 +80,13 @@ func TestDiffGraphsIncludeTransitive(t *testing.T) {
 
 func TestDiffGraphsStopsAtSubrepos(t *testing.T) {
 	s1 := core.NewDefaultBuildState()
-	s2 := core.NewDefaultBuildState()
 	t1 := addTarget(s1, "//:modfile", nil, "go.mod")
 	t2 := addTarget(s1, "//third_party/go:mod", t1)
 	t3 := addTarget(s1, "///third_party/go/mod//:mod", nil)
 	t3.Subrepo = core.NewSubrepo(s1, "go_mod", "third_party/go", t2, cli.Arch{}, false)
 	addTarget(s1, "//src/core:core", t3)
 
+	s2 := core.NewDefaultBuildState()
 	t1 = addTarget(s2, "//:modfile", nil, "go.mod")
 	t2 = addTarget(s2, "//third_party/go:mod", t1)
 	t3 = addTarget(s2, "///third_party/go/mod//:mod", nil)
@@ -99,18 +99,18 @@ func TestDiffGraphsStopsAtSubrepos(t *testing.T) {
 
 func TestDiffGraphsStillChecksTargetsInSubrepos(t *testing.T) {
 	s1 := core.NewDefaultBuildState()
-	s2 := core.NewDefaultBuildState()
 	t1 := addTarget(s1, "//:modfile", nil, "go.mod")
 	t2 := addTarget(s1, "//third_party/go:mod", t1)
 	t3 := addTarget(s1, "///third_party/go/mod//:mod", nil)
 	t3.Subrepo = core.NewSubrepo(s1, "go_mod", "third_party/go", t2, cli.Arch{}, false)
-	t4 := addTarget(s1, "//src/core:core", t3)
+	addTarget(s1, "//src/core:core", t3)
 
+	s2 := core.NewDefaultBuildState()
 	t1 = addTarget(s2, "//:modfile", nil, "go.mod")
 	t2 = addTarget(s2, "//third_party/go:mod", t1)
 	t3 = addTarget(s2, "///third_party/go/mod//:mod", nil, "test.go")
 	t3.Subrepo = core.NewSubrepo(s2, "go_mod", "third_party/go", t2, cli.Arch{}, false)
-	t4 = addTarget(s2, "//src/core:core", t3)
+	t4 := addTarget(s2, "//src/core:core", t3)
 
 	// t3 should now count as changed - it has a different source file - and that should propagate to t4
 	assert.EqualValues(t, []core.BuildLabel{t1.Label, t4.Label, t2.Label, t3.Label}, DiffGraphs(s1, s2, []string{"go.mod"}, -1, true))

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -120,6 +120,9 @@ func buildRevdeps(graph *core.BuildGraph, includeSubrepos bool) map[core.BuildLa
 				}
 			}
 		}
+		// Targets in a subrepo don't express an explicit dependency on their subrepo's target.
+		// However this is often useful for query commands where you expect to see this kind of
+		// relationship. Hence, if requested, we add the extra 'dependency' here.
 		if includeSubrepos && t.Subrepo != nil && t.Subrepo.Target != nil {
 			revdeps[t.Subrepo.Target.Label] = append(revdeps[t.Subrepo.Target.Label], t)
 		}

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -10,7 +10,7 @@ import (
 
 // ReverseDeps finds all transitive targets that depend on the set of input labels.
 func ReverseDeps(state *core.BuildState, labels []core.BuildLabel, level int, hidden bool) {
-	targets := FindRevdeps(state, labels, hidden, true, level)
+	targets := FindRevdeps(state, labels, hidden, true, true, level)
 	ls := make(core.BuildLabels, 0, len(targets))
 
 	for target := range targets {
@@ -81,7 +81,7 @@ type revdeps struct {
 }
 
 // newRevdeps creates a new reverse dependency searcher. revdeps is non-reusable.
-func newRevdeps(graph *core.BuildGraph, hidden, followSubincludes bool, maxDepth int) *revdeps {
+func newRevdeps(graph *core.BuildGraph, hidden, followSubincludes, includeSubrepos bool, maxDepth int) *revdeps {
 	// Initialise a map of labels to the packages that subinclude them upfront so we can include those targets as
 	// dependencies efficiently later
 	subincludes := make(map[core.BuildLabel][]*core.Package)
@@ -94,7 +94,7 @@ func newRevdeps(graph *core.BuildGraph, hidden, followSubincludes bool, maxDepth
 	}
 
 	return &revdeps{
-		revdeps:           buildRevdeps(graph),
+		revdeps:           buildRevdeps(graph, includeSubrepos),
 		subincludes:       subincludes,
 		followSubincludes: followSubincludes,
 		os: &openSet{
@@ -107,7 +107,7 @@ func newRevdeps(graph *core.BuildGraph, hidden, followSubincludes bool, maxDepth
 }
 
 // buildRevdeps builds the reverse dependency map from a build graph.
-func buildRevdeps(graph *core.BuildGraph) map[core.BuildLabel][]*core.BuildTarget {
+func buildRevdeps(graph *core.BuildGraph, includeSubrepos bool) map[core.BuildLabel][]*core.BuildTarget {
 	targets := graph.AllTargets()
 	revdeps := make(map[core.BuildLabel][]*core.BuildTarget, len(targets))
 	for _, t := range targets {
@@ -120,7 +120,7 @@ func buildRevdeps(graph *core.BuildGraph) map[core.BuildLabel][]*core.BuildTarge
 				}
 			}
 		}
-		if t.Subrepo != nil && t.Subrepo.Target != nil {
+		if includeSubrepos && t.Subrepo != nil && t.Subrepo.Target != nil {
 			revdeps[t.Subrepo.Target.Label] = append(revdeps[t.Subrepo.Target.Label], t)
 		}
 	}
@@ -128,8 +128,8 @@ func buildRevdeps(graph *core.BuildGraph) map[core.BuildLabel][]*core.BuildTarge
 }
 
 // FindRevdeps will return a set of build targets that are reverse dependencies of the provided labels.
-func FindRevdeps(state *core.BuildState, targets core.BuildLabels, hidden, followSubincludes bool, depth int) map[*core.BuildTarget]struct{} {
-	r := newRevdeps(state.Graph, hidden, followSubincludes, depth)
+func FindRevdeps(state *core.BuildState, targets core.BuildLabels, hidden, followSubincludes, includeSubrepos bool, depth int) map[*core.BuildTarget]struct{} {
+	r := newRevdeps(state.Graph, hidden, followSubincludes, includeSubrepos, depth)
 	// Initialise the open set with the original targets
 	for _, label := range targets {
 		target := state.Graph.TargetOrDie(label)

--- a/src/query/reverse_deps_test.go
+++ b/src/query/reverse_deps_test.go
@@ -67,7 +67,7 @@ func TestReverseDepsWithHidden(t *testing.T) {
 }
 
 func revDepsLabels(state *core.BuildState, labels []core.BuildLabel, hidden bool, depth int) core.BuildLabels {
-	ts := FindRevdeps(state, labels, hidden, true, depth)
+	ts := FindRevdeps(state, labels, hidden, true, true, depth)
 
 	ret := make([]core.BuildLabel, 0, len(ts))
 	for t := range ts {


### PR DESCRIPTION
This implements the discussions we've had over the past couple of days.

Taking our usual go_repo setup as an example, if we modify `go.mod`, we expect to see `plz query changes` show `//:modfile` and lots of `//third_party/go:` things as changed, but _not_ the whole rest of the repo, because we can interrogate the actual targets in the subrepos to find out if they've changed or not.

This tweaks the logic a bit so it 'stops' searching at subrepos, and will only start again if the targets in them have themselves changed. This should avoid the go.mod file being a critical change that hits the entire rest of the repo.