### PR TITLE
no_test_output implies no_test_coverage

### DIFF
--- a/rules/misc_rules.build_defs
+++ b/rules/misc_rules.build_defs
@@ -183,7 +183,7 @@ def gentest(name:str, test_cmd:str|list|dict, labels:list&features&tags=None, cm
                              be made available.
       flaky (bool | int): If true the test will be marked as flaky and automatically retried.
       no_test_output (bool): If true the test is not expected to write any output results, it will
-                             pass if the command exits with 0 and fail otherwise.
+                             pass if the command exits with 0 and fail otherwise. Implies no_test_coverage as well.
       no_test_coverage (bool): If true, the test is not expected to produce any coverage output under
                                `plz cover`. By default this is false, but coverage is optional, so
                                Please will not fail if no coverage file is output; this is mostly relevant

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -166,7 +166,7 @@ func createTarget(s *scope, args []pyObject) *core.BuildTarget {
 		target.Test.Timeout = sizeAndTimeout(s, size, args[testTimeoutBuildRuleArgIdx], s.state.Config.Test.Timeout)
 		target.Test.Sandbox = isTruthy(testSandboxBuildRuleArgIdx)
 		target.Test.NoOutput = isTruthy(noTestOutputBuildRuleArgIdx)
-		target.Test.NoCoverage = isTruthy(noTestCoverageArgIdx)
+		target.Test.NoCoverage = target.Test.NoOutput || isTruthy(noTestCoverageArgIdx)
 	}
 
 	if err := validateSandbox(s.state, target); err != nil {


### PR DESCRIPTION
_Theoretically_ these aren't the same thing, but it seems incredibly unlikely that any test with `no_test_output` is actually going to generate coverage - these are nearly always "run a shell script" or similar.
Should be a bit simpler not to have to specify both in many places.