### PR TITLE
Add id attributes to all h1 and h2 tags in docs site

### DIFF
--- a/docs/acknowledgements.html
+++ b/docs/acknowledgements.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Acknowledgements</h1>
+<h1 id="acknowledgements" class="title-1">Acknowledgements</h1>
 
 <p>The core contributors of the team so far are:</p>
 

--- a/docs/basics.html
+++ b/docs/basics.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Please basics</h1>
+<h1 id="please-basics" class="title-1">Please basics</h1>
 
 <p>
   If you're familiar with Blaze / Bazel, Buck or Pants you will probably find
@@ -6,7 +6,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">BUILD files</h2>
+  <h2 id="build-files" class="title-2">BUILD files</h2>
 
   <p>
     Please targets are defined in files named BUILD. These are analogous to
@@ -23,7 +23,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Build targets</h2>
+  <h2 class="title-2" id="build-targets">Build targets</h2>
 
   <p>
     Each BUILD file can contain a number of <em>build targets</em>. These targets are the tasks that the build system
@@ -272,9 +272,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
-    Okay, great, so how do I actually use them?
-  </h2>
+  <h2 id="how-to-use-targets" class="title-2">Okay, great, so how do I actually use them?</h2>
 
   <p>
     Let's assume the build rules given above are defined in a file in your repo
@@ -361,9 +359,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
-    The BUILD file format
-  </h2>
+  <h2 id="file-format" class="title-2">The BUILD file format</h2>
 
   <p>
     You may have noticed that the invocations in BUILD files look a bit like

--- a/docs/build_rules.html
+++ b/docs/build_rules.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Writing build rules</h1>
+<h1 id="writing-build-rules" class="title-1">Writing build rules</h1>
 
 <p>
   Please is designed to support interleaving custom build commands as
@@ -715,7 +715,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Tests</h2>
+  <h2 id="tests" class="title-2">Tests</h2>
 
   <p>
     As well as <code class="code">genrule()</code>, there's also

--- a/docs/cache.html
+++ b/docs/cache.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Please cache</h1>
+<h1 id="please-cache" class="title-1">Please cache</h1>
 
 <p>
   In various places in these docs you might find reference to caches. Please can
@@ -22,7 +22,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">The directory cache</h2>
+  <h2 id="directory-cache" class="title-2">The directory cache</h2>
 
   <p>
     This is the simplest kind of cache; it's on by default and simply is a
@@ -41,7 +41,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">The HTTP cache</h2>
+  <h2 class="title-2" id="http-cache">The HTTP cache</h2>
 
   <p>
     This is a more advanced cache which, as one would expect, can run on a
@@ -100,7 +100,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Scriptable, command driven, cache</h2>
+  <h2 id="scriptable-cache" class="title-2">Scriptable, command driven, cache</h2>
 
   <p>
     You can realize a centralised cache also by managing the remote access

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Please commands</h1>
+<h1 id="please-commands" class="title-1">Please commands</h1>
 
 <p>
   Please has a rich command line interface that can be used to build and test
@@ -6,7 +6,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">Tab completion</h2>
+  <h2 id="tab-completion" class="title-2">Tab completion</h2>
 
   <p>
     To get the most our of the Please command line interface, it is highly
@@ -26,7 +26,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Common flags</h2>
+  <h2 class="title-2" id="common-flags">Common flags</h2>
 
   <p>These flags are common to all (or nearly all) operations.</p>
 

--- a/docs/config.html
+++ b/docs/config.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Please config file reference</h1>
+<h1 id="config-file-reference" class="title-1">Please config file reference</h1>
 
 <p>
   The root of a Please repo is identified by a <code class="code">.plzconfig</code> file.

--- a/docs/cross_compiling.html
+++ b/docs/cross_compiling.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Cross-compiling</h1>
+<h1 id="cross-compiling" class="title-1">Cross-compiling</h1>
 
 <p>
   From v12.2 onwards, Please has cross-compilation support. This allows you to
@@ -25,7 +25,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">Technical notes</h2>
+  <h2 id="technical-notes" class="title-2">Technical notes</h2>
 
   <p>
     Cross compilation is primarily achieved through global variables in the
@@ -73,7 +73,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Language status</h2>
+  <h2 id="langauge-status" class="title-2">Language status</h2>
 
   <p>
     The various builtin languages have differing levels of support. Currently

--- a/docs/dependencies.html
+++ b/docs/dependencies.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Third-party dependencies</h1>
+<h1 id="third-party-deps" class="title-1">Third-party dependencies</h1>
 
 <p>
   Sooner or later, most projects end up needing a dependency on some third-party
@@ -272,7 +272,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="comparison" class="title-2">
     Comparison to other systems
   </h2>
 
@@ -335,7 +335,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Verification</h2>
+  <h2 id="verification" class="title-2">Verification</h2>
 
   <p>
     An important concept of Please is strict validation of inputs and outputs of

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -1,7 +1,7 @@
-<h1 class="title-1">FAQ</h1>
+<h1 id="faq" lass="title-1">FAQ</h1>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="run" class="title-2">
     Can I run it on my computer?
   </h2>
 
@@ -104,7 +104,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">What's the licence?</h2>
+  <h2 id="licence" class="title-2">What's the licence?</h2>
 
   <p>
     <a
@@ -118,7 +118,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="more-info" class="title-2">
     Where can I get more information? / My question isn't answered here
   </h2>
 
@@ -150,7 +150,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="alternatives-language" class="title-2">
     Why use Please instead of go build / Maven / Gradle?
   </h2>
 
@@ -176,7 +176,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="alternatives-blaze" class="title-2">
     Why use Please instead of Bazel, Buck or Pants?
   </h2>
 
@@ -213,7 +213,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="design" class="title-2">
     What inspired the design of Please?
   </h2>
 
@@ -240,7 +240,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Why is it so fast?</h2>
+  <h2 id="fast" class="title-2">Why is it so fast?</h2>
 
   <p>
     Firstly, all the rules explicitly declare their dependencies, so Please can
@@ -284,7 +284,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="file-format-parsing" class="title-2">
     How do you parse the BUILD files? What format are they?
   </h2>
 
@@ -331,7 +331,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="parser" class="title-2">
     Okay, but what exactly are you using to parse the files?
   </h2>
 
@@ -344,7 +344,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="bootstrap" class="title-2">
     How does Please build itself? Do I need Please to build Please?
   </h2>
 
@@ -360,7 +360,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Why write it in Go?</h2>
+  <h2 id="why-go" class="title-2">Why write it in Go?</h2>
 
   <p>
     We excluded most other languages that any of us were familiar with through a
@@ -396,7 +396,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="repo" class="title-2">
     Is this the primary repo, or do you have a secret internal version too?
   </h2>
 
@@ -427,7 +427,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="versioning" class="title-2">
     How does the versioning scheme work? What are the compatibility guarantees?
   </h2>
 
@@ -488,7 +488,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="appearance" class="title-2">
     What does it look like when I'm running it?
   </h2>
 
@@ -505,7 +505,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="colours" class="title-2">
     What do the colours in the console output mean?
   </h2>
 
@@ -558,7 +558,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="please-name" class="title-2">
     Why's it called Please?
   </h2>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,8 +29,8 @@
       </div>
     </div>
     <div class="white center tc">
-        <h1 class="normal please-build mt0">please<span class="violet">.build</span></h1>
-        <h2 class="f3 f2-l">Build things your way</h2>
+        <h1 id="please.build" class="normal please-build mt0">please<span class="violet">.build</span></h1>
+        <h2 id="about" class="f3 f2-l">Build things your way</h2>
         <p class="white normal f4">
             <span class="violet">Please</span> is a cross-language build system with an
             emphasis on high performance, extensibility and correctness
@@ -53,13 +53,13 @@
   </div>
   <div id="why" class="bg-dark-gray pb6 pt4">
     <div class="w-100 mw9 center tc">
-      <h1 class="turquoise f1">Why Please?</h1>
+      <h1 id="why-please" class="turquoise f1">Why Please?</h1>
       <div class="flex flex-column flex-row-l flex-wrap-l mt5">
         <section class="pt5 pl4-l w-25-l pa2">
           <div class="mw7">
             <img class="h3" alt="" src="images/hexagon_r.png" />
 
-            <h2 class="red normal f2 mt3">
+            <h2 id="reproducible" class="red normal f2 mt3">
               Reproducible
             </h2>
             <p class="white">
@@ -74,7 +74,7 @@
           <div class="mw7">
             <img class="h3 rotate-90" alt="" src="images/triangle_v.png" />
 
-            <h2 class="violet normal f2 mt3">
+            <h2 id="fast-incremental" class="violet normal f2 mt3">
               Fast and incremental
             </h2>
             <p class="white">
@@ -88,7 +88,7 @@
         <section class="pt5 w-25-l pa2">
           <div class="mw7">
             <img class="h3" alt="" src="images/square_g.png" />
-            <h2 class="green normal f2 mt3">
+            <h2 id="not-just-build-system" class="green normal f2 mt3">
               Not just a build system
             </h2>
             <p class="white">
@@ -102,7 +102,7 @@
           <div class="mw7">
             <img class="h3" alt="" src="images/circle_t.png" />
 
-            <h2 class="turquoise normal f2 mt3">
+            <h2 id="any-technology" class="turquoise normal f2 mt3">
               For any technology
             </h2>
             <p class="white">
@@ -138,7 +138,7 @@
                 src="/images/circle_y.png"
         />
       </div>
-      <h2 class="mb4 silver f3 normal">
+      <h2 id="get-started" class="mb4 silver f3 normal">
         <span class="white">Want Please?</span> Get started:
       </h2>
       <p class="f3">

--- a/docs/language.html
+++ b/docs/language.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">The BUILD language</h1>
+<h1 id="build-language" class="title-1">The BUILD language</h1>
 
 <p>
   Please's BUILD files typically contain a series of build rule declarations.
@@ -40,7 +40,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">Types</h2>
+  <h2 id="types" class="title-2">Types</h2>
 
   <p>The set of builtin types are again fairly familiar:</p>
 
@@ -96,7 +96,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Functions</h2>
+  <h2 id="functions" class="title-2">Functions</h2>
 
   <p>
     The build language has a rich set of builtin functions that largely resemble
@@ -110,7 +110,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Style</h2>
+  <h2 id="style" class="title-2">Style</h2>
 
   <p>
     We normally write BUILD files in an idiom which doesn't quite match standard

--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">The Lexicon of Please</h1>
+<h1 class="title-1" id="lexicon">The Lexicon of Please</h1>
 
 <p>
   This is the reference for the complete set of builtin rules &amp; functions.

--- a/docs/performance.html
+++ b/docs/performance.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Performance</h1>
+<h1 id="performance" class="title-1">Performance</h1>
 Please does away with upfront analysis phases, and instead opts to analyse the build graph on the fly. Performance
 is integral to this approach, so we need some way to track it. Plotted here are some graphs of benchmarks we run against
 each commit. These are used to identify any regressions to performance we may introduce, and to verify any optimisation
@@ -6,7 +6,7 @@ efforts have been successful.
 
 <p class="red">This page is a work in progress and will be improved over time as we implement more benchmarks.</p>
 
-<h2 class="title-2">Overall parse performance</h2>
+<h2 id="parse-performance" class="title-2">Overall parse performance</h2>
 <p>This benchmark aims to provide a good indicator of the overall parse performance of Please. This
     benchmark covers parsing and executing BUILD files, adding targets to the graph, and resolving
     dependencies. The test measures the time to analyse a large (~300,000 targets) synthetic graph.
@@ -16,7 +16,7 @@ efforts have been successful.
     minimum and maximum times.</p>
 <div id="parse_chart" style="width: 100%; height: 400px"></div>
 
-<h2 class="title-2">Peak memory usage</h2>
+<h2 id="peak-memory-usage" class="title-2">Peak memory usage</h2>
 <p>Comparing memory utilisation in Please with Bazel is difficult because the runtimes have very different memory
     models. Bazel runs on the JVM so has a predetermined maximum heap size that is configurable through JVM options, and
     The JVM doesn't generally return memory back to the OS once it has been allocated. This means that tweaking this
@@ -32,7 +32,7 @@ efforts have been successful.
     eventually be returned to the OS over time.
 <div id="mem_chart" style="width: 100%; height: 400px"></div>
 
-<h2 class="title-2">Provide for performance</h2>
+<h2 id="provide-for-performance" class="title-2">Provide for performance</h2>
 <p>At the core of resolving dependencies for targets is the <code class="code">provideFor()</code> method. This method
     resolves named dependencies, handling the require/provide semantics where necessary. It is called every time a target
     depends on another, so is critical to the performance of Please.</p>

--- a/docs/pleasings.html
+++ b/docs/pleasings.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Extra rules (aka. Pleasings)</h1>
+<h1 id="pleasings" class="title-1">Extra rules (aka. Pleasings)</h1>
 
 <p>
   Please comes with built-in rules for Go, Python, Java, C++, Protocol Buffers
@@ -23,7 +23,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="loading-additional" class="title-2">
     Loading additional rules
   </h2>
 
@@ -74,7 +74,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="subinclude" class="title-2">
     The more repeatable solution
   </h2>
 

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Please Plugins</h1>
+<h1 id="plugins" class="title-1">Please Plugins</h1>
 
 <p>
     Plugins are a way to extend Please with build rules for additional languages or technologies. The quickest way to get

--- a/docs/post_build.html
+++ b/docs/post_build.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Pre- and post-build functions</h1>
+<h1 id="pre-post-build-functions" class="title-1">Pre- and post-build functions</h1>
 
 <p>
   It's possible in Please to define callbacks into the build language that are
@@ -17,7 +17,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="pre-build-function" class="title-2">
     Pre-build function
   </h2>
 
@@ -61,7 +61,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="post-build-function" class="title-2">
     Post-build function
   </h2>
 
@@ -124,7 +124,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="hints" class="title-2">
     Hints
   </h2>
 

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -1,7 +1,7 @@
-<h1 class="title-1">Please quickstart</h1>
+<h1 id="quickstart" class="title-1">Please quickstart</h1>
 
 <section class="mt4">
-  <h2 class="title-2">System requirements</h2>
+  <h2 id="system-requirements" class="title-2">System requirements</h2>
 
   <p>
     Please supports Linux, macOS and FreeBSD at the moment. The included build
@@ -18,7 +18,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Installing</h2>
+  <h2 id="installing" class="title-2">Installing</h2>
 
   <p><code class="code">curl https://get.please.build | bash</code></p>
 
@@ -69,7 +69,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Shell completion</h2>
+  <h2 id="shell-completion" class="title-2">Shell completion</h2>
 
   <p>Please comes with a completion script for Bash and zsh built-in.</p>
 
@@ -96,7 +96,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="lang-server" class="title-2">
     BUILD file Language Protocol Server
   </h2>
 
@@ -126,7 +126,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Getting started</h2>
+  <h2 id="getting-started" class="title-2">Getting started</h2>
 
   <p>
     Run <code class="code">plz init</code> at the root of your repo to create
@@ -143,7 +143,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">More info</h2>
+  <h2 id="more-info" class="title-2">More info</h2>
 
   <p>
     If you want more information on Please, you can raise issues on

--- a/docs/quickstart_dropoff.html
+++ b/docs/quickstart_dropoff.html
@@ -1,7 +1,7 @@
-<h1 class="title-1">So what next?</h1>
+<h1 id="what-next" class="title-1">So what next?</h1>
 
 <section class="mt4">
-  <h2 class="title-2">Read the docs</h2>
+  <h2 id="read-the-docs" class="title-2">Read the docs</h2>
 
   <p>
     Hopefully you've got a basic idea of how Please works, however Please has a
@@ -42,7 +42,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="adpoter" class="title-2">
     Add yourself as an adopter
   </h2>
 
@@ -61,7 +61,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Come say hello</h2>
+  <h2 id="say-hello" class="title-2">Come say hello</h2>
 
   <p>
     The best way to ask questions about please and interact with the growing

--- a/docs/remote_builds.html
+++ b/docs/remote_builds.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Remote build execution</h1>
+<h1 id="remote-build-execution" class="title-1">Remote build execution</h1>
 
 <p class="red">
   This feature is still experimental; some aspects may not work fully or at all

--- a/docs/require_provide.html
+++ b/docs/require_provide.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Require / Provide</h1>
+<h1 id="require-provide" class="title-1">Require / Provide</h1>
 
 <p>
   This is a generalised mechanism for rules to provide specialised dependencies

--- a/docs/test/docs_test.go
+++ b/docs/test/docs_test.go
@@ -2,11 +2,12 @@ package test
 
 import (
 	"fmt"
-	"github.com/thought-machine/please/src/core"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/thought-machine/please/src/core"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -89,11 +90,12 @@ var ignoreConfigFields = map[string]struct{}{
 
 // IDs in the html that are for other purposes other than documenting config.
 var nonConfigIds = map[string]struct{}{
-	"menu-list":    {},
-	"nav-graphic":  {},
-	"side-images":  {},
-	"menu-button":  {},
-	"main-content": {},
+	"config-file-reference": {},
+	"menu-list":             {},
+	"nav-graphic":           {},
+	"side-images":           {},
+	"menu-button":           {},
+	"main-content":          {},
 }
 
 func TestConfigDocumented(t *testing.T) {

--- a/docs/tests.html
+++ b/docs/tests.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Testing with Please</h1>
+<h1 id="testing" class="title-1">Testing with Please</h1>
 
 <p>
   Tests in Please are run using <code class="code">plz test</code> (or
@@ -13,7 +13,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="what-to-test" class="title-2">
     Specifying what to test
   </h2>
 
@@ -58,7 +58,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="success-failure" class="title-2">
     Success and failure
   </h2>
 
@@ -155,7 +155,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="hermeticity-reproducibility" class="title-2">
     Hermeticity and reproducibility
   </h2>
 


### PR DESCRIPTION
Adding an `id` attribute creates anchor tags to which we can link from search results.