### PR TITLE
Create search items list for Fuse.js

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -35,23 +35,32 @@ genrule(
 )
 
 genrule(
-    name = "lexicon_html",
-    srcs = deps + [
+    name = "lexicon_content",
+    srcs = [
         "lexicon.html",
         "lexicon_entry.html",
-        "template.html",
         ":rules",
+    ],
+    outs = ["lexicon_content.html"],
+    cmd = [
+        '"$TOOL" -i docs/lexicon.html -i docs/lexicon_entry.html docs/rules.json > "$OUT"',
+    ],
+    tools = ["//docs/tools/lexicon_templater"],
+)
+
+genrule(
+    name = "lexicon_html",
+    srcs = deps + [
+        ":lexicon_content",
+        "template.html",
     ],
     outs = ["lexicon.html"],
     cmd = [
-        '"$TOOLS_LEX" -i docs/lexicon.html -i docs/lexicon_entry.html docs/rules.json > "$OUT"',
-        '"$TOOLS_TMPL" --template docs/template.html --in lexicon.html > tmp.html',
+        'mv docs/lexicon_content.html "$OUT"',
+        '"$TOOL" --template docs/template.html --in lexicon.html > tmp.html',
         'mv tmp.html "$OUT"',
     ],
-    tools = {
-        "lex": ["//docs/tools/lexicon_templater"],
-        "tmpl": ["//docs/tools/templater"],
-    },
+    tools = ["//docs/tools/templater"],
     visibility = ["//docs/test/..."],
 )
 
@@ -80,43 +89,62 @@ filegroup(
 )
 
 genrule(
-    name = "plugins_html",
+    name = "plugins_content",
     srcs = deps + [
         "lexicon.html",
         "lexicon_entry.html",
         "template.html",
         "plugins.html",
     ],
+    outs = ["plugins_content.html"],
+    cmd = [
+        '"$TOOL" --plugin docs/plugins.html --lex docs/lexicon_entry.html docs/*_plugin.json > "$OUT"',
+    ],
+    tools = ["//docs/tools/plugin_templater"],
+    deps = [":plugins"],
+)
+
+genrule(
+    name = "plugins_html",
+    srcs = deps + [
+        ":plugins_content",
+        "template.html",
+    ],
     outs = ["plugins.html"],
     cmd = [
-        '"$TOOLS_PLUGIN" --plugin docs/plugins.html --lex docs/lexicon_entry.html docs/*_plugin.json > "$OUT"',
-        '"$TOOLS_TMPL" --template docs/template.html --in plugins.html > tmp.html',
+        'mv docs/plugins_content.html "$OUT"',
+        '"$TOOL" --template docs/template.html --in plugins.html > tmp.html',
         'mv tmp.html "$OUT"',
     ],
-    tools = {
-        "plugin": ["//docs/tools/plugin_templater"],
-        "tmpl": ["//docs/tools/templater"],
-    },
+    tools = ["//docs/tools/templater"],
     visibility = ["//docs/test/..."],
-    deps = [":plugins"],
+)
+
+genrule(
+    name = "config_content",
+    srcs = [
+        "config.html",
+    ],
+    outs = ["config_content.html"],
+    cmd = [
+        '"$TOOL" > "$OUT"',
+    ],
+    tools = ["//docs/tools/config_templater"],
 )
 
 genrule(
     name = "config_html",
     srcs = [
-        "config.html",
+        ":config_content",
         "template.html",
     ],
     outs = ["config.html"],
     cmd = [
-        '"$TOOLS_CONFIG" > config.html',
-        '"$TOOLS_TMPL" --template docs/template.html --in config.html > tmp.html',
+        'mv docs/config_content.html "$OUT"',
+        '"$TOOL" --template docs/template.html --in config.html > tmp.html',
         'mv tmp.html "$OUT"',
     ],
-    tools = {
-        "config": ["//docs/tools/config_templater"],
-        "tmpl": ["//docs/tools/templater"],
-    },
+    tools = ["//docs/tools/templater"],
 )
 
 genrule(

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -162,6 +162,29 @@ genrule(
     },
 )
 
+genrule(
+    name = "fusejs_list_json",
+    srcs = glob(
+        [
+            "*.html",
+        ],
+        exclude = [
+            "template.html",
+            "lexicon*.html",
+            "config.html",
+            "error.html",
+            "plugins.html",
+        ],
+    ) + [
+        ":lexicon_content",
+        ":plugins_content",
+        ":config_content",
+    ],
+    outs = ["fusejs_list.json"],
+    cmd = '"$TOOL" --file_paths="$SRCS" --file_prefix="docs/" > "$OUT"',
+    tools = ["//docs/tools/fusejs_list_builder"],
+)
+
 filegroup(
     name = "docs",
     srcs = glob(["images/*.png"]) + deps + [
@@ -177,6 +200,7 @@ filegroup(
         "error.html",
         "images/thoughtmachine.png",
         "plz-recording.json",
+        ":fusejs_list_json",
         "//third_party/js:asciinema",
         "favicon",
         ":codelabs_html",

--- a/docs/acknowledgements.html
+++ b/docs/acknowledgements.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Acknowledgements</h1>
+<h1 id="acknowledgements" class="title-1">Acknowledgements</h1>
 
 <p>The core contributors of the team so far are:</p>
 

--- a/docs/basics.html
+++ b/docs/basics.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Please basics</h1>
+<h1 id="please-basics" class="title-1">Please basics</h1>
 
 <p>
   If you're familiar with Blaze / Bazel, Buck or Pants you will probably find
@@ -6,7 +6,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">BUILD files</h2>
+  <h2 id="build-files" class="title-2">BUILD files</h2>
 
   <p>
     Please targets are defined in files named BUILD. These are analogous to
@@ -23,7 +23,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Build targets</h2>
+  <h2 class="title-2" id="build-targets">Build targets</h2>
 
   <p>
     Each BUILD file can contain a number of <em>build targets</em>. These targets are the tasks that the build system
@@ -272,9 +272,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
-    Okay, great, so how do I actually use them?
-  </h2>
+  <h2 id="how-to-use-targets" class="title-2">Okay, great, so how do I actually use them?</h2>
 
   <p>
     Let's assume the build rules given above are defined in a file in your repo
@@ -361,9 +359,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
-    The BUILD file format
-  </h2>
+  <h2 id="file-format" class="title-2">The BUILD file format</h2>
 
   <p>
     You may have noticed that the invocations in BUILD files look a bit like

--- a/docs/build_rules.html
+++ b/docs/build_rules.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Writing build rules</h1>
+<h1 id="writing-build-rules" class="title-1">Writing build rules</h1>
 
 <p>
   Please is designed to support interleaving custom build commands as
@@ -715,7 +715,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Tests</h2>
+  <h2 id="tests" class="title-2">Tests</h2>
 
   <p>
     As well as <code class="code">genrule()</code>, there's also

--- a/docs/cache.html
+++ b/docs/cache.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Please cache</h1>
+<h1 id="please-cache" class="title-1">Please cache</h1>
 
 <p>
   In various places in these docs you might find reference to caches. Please can
@@ -22,7 +22,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">The directory cache</h2>
+  <h2 id="directory-cache" class="title-2">The directory cache</h2>
 
   <p>
     This is the simplest kind of cache; it's on by default and simply is a
@@ -41,7 +41,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">The HTTP cache</h2>
+  <h2 class="title-2" id="http-cache">The HTTP cache</h2>
 
   <p>
     This is a more advanced cache which, as one would expect, can run on a
@@ -100,7 +100,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Scriptable, command driven, cache</h2>
+  <h2 id="scriptable-cache" class="title-2">Scriptable, command driven, cache</h2>
 
   <p>
     You can realize a centralised cache also by managing the remote access

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Please commands</h1>
+<h1 id="please-commands" class="title-1">Please commands</h1>
 
 <p>
   Please has a rich command line interface that can be used to build and test
@@ -6,7 +6,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">Tab completion</h2>
+  <h2 id="tab-completion" class="title-2">Tab completion</h2>
 
   <p>
     To get the most our of the Please command line interface, it is highly
@@ -26,7 +26,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Common flags</h2>
+  <h2 class="title-2" id="common-flags">Common flags</h2>
 
   <p>These flags are common to all (or nearly all) operations.</p>
 

--- a/docs/config.html
+++ b/docs/config.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Please config file reference</h1>
+<h1 id="config-file-reference" class="title-1">Please config file reference</h1>
 
 <p>
   The root of a Please repo is identified by a <code class="code">.plzconfig</code> file.

--- a/docs/cross_compiling.html
+++ b/docs/cross_compiling.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Cross-compiling</h1>
+<h1 id="cross-compiling" class="title-1">Cross-compiling</h1>
 
 <p>
   From v12.2 onwards, Please has cross-compilation support. This allows you to
@@ -25,7 +25,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">Technical notes</h2>
+  <h2 id="technical-notes" class="title-2">Technical notes</h2>
 
   <p>
     Cross compilation is primarily achieved through global variables in the
@@ -73,7 +73,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Language status</h2>
+  <h2 id="langauge-status" class="title-2">Language status</h2>
 
   <p>
     The various builtin languages have differing levels of support. Currently

--- a/docs/dependencies.html
+++ b/docs/dependencies.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Third-party dependencies</h1>
+<h1 id="third-party-deps" class="title-1">Third-party dependencies</h1>
 
 <p>
   Sooner or later, most projects end up needing a dependency on some third-party
@@ -272,7 +272,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="comparison" class="title-2">
     Comparison to other systems
   </h2>
 
@@ -335,7 +335,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Verification</h2>
+  <h2 id="verification" class="title-2">Verification</h2>
 
   <p>
     An important concept of Please is strict validation of inputs and outputs of

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -1,7 +1,7 @@
-<h1 class="title-1">FAQ</h1>
+<h1 id="faq" lass="title-1">FAQ</h1>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="run" class="title-2">
     Can I run it on my computer?
   </h2>
 
@@ -104,7 +104,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">What's the licence?</h2>
+  <h2 id="licence" class="title-2">What's the licence?</h2>
 
   <p>
     <a
@@ -118,7 +118,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="more-info" class="title-2">
     Where can I get more information? / My question isn't answered here
   </h2>
 
@@ -150,7 +150,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="alternatives-language" class="title-2">
     Why use Please instead of go build / Maven / Gradle?
   </h2>
 
@@ -176,7 +176,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="alternatives-blaze" class="title-2">
     Why use Please instead of Bazel, Buck or Pants?
   </h2>
 
@@ -213,7 +213,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="design" class="title-2">
     What inspired the design of Please?
   </h2>
 
@@ -240,7 +240,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Why is it so fast?</h2>
+  <h2 id="fast" class="title-2">Why is it so fast?</h2>
 
   <p>
     Firstly, all the rules explicitly declare their dependencies, so Please can
@@ -284,7 +284,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="file-format-parsing" class="title-2">
     How do you parse the BUILD files? What format are they?
   </h2>
 
@@ -331,7 +331,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="parser" class="title-2">
     Okay, but what exactly are you using to parse the files?
   </h2>
 
@@ -344,7 +344,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="bootstrap" class="title-2">
     How does Please build itself? Do I need Please to build Please?
   </h2>
 
@@ -360,7 +360,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Why write it in Go?</h2>
+  <h2 id="why-go" class="title-2">Why write it in Go?</h2>
 
   <p>
     We excluded most other languages that any of us were familiar with through a
@@ -396,7 +396,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="repo" class="title-2">
     Is this the primary repo, or do you have a secret internal version too?
   </h2>
 
@@ -427,7 +427,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="versioning" class="title-2">
     How does the versioning scheme work? What are the compatibility guarantees?
   </h2>
 
@@ -488,7 +488,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="appearance" class="title-2">
     What does it look like when I'm running it?
   </h2>
 
@@ -505,7 +505,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="colours" class="title-2">
     What do the colours in the console output mean?
   </h2>
 
@@ -558,7 +558,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="please-name" class="title-2">
     Why's it called Please?
   </h2>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,8 +29,8 @@
       </div>
     </div>
     <div class="white center tc">
-        <h1 class="normal please-build mt0">please<span class="violet">.build</span></h1>
-        <h2 class="f3 f2-l">Build things your way</h2>
+        <h1 id="please.build" class="normal please-build mt0">please<span class="violet">.build</span></h1>
+        <h2 id="about" class="f3 f2-l">Build things your way</h2>
         <p class="white normal f4">
             <span class="violet">Please</span> is a cross-language build system with an
             emphasis on high performance, extensibility and correctness
@@ -53,13 +53,13 @@
   </div>
   <div id="why" class="bg-dark-gray pb6 pt4">
     <div class="w-100 mw9 center tc">
-      <h1 class="turquoise f1">Why Please?</h1>
+      <h1 id="why-please" class="turquoise f1">Why Please?</h1>
       <div class="flex flex-column flex-row-l flex-wrap-l mt5">
         <section class="pt5 pl4-l w-25-l pa2">
           <div class="mw7">
             <img class="h3" alt="" src="images/hexagon_r.png" />
 
-            <h2 class="red normal f2 mt3">
+            <h2 id="reproducible" class="red normal f2 mt3">
               Reproducible
             </h2>
             <p class="white">
@@ -74,7 +74,7 @@
           <div class="mw7">
             <img class="h3 rotate-90" alt="" src="images/triangle_v.png" />
 
-            <h2 class="violet normal f2 mt3">
+            <h2 id="fast-incremental" class="violet normal f2 mt3">
               Fast and incremental
             </h2>
             <p class="white">
@@ -88,7 +88,7 @@
         <section class="pt5 w-25-l pa2">
           <div class="mw7">
             <img class="h3" alt="" src="images/square_g.png" />
-            <h2 class="green normal f2 mt3">
+            <h2 id="not-just-build-system" class="green normal f2 mt3">
               Not just a build system
             </h2>
             <p class="white">
@@ -102,7 +102,7 @@
           <div class="mw7">
             <img class="h3" alt="" src="images/circle_t.png" />
 
-            <h2 class="turquoise normal f2 mt3">
+            <h2 id="any-technology" class="turquoise normal f2 mt3">
               For any technology
             </h2>
             <p class="white">
@@ -138,7 +138,7 @@
                 src="/images/circle_y.png"
         />
       </div>
-      <h2 class="mb4 silver f3 normal">
+      <h2 id="get-started" class="mb4 silver f3 normal">
         <span class="white">Want Please?</span> Get started:
       </h2>
       <p class="f3">

--- a/docs/language.html
+++ b/docs/language.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">The BUILD language</h1>
+<h1 id="build-language" class="title-1">The BUILD language</h1>
 
 <p>
   Please's BUILD files typically contain a series of build rule declarations.
@@ -40,7 +40,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">Types</h2>
+  <h2 id="types" class="title-2">Types</h2>
 
   <p>The set of builtin types are again fairly familiar:</p>
 
@@ -96,7 +96,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Functions</h2>
+  <h2 id="functions" class="title-2">Functions</h2>
 
   <p>
     The build language has a rich set of builtin functions that largely resemble
@@ -110,7 +110,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Style</h2>
+  <h2 id="style" class="title-2">Style</h2>
 
   <p>
     We normally write BUILD files in an idiom which doesn't quite match standard

--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">The Lexicon of Please</h1>
+<h1 class="title-1" id="lexicon">The Lexicon of Please</h1>
 
 <p>
   This is the reference for the complete set of builtin rules &amp; functions.

--- a/docs/performance.html
+++ b/docs/performance.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Performance</h1>
+<h1 id="performance" class="title-1">Performance</h1>
 Please does away with upfront analysis phases, and instead opts to analyse the build graph on the fly. Performance
 is integral to this approach, so we need some way to track it. Plotted here are some graphs of benchmarks we run against
 each commit. These are used to identify any regressions to performance we may introduce, and to verify any optimisation
@@ -6,7 +6,7 @@ efforts have been successful.
 
 <p class="red">This page is a work in progress and will be improved over time as we implement more benchmarks.</p>
 
-<h2 class="title-2">Overall parse performance</h2>
+<h2 id="parse-performance" class="title-2">Overall parse performance</h2>
 <p>This benchmark aims to provide a good indicator of the overall parse performance of Please. This
     benchmark covers parsing and executing BUILD files, adding targets to the graph, and resolving
     dependencies. The test measures the time to analyse a large (~300,000 targets) synthetic graph.
@@ -16,7 +16,7 @@ efforts have been successful.
     minimum and maximum times.</p>
 <div id="parse_chart" style="width: 100%; height: 400px"></div>
 
-<h2 class="title-2">Peak memory usage</h2>
+<h2 id="peak-memory-usage" class="title-2">Peak memory usage</h2>
 <p>Comparing memory utilisation in Please with Bazel is difficult because the runtimes have very different memory
     models. Bazel runs on the JVM so has a predetermined maximum heap size that is configurable through JVM options, and
     The JVM doesn't generally return memory back to the OS once it has been allocated. This means that tweaking this
@@ -32,7 +32,7 @@ efforts have been successful.
     eventually be returned to the OS over time.
 <div id="mem_chart" style="width: 100%; height: 400px"></div>
 
-<h2 class="title-2">Provide for performance</h2>
+<h2 id="provide-for-performance" class="title-2">Provide for performance</h2>
 <p>At the core of resolving dependencies for targets is the <code class="code">provideFor()</code> method. This method
     resolves named dependencies, handling the require/provide semantics where necessary. It is called every time a target
     depends on another, so is critical to the performance of Please.</p>

--- a/docs/pleasings.html
+++ b/docs/pleasings.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Extra rules (aka. Pleasings)</h1>
+<h1 id="pleasings" class="title-1">Extra rules (aka. Pleasings)</h1>
 
 <p>
   Please comes with built-in rules for Go, Python, Java, C++, Protocol Buffers
@@ -23,7 +23,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="loading-additional" class="title-2">
     Loading additional rules
   </h2>
 
@@ -74,7 +74,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="subinclude" class="title-2">
     The more repeatable solution
   </h2>
 

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Please Plugins</h1>
+<h1 id="plugins" class="title-1">Please Plugins</h1>
 
 <p>
     Plugins are a way to extend Please with build rules for additional languages or technologies. The quickest way to get

--- a/docs/post_build.html
+++ b/docs/post_build.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Pre- and post-build functions</h1>
+<h1 id="pre-post-build-functions" class="title-1">Pre- and post-build functions</h1>
 
 <p>
   It's possible in Please to define callbacks into the build language that are
@@ -17,7 +17,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="pre-build-function" class="title-2">
     Pre-build function
   </h2>
 
@@ -61,7 +61,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="post-build-function" class="title-2">
     Post-build function
   </h2>
 
@@ -124,7 +124,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="hints" class="title-2">
     Hints
   </h2>
 

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -1,7 +1,7 @@
-<h1 class="title-1">Please quickstart</h1>
+<h1 id="quickstart" class="title-1">Please quickstart</h1>
 
 <section class="mt4">
-  <h2 class="title-2">System requirements</h2>
+  <h2 id="system-requirements" class="title-2">System requirements</h2>
 
   <p>
     Please supports Linux, macOS and FreeBSD at the moment. The included build
@@ -18,7 +18,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Installing</h2>
+  <h2 id="installing" class="title-2">Installing</h2>
 
   <p><code class="code">curl https://get.please.build | bash</code></p>
 
@@ -69,7 +69,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Shell completion</h2>
+  <h2 id="shell-completion" class="title-2">Shell completion</h2>
 
   <p>Please comes with a completion script for Bash and zsh built-in.</p>
 
@@ -96,7 +96,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="lang-server" class="title-2">
     BUILD file Language Protocol Server
   </h2>
 
@@ -126,7 +126,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Getting started</h2>
+  <h2 id="getting-started" class="title-2">Getting started</h2>
 
   <p>
     Run <code class="code">plz init</code> at the root of your repo to create
@@ -143,7 +143,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">More info</h2>
+  <h2 id="more-info" class="title-2">More info</h2>
 
   <p>
     If you want more information on Please, you can raise issues on

--- a/docs/quickstart_dropoff.html
+++ b/docs/quickstart_dropoff.html
@@ -1,7 +1,7 @@
-<h1 class="title-1">So what next?</h1>
+<h1 id="what-next" class="title-1">So what next?</h1>
 
 <section class="mt4">
-  <h2 class="title-2">Read the docs</h2>
+  <h2 id="read-the-docs" class="title-2">Read the docs</h2>
 
   <p>
     Hopefully you've got a basic idea of how Please works, however Please has a
@@ -42,7 +42,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="adpoter" class="title-2">
     Add yourself as an adopter
   </h2>
 
@@ -61,7 +61,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">Come say hello</h2>
+  <h2 id="say-hello" class="title-2">Come say hello</h2>
 
   <p>
     The best way to ask questions about please and interact with the growing

--- a/docs/remote_builds.html
+++ b/docs/remote_builds.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Remote build execution</h1>
+<h1 id="remote-build-execution" class="title-1">Remote build execution</h1>
 
 <p class="red">
   This feature is still experimental; some aspects may not work fully or at all

--- a/docs/require_provide.html
+++ b/docs/require_provide.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Require / Provide</h1>
+<h1 id="require-provide" class="title-1">Require / Provide</h1>
 
 <p>
   This is a generalised mechanism for rules to provide specialised dependencies

--- a/docs/test/docs_test.go
+++ b/docs/test/docs_test.go
@@ -2,11 +2,12 @@ package test
 
 import (
 	"fmt"
-	"github.com/thought-machine/please/src/core"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/thought-machine/please/src/core"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -89,11 +90,12 @@ var ignoreConfigFields = map[string]struct{}{
 
 // IDs in the html that are for other purposes other than documenting config.
 var nonConfigIds = map[string]struct{}{
-	"menu-list":    {},
-	"nav-graphic":  {},
-	"side-images":  {},
-	"menu-button":  {},
-	"main-content": {},
+	"config-file-reference": {},
+	"menu-list":             {},
+	"nav-graphic":           {},
+	"side-images":           {},
+	"menu-button":           {},
+	"main-content":          {},
 }
 
 func TestConfigDocumented(t *testing.T) {

--- a/docs/tests.html
+++ b/docs/tests.html
@@ -1,4 +1,4 @@
-<h1 class="title-1">Testing with Please</h1>
+<h1 id="testing" class="title-1">Testing with Please</h1>
 
 <p>
   Tests in Please are run using <code class="code">plz test</code> (or
@@ -13,7 +13,7 @@
 </p>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="what-to-test" class="title-2">
     Specifying what to test
   </h2>
 
@@ -58,7 +58,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="success-failure" class="title-2">
     Success and failure
   </h2>
 
@@ -155,7 +155,7 @@
 </section>
 
 <section class="mt4">
-  <h2 class="title-2">
+  <h2 id="hermeticity-reproducibility" class="title-2">
     Hermeticity and reproducibility
   </h2>
 

--- a/docs/tools/fusejs_list_builder/BUILD
+++ b/docs/tools/fusejs_list_builder/BUILD
@@ -1,0 +1,10 @@
+go_binary(
+    name = "fusejs_list_builder",
+    srcs = ["main.go"],
+    visibility = ["//docs/..."],
+    deps = [
+        "///third_party/go/github.com_peterebden_go-cli-init_v5//flags",
+        "//docs/tools/fusejs_list_builder/fusejslist",
+        "//docs/tools/fusejs_list_builder/processhtml",
+    ],
+)

--- a/docs/tools/fusejs_list_builder/fusejslist/BUILD
+++ b/docs/tools/fusejs_list_builder/fusejslist/BUILD
@@ -1,0 +1,7 @@
+go_library(
+    name = "fusejslist",
+    srcs = [
+        "types.go",
+    ],
+    visibility = ["//docs/tools/fusejs_list_builder/..."],
+)

--- a/docs/tools/fusejs_list_builder/fusejslist/types.go
+++ b/docs/tools/fusejs_list_builder/fusejslist/types.go
@@ -1,0 +1,12 @@
+// Package fuselist defines the types of the list consumed by the Fuse.js constructor
+package fusejslist
+
+type ListItem struct {
+	PageTitle        string `json:"pageTitle"`
+	PagePath         string `json:"pagePath"`
+	Heading          string `json:"heading"`
+	HeadingAnchorTag string `json:"headingAnchorTag"`
+	TextContent      string `json:"textContent"`
+}
+
+type List []*ListItem

--- a/docs/tools/fusejs_list_builder/main.go
+++ b/docs/tools/fusejs_list_builder/main.go
@@ -1,0 +1,48 @@
+// Package main creates a JSON list of search items for use with Fusejs.js.
+//
+// It takes in a list of HTML files and creates a search item for each section
+// of content which begins with a <h1> or <h2> tag. In each input file, each
+// <h1> or <h2> tag MUST have an id attribute.
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/peterebden/go-cli-init/v5/flags"
+
+	"github.com/thought-machine/please/docs/tools/fusejs_list_builder/fusejslist"
+	"github.com/thought-machine/please/docs/tools/fusejs_list_builder/processhtml"
+)
+
+var opts struct {
+	FilePaths  string `long:"file_paths" required:"true" description:"Space-separated list of paths of input HTML files"`
+	FilePrefix string `long:"file_prefix" required:"true" description:"Prefix to file paths which should be removed in the generated list."`
+}
+
+func main() {
+	flags.ParseFlagsOrDie("Docs template", &opts, nil)
+
+	filePaths := strings.Split(opts.FilePaths, " ")
+
+	var fusejsList fusejslist.List
+
+	for _, filePath := range filePaths {
+		file, err := os.Open(filePath)
+		must(err)
+
+		fileFusejsList, err := processhtml.ProcessHTMLFile(file, strings.TrimPrefix(filePath, opts.FilePrefix))
+		must(err)
+
+		fusejsList = append(fusejsList, fileFusejsList...)
+	}
+
+	must(json.NewEncoder(os.Stdout).Encode(fusejsList))
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/docs/tools/fusejs_list_builder/processhtml/BUILD
+++ b/docs/tools/fusejs_list_builder/processhtml/BUILD
@@ -1,0 +1,15 @@
+go_library(
+    name = "processhtml",
+    srcs = [
+        "errors.go",
+        "html_traverser.go",
+        "process_html_file.go",
+    ],
+    visibility = ["//docs/tools/fusejs_list_builder/..."],
+    deps = [
+        "///third_party/go/github.com_k3a_html2text//:html2text",
+        "///third_party/go/golang.org_x_net//html",
+        "///third_party/go/golang.org_x_net//html/atom",
+        "//docs/tools/fusejs_list_builder/fusejslist",
+    ],
+)

--- a/docs/tools/fusejs_list_builder/processhtml/errors.go
+++ b/docs/tools/fusejs_list_builder/processhtml/errors.go
@@ -1,0 +1,10 @@
+package processhtml
+
+import "errors"
+
+var (
+	ErrHeadingMissingIDAttr = errors.New("heading tag missing 'id' attribute")
+	ErrNotDocumentNode      = errors.New("not an HTML document node")
+	ErrParsingHTMLFile      = errors.New("parsing HTML file")
+	ErrRenderingHTML        = errors.New("rendering HTML")
+)

--- a/docs/tools/fusejs_list_builder/processhtml/html_traverser.go
+++ b/docs/tools/fusejs_list_builder/processhtml/html_traverser.go
@@ -1,0 +1,174 @@
+package processhtml
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+
+	"github.com/k3a/html2text"
+
+	"github.com/thought-machine/please/docs/tools/fusejs_list_builder/fusejslist"
+)
+
+func nodeText(node *html.Node) (string, error) {
+	var sb strings.Builder
+	if err := html.Render(&sb, node); err != nil {
+		return "", fmt.Errorf("%w: %w", ErrRenderingHTML, err)
+	}
+
+	renderedHTML := sb.String()
+	htmlText := html2text.HTML2TextWithOptions(renderedHTML, html2text.WithUnixLineBreaks())
+	return strings.TrimSpace(htmlText), nil
+}
+
+func idAttr(node *html.Node) string {
+	for _, attr := range node.Attr {
+		if attr.Key == "id" {
+			return attr.Val
+		}
+	}
+	return ""
+}
+
+// contentPart represents a heading or a section of text on the page
+type contentPart struct {
+	Heading          bool
+	HeadingAnchorTag string
+	Text             string
+}
+
+// HTMLTraverser traverses an HTML document, producing a list of entries for Fuse.js
+type HTMLTraverser struct {
+	PagePath string
+
+	pageTitle    string
+	contentParts []*contentPart
+}
+
+func (t *HTMLTraverser) processTextNode(node *html.Node) error {
+	if node.Type != html.TextNode {
+		panic(fmt.Sprintf(
+			"processTextNode() called on html.NodeType %v (it should only be called on a html.TextNode)",
+			node.Type,
+		))
+	}
+
+	nodeText, err := nodeText(node)
+	if err != nil {
+		return err
+	}
+
+	t.contentParts = append(t.contentParts, &contentPart{
+		Text: nodeText,
+	})
+	return nil
+}
+
+func (t *HTMLTraverser) processElementNode(node *html.Node) error {
+	if node.Type != html.ElementNode {
+		panic(fmt.Sprintf(
+			"processElementNode() called on html.NodeType %v (it should only be called on a html.ElementNode)",
+			node.Type,
+		))
+	}
+
+	if node.DataAtom == atom.H1 {
+		nodeText, err := nodeText(node)
+		if err != nil {
+			return err
+		}
+
+		if t.pageTitle != "" {
+			t.pageTitle = fmt.Sprintf("%s, %s", t.pageTitle, nodeText)
+		} else {
+			t.pageTitle = nodeText
+		}
+	}
+
+	if node.DataAtom == atom.H1 || node.DataAtom == atom.H2 {
+		nodeText, err := nodeText(node)
+		if err != nil {
+			return err
+		}
+
+		anchorTag := idAttr(node)
+		if anchorTag == "" {
+			return fmt.Errorf("%w: heading '%s' on page '%s'", ErrHeadingMissingIDAttr, nodeText, t.pageTitle)
+		}
+
+		t.contentParts = append(t.contentParts, &contentPart{
+			Heading:          true,
+			HeadingAnchorTag: anchorTag,
+			Text:             nodeText,
+		})
+		return nil
+	}
+
+	return t.traverseChildren(node)
+}
+
+func (t *HTMLTraverser) traverseChildren(node *html.Node) error {
+	for c := node.FirstChild; c != nil; c = c.NextSibling {
+		if err := t.traverse(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *HTMLTraverser) traverse(node *html.Node) error {
+	switch node.Type {
+	case html.TextNode:
+		return t.processTextNode(node)
+	case html.ElementNode:
+		return t.processElementNode(node)
+	}
+
+	return t.traverseChildren(node)
+}
+
+// TraverseDocument produces a list of entries for Fuse.js from a HTML document.
+// The PageTitle field is inferred from the <h1> elements in the document.
+func (t *HTMLTraverser) TraverseDocument(node *html.Node) (fusejslist.List, error) {
+	if node.Type != html.DocumentNode {
+		return nil, ErrNotDocumentNode
+	}
+
+	if err := t.traverse(node); err != nil {
+		return nil, err
+	}
+
+	var fusejsListItems fusejslist.List
+
+	currHeading := ""
+	currHeadingTag := ""
+	var currTextContentParts []string
+
+	for i := 0; i <= len(t.contentParts); i++ {
+		if i < len(t.contentParts) && !t.contentParts[i].Heading {
+			if t.contentParts[i].Text != "" {
+				currTextContentParts = append(currTextContentParts, t.contentParts[i].Text)
+			}
+			continue
+		}
+
+		if len(currTextContentParts) > 0 {
+			fusejsListItems = append(fusejsListItems, &fusejslist.ListItem{
+				PagePath:         t.PagePath,
+				PageTitle:        t.pageTitle,
+				Heading:          currHeading,
+				HeadingAnchorTag: currHeadingTag,
+				TextContent:      strings.Join(currTextContentParts, " "),
+			})
+		}
+
+		if i < len(t.contentParts) {
+			currHeading = t.contentParts[i].Text
+			currHeadingTag = t.contentParts[i].HeadingAnchorTag
+			currTextContentParts = []string{}
+		}
+	}
+	return fusejsListItems, nil
+}

--- a/docs/tools/fusejs_list_builder/processhtml/process_html_file.go
+++ b/docs/tools/fusejs_list_builder/processhtml/process_html_file.go
@@ -1,0 +1,22 @@
+package processhtml
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/net/html"
+
+	"github.com/thought-machine/please/docs/tools/fusejs_list_builder/fusejslist"
+)
+
+func ProcessHTMLFile(f *os.File, path string) (fusejslist.List, error) {
+	docNode, err := html.Parse(f)
+	if err != nil {
+		return nil, fmt.Errorf("%w - %s: %w", ErrParsingHTMLFile, f.Name(), err)
+	}
+
+	t := &HTMLTraverser{
+		PagePath: path,
+	}
+	return t.TraverseDocument(docNode)
+}

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -533,9 +533,9 @@ go_repo(
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "cloud.google.com/go/compute",
     version = "v1.25.0",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
@@ -544,145 +544,145 @@ go_repo(
 )
 
 go_repo(
+    licences = ["MIT"],
     module = "github.com/go-ole/go-ole",
     version = "v1.3.0",
-    licences = ["MIT"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "google.golang.org/appengine",
     version = "v1.6.8",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "google.golang.org/genproto/googleapis/rpc",
     version = "v0.0.0-20240304212257-790db918fca8",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["MIT"],
     module = "github.com/secure-systems-lab/go-securesystemslib",
     version = "v0.8.0",
-    licences = ["MIT"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "gopkg.in/go-jose/go-jose.v2",
     version = "v2.6.3",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "google.golang.org/genproto/googleapis/api",
     version = "v0.0.0-20240304212257-790db918fca8",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "google.golang.org/genproto/googleapis/bytestream",
     version = "v0.0.0-20240304212257-790db918fca8",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "github.com/sigstore/sigstore/pkg/signature/kms/gcp",
     version = "v1.8.2",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["MIT"],
     module = "github.com/felixge/httpsnoop",
     version = "v1.0.4",
-    licences = ["MIT"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "github.com/go-logr/logr",
     version = "v1.4.1",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "github.com/go-logr/stdr",
     version = "v1.2.2",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "github.com/google/s2a-go",
     version = "v0.1.7",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["MIT"],
     module = "github.com/jellydator/ttlcache/v3",
     version = "v3.2.0",
-    licences = ["MIT"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc",
     version = "v0.49.0",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
     version = "v0.49.0",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "go.opentelemetry.io/otel",
     version = "v1.24.0",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "go.opentelemetry.io/otel/metric",
     version = "v1.24.0",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "go.opentelemetry.io/otel/trace",
     version = "v1.24.0",
-    licences = ["Apache-2.0"],
 )
 
 go_repo(
+    licences = ["BSD-3-Clause"],
     module = "golang.org/x/time",
     version = "v0.5.0",
-    licences = ["BSD-3-Clause"],
 )
 
 go_repo(
+    licences = ["BSD-3-Clause"],
     module = "github.com/lufia/plan9stats",
     version = "v0.0.0-20240226150601-1dcf7310316a",
-    licences = ["BSD-3-Clause"],
 )
 
 go_repo(
+    licences = ["MIT"],
     module = "github.com/power-devops/perfstat",
     version = "v0.0.0-20240221224432-82ca36839d55",
-    licences = ["MIT"],
 )
 
 go_repo(
+    licences = ["MPL-2.0"],
     module = "github.com/shoenig/go-m1cpu",
     version = "v0.1.6",
-    licences = ["MPL-2.0"],
 )
 
 go_repo(
+    licences = ["MIT"],
     module = "github.com/yusufpapurcu/wmi",
     version = "v1.2.4",
-    licences = ["MIT"],
 )
 
 go_repo(
+    licences = ["Apache-2.0"],
     module = "github.com/grpc-ecosystem/go-grpc-prometheus",
     version = "v1.2.0",
-    licences = ["Apache-2.0"],
 )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -686,3 +686,9 @@ go_repo(
     module = "github.com/grpc-ecosystem/go-grpc-prometheus",
     version = "v1.2.0",
 )
+
+go_repo(
+    licences = ["MIT"],
+    module = "github.com/k3a/html2text",
+    version = "v1.2.1",
+)


### PR DESCRIPTION
I intend to use [Fuse.js](https://fusejs.io/) to implement searching of the documentation website on the browser-side. It is lightweigh, well-maintained and does the job,

This commit creates the list of items through which Fuse.js searches, and includes this in the set of static files.