### PR TITLE
Add sharing options to debug as well

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ Version 17.9.0
     * Remove mention of pleasings from plz init message (#3173)
     * Report remote worker name in interactive output (#3178)
     * New `no_test_coverage` option to explicitly opt tests out of producing coverage (#3188)
+    * Add sandbox flags to `plz debug` matching `plz exec`'s behaviour
 
 Version 17.8.7
 --------------

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,7 +10,7 @@ Version 17.9.0
     * Remove mention of pleasings from plz init message (#3173)
     * Report remote worker name in interactive output (#3178)
     * New `no_test_coverage` option to explicitly opt tests out of producing coverage (#3188)
-    * Add sandbox flags to `plz debug` matching `plz exec`'s behaviour
+    * Add sandbox flags to `plz debug` matching `plz exec`'s behaviour (#3200)
 
 Version 17.8.7
 --------------

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.7.0",
     "java": "v0.4.0",
-    "go": "v1.17.4",
+    "go": "v1.17.5",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/src/debug/debug.go
+++ b/src/debug/debug.go
@@ -12,7 +12,7 @@ import (
 
 var log = logging.Log
 
-func Debug(state *core.BuildState, label core.BuildLabel, args, env []string) int {
+func Debug(state *core.BuildState, label core.BuildLabel, args, env []string, shareNetwork, shareMount bool) int {
 	target := state.Graph.TargetOrDie(label)
 	if len(target.Debug.Command) == 0 {
 		log.Fatalf("The build definition used by %s doesn't appear to support debugging yet", target.Label)
@@ -21,7 +21,7 @@ func Debug(state *core.BuildState, label core.BuildLabel, args, env []string) in
 	// Runtime directory.
 	dir := filepath.Join(core.OutDir, "debug", target.Label.Subrepo, target.Label.PackageName)
 
-	sandbox := target.Sandbox
+	sandbox := target.Sandbox || !shareMount
 	if target.IsTest() {
 		sandbox = target.Test.Sandbox
 		env = append(env, "TESTS="+strings.Join(args, " "))
@@ -31,7 +31,7 @@ func Debug(state *core.BuildState, label core.BuildLabel, args, env []string) in
 
 	// The value of `port` takes priority in deciding whether the network namespace should
 	// be shared or not, otherwise clients (i.e. IDEs) might not be able to connect to the debugger.
-	shareNetwork := state.DebugPort != 0 || !sandbox
+	shareNetwork = shareNetwork || state.DebugPort != 0 || !sandbox
 
 	return exec.Exec(state, core.AnnotatedOutputLabel{BuildLabel: label}, dir, env, cmd, nil, state.DebugPort == 0, process.NewSandboxConfig(!shareNetwork, sandbox))
 }

--- a/src/debug/debug.go
+++ b/src/debug/debug.go
@@ -21,9 +21,9 @@ func Debug(state *core.BuildState, label core.BuildLabel, args, env []string, sh
 	// Runtime directory.
 	dir := filepath.Join(core.OutDir, "debug", target.Label.Subrepo, target.Label.PackageName)
 
-	sandbox := target.Sandbox || !shareMount
+	targetSandbox := target.Sandbox
 	if target.IsTest() {
-		sandbox = target.Test.Sandbox
+		targetSandbox = target.Test.Sandbox
 		env = append(env, "TESTS="+strings.Join(args, " "))
 	}
 	// Append passed in arguments to the debug command.
@@ -31,7 +31,8 @@ func Debug(state *core.BuildState, label core.BuildLabel, args, env []string, sh
 
 	// The value of `port` takes priority in deciding whether the network namespace should
 	// be shared or not, otherwise clients (i.e. IDEs) might not be able to connect to the debugger.
-	shareNetwork = shareNetwork || state.DebugPort != 0 || !sandbox
+	shareNetwork = shareNetwork || state.DebugPort != 0 || !targetSandbox
+	shareMount = shareMount || !targetSandbox
 
-	return exec.Exec(state, core.AnnotatedOutputLabel{BuildLabel: label}, dir, env, cmd, nil, state.DebugPort == 0, process.NewSandboxConfig(!shareNetwork, sandbox))
+	return exec.Exec(state, core.AnnotatedOutputLabel{BuildLabel: label}, dir, env, cmd, nil, state.DebugPort == 0, process.NewSandboxConfig(!shareNetwork, !shareMount))
 }

--- a/src/please.go
+++ b/src/please.go
@@ -171,7 +171,11 @@ var opts struct {
 	} `command:"cover" description:"Builds and tests one or more targets, and calculates coverage."`
 
 	Debug struct {
-		Port int               `short:"p" long:"port" description:"Debugging server port"`
+		Port  int `short:"p" long:"port" description:"Debugging server port"`
+		Share struct {
+			Network bool `long:"share_network" description:"Share network namespace"`
+			Mount   bool `long:"share_mount" description:"Share mount namespace"`
+		} `group:"Options to override mount and network namespacing on linux, if configured"`
 		Env  map[string]string `short:"e" long:"env" description:"Environment variables to set for the debugged process"`
 		Args struct {
 			Target core.BuildLabel `positional-arg-name:"target" description:"Target to debug"`
@@ -544,7 +548,7 @@ var buildFunctions = map[string]func() int{
 		if !success {
 			return toExitCode(success, state)
 		}
-		return debug.Debug(state, opts.Debug.Args.Target, opts.Debug.Args.Args, exec.ConvertEnv(opts.Debug.Env))
+		return debug.Debug(state, opts.Debug.Args.Target, opts.Debug.Args.Args, exec.ConvertEnv(opts.Debug.Env), opts.Debug.Share.Network, opts.Debug.Share.Mount)
 	},
 	"exec": func() int {
 		success, state := runBuild([]core.BuildLabel{opts.Exec.Args.Target.BuildLabel}, true, false, false)


### PR DESCRIPTION
Sometimes I need to share file system for a `plz debug` run, so this exposes the options similar to Exec.

