### PR TITLE
Allow file-based completion for various arguments

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.7.0",
     "java": "v0.4.0",
-    "go": "v1.17.5",
+    "go": "v1.19.0",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/src/cli/flags.go
+++ b/src/cli/flags.go
@@ -212,10 +212,15 @@ func (f *Filepath) Complete(match string) []flags.Completion {
 type Filepaths []Filepath
 
 // AsStrings returns this slice of filepaths as a slice of strings.
+// It understands the - character to mean reading input from stdin.
 func (f Filepaths) AsStrings() []string {
-	ret := make([]string, len(f))
-	for i, fp := range f {
-		ret[i] = string(fp)
+	ret := make([]string, 0, len(f))
+	for _, fp := range f {
+		if fp == "-" {
+			ret = append(ret, cli.ReadAllStdin()...)
+		} else {
+			ret = append(ret, string(fp))
+		}
 	}
 	return ret
 }

--- a/src/help/rules.go
+++ b/src/help/rules.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/thought-machine/please/rules"
-	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
@@ -22,7 +21,7 @@ var log = logging.Log
 //
 //	a) all builtin rules if no files are passed, or
 //	b) all rules in the given files.
-func PrintRuleArgs(files cli.StdinStrings) {
+func PrintRuleArgs(files []string) {
 	var funcMap map[string]*asp.Statement
 	if len(files) > 0 {
 		log.Debugf("Got some files")
@@ -119,7 +118,7 @@ func getFunctionsFromState(state *core.BuildState) map[string]*asp.Statement {
 	return AllBuiltinFunctions(state)
 }
 
-func getFunctionsFromFiles(files cli.StdinStrings) map[string]*asp.Statement {
+func getFunctionsFromFiles(files []string) map[string]*asp.Statement {
 	state := newState()
 	p := asp.NewParser(state)
 	return parseFilesForFunctions(p, files)

--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -136,9 +136,6 @@ func getConfigKey(aspKey, configKey string) string {
 
 // pluginConfig loads the plugin's config into a pyDict. It will load con
 func pluginConfig(pluginState *core.BuildState, pkgState *core.BuildState) pyDict {
-	log.Debug("pluginState %s", pluginState.CurrentSubrepo)
-	log.Debug("pkgState %s", pkgState.CurrentSubrepo)
-
 	pluginName := strings.ToLower(pluginState.RepoConfig.PluginDefinition.Name)
 	var extraVals map[string][]string
 	var ret pyDict

--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -136,6 +136,9 @@ func getConfigKey(aspKey, configKey string) string {
 
 // pluginConfig loads the plugin's config into a pyDict. It will load con
 func pluginConfig(pluginState *core.BuildState, pkgState *core.BuildState) pyDict {
+	log.Debug("pluginState %s", pluginState.CurrentSubrepo)
+	log.Debug("pkgState %s", pkgState.CurrentSubrepo)
+
 	pluginName := strings.ToLower(pluginState.RepoConfig.PluginDefinition.Name)
 	var extraVals map[string][]string
 	var ret pyDict

--- a/src/please.go
+++ b/src/please.go
@@ -411,18 +411,18 @@ var opts struct {
 			EchoFiles     bool `long:"echo_files" description:"Echo the file for which the printed output is responsible."`
 			IgnoreUnknown bool `long:"ignore_unknown" description:"Ignore any files that are not inputs to existing build targets"`
 			Args          struct {
-				Files cli.StdinStrings `positional-arg-name:"files" description:"Files to query as sources to targets" required:"true"`
+				Files cli.Filepaths `positional-arg-name:"files" description:"Files to query as sources to targets" required:"true"`
 			} `positional-args:"true" required:"true"`
 		} `command:"whatinputs" description:"Prints out target(s) with provided file(s) as inputs"`
 		WhatOutputs struct {
 			EchoFiles bool `long:"echo_files" description:"Echo the file for which the printed output is responsible."`
 			Args      struct {
-				Files cli.StdinStrings `positional-arg-name:"files" required:"true" description:"Files to query targets responsible for"`
+				Files cli.Filepaths `positional-arg-name:"files" required:"true" description:"Files to query targets responsible for"`
 			} `positional-args:"true"`
 		} `command:"whatoutputs" description:"Prints out target(s) responsible for outputting provided file(s)"`
 		Rules struct {
 			Args struct {
-				Files cli.StdinStrings `positional-arg-name:"files" description:"Files to parse for build rules." hidden:"true"`
+				Files cli.Filepaths `positional-arg-name:"files" description:"Files to parse for build rules." hidden:"true"`
 			} `positional-args:"true"`
 		} `command:"rules" description:"Prints built-in rules to stdout as JSON"`
 		Changes struct {
@@ -433,7 +433,7 @@ var opts struct {
 			Inexact          bool   `long:"inexact" description:"Calculate changes more quickly and without doing any SCM checkouts, but may miss some targets."`
 			In               string `long:"in" description:"Calculate changes contained within given scm spec (commit range/sha/ref/etc). Implies --inexact."`
 			Args             struct {
-				Files cli.StdinStrings `positional-arg-name:"files" description:"Files to calculate changes for. Overrides flags relating to SCM operations."`
+				Files cli.Filepaths `positional-arg-name:"files" description:"Files to calculate changes for. Overrides flags relating to SCM operations."`
 			} `positional-args:"true"`
 		} `command:"changes" description:"Calculates the set of changed targets in regard to a set of modified files or SCM commits."`
 		Filter struct {
@@ -868,7 +868,7 @@ var buildFunctions = map[string]func() int{
 		})
 	},
 	"query.whatinputs": func() int {
-		files := opts.Query.WhatInputs.Args.Files.Get()
+		files := opts.Query.WhatInputs.Args.Files.AsStrings()
 		// Make all these relative to the repo root; many things do not work if they're absolute.
 		for i, file := range files {
 			if filepath.IsAbs(file) {
@@ -893,11 +893,11 @@ var buildFunctions = map[string]func() int{
 	},
 	"query.whatoutputs": func() int {
 		return runQuery(true, core.WholeGraph, func(state *core.BuildState) {
-			query.WhatOutputs(state.Graph, opts.Query.WhatOutputs.Args.Files.Get(), opts.Query.WhatOutputs.EchoFiles)
+			query.WhatOutputs(state.Graph, opts.Query.WhatOutputs.Args.Files.AsStrings(), opts.Query.WhatOutputs.EchoFiles)
 		})
 	},
 	"query.rules": func() int {
-		help.PrintRuleArgs(opts.Query.Rules.Args.Files)
+		help.PrintRuleArgs(opts.Query.Rules.Args.Files.AsStrings())
 		return 0
 	},
 	"query.changes": func() int {
@@ -930,7 +930,7 @@ var buildFunctions = map[string]func() int{
 			})
 		}
 		if len(opts.Query.Changes.Args.Files) > 0 {
-			return runInexact(opts.Query.Changes.Args.Files.Get())
+			return runInexact(opts.Query.Changes.Args.Files.AsStrings())
 		}
 		scm := scm.MustNew(core.RepoRoot)
 		if opts.Query.Changes.In != "" {


### PR DESCRIPTION
Several of them weren't offering completions, when they should do it based on paths on the file system. Have swapped them to Filepaths to get this behaviour, adding the ability to it to read from stdin when given `-` as an input.

This also means that some _other_ flags will now interpret the `-` as stdin as well where previously they didn't. I think this makes sense to be more consistent although maybe not all of them are very useful.

Outcome: `plz query whatinputs src/ple<tab>` -> `plz query whatinputs src/please.go`, whereas previously it sat there unhelpfully.