### PR TITLE
Report plugin name when failing to override plugin config field value

### DIFF
--- a/src/core/config.go
+++ b/src/core/config.go
@@ -863,7 +863,7 @@ func (config *Configuration) TagsToFields() map[string]reflect.StructField {
 func applyPluginOverride(config *Configuration, pluginName, configKey, value string) error {
 	plugin, ok := config.Plugin[pluginName]
 	if !ok {
-		return fmt.Errorf("no plugin with ID %v", plugin)
+		return fmt.Errorf("no plugin with ID %s", pluginName)
 	}
 
 	plugin.ExtraValues[strings.ToLower(configKey)] = []string{value}


### PR DESCRIPTION
If the plugin with the name `pluginName` hasn't been registered, `plugin` will always be nil. In the error message, report `pluginName` rather than `plugin`.

Fixes #3120.