### PR TITLE
Implement `keys`, `values` and `items` methods for `config` builtin type

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -138,9 +138,23 @@ def setdefault(self:config, key:str, default=None) -> config:
         return self[key]
     self[key] = default
     return default
-def config_get(self:config, key:str, default=None) -> config:
+def keys(self:dict) -> list:
+    pass
+def values(self:dict) -> list:
+    pass
+def items(self:dict) -> list:
+    pass
+def copy(self:dict) -> dict:
     pass
 
+def config_get(self:config, key:str, default=None) -> config:
+    pass
+def config_keys(self:config) -> list:
+    pass
+def config_items(self:config) -> list:
+    pass
+def config_values(self:config) -> list:
+    pass
 
 def get_base_path(label:str=None, subinclude_context:bool=None) -> str:
     pass
@@ -169,17 +183,6 @@ def tag(name:str, tag:str):
         tag("_name#foo", "bar") -> "_name#foo_bar"
     """
     pass
-
-
-def keys(self:dict) -> list:
-    pass
-def values(self:dict) -> list:
-    pass
-def items(self:dict) -> list:
-    pass
-def copy(self:dict) -> dict:
-    pass
-
 
 def git_branch(short:bool=True) -> str:
     fail('Disabled in config')

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -110,6 +110,9 @@ func registerBuiltins(s *scope) {
 	s.interpreter.configMethods = map[string]*pyFunc{
 		"get":        setNativeCode(s, "config_get", configGet),
 		"setdefault": s.Lookup("setdefault").(*pyFunc),
+		"keys":       setNativeCode(s, "config_keys", configKeys),
+		"items":      setNativeCode(s, "config_items", configItems),
+		"values":     setNativeCode(s, "config_values", configValues),
 	}
 	if s.state.Config.Parse.GitFunctions {
 		setNativeCode(s, "git_branch", execGitBranch)
@@ -720,6 +723,38 @@ func fromStringList(l []string) pyList {
 func configGet(s *scope, args []pyObject) pyObject {
 	self := args[0].(*pyConfig)
 	return self.Get(string(args[1].(pyString)), args[2])
+}
+
+func configKeys(s *scope, args []pyObject) pyObject {
+	self := args[0].(*pyConfig)
+	keys := self.Keys()
+	ret := make(pyList, len(keys))
+	for i, k := range keys {
+		ret[i] = pyString(k)
+	}
+	return ret
+}
+
+func configValues(s *scope, args []pyObject) pyObject {
+	self := args[0].(*pyConfig)
+	keys := self.Keys()
+	ret := make(pyList, len(keys))
+	for i, k := range self.Keys() {
+		// Safe to use MustGet here, since we know the key exists:
+		ret[i] = self.MustGet(k)
+	}
+	return ret
+}
+
+func configItems(s *scope, args []pyObject) pyObject {
+	self := args[0].(*pyConfig)
+	keys := self.Keys()
+	ret := make(pyList, len(keys))
+	for i, k := range self.Keys() {
+		// Safe to use MustGet here, since we know the key exists:
+		ret[i] = pyList{pyString(k), self.MustGet(k)}
+	}
+	return ret
 }
 
 func dictGet(s *scope, args []pyObject) pyObject {

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -120,6 +120,14 @@ func TestInterpreterBuiltins(t *testing.T) {
 	assert.NotNil(t, s.pkg.Target("lib"))
 }
 
+func TestInterpreterConfig(t *testing.T) {
+	s, err := parseFile("src/parse/asp/test_data/interpreter/config.build")
+	require.NoError(t, err)
+	for _, v := range []string{"g", "k1", "k2", "v", "i"} {
+		assert.EqualValues(t, True, s.Lookup(v))
+	}
+}
+
 func TestInterpreterParentheses(t *testing.T) {
 	s, err := parseFile("src/parse/asp/test_data/interpreter/parentheses.build")
 	require.NoError(t, err)

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -944,6 +944,24 @@ func (c *pyConfig) Copy() *pyConfig {
 	return &pyConfig{base: c.base}
 }
 
+// Keys returns the keys of this config object in order, similarly to a dict but it includes keys in
+// both internal maps.
+func (c *pyConfig) Keys() []string {
+	ret := make([]string, 0)
+	for k, _ := range c.base.dict {
+		ret = append(ret, k)
+	}
+	if c.overlay != nil {
+		for k, _ := range c.overlay {
+			ret = append(ret, k)
+		}
+	}
+	sort.Strings(ret)
+	// Remove duplicate keys that appear in both the base and overlay dicts
+	ret = slices.Compact(ret)
+	return ret
+}
+
 // Get implements the get() method, similarly to a dict but looks up in both internal maps.
 func (c *pyConfig) Get(key string, fallback pyObject) pyObject {
 	if c.overlay != nil {

--- a/src/parse/asp/test_data/interpreter/config.build
+++ b/src/parse/asp/test_data/interpreter/config.build
@@ -1,0 +1,13 @@
+g = CONFIG.get("ARCAT_TOOL") == "/////_please:arcat"
+
+keys = CONFIG.keys()
+k1 = "ARCAT_TOOL" in keys
+keys_sorted = sorted(keys)
+k2 = keys == keys_sorted
+
+v = "/////_please:arcat" in CONFIG.values()
+
+i = False
+for key, val in CONFIG.items():
+    if key == "ARCAT_TOOL" and val == "/////_please:arcat":
+        i = True


### PR DESCRIPTION
These are the missing methods that prevent the `config` type from behaving like the `dict` type. `values` isn't particularly useful for the `config` type, but is included for completeness.