### PR TITLE
Output debug message when plugin config is loaded

### DIFF
--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -204,6 +204,8 @@ func (i *interpreter) loadPluginConfig(s *scope, pluginState *core.BuildState) {
 		return
 	}
 
+	log.Debugf("Loading configuration for plugin %s", pluginName)
+
 	if s.config.overlay == nil {
 		s.config.overlay = pyDict{}
 	}


### PR DESCRIPTION
This clarifies the point at which a plugin's configuration is merged into the main configuration.