### PR TITLE
Use go-rules v1.20.0 everywhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ jobs:
            command: tar -xzf /tmp/workspace/darwin_arm64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:1 -o plugin.go.cctool:clang -o "plugin.go.cflags:-target x86_64-apple-macos13" //package:release_files
+           command: ./please/please build -p --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:true -o plugin.go.cctool:clang -o "plugin.go.cflags:-target x86_64-apple-macos13" //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.7.0",
     "java": "v0.4.0",
-    "go": "v1.19.0",
+    "go": "v1.20.0",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,7 +1,7 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v1.17.3",
+    revision = "v1.20.0",
 )
 
 plugin_repo(

--- a/test/entry_point/test_repo/plugins/BUILD_FILE
+++ b/test/entry_point/test_repo/plugins/BUILD_FILE
@@ -7,5 +7,5 @@ plugin_repo(
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v1.7.6",
+    revision = "v1.20.0",
 )

--- a/tools/build_langserver/lsp/test_data/plugins/test.build
+++ b/tools/build_langserver/lsp/test_data/plugins/test.build
@@ -1,5 +1,5 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v1.2.1",
+    revision = "v1.20.0",
 )


### PR DESCRIPTION
Use go-rules v1.20.0 to build Please, for the Go plugin documentation, and in tests that include go-rules.