### PR TITLE
Use go-rules v1.20.1 everywhere

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.7.0",
     "java": "v0.4.0",
-    "go": "v1.20.0",
+    "go": "v1.20.1",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,7 +1,7 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v1.20.0",
+    revision = "v1.20.1",
 )
 
 plugin_repo(

--- a/test/entry_point/test_repo/plugins/BUILD_FILE
+++ b/test/entry_point/test_repo/plugins/BUILD_FILE
@@ -7,5 +7,5 @@ plugin_repo(
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v1.20.0",
+    revision = "v1.20.1",
 )

--- a/test/plugins/test_repo/plugins/BUILD_FILE
+++ b/test/plugins/test_repo/plugins/BUILD_FILE
@@ -5,5 +5,6 @@ plugin_repo(
 
 plugin_repo(
     name = "go",
-    revision = "v1.16.5",
+    plugin = "go-rules",
+    revision = "v1.20.1",
 )

--- a/test/plz_exec/test_repo/plugins/BUILD_FILE
+++ b/test/plz_exec/test_repo/plugins/BUILD_FILE
@@ -5,5 +5,6 @@ plugin_repo(
 
 plugin_repo(
     name = "go",
-    revision = "v1.16.5",
+    plugin = "go-rules",
+    revision = "v1.20.1",
 )

--- a/test/proto_plugin/test_repo/plugins/BUILD_FILE
+++ b/test/proto_plugin/test_repo/plugins/BUILD_FILE
@@ -5,7 +5,8 @@ plugin_repo(
 
 plugin_repo(
     name = "go",
-    revision = "v1.16.8",
+    plugin = "go-rules",
+    revision = "v1.20.1",
 )
 
 plugin_repo(

--- a/tools/build_langserver/lsp/test_data/plugins/test.build
+++ b/tools/build_langserver/lsp/test_data/plugins/test.build
@@ -1,5 +1,5 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v1.20.0",
+    revision = "v1.20.1",
 )


### PR DESCRIPTION
Use go-rules v1.20.1 to build Please, for the Go plugin documentation, and in tests that include go-rules.