### PR TITLE
Return `None` for empty optional plugin config fields

### DIFF
--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -179,7 +179,7 @@ func pluginConfig(pluginState *core.BuildState, pkgState *core.BuildState) pyDic
 		if definition.Repeatable {
 			l := make(pyList, 0, len(value))
 			for _, v := range value {
-				l = append(l, toPyObject(fullConfigKey, v, definition.Type))
+				l = append(l, toPyObject(fullConfigKey, v, definition.Type, definition.Optional))
 			}
 			ret[key] = l
 		} else {
@@ -187,7 +187,7 @@ func pluginConfig(pluginState *core.BuildState, pkgState *core.BuildState) pyDic
 			if len(value) == 1 {
 				val = value[0]
 			}
-			ret[key] = toPyObject(fullConfigKey, val, definition.Type)
+			ret[key] = toPyObject(fullConfigKey, val, definition.Type, definition.Optional)
 		}
 	}
 	return ret
@@ -219,34 +219,33 @@ func (i *interpreter) loadPluginConfig(s *scope, pluginState *core.BuildState) {
 	s.config.overlay[key] = cfg
 }
 
-func toPyObject(key, val, toType string) pyObject {
-	if toType == "" || toType == "str" {
+func toPyObject(key, val, toType string, optional bool) pyObject {
+	if optional && val == "" {
+		return pyNone{}
+	}
+
+	switch toType {
+	case "", "str":
 		return pyString(val)
-	}
-
-	if toType == "bool" {
-		val = strings.ToLower(val)
-		if val == "true" || val == "yes" || val == "on" {
+	case "bool":
+		switch strings.ToLower(val) {
+		case "true", "yes", "on":
 			return pyBool(true)
-		}
-		if val == "false" || val == "no" || val == "off" || val == "" {
+		case "false", "no", "off":
 			return pyBool(false)
+		default:
+			log.Fatalf("%s: invalid bool value: %v", key, val)
+			return pyNone{}
 		}
-		log.Fatalf("%s: Invalid boolean value %v", key, val)
-	}
-
-	if toType == "int" {
-		if val == "" {
-			return pyInt(0)
-		}
-
+	case "int":
 		i, err := strconv.Atoi(val)
 		if err != nil {
-			log.Fatalf("%s: Invalid int value %v", key, val)
+			log.Fatalf("%s: invalid int value: %v", key, val)
+			return pyNone{}
 		}
 		return pyInt(i)
+	default:
+		log.Fatalf("%s: invalid plugin configuration field type: %v", key, toType)
+		return pyNone{}
 	}
-
-	log.Fatalf("%s: invalid config type %v", key, toType)
-	return pyNone{}
 }

--- a/test/plugins/BUILD
+++ b/test/plugins/BUILD
@@ -10,6 +10,16 @@ genrule(
     cmd = "mv $SRCS_PLUGIN foo_plugin && mv $SRCS_TOOL foo_plugin/tools && tar -czf $OUT foo_plugin",
 )
 
+genrule(
+    name = "config_field_value_plugin",
+    srcs = ["config_field_value_plugin"],
+    outs = ["config_field_value_plugin.tar.gz"],
+    cmd = [
+        "mv $SRCS config_field_value_plugin",
+        "tar -czf $OUTS config_field_value_plugin",
+    ],
+)
+
 def plugin_e2e_test(name, plz_command, expected_output=None, expected_failure=False, expect_output_contains=None):
     return please_repo_e2e_test(
         name = name,
@@ -135,3 +145,27 @@ plugin_e2e_test(
     },
     plz_command = "plz build -o plugin.foo.modulepath:something --arch foo_bar66 //:output_fooc",
 )
+
+config_field_value_tests = {
+    "str_required": "req",
+    "str_optional": "opt",
+    "bool_required": "True",
+    "bool_optional": "True",
+    "int_required": "2",
+    "int_optional": "3",
+}
+
+for field, val in config_field_value_tests.items():
+    field_cli = field.replace("_", "")
+    field_out = field.upper()
+    please_repo_e2e_test(
+        name = f"{field}_config_field_value_test",
+        data = {
+            "plugin": [":config_field_value_plugin"],
+        },
+        expect_output_contains = {
+            "plz-out/gen/test/config_field_value_test": f"{field_out}='{val}'",
+        },
+        plz_command = f"plz build -o please.pluginrepo:file://$TMP_DIR/$DATA_PLUGIN -o plugin.config_field_value.{field_cli}:{val} //test:config_field_value_test",
+        repo = "config_field_value_test_repo",
+    )

--- a/test/plugins/config_field_value_plugin/.plzconfig
+++ b/test/plugins/config_field_value_plugin/.plzconfig
@@ -1,0 +1,32 @@
+[PluginDefinition]
+Name = config_field_value
+
+[PluginConfig "str_required"]
+Type = str
+Inherit = false
+DefaultValue =
+
+[PluginConfig "str_optional"]
+Type = str
+Optional = true
+Inherit = false
+
+[PluginConfig "int_required"]
+Type = int
+Inherit = false
+DefaultValue = 0
+
+[PluginConfig "int_optional"]
+Type = int
+Optional = true
+Inherit = false
+
+[PluginConfig "bool_required"]
+Type = bool
+Inherit = false
+DefaultValue = false
+
+[PluginConfig "bool_optional"]
+Type = bool
+Optional = true
+Inherit = false

--- a/test/plugins/config_field_value_plugin/build_defs/BUILD_FILE
+++ b/test/plugins/config_field_value_plugin/build_defs/BUILD_FILE
@@ -1,0 +1,5 @@
+export_file(
+    name = "defs",
+    src = "defs.build_defs",
+    visibility = ["PUBLIC"],
+)

--- a/test/plugins/config_field_value_plugin/build_defs/defs.build_defs
+++ b/test/plugins/config_field_value_plugin/build_defs/defs.build_defs
@@ -1,0 +1,2 @@
+# This file only exists so that config_field_value_test_repo has a target to
+# build, which will cause this plugin to be loaded.

--- a/test/plugins/config_field_value_test_repo/.plzconfig
+++ b/test/plugins/config_field_value_test_repo/.plzconfig
@@ -1,0 +1,2 @@
+[Plugin "config_field_value"]
+Target = //plugins:config_field_value

--- a/test/plugins/config_field_value_test_repo/plugins/BUILD_FILE
+++ b/test/plugins/config_field_value_test_repo/plugins/BUILD_FILE
@@ -1,0 +1,4 @@
+plugin_repo(
+    name = "config_field_value",
+    revision = "v0.0.1",
+)

--- a/test/plugins/config_field_value_test_repo/test/BUILD_FILE
+++ b/test/plugins/config_field_value_test_repo/test/BUILD_FILE
@@ -1,0 +1,7 @@
+subinclude("///config_field_value//build_defs:defs")
+
+text_file(
+    name = "config_field_value_test",
+    out = "config_field_value_test",
+    content = "\n".join([f"{k}='{v}'" for k, v in CONFIG.CONFIG_FIELD_VALUE.items()]),
+)


### PR DESCRIPTION
Specifying an empty value for an optional plugin configuration field causes the field to be set to the type's default value (`""` for strings, `0` for integers, `False` for booleans) from the perspective of ASP. This makes it impossible to tell whether an optional field was actually assigned a value inside a `BUILD` file.

For optional fields, return `None` if no value is assigned.