### PR TITLE
Make `1`/`0` synonyms for `true`/`false` in boolean plugin config fields

### DIFF
--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -229,9 +229,9 @@ func toPyObject(key, val, toType string, optional bool) pyObject {
 		return pyString(val)
 	case "bool":
 		switch strings.ToLower(val) {
-		case "true", "yes", "on":
+		case "true", "yes", "on", "1":
 			return pyBool(true)
-		case "false", "no", "off":
+		case "false", "no", "off", "0":
 			return pyBool(false)
 		default:
 			log.Fatalf("%s: invalid bool value: %v", key, val)


### PR DESCRIPTION
This will aid users in the transition of go-rules' `cgo_enabled` field from being of type `str` to being of type `bool` (see https://github.com/please-build/go-rules/pull/274).