### PR TITLE
Don't compare unexported fields when comparing subrepos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/golang/protobuf v1.5.4
+	github.com/google/go-cmp v0.6.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/ProtonMail/go-crypto v0.0.0-20210920135941-2c5829bbf927 h1:OSZDIq6u4i
 github.com/ProtonMail/go-crypto v0.0.0-20210920135941-2c5829bbf927/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4uEoM0=
 github.com/alessio/shellescape v1.4.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
-github.com/bazelbuild/remote-apis v0.0.0-20210718193713-0ecef08215cf h1:DjbO/OLNTvELsPJRy5qU/aIsozQxBQVek+vTO49ybus=
-github.com/bazelbuild/remote-apis v0.0.0-20210718193713-0ecef08215cf/go.mod h1:ry8Y6CkQqCVcYsjPOlLXDX2iRVjOnjogdNwhvHmRcz8=
 github.com/bazelbuild/remote-apis v0.0.0-20240409135018-1f36c310b28d h1:0aFLY/13huh7hMwsxXXf2etOuS4GrdTk37aJEXYEsic=
 github.com/bazelbuild/remote-apis v0.0.0-20240409135018-1f36c310b28d/go.mod h1:ry8Y6CkQqCVcYsjPOlLXDX2iRVjOnjogdNwhvHmRcz8=
 github.com/bazelbuild/remote-apis-sdks v0.0.0-20221114180157-e62cf9b8696a h1:zIP0R2m8O2VgQlDlMYM0jGmJ+BPx4FQ6+ETRERaLMkM=

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -21,6 +21,8 @@ go_library(
         "///third_party/go/github.com_thought-machine_go-flags//:go-flags",
         "///third_party/go/github.com_zeebo_blake3//:blake3",
         "///third_party/go/golang.org_x_sync//errgroup",
+        "///third_party/go/github.com_google_go-cmp//cmp",
+        "///third_party/go/github.com_google_go-cmp//cmp/cmpopts",
         "//src/cli",
         "//src/cli/logging",
         "//src/cmap",

--- a/src/core/graph.go
+++ b/src/core/graph.go
@@ -5,7 +5,6 @@
 package core
 
 import (
-	"reflect"
 	"sort"
 
 	"github.com/thought-machine/please/src/cmap"
@@ -105,7 +104,7 @@ func (graph *BuildGraph) AddSubrepo(subrepo *Subrepo) {
 func (graph *BuildGraph) MaybeAddSubrepo(subrepo *Subrepo) *Subrepo {
 	if !graph.subrepos.Add(subrepo.Name, subrepo) {
 		old := graph.subrepos.Get(subrepo.Name)
-		if !reflect.DeepEqual(old, subrepo) {
+		if !old.Equal(subrepo) {
 			log.Fatalf("Found multiple definitions for subrepo '%s' (%+v s %+v)", old.Name, old, subrepo)
 		}
 		return old

--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/thought-machine/please/src/cli"
-	"github.com/thought-machine/please/src/fs"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/fs"
 )
 
 // A Subrepo stores information about a registered subrepository, typically one

--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/fs"
 )

--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/fs"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 // A Subrepo stores information about a registered subrepository, typically one
@@ -66,6 +68,11 @@ func (s *Subrepo) FS() iofs.FS {
 // IsRemoteSubrepo returns true when the subrepo sources are remote i.e. not downloaded to plz-out
 func (s *Subrepo) IsRemoteSubrepo() bool {
 	return s.Root != "" && s.Target != nil && !s.Target.Local && s.State.RemoteClient != nil
+}
+
+// Equal returns true if this subrepo is equivalent to another, or false if it is not.
+func (s *Subrepo) Equal(other *Subrepo) bool {
+	return cmp.Equal(s, other, cmpopts.IgnoreFields(Subrepo{}, "fs", "fsSync"))
 }
 
 // SubrepoForArch creates a new subrepo for the given architecture.


### PR DESCRIPTION
Two subrepos can be equal even if their unexported `fs` and `fsSync` fields differ. Exclude them when checking the equality of two subrepos.

Fixes #3222.