### PR TITLE
Licences are now SPDX expressions

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -58,8 +58,8 @@ genrule(
 # Plugin versions to pull the docs from
 plugins = {
     "python": "v1.7.0",
-    "java": "v0.4.0",
-    "go": "v1.20.1",
+    "java": "v0.4.1",
+    "go": "v1.21.1",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -951,6 +951,9 @@
       Adds a new licence to a target. The assumption (as usual) is that if
       multiple are added, they are options, so any one can be accepted.
     </p>
+    <p>
+      Deprecated in favour of <code>set_licence</code>.
+    </p>
 
     <div class="overflow-x-auto">
       <table class="table">
@@ -981,6 +984,45 @@
   </section>
 
   <section class="mt4">
+    <h3 class="title-3" id="set_licence">
+      set_licence
+    </h3>
+
+    <code class="code-signature">set_licence(target, licence)</code>
+
+    <p>
+      Sets the target's licence to the given SPDX expression. Note that no normalisation is done on it.
+    </p>
+
+    <div class="overflow-x-auto">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Argument</th>
+            <th>Default</th>
+            <th>Type</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>target</td>
+            <td></td>
+            <td>str</td>
+            <td>Label of the target to add the licence to.</td>
+          </tr>
+          <tr>
+            <td>licence</td>
+            <td></td>
+            <td>str</td>
+            <td>SPDX expression defining licensing of the target</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="mt4">
     <h3 class="title-3" id="get_licences">
       get_licences
     </h3>
@@ -989,6 +1031,9 @@
 
     <p>
       Returns all the licences that are currently known to apply to a target.
+    </p>
+    <p>
+      Deprecated in favour of get_licence.
     </p>
 
     <div class="overflow-x-auto">
@@ -1007,6 +1052,39 @@
             <td></td>
             <td>str</td>
             <td>Label of the target to get licences for.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="mt4">
+    <h3 class="title-3" id="get_licence">
+      get_licence
+    </h3>
+
+    <code class="code-signature">get_licence(target)</code>
+
+    <p>
+      Returns the licence expression of the given target.
+    </p>
+
+    <div class="overflow-x-auto">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Argument</th>
+            <th>Default</th>
+            <th>Type</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>target</td>
+            <td></td>
+            <td>str</td>
+            <td>Label of the target to get the licence expression for.</td>
           </tr>
         </tbody>
       </table>

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/github/go-spdx/v2 v2.3.1 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/mostynb/zstdpool-syncpool v0.0.13 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
+	github.com/peterebden/go-spdx/v2 v2.4.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/github/go-spdx/v2 v2.3.1 h1:ffGuHTbHuHzWPt53n8f9o8clGutuLPObo3zB4JAjxU8=
+github.com/github/go-spdx/v2 v2.3.1/go.mod h1:2ZxKsOhvBp+OYBDlsGnUMcchLeo2mrpEBn2L1C+U3IQ=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,12 @@ github.com/peterebden/go-cli-init/v5 v5.2.1 h1:o+7EjS/PiYDvFUQRQVXJRjinmUzDjqcea
 github.com/peterebden/go-cli-init/v5 v5.2.1/go.mod h1:0eBDoCJjj3BWyEtidFcP0TlD14cRtOtLCrTG/OVPB74=
 github.com/peterebden/go-deferred-regex v1.1.0 h1:XNpUuRDU7iU59Toy+OJp9LUvsun5i3kEbe3c73oyCZg=
 github.com/peterebden/go-deferred-regex v1.1.0/go.mod h1:EhIu4zsN+60671cx29rzxPSIEnDd2vOia4RFSOaYpRI=
+github.com/peterebden/go-spdx/v2 v2.4.1 h1:ah4SjMgKyFXqR5qkBGwKbtevTV3UK3+17OiPNw18GVM=
+github.com/peterebden/go-spdx/v2 v2.4.1/go.mod h1:6KrhEd9kpULcLYV6rGkV47Rolvt2IFcaRCyewNnLkLA=
+github.com/peterebden/go-spdx/v2 v2.4.2 h1:u+lPJXPPK1cJpCtDQBlUgu/cXgOg/dYUWKHUyHxakYI=
+github.com/peterebden/go-spdx/v2 v2.4.2/go.mod h1:6KrhEd9kpULcLYV6rGkV47Rolvt2IFcaRCyewNnLkLA=
+github.com/peterebden/go-spdx/v2 v2.4.3 h1:iiOEYy8+qvyTA3IBqVgLGpwTl5MAmU0Ej39w+8xr5gQ=
+github.com/peterebden/go-spdx/v2 v2.4.3/go.mod h1:6KrhEd9kpULcLYV6rGkV47Rolvt2IFcaRCyewNnLkLA=
 github.com/peterebden/go-sri v1.1.1 h1:KK8yZ5/NX8YzWUY9QvhrP220QsvEKANLLAgvw35AkyU=
 github.com/peterebden/go-sri v1.1.1/go.mod h1:KIRxtog35NfDWec5LV/iBqqfOEPcMpePZLc7EPE6goQ=
 github.com/peterebden/tools v0.0.0-20190805132753-b2a0db951d2a h1:R4xz7BkSIQOS5CFmaadk2gwwOzy/u2Jvnimf1NHD2LY=

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -266,8 +266,12 @@ def add_entry_point(target:str, name:str, out:str):
 def get_entry_points(target:str) -> dict:
     pass
 def add_licence(target:str, licence:str):
+    """Deprecated in favour of set_licence"""
+def set_licence(target:str, licence: str):
     pass
 def get_licences(target:str):
+    """Deprecated in favour of get_licence"""
+def get_licence(target:str):
     pass
 def get_command(target:str, config:str=''):
     pass

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -290,13 +290,9 @@ func TestLicenceEnforcement(t *testing.T) {
 
 	// A license (non case sensitive) that is not in the list of accepted licenses will panic.
 	assert.Panics(t, func() {
-		target.Licences = append(target.Licences, "Bsd")
+		target.Licence = "Bsd"
 		checkLicences(state, target)
 	}, "A target with a non-accepted licence will panic")
-
-	// Accepting bsd should resolve the panic
-	state.Config.Licences.Accept = append(state.Config.Licences.Accept, "BSD")
-	checkLicences(state, target)
 
 	// Now construct a new "bad" target.
 	state, target = newState("//pkg:bad")
@@ -304,8 +300,8 @@ func TestLicenceEnforcement(t *testing.T) {
 	state.Config.Licences.Accept = append(state.Config.Licences.Accept, "mit")
 
 	// Adding an explicitly rejected licence should panic no matter what.
-	target.Licences = append(target.Licences, "GPL")
 	assert.Panics(t, func() {
+		target.Licence = "GPL"
 		checkLicences(state, target)
 	}, "Trying to add GPL should panic (case insensitive)")
 }

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -172,10 +172,7 @@ func ruleHash(state *core.BuildState, target *core.BuildTarget, runtime bool) []
 			h.Write([]byte(out))
 		}
 	}
-	for _, licence := range target.Licences {
-		h.Write([]byte(licence))
-	}
-
+	h.Write([]byte(target.Licence))
 	for _, output := range target.OptionalOutputs {
 		h.Write([]byte(output))
 	}

--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -41,7 +41,7 @@ var KnownFields = map[string]bool{
 	"PostBuildHash":               true,
 	"outputs":                     true,
 	"namedOutputs":                true,
-	"Licences":                    true,
+	"Licence":                     true,
 	"Sandbox":                     true,
 	"Tools":                       true,
 	"namedTools":                  true,

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -13,6 +13,7 @@ go_library(
         "///third_party/go/github.com_coreos_go-semver//semver",
         "///third_party/go/github.com_google_shlex//:shlex",
         "///third_party/go/github.com_peterebden_go-deferred-regex//:go-deferred-regex",
+        "///third_party/go/github.com_peterebden_go-spdx_v2//spdxexp",
         "///third_party/go/github.com_pkg_xattr//:xattr",
         "///third_party/go/github.com_please-build_gcfg//:gcfg",
         "///third_party/go/github.com_please-build_gcfg//types",

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1890,12 +1890,12 @@ func (target *BuildTarget) PackageDir() string {
 // CheckLicences checks the target's licences against the accepted/rejected list.
 // It returns the licence expression that was accepted and an error if it did not match.
 func (target *BuildTarget) CheckLicences(config *Configuration) (string, error) {
-	if target.Licence == "" || len(config.Licences.Accept) == 0 {
+	if target.Licence == "" || (len(config.Licences.Accept) == 0 && len(config.Licences.Reject) == 0) {
 		return "", nil
 	}
 	accepted, err := spdxexp.ExpressionSatisfies(target.Licence, config.Licences.Accept)
 	if err != nil {
-		return "", fmt.Errorf("Target %s has invalid licence %s: %s", target, target.Licence, err)
+		return "", fmt.Errorf("Target %s has invalid licence '%s': %s", target, target.Licence, err)
 	} else if accepted == "" {
 		return "", fmt.Errorf("The licences for %s are not accepted in this repository: %s", target, target.Licence)
 	}

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1893,7 +1893,7 @@ func (target *BuildTarget) CheckLicences(config *Configuration) (string, error) 
 	if target.Licence == "" || (len(config.Licences.Accept) == 0 && len(config.Licences.Reject) == 0) {
 		return "", nil
 	}
-	accepted, err := spdxexp.ExpressionSatisfies(target.Licence, config.Licences.Accept)
+	accepted, err := spdxexp.ExpressionSatisfies(target.Licence, config.AcceptedLicences())
 	if err != nil {
 		return "", fmt.Errorf("Target %s has invalid licence '%s': %s", target, target.Licence, err)
 	} else if accepted == "" {

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -152,8 +152,8 @@ type BuildTarget struct {
 	// Acceptable hashes of the outputs of this rule. If the output doesn't match any of these
 	// it's an error at build time. Can be used to validate third-party deps.
 	Hashes []string
-	// Licences that this target is subject to.
-	Licences []string
+	// SPDX licence expression that this target is subject to.
+	Licence string
 	// Any secrets that this rule requires.
 	// Secrets are similar to sources but are always absolute system paths and affect the hash
 	// differently; they are not used to determine the hash for retrieving a file from cache, but
@@ -1762,17 +1762,6 @@ func (target *BuildTarget) insert(sl []string, s string) []string {
 		}
 	}
 	return append(sl, s)
-}
-
-// AddLicence adds a licence to the target if it's not already there.
-func (target *BuildTarget) AddLicence(licence string) {
-	licence = strings.TrimSpace(licence)
-	for _, l := range target.Licences {
-		if l == licence {
-			return
-		}
-	}
-	target.Licences = append(target.Licences, licence)
 }
 
 // AddHash adds a new acceptable hash to the target.

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -954,19 +954,24 @@ func TestIsTool(t *testing.T) {
 
 func TestCheckLicences(t *testing.T) {
 	config := DefaultConfiguration()
-	config.Licences.Accept = []string{"BSD"}
+	config.Licences.Accept = []string{"BSD", "Apache-2.0"}
 	config.Licences.Reject = []string{"GPL"}
 
 	target := makeTarget1("//src/core/test_data/project", "PUBLIC")
-	target.Licences = []string{"BSD", "GPL"}
+	target.Licence = "BSD OR GPL"
 	accepted, err := target.CheckLicences(config)
 	assert.NoError(t, err)
 	assert.Equal(t, "BSD", accepted)
 
-	target.Licences = []string{"MIT", "GPL"}
+	target.Licence = "MIT OR GPL"
 	accepted, err = target.CheckLicences(config)
 	assert.Error(t, err)
 	assert.Equal(t, "", accepted)
+
+	target.Licence = "BSD AND Apache-2.0 OR GPL"
+	accepted, err = target.CheckLicences(config)
+	assert.NoError(t, err)
+	assert.Equal(t, "BSD AND Apache-2.0", accepted)
 }
 
 func makeTarget1(label, visibility string, deps ...*BuildTarget) *BuildTarget {

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -689,6 +689,7 @@ type Configuration struct {
 	buildEnvStored *storedBuildEnv
 
 	FeatureFlags struct {
+		SPDXLicencesOnly bool `help:"Licences on build targets can only be strings containing SPDX expressions, not lists."`
 	} `help:"Flags controlling preview features for the next release. Typically these config options gate breaking changes and only have a lifetime of one major release."`
 	Metrics struct {
 		PrometheusGatewayURL string       `help:"The gateway URL to push prometheus updates to."`

--- a/src/core/stamp.go
+++ b/src/core/stamp.go
@@ -22,11 +22,15 @@ func StampFile(config *Configuration, target *BuildTarget) []byte {
 
 func populateStampInfo(config *Configuration, target *BuildTarget, info *stampInfo) {
 	accepted, _ := target.CheckLicences(config)
-	info.Targets[target.Label] = targetInfo{
-		Licences:        target.Licences,
+	ti := targetInfo{
+		Licence:         target.Licence,
 		AcceptedLicence: accepted,
 		Labels:          target.Labels,
 	}
+	if target.Licence != "" {
+		ti.Licences = []string{target.Licence}
+	}
+	info.Targets[target.Label] = ti
 	for _, dep := range target.Dependencies() {
 		if _, present := info.Targets[dep.Label]; !present {
 			populateStampInfo(config, dep, info)
@@ -40,6 +44,7 @@ type stampInfo struct {
 
 type targetInfo struct {
 	Labels          []string `json:"labels,omitempty"`
-	Licences        []string `json:"licences,omitempty"`
+	Licence         string   `json:"licence,omitempty"`
+	Licences        []string `json:"licences,omitempty"` // Deprecated in favour of Licence
 	AcceptedLicence string   `json:"accepted_licence,omitempty"`
 }

--- a/src/core/stamp_test.go
+++ b/src/core/stamp_test.go
@@ -14,14 +14,14 @@ func TestStampFile(t *testing.T) {
 	t3 := NewBuildTarget(ParseBuildLabel("//third_party/go:errors", ""))
 	t1.AddLabel("go")
 	t3.AddLabel("go_get:github.com/pkg/errors")
-	t3.AddLicence("bsd-2-clause")
+	t3.Licence = "bsd-2-clause"
 	t1.AddDependency(t2.Label)
 	t1.resolveDependency(t2.Label, t2)
 	t1.AddDependency(t3.Label)
 	t1.resolveDependency(t3.Label, t3)
 	t2.AddDependency(t3.Label)
 	t2.resolveDependency(t3.Label, t3)
-	expected := []byte(`{
+	const expected = `{
   "targets": {
     "//src/core:core": {
       "labels": [
@@ -33,12 +33,14 @@ func TestStampFile(t *testing.T) {
       "labels": [
         "go_get:github.com/pkg/errors"
       ],
+      "licence": "bsd-2-clause",
       "licences": [
         "bsd-2-clause"
       ],
-      "accepted_licence": "bsd-2-clause"
+      "accepted_licence": "BSD-2-Clause"
     }
   }
-}`)
-	assert.Equal(t, expected, StampFile(config, t1))
+}`
+
+	assert.Equal(t, expected, string(StampFile(config, t1)))
 }

--- a/src/parse/asp/BUILD
+++ b/src/parse/asp/BUILD
@@ -12,6 +12,7 @@ go_library(
         "///third_party/go/github.com_Masterminds_semver_v3//:v3",
         "///third_party/go/github.com_manifoldco_promptui//:promptui",
         "///third_party/go/github.com_please-build_gcfg//types",
+        "///third_party/go/github.com_peterebden_go-deferred-regex//:go-deferred-regex",
         "//src/cli",
         "//src/cli/logging",
         "//src/cmap",

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1318,7 +1318,7 @@ func addLicence(s *scope, args []pyObject) pyObject {
 	if target.Licence != "" {
 		target.Licence += " OR "
 	}
-	target.Licence += string(args[1].(pyString))
+	target.Licence += strings.TrimSpace(strings.ReplaceAll(string(args[1].(pyString)), " ", "-"))
 	return None
 }
 

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/manifoldco/promptui"
+	"github.com/peterebden/go-deferred-regex"
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"
@@ -23,6 +24,8 @@ import (
 
 // A nativeFunc is a function that implements a builtin function natively.
 type nativeFunc func(*scope, []pyObject) pyObject
+
+var normaliseLicence = deferredregex.DeferredRegex{Re: `[ (),]`}
 
 // registerBuiltins sets up the "special" builtins that map to native code.
 func registerBuiltins(s *scope) {
@@ -1318,7 +1321,7 @@ func addLicence(s *scope, args []pyObject) pyObject {
 	if target.Licence != "" {
 		target.Licence += " OR "
 	}
-	target.Licence += strings.TrimSpace(strings.ReplaceAll(string(args[1].(pyString)), " ", "-"))
+	target.Licence += normaliseLicence.ReplaceAllString(strings.TrimSpace(string(args[1].(pyString))), "-")
 	return None
 }
 

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1315,13 +1315,16 @@ func getEntryPoints(s *scope, args []pyObject) pyObject {
 // addLicence adds a licence to a target.
 func addLicence(s *scope, args []pyObject) pyObject {
 	target := getTargetPost(s, string(args[0].(pyString)))
-	target.AddLicence(string(args[1].(pyString)))
+	if target.Licence != "" {
+		target.Licence += " OR "
+	}
+	target.Licence += string(args[1].(pyString))
 	return None
 }
 
 // getLicences returns the licences for a single target.
 func getLicences(s *scope, args []pyObject) pyObject {
-	return fromStringList(getTargetPost(s, string(args[0].(pyString))).Licences)
+	return pyList{pyString(getTargetPost(s, string(args[0].(pyString))).Licence)}
 }
 
 // getCommand gets the command of a target, optionally for a configuration.

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -73,7 +73,9 @@ func registerBuiltins(s *scope) {
 	setNativeCode(s, "add_entry_point", addEntryPoint)
 	setNativeCode(s, "get_entry_points", getEntryPoints)
 	setNativeCode(s, "add_licence", addLicence)
+	setNativeCode(s, "set_licence", setLicence)
 	setNativeCode(s, "get_licences", getLicences)
+	setNativeCode(s, "get_licence", getLicence)
 	setNativeCode(s, "get_command", getCommand)
 	setNativeCode(s, "set_command", setCommand)
 	setNativeCode(s, "json", valueAsJSON)
@@ -1325,9 +1327,21 @@ func addLicence(s *scope, args []pyObject) pyObject {
 	return None
 }
 
+// setLicence sets the target's licence to the given string. Note that it must be a valid SPDX identifier.
+func setLicence(s *scope, args []pyObject) pyObject {
+	target := getTargetPost(s, string(args[0].(pyString)))
+	target.Licence += string(args[1].(pyString))
+	return None
+}
+
 // getLicences returns the licences for a single target.
 func getLicences(s *scope, args []pyObject) pyObject {
 	return pyList{pyString(getTargetPost(s, string(args[0].(pyString))).Licence)}
+}
+
+// getLicence returns the licence for a single target.
+func getLicences(s *scope, args []pyObject) pyObject {
+	return pyString(getTargetPost(s, string(args[0].(pyString))).Licence)
 }
 
 // getCommand gets the command of a target, optionally for a configuration.

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1319,6 +1319,7 @@ func getEntryPoints(s *scope, args []pyObject) pyObject {
 
 // addLicence adds a licence to a target.
 func addLicence(s *scope, args []pyObject) pyObject {
+	s.Assert(!s.state.Config.FeatureFlags.SPDXLicencesOnly, "The add_licence builtin has been replaced with set_licence")
 	target := getTargetPost(s, string(args[0].(pyString)))
 	if target.Licence != "" {
 		target.Licence += " OR "
@@ -1336,11 +1337,12 @@ func setLicence(s *scope, args []pyObject) pyObject {
 
 // getLicences returns the licences for a single target.
 func getLicences(s *scope, args []pyObject) pyObject {
+	s.Assert(!s.state.Config.FeatureFlags.SPDXLicencesOnly, "The get_licences builtin has been replaced with get_licence")
 	return pyList{pyString(getTargetPost(s, string(args[0].(pyString))).Licence)}
 }
 
 // getLicence returns the licence for a single target.
-func getLicences(s *scope, args []pyObject) pyObject {
+func getLicence(s *scope, args []pyObject) pyObject {
 	return pyString(getTargetPost(s, string(args[0].(pyString))).Licence)
 }
 

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -274,27 +274,29 @@ func populateTarget(s *scope, t *core.BuildTarget, args []pyObject) {
 	addStrings(s, "labels", args[labelsBuildRuleArgIdx], t.AddLabel)
 	addStrings(s, "hashes", args[hashesBuildRuleArgIdx], t.AddHash)
 	addStrings(s, "requires", args[requiresBuildRuleArgIdx], t.AddRequire)
-	if expr, ok := args[licencesBuildRuleArgIdx].(pyString); ok {
-		target.Licence = string(expr)
-	} else {
-		// TODO(v18): Remove all this once strings are the only option.
-		s.Assert(!s.state.config.FeatureFlags.SPDXLicencesOnly, "The licences argument must be a string")
-		l, ok := asList(args[licencesBuildRuleArgIdx])
-		s.Assert(ok, "The licences argument must be a string or list (was %s)", l.Type())
-		if len(l) == 1 {
-			// minor optimisation: avoid allocating a slice etc for the overwhelmingly common case of a single licence
-			str, ok := l[0].(pyString)
-			s.Assert(ok, "Items in the licences argument must be strings (was %s)", s.Type())
-			target.Licence = string(str)
+	if arg := args[licencesBuildRuleArgIdx]; arg != None {
+		if expr, ok := arg.(pyString); ok {
+			t.Licence = string(expr)
 		} else {
-			l2 := make([]string, len(l))
-			for i, x := range l {
-				str, ok := x.(pyString)
-				s.Assert(ok, "Items in the licences argument must be strings (was %s)", s.Type())
-				l2[i] = string(str)
+			// TODO(v18): Remove all this once strings are the only option.
+			s.Assert(!s.state.Config.FeatureFlags.SPDXLicencesOnly, "The licences argument must be a string")
+			l, ok := asList(arg)
+			s.Assert(ok, "The licences argument must be a string or list (was %s)", arg.Type())
+			if len(l) == 1 {
+				// minor optimisation: avoid allocating a slice etc for the overwhelmingly common case of a single licence
+				str, ok := l[0].(pyString)
+				s.Assert(ok, "Items in the licences argument must be strings (was %s)", str.Type())
+				t.Licence = string(str)
+			} else {
+				l2 := make([]string, len(l))
+				for i, x := range l {
+					str, ok := x.(pyString)
+					s.Assert(ok, "Items in the licences argument must be strings (was %s)", str.Type())
+					l2[i] = string(str)
+				}
+				// Passing a list to Please is implicitly a series of alternative licences
+				t.Licence = strings.Join(l2, " OR ")
 			}
-			// Passing a list to Please is implicitly a series of alternative licences
-			target.Licence = strings.Join(l2, " OR ")
 		}
 	}
 	if vis, ok := asList(args[visibilityBuildRuleArgIdx]); ok && len(vis) != 0 {

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -276,7 +276,8 @@ func populateTarget(s *scope, t *core.BuildTarget, args []pyObject) {
 	addStrings(s, "requires", args[requiresBuildRuleArgIdx], t.AddRequire)
 	if arg := args[licencesBuildRuleArgIdx]; arg != None {
 		if expr, ok := arg.(pyString); ok {
-			t.Licence = string(expr)
+			// TODO(v18): Remove the replace here once all licences are expected to be SPDX expressions
+			t.Licence = strings.ReplaceAll(string(expr), " ", "-")
 		} else {
 			// TODO(v18): Remove all this once strings are the only option.
 			s.Assert(!s.state.Config.FeatureFlags.SPDXLicencesOnly, "The licences argument must be a string")
@@ -286,13 +287,13 @@ func populateTarget(s *scope, t *core.BuildTarget, args []pyObject) {
 				// minor optimisation: avoid allocating a slice etc for the overwhelmingly common case of a single licence
 				str, ok := l[0].(pyString)
 				s.Assert(ok, "Items in the licences argument must be strings (was %s)", str.Type())
-				t.Licence = string(str)
+				t.Licence = strings.ReplaceAll(string(str), " ", "-")
 			} else {
 				l2 := make([]string, len(l))
 				for i, x := range l {
 					str, ok := x.(pyString)
 					s.Assert(ok, "Items in the licences argument must be strings (was %s)", str.Type())
-					l2[i] = string(str)
+					l2[i] = strings.ReplaceAll(string(str), " ", "-")
 				}
 				// Passing a list to Please is implicitly a series of alternative licences
 				t.Licence = strings.Join(l2, " OR ")

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -689,7 +689,12 @@ go_repo(
 
 go_repo(
     licences = ["MIT"],
-    module = "github.com/github/go-spdx",
-    version = "v2.3.1",
+    module = "github.com/peterebden/go-spdx/v2",
+    version = "v2.4.3",
 )
 
+go_repo(
+    licences = ["MIT"],
+    module = "github.com/github/go-spdx/v2",
+    version = "v2.3.1",
+)

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -686,3 +686,10 @@ go_repo(
     module = "github.com/grpc-ecosystem/go-grpc-prometheus",
     version = "v1.2.0",
 )
+
+go_repo(
+    licences = ["MIT"],
+    module = "github.com/github/go-spdx",
+    version = "v2.3.1",
+)
+


### PR DESCRIPTION
We've discussed this quite a bit internally, it has several advantages over the current setup:
 - The list of licences is not obvious that it is OR. (It is documented and always has been, but this is often gotten wrong regardless)
 - We end up having SPDX-like sub-expressions anyway like `MIT AND Zlib`, but these have to be accepted as though they were a licence in their own right; fortunately they aren't common but we shouldn't have to accept every permutation separately.
 - We align better with the relevant standard.

I am slightly worried that the SPDX library is stricter about licence identifiers. I've had to adjust the behaviour a bit so it will pass licences that are not on the list as-is, but they do still need to be structurally valid (i.e. `MPL-2.0` not `The Mozilla Public License, version 2.0 (with Chocolate Coating)`). I don't particularly want to maintain a completely separate implementation internally with the old list-based thing though.

This also deprecates the `add_licence` and `get_licences` builtins in favour of new ones, `get_licence` and `set_licence` which operate just on a single string. 