### PR TITLE
Implement force deletion for RemoveAll

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.7.2",
     "java": "v0.4.1",
-    "go": "v1.21.1",
+    "go": "v1.21.2",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -743,7 +743,7 @@ func moveOutput(state *core.BuildState, target *core.BuildTarget, tmpOutput, rea
 			log.Debug("Checking %s vs. %s, hashes match", tmpOutput, realOutput)
 			return false, nil
 		}
-		if err := os.RemoveAll(realOutput); err != nil {
+		if err := fs.RemoveAll(realOutput); err != nil {
 			return true, err
 		}
 	}
@@ -773,7 +773,7 @@ func moveOutput(state *core.BuildState, target *core.BuildTarget, tmpOutput, rea
 func RemoveOutputs(target *core.BuildTarget) error {
 	for _, output := range target.Outputs() {
 		out := filepath.Join(target.OutDir(), output)
-		if err := os.RemoveAll(out); err != nil {
+		if err := fs.RemoveAll(out); err != nil {
 			return err
 		} else if err := fs.EnsureDir(out); err != nil {
 			return err

--- a/src/build/filegroup.go
+++ b/src/build/filegroup.go
@@ -83,7 +83,7 @@ func (builder *filegroupBuilder) Build(state *core.BuildState, target *core.Buil
 		return false, nil
 	}
 	// Must actually build the file.
-	if err := os.RemoveAll(to); err != nil {
+	if err := fs.RemoveAll(to); err != nil {
 		return true, err
 	} else if err := fs.EnsureDir(to); err != nil {
 		return true, err

--- a/src/build/filegroup.go
+++ b/src/build/filegroup.go
@@ -103,7 +103,7 @@ func (builder *filegroupBuilder) Build(state *core.BuildState, target *core.Buil
 // We don't force this to be done in bash to avoid errors with maximum command lengths,
 // and it's actually quite fiddly to get just so there.
 func buildFilegroup(state *core.BuildState, target *core.BuildTarget) (bool, error) {
-	if err := prepareDirectory(state.ProcessExecutor, target.OutDir(), false); err != nil {
+	if err := prepareDirectory(target.OutDir(), false); err != nil {
 		return true, err
 	}
 	changed := false

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -388,7 +388,7 @@ func loadTargetMetadata(target *core.BuildTarget) (*core.BuildMetadata, error) {
 // StoreTargetMetadata stores the target metadata into a file in the output directory of the target.
 func StoreTargetMetadata(target *core.BuildTarget, md *core.BuildMetadata) error {
 	filename := targetBuildMetadataFileName(target)
-	if err := os.RemoveAll(filename); err != nil {
+	if err := fs.RemoveAll(filename); err != nil {
 		return fmt.Errorf("failed to remove existing %s build metadata file: %w", target.Label, err)
 	} else if err := os.MkdirAll(filepath.Dir(filename), core.DirPermissions); err != nil {
 		return fmt.Errorf("Failed to create directory for build metadata file for %s: %w", target, err)

--- a/src/cache/BUILD
+++ b/src/cache/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//src/cli/logging",
         "//src/core",
         "//src/fs",
-        "//src/process",
     ],
 )
 

--- a/src/cache/BUILD
+++ b/src/cache/BUILD
@@ -1,13 +1,6 @@
 go_library(
     name = "cache",
-    srcs = [
-        "async_cache.go",
-        "cache.go",
-        "cmd_cache.go",
-        "dir_cache.go",
-        "http_cache.go",
-        "noop.go",
-    ],
+    srcs = glob(["*.go"], exclude=["*_test.go"]),
     pgo_file = "//:pgo",
     visibility = ["PUBLIC"],
     deps = [
@@ -22,21 +15,10 @@ go_library(
     ],
 )
 
-filegroup(
-    name = "test_data",
-    srcs = ["test_data"],
-    test_only = True,
-)
-
 go_test(
     name = "cache_test",
-    srcs = [
-        "async_cache_test.go",
-        "cmd_cache_test.go",
-        "dir_cache_test.go",
-        "http_cache_test.go",
-    ],
-    data = [":test_data"],
+    srcs = glob(["*_test.go"]),
+    data = ["test_data"],
     deps = [
         ":cache",
         "///third_party/go/github.com_stretchr_testify//assert",

--- a/src/cache/dir_cache.go
+++ b/src/cache/dir_cache.go
@@ -36,7 +36,7 @@ func (cache *dirCache) Store(target *core.BuildTarget, key []byte, files []strin
 	cacheDir := cache.getPath(target, key, "")
 	tmpDir := cache.getFullPath(target, key, "", "=")
 	cache.markDir(cacheDir, 0)
-	if err := os.RemoveAll(cacheDir); err != nil {
+	if err := fs.RemoveAll(cacheDir); err != nil {
 		log.Warning("Failed to remove existing cache directory %s: %s", cacheDir, err)
 		return
 	}
@@ -64,7 +64,7 @@ func (cache *dirCache) storeCompressed(target *core.BuildTarget, filename string
 	log.Debug("Storing %s: %s in dir cache...", target.Label, filename)
 	if err := cache.storeCompressed2(target, filename, files); err != nil {
 		log.Warning("Failed to store files in cache: %s", err)
-		os.RemoveAll(filename) // Just a best-effort removal at this point
+		fs.RemoveAll(filename) // Just a best-effort removal at this point
 		return 0
 	}
 	// It's too hard to tell from a tar.Writer how big the resulting tarball is. Easier to just re-stat it here.
@@ -153,7 +153,7 @@ func (cache *dirCache) ensureStoreReady(filename string) error {
 	dir := filepath.Dir(filename)
 	if err := os.MkdirAll(dir, core.DirPermissions); err != nil {
 		return err
-	} else if err := os.RemoveAll(filename); err != nil {
+	} else if err := fs.RemoveAll(filename); err != nil {
 		return err
 	}
 	return nil
@@ -285,7 +285,7 @@ func (cache *dirCache) ensureRetrieveReady(target *core.BuildTarget, out string)
 	}
 	// It seems to be quite important that we unlink the existing file first to avoid ETXTBSY errors
 	// in cases where we're running an existing binary (as Please does during bootstrap, for example).
-	if err := os.RemoveAll(fullOut); err != nil {
+	if err := fs.RemoveAll(fullOut); err != nil {
 		return "", err
 	}
 	return fullOut, nil
@@ -293,7 +293,7 @@ func (cache *dirCache) ensureRetrieveReady(target *core.BuildTarget, out string)
 
 func (cache *dirCache) Clean(target *core.BuildTarget) {
 	// Remove for all possible keys, so can't get getPath here
-	if err := os.RemoveAll(filepath.Join(cache.Dir, target.Label.PackageName, target.Label.Name)); err != nil {
+	if err := fs.RemoveAll(filepath.Join(cache.Dir, target.Label.PackageName, target.Label.Name)); err != nil {
 		log.Warning("Failed to remove artifacts for %s from dir cache: %s", target.Label, err)
 	}
 }
@@ -448,7 +448,7 @@ func (cache *dirCache) clean(highWaterMark, lowWaterMark uint64) uint64 {
 			log.Errorf("Couldn't rename %s: %s", entry.Path, err)
 			continue
 		}
-		if err := os.RemoveAll(newPath); err != nil {
+		if err := fs.RemoveAll(newPath); err != nil {
 			log.Errorf("Couldn't remove %s: %s", newPath, err)
 			continue
 		}

--- a/src/cache/http_cache.go
+++ b/src/cache/http_cache.go
@@ -18,7 +18,6 @@ import (
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
-	"github.com/thought-machine/please/src/process"
 )
 
 type httpCache struct {
@@ -204,7 +203,7 @@ func openFile(header *tar.Header) (*os.File, error) {
 	if err != nil {
 		if os.IsPermission(err) {
 			// The file might already exist and be ro. If so, remove it.
-			if err := fs.ForceRemove(process.New(), header.Name); err != nil {
+			if err := fs.RemoveAll(header.Name); err != nil {
 				log.Debug("failed to remove existing file when restoring from the cache: %w", err)
 			}
 			return os.OpenFile(header.Name, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, os.FileMode(header.Mode))

--- a/src/clean/clean.go
+++ b/src/clean/clean.go
@@ -97,7 +97,7 @@ func deleteDir(dir string, async bool) error {
 	}
 	if async {
 		// Note that we can't fork() directly and continue running Go code, but ForkExec() works okay.
-		// Hence why we're using rm rather than fork() + os.RemoveAll.
+		// Hence why we're using rm rather than fork() + fs.RemoveAll.
 		_, err = syscall.ForkExec(rm, []string{rm, "-rf", newDir}, nil)
 		return err
 	}

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -374,7 +374,7 @@ func PrepareSourcePair(pair SourcePair) error {
 
 // PrepareRuntimeDir prepares a directory with a target's runtime data for a command to be run on.
 func PrepareRuntimeDir(state *BuildState, target *BuildTarget, dir string) error {
-	if err := fs.ForceRemove(state.ProcessExecutor, dir); err != nil {
+	if err := fs.RemoveAll(dir); err != nil {
 		return err
 	}
 

--- a/src/fs/BUILD
+++ b/src/fs/BUILD
@@ -1,17 +1,6 @@
 go_library(
     name = "fs",
-    srcs = [
-        "attr.go",
-        "copy.go",
-        "executable.go",
-        "fs.go",
-        "glob.go",
-        "hash.go",
-        "home.go",
-        "iofs.go",
-        "sort.go",
-        "walk.go",
-    ],
+    srcs = glob(["*.go"], exclude=["*_test.go"]),
     pgo_file = "//:pgo",
     visibility = ["PUBLIC"],
     deps = [
@@ -19,22 +8,12 @@ go_library(
         "///third_party/go/github.com_peterebden_go-deferred-regex//:go-deferred-regex",
         "///third_party/go/github.com_pkg_xattr//:xattr",
         "//src/cli/logging",
-        "//src/process",
     ],
 )
 
 go_test(
     name = "fs_test",
-    srcs = [
-        "copy_test.go",
-        "fs_test.go",
-        "glob_integration_test.go",
-        "glob_test.go",
-        "hash_benchmark_test.go",
-        "hash_test.go",
-        "home_test.go",
-        "sort_test.go",
-    ],
+    srcs = glob(["*_test.go"], exclude=["glob_integration_test.go", "*_benchmark_test.go"]),
     data = ["test_data"],
     deps = [
         ":fs",

--- a/src/fs/copy_test.go
+++ b/src/fs/copy_test.go
@@ -38,7 +38,7 @@ func TestLink(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			dir, err := os.MkdirTemp("", "testlink")
 			require.NoError(t, err)
-			defer os.RemoveAll(dir)
+			defer fs.RemoveAll(dir)
 
 			src := filepath.Join(dir, "src")
 			if tt.srcExists {
@@ -95,7 +95,7 @@ func TestSymlink(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			dir, err := os.MkdirTemp("", "testlink")
 			require.NoError(t, err)
-			defer os.RemoveAll(dir)
+			defer fs.RemoveAll(dir)
 
 			src := filepath.Join(dir, "src")
 			if tt.srcExists {

--- a/src/fs/copy_test.go
+++ b/src/fs/copy_test.go
@@ -95,7 +95,7 @@ func TestSymlink(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			dir, err := os.MkdirTemp("", "testlink")
 			require.NoError(t, err)
-			defer fs.RemoveAll(dir)
+			defer os.RemoveAll(dir)
 
 			src := filepath.Join(dir, "src")
 			if tt.srcExists {

--- a/src/fs/copy_test.go
+++ b/src/fs/copy_test.go
@@ -38,7 +38,7 @@ func TestLink(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			dir, err := os.MkdirTemp("", "testlink")
 			require.NoError(t, err)
-			defer fs.RemoveAll(dir)
+			defer os.RemoveAll(dir)
 
 			src := filepath.Join(dir, "src")
 			if tt.srcExists {

--- a/src/fs/fs.go
+++ b/src/fs/fs.go
@@ -190,7 +190,7 @@ func copyFile(from, to string) (err error) {
 // RemoveAll will try and remove the path with `os.RemoveAll`; if that fails with a permission error,
 // it will attempt to adjust permissions to make things writable, then remove them.
 func RemoveAll(path string) error {
-	if err := os.RemoveAll(path); err == nil || !errors.Is(err.(*os.PathError).Err, os.ErrPermission) {
+	if err := os.RemoveAll(path); err == nil || !errors.Is(err, os.ErrPermission) {
 		return err
 	} else if err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
 		const writable = 0o220

--- a/src/fs/fs.go
+++ b/src/fs/fs.go
@@ -145,7 +145,7 @@ func renameFile(from, to string) (err error) {
 	if err != nil {
 		return err
 	}
-	err = os.RemoveAll(from)
+	err = fs.RemoveAll(from)
 	if err != nil {
 		return err
 	}
@@ -186,11 +186,11 @@ func copyFile(from, to string) (err error) {
 	return nil
 }
 
-// ForceRemove will try and remove the path with `os.RemoveAll`, and if that fails, it will use `rm -rf` running the
+// ForceRemove will try and remove the path with `fs.RemoveAll`, and if that fails, it will use `rm -rf` running the
 // command in any namespace that please is configured to.
 func ForceRemove(exec *process.Executor, path string) error {
 	// Try and remove it normally first
-	if err := os.RemoveAll(path); err == nil || os.IsNotExist(err) {
+	if err := fs.RemoveAll(path); err == nil || os.IsNotExist(err) {
 		return nil
 	}
 

--- a/src/please.go
+++ b/src/please.go
@@ -513,7 +513,7 @@ var buildFunctions = map[string]func() int{
 			opts.BuildFlags.Config = "cover"
 		}
 		targets, args := testTargets(opts.Cover.Args.Target, opts.Cover.Args.Args, opts.Cover.Failed, opts.Cover.TestResultsFile)
-		os.RemoveAll(string(opts.Cover.CoverageResultsFile))
+		fs.RemoveAll(string(opts.Cover.CoverageResultsFile))
 		success, state := doTest(targets, args, opts.Cover.SurefireDir, opts.Cover.TestResultsFile)
 		test.AddOriginalTargetsToCoverage(state, opts.Cover.IncludeAllFiles)
 		test.RemoveFilesFromCoverage(state.Coverage, state.Config.Cover.ExcludeExtension, state.Config.Cover.ExcludeGlob)
@@ -1091,8 +1091,8 @@ func runQuery(needFullParse bool, labels []core.BuildLabel, onSuccess func(state
 }
 
 func doTest(targets []core.BuildLabel, args []string, surefireDir cli.Filepath, resultsFile cli.Filepath) (bool, *core.BuildState) {
-	os.RemoveAll(string(surefireDir))
-	os.RemoveAll(string(resultsFile))
+	fs.RemoveAll(string(surefireDir))
+	fs.RemoveAll(string(resultsFile))
 	os.MkdirAll(string(surefireDir), core.DirPermissions)
 	opts.Test.StateArgs = args
 	success, state := runBuild(targets, true, true, false)

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -535,7 +535,7 @@ func (c *Client) DownloadInputs(target *core.BuildTarget, targetDir string, isTe
 		return fmt.Errorf("could not calculate digest for directory proto: %w", err)
 	}
 
-	if err := os.RemoveAll(targetDir); err != nil {
+	if err := fs.RemoveAll(targetDir); err != nil {
 		return fmt.Errorf("could not delete target directory %q: %w", targetDir, err)
 	}
 
@@ -548,7 +548,7 @@ func (c *Client) DownloadInputs(target *core.BuildTarget, targetDir string, isTe
 
 // moveTmpFilesToOutDir moves files from the target tmp dir to the out dir, handling output directories as well
 func moveTmpFilesToOutDir(target *core.BuildTarget) error {
-	defer os.RemoveAll(target.TmpDir())
+	defer fs.RemoveAll(target.TmpDir())
 
 	// Copy the contents of the output_dirs to the target output dir
 	for _, outDir := range target.OutputDirectories {
@@ -558,7 +558,7 @@ func moveTmpFilesToOutDir(target *core.BuildTarget) error {
 		}
 
 		// Remove the dir so it doesn't get picked up as an output in the next step
-		if err := os.RemoveAll(dir); err != nil {
+		if err := fs.RemoveAll(dir); err != nil {
 			return err
 		}
 	}

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -570,7 +570,7 @@ func (c *Client) targetPlatformProperties(target *core.BuildTarget) *pb.Platform
 func removeOutputs(target *core.BuildTarget) error {
 	outDir := target.OutDir()
 	for _, out := range target.Outputs() {
-		if err := os.RemoveAll(filepath.Join(outDir, out)); err != nil {
+		if err := fs.RemoveAll(filepath.Join(outDir, out)); err != nil {
 			return fmt.Errorf("Failed to remove output for %s: %s", target, err)
 		}
 	}

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -83,7 +83,7 @@ func Sequential(state *core.BuildState, labels []core.AnnotatedOutputLabel, args
 }
 
 func prepareRun() {
-	if err := os.RemoveAll("plz-out/run"); err != nil && !os.IsNotExist(err) {
+	if err := fs.RemoveAll("plz-out/run"); err != nil && !os.IsNotExist(err) {
 		log.Warningf("failed to clean up old run working directory: %v", err)
 	}
 }

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -290,7 +290,7 @@ func logTargetResults(state *core.BuildState, target *core.BuildTarget, coverage
 	if target.Test.Results.TestCases.AllSucceeded() {
 		// Clean up the test directory.
 		if state.CleanWorkdirs {
-			if err := fs.ForceRemove(state.ProcessExecutor, target.TestDir(run)); err != nil {
+			if err := fs.RemoveAll(target.TestDir(run)); err != nil {
 				log.Warning("Failed to remove test directory for %s: %s", target.Label, err)
 			}
 		}

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -517,13 +517,13 @@ func parseCoverageFile(state *core.BuildState, target *core.BuildTarget, coverag
 
 // RemoveTestOutputs removes any cached test or coverage result files for a target.
 func RemoveTestOutputs(target *core.BuildTarget) error {
-	if err := os.RemoveAll(target.TestResultsFile()); err != nil {
+	if err := fs.RemoveAll(target.TestResultsFile()); err != nil {
 		return err
-	} else if err := os.RemoveAll(target.CoverageFile()); err != nil {
+	} else if err := fs.RemoveAll(target.CoverageFile()); err != nil {
 		return err
 	}
 	for _, output := range target.Test.Outputs {
-		if err := os.RemoveAll(filepath.Join(target.OutDir(), output)); err != nil {
+		if err := fs.RemoveAll(filepath.Join(target.OutDir(), output)); err != nil {
 			return err
 		}
 	}

--- a/src/update/clean.go
+++ b/src/update/clean.go
@@ -40,7 +40,7 @@ func clean(config *core.Configuration, manualUpdate bool) {
 	sort.Sort(versions)
 	for _, version := range versions[:numToClean] {
 		log.Notice("Cleaning old version %s...", version)
-		if err := os.RemoveAll(filepath.Join(config.Please.Location, version.String())); err != nil {
+		if err := fs.RemoveAll(filepath.Join(config.Please.Location, version.String())); err != nil {
 			log.Error("Couldn't remove %s: %s", version, err)
 		}
 	}

--- a/src/update/clean.go
+++ b/src/update/clean.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/thought-machine/please/src/cli"
 	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/fs"
 )
 
 // clean checks for any stale versions in the download directory and wipes them out if OK.

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -76,7 +76,7 @@ func CheckAndUpdate(config *core.Configuration, updatesEnabled, updateCommand, f
 	// If the destination exists and the user passed --force, remove it to force a redownload.
 	newDir := filepath.Join(config.Please.Location, config.Please.Version.VersionString())
 	if forceUpdate && core.PathExists(newDir) {
-		if err := os.RemoveAll(newDir); err != nil {
+		if err := fs.RemoveAll(newDir); err != nil {
 			log.Fatalf("Failed to remove existing directory: %s", err)
 		}
 	}
@@ -317,7 +317,7 @@ func linkNewFile(config *core.Configuration, file string) {
 	newDir := filepath.Join(config.Please.Location, config.Please.Version.VersionString())
 	globalFile := filepath.Join(config.Please.Location, file)
 	downloadedFile := filepath.Join(newDir, file)
-	if err := os.RemoveAll(globalFile); err != nil {
+	if err := fs.RemoveAll(globalFile); err != nil {
 		log.Fatalf("Failed to remove existing file %s: %s", globalFile, err)
 	}
 	if err := os.Symlink(downloadedFile, globalFile); err != nil {
@@ -335,7 +335,7 @@ func fileMode(filename string) os.FileMode {
 
 func cleanDir(newDir string) {
 	log.Notice("Attempting to clean directory %s", newDir)
-	if err := os.RemoveAll(newDir); err != nil {
+	if err := fs.RemoveAll(newDir); err != nil {
 		log.Errorf("Failed to clean %s: %s", newDir, err)
 	}
 }

--- a/test/BUILD
+++ b/test/BUILD
@@ -463,3 +463,20 @@ plz_e2e_test(
     expect_output_contains = "$TEST",
     expected_failure = True,
 )
+
+gentest(
+    name = "rm_ro_test_case",
+    labels = ["manual"],
+    no_test_output = True,
+    test_cmd = " && ".join([
+        "mkdir subdir",
+        "touch subdir/file.txt",
+        "chmod -w subdir",
+    ]),
+)    
+
+plz_e2e_test(
+    name = "rm_ro_test",
+    cmd = "plz test //test:rm_ro_test_case",
+    expect_output_doesnt_contain = "ERROR",
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -471,12 +471,13 @@ gentest(
     test_cmd = " && ".join([
         "mkdir subdir",
         "touch subdir/file.txt",
+        "chmod -w subdir/file.txt",
         "chmod -w subdir",
     ]),
-)    
+)
 
 plz_e2e_test(
     name = "rm_ro_test",
-    cmd = "plz test //test:rm_ro_test_case",
+    cmd = "plz test --rerun //test:rm_ro_test_case",
     expect_output_doesnt_contain = "ERROR",
 )

--- a/tools/http_cache/cache/cache.go
+++ b/tools/http_cache/cache/cache.go
@@ -43,7 +43,7 @@ func (c *Cache) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 
 func (c *Cache) store(uri string, data io.Reader) error {
 	path := filepath.Join(c.Dir, uri)
-	if err := os.RemoveAll(uri); err != nil {
+	if err := fs.RemoveAll(uri); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This replaces `fs.ForceRemove` with `fs.RemoveAll` and changes every call to `os.RemoveAll` to use it.
It attempts a standard delete, then if that fails attempts to chmod any non-writable directories it can find, then delete again.

This is IMO a bit cleaner than the previous implementation which was shelling out to `rm`, requiring a process executor (It's also less Unix-specific, which could be relevant in a far future if we ever tried to get Windows working). I wonder if that was one reason that only a small handful of cases called `ForceRemove`; anyway, it's not needed now.

Will fix / work around #3235 although I still fundamentally think Go should be doing something sensible there. I've bootstrapped a copy of Please on this machine (at least up to the Python stuff that I haven't finished fixing yet) with 1.23.0 and it seems fine.