### PR TITLE
Deal with require/provide in query deps

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -57,7 +57,7 @@ genrule(
 
 # Plugin versions to pull the docs from
 plugins = {
-    "python": "v1.7.2",
+    "python": "v1.7.3",
     "java": "v0.4.1",
     "go": "v1.21.2",
     "cc": "v0.4.0",


### PR DESCRIPTION
Seeing some cases where this dies with "target not found in build graph"
I don't have a nice minimal case but it does fix that on our internal repo.

I don't know if there's a neater way to make `query` stuff be less explicitly aware of this. Maybe an idea for a future refactor.