### PR TITLE
Stop invoking 'rm' as a subprocess

### DIFF
--- a/.circleci/http_cache_test.sh
+++ b/.circleci/http_cache_test.sh
@@ -12,7 +12,7 @@ mkdir "$DIR"
 tar -xzf /tmp/workspace/linux_amd64/please_*.tar.gz --strip-components=1 -C "$DIR"
 
 # Start the server in the background
-"${DIR}/please" run parallel -p -v notice --colour --detach //tools/http_cache:run_local
+"${DIR}/please" run parallel --env -p -v notice --colour --detach //tools/http_cache:run_local
 
 # Test we can rebuild plz itself.
 "${DIR}/please" test --profile localcache -p -v notice --colour //src/...

--- a/src/clean/clean_test.go
+++ b/src/clean/clean_test.go
@@ -23,6 +23,7 @@ func TestAsyncDeleteDir(t *testing.T) {
 }
 
 func dirExists(t *testing.T, name string) bool {
+	t.Helper()
 	if fs.PathExists(name) {
 		return true
 	}

--- a/src/please.go
+++ b/src/please.go
@@ -665,12 +665,6 @@ var buildFunctions = map[string]func() int{
 		return 1
 	},
 	"clean": func() int {
-		if opts.Clean.Rm != "" {
-			if err := fs.RemoveAll(opts.Clean.Rm); err != nil {
-				log.Fatalf("%s", err)
-			}
-			return 0
-		}
 		config.Cache.DirClean = false // don't run the normal cleaner
 		if len(opts.Clean.Args.Targets) == 0 && core.InitialPackage()[0].PackageName == "" {
 			if len(opts.BuildFlags.Include) == 0 && len(opts.BuildFlags.Exclude) == 0 {
@@ -1425,6 +1419,12 @@ func initBuild(args []string) string {
 		// Shortcut these as they're special commands used for please sandboxing
 		// going through the normal init path would be too slow
 		return args[1]
+	} else if opts.Clean.Rm != "" {
+		// Avoid initialising logging so we don't create an additional file.
+		if err := fs.RemoveAll(opts.Clean.Rm); err != nil {
+			log.Fatalf("%s", err)
+		}
+		os.Exit(0)
 	}
 	if _, present := os.LookupEnv("GO_FLAGS_COMPLETION"); present {
 		cli.InitLogging(cli.MinVerbosity)

--- a/src/please.go
+++ b/src/please.go
@@ -1419,12 +1419,6 @@ func initBuild(args []string) string {
 		// Shortcut these as they're special commands used for please sandboxing
 		// going through the normal init path would be too slow
 		return args[1]
-	} else if opts.Clean.Rm != "" {
-		// Avoid initialising logging so we don't create an additional file.
-		if err := fs.RemoveAll(opts.Clean.Rm); err != nil {
-			log.Fatalf("%s", err)
-		}
-		os.Exit(0)
 	}
 	if _, present := os.LookupEnv("GO_FLAGS_COMPLETION"); present {
 		cli.InitLogging(cli.MinVerbosity)
@@ -1467,6 +1461,12 @@ func initBuild(args []string) string {
 		os.Exit(buildFunctions[command]())
 	} else if opts.OutputFlags.CompletionScript {
 		fmt.Printf("%s\n", string(assets.PlzComplete))
+		os.Exit(0)
+	} else if opts.Clean.Rm != "" {
+		// Avoid initialising logging so we don't create an additional file.
+		if err := fs.RemoveAll(opts.Clean.Rm); err != nil {
+			log.Fatalf("%s", err)
+		}
 		os.Exit(0)
 	}
 	// Read the config now

--- a/src/please.go
+++ b/src/please.go
@@ -247,6 +247,7 @@ var opts struct {
 
 	Clean struct {
 		NoBackground bool     `long:"nobackground" short:"f" description:"Don't fork & detach until clean is finished."`
+		Rm           string   `long:"rm" hidden:"true" description:"Removes a specific directory. Only used internally to do async removals."`
 		Args         struct { // Inner nesting is necessary to make positional-args work :(
 			Targets []core.BuildLabel `positional-arg-name:"targets" description:"Targets to clean (default is to clean everything)"`
 		} `positional-args:"true"`
@@ -664,6 +665,12 @@ var buildFunctions = map[string]func() int{
 		return 1
 	},
 	"clean": func() int {
+		if opts.Clean.Rm != "" {
+			if err := fs.RemoveAll(opts.Clean.Rm); err != nil {
+				log.Fatalf("%s", err)
+			}
+			return 0
+		}
 		config.Cache.DirClean = false // don't run the normal cleaner
 		if len(opts.Clean.Args.Targets) == 0 && core.InitialPackage()[0].PackageName == "" {
 			if len(opts.BuildFlags.Include) == 0 && len(opts.BuildFlags.Exclude) == 0 {

--- a/tools/http_cache/BUILD
+++ b/tools/http_cache/BUILD
@@ -3,14 +3,14 @@ go_binary(
     srcs = ["main.go"],
     visibility = ["PUBLIC"],
     deps = [
-        "///third_party/go/gopkg.in_op_go-logging.v1//:go-logging.v1",
         "//src/cli",
+        "//src/cli/logging",
         "//tools/http_cache/cache",
     ],
 )
 
 sh_cmd(
     name = "run_local",
-    srcs = [":http_cache"],
-    cmd = "exec $(out_location :http_cache) -p 1771 -d /tmp/please_http_cache",
+    data = [":http_cache"],
+    cmd = r"exec \\$DATA -p 1771 -d /tmp/please_http_cache",
 )

--- a/tools/http_cache/BUILD
+++ b/tools/http_cache/BUILD
@@ -11,6 +11,6 @@ go_binary(
 
 sh_cmd(
     name = "run_local",
-    data = [":http_cache"],
-    cmd = r"exec \\$DATA -p 1771 -d /tmp/please_http_cache",
+    srcs = [":http_cache"],
+    cmd = "exec $(out_location :http_cache) -p 1771 -d /tmp/please_http_cache",
 )

--- a/tools/http_cache/cache/BUILD
+++ b/tools/http_cache/cache/BUILD
@@ -3,7 +3,7 @@ go_library(
     srcs = ["cache.go"],
     visibility = ["PUBLIC"],
     deps = [
-        "///third_party/go/gopkg.in_op_go-logging.v1//:go-logging.v1",
+        "//src/cli/logging",
         "//src/fs",
     ],
 )

--- a/tools/http_cache/cache/cache.go
+++ b/tools/http_cache/cache/cache.go
@@ -7,12 +7,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"gopkg.in/op/go-logging.v1"
-
 	"github.com/thought-machine/please/src/fs"
+	logger "github.com/thought-machine/please/src/cli/logging"
 )
 
-var log = logging.MustGetLogger("httpcache")
+var log = logger.Log
 
 // Cache implements a http handler for caching files. Effectively a read/write http.FileSystem
 type Cache struct {

--- a/tools/http_cache/cache/cache.go
+++ b/tools/http_cache/cache/cache.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/thought-machine/please/src/fs"
 	logger "github.com/thought-machine/please/src/cli/logging"
+	"github.com/thought-machine/please/src/fs"
 )
 
 var log = logger.Log

--- a/tools/http_cache/main.go
+++ b/tools/http_cache/main.go
@@ -6,17 +6,16 @@ import (
 	"os"
 	"path/filepath"
 
-	"gopkg.in/op/go-logging.v1"
-
 	"github.com/thought-machine/please/src/cli"
+	logger "github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/tools/http_cache/cache"
 )
 
-var log = logging.MustGetLogger("httpcache")
+var log = logger.Log
 
 var opts = struct {
 	Usage     string
-	Verbosity cli.Verbosity `short:"v" long:"verbosity" default:"warning" description:"Verbosity of output (higher number = more output)"`
+	Verbosity cli.Verbosity `short:"v" long:"verbosity" default:"notice" description:"Verbosity of output (higher number = more output)"`
 	CacheDir  string        `short:"d" long:"dir" default:"" description:"The directory to store cached artifacts in."`
 	Port      int           `short:"p" long:"port" description:"The port to run the server on" default:"8080"`
 }{
@@ -29,6 +28,7 @@ cache for please however this is a lightweight and easy to configure option.
 
 func main() {
 	cli.ParseFlagsOrDie("HTTP Cache", &opts)
+	cli.InitLogging(opts.Verbosity)
 
 	if opts.CacheDir == "" {
 		userCacheDir, err := os.UserCacheDir()
@@ -38,7 +38,7 @@ func main() {
 		opts.CacheDir = filepath.Join(userCacheDir, "please_http_cache")
 	}
 
-	log.Infof("Started please http cache at 127.0.0.1:%v serving out of %v", opts.Port, opts.CacheDir)
+	log.Notice("Started please http cache at 127.0.0.1:%v serving out of %v", opts.Port, opts.CacheDir)
 	err := http.ListenAndServe(fmt.Sprint(":", opts.Port), cache.New(opts.CacheDir))
 	if err != nil {
 		log.Panic(err)


### PR DESCRIPTION
Small follow-up to #3236 : I don't like that we find & exec `rm`, it tends to leave `.plz_clean` tombstones around if we have readonly dirs. It's also less portable (if we ever did do Windows for example).

This allows us to re-exec ourselves to remove a directory, so we take advantage of our 'force remove' logic. It also fixes up the test which was not very sensical before but was even less after this.