### PR TITLE
Update lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.58
+          version: v1.60
           args: src/... tools/...
           skip-pkg-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,5 @@
 run:
   timeout: 5m
-  skip-dirs:
-    - test_data
 
 issues:
   exclude:
@@ -19,6 +17,8 @@ issues:
     - redefines-builtin-id
     - superfluous-else
     - indent-error-flow # revive getting a bit too pushy here
+  exclude-dirs:
+    - test_data
   exclude-rules:
     - path: _test\.go
       linters:
@@ -44,7 +44,6 @@ linters:
     - containedctx
     - dogsled
     - dupl
-    - exportloopref
     - gci
     - gocritic
     - gofmt

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -1009,7 +1009,7 @@ func (state *BuildState) ActivateTarget(pkg *Package, label, dependent BuildLabe
 			if dependent != OriginalTarget {
 				msg += fmt.Sprintf(" (depended on by %s)", dependent)
 			}
-			return fmt.Errorf(msg + suggestTargets(pkg, label, dependent))
+			return fmt.Errorf("%s", msg+suggestTargets(pkg, label, dependent))
 		}
 	}
 	if state.ParsePackageOnly && !mode.IsForSubinclude() {

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -262,8 +262,7 @@ func printTestResults(state *core.BuildState, failedTargets map[core.BuildLabel]
 			printf("${RED}%s${RESET} ${WHITE_ON_RED}Timed out${RESET}\n", target.Label)
 		}
 	}
-	printf(fmt.Sprintf("${BOLD_WHITE}%s and %s${BOLD_WHITE}.${RESET}\n",
-		pluralise(len(targets), "test target", "test targets"), testResultMessage(aggregate, false)))
+	printf("${BOLD_WHITE}%s and %s${BOLD_WHITE}.${RESET}\n", pluralise(len(targets), "test target", "test targets"), testResultMessage(aggregate, false))
 	printf("${BOLD_WHITE}Total time: %s real, %s compute.${RESET}\n", duration, aggregate.Duration.Round(durationGranularity))
 }
 

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -311,7 +311,7 @@ func (s *scope) WaitForSubincludedTarget(l, dependent core.BuildLabel) *core.Bui
 
 // builtinFail raises an immediate error that can't be intercepted.
 func builtinFail(s *scope, args []pyObject) pyObject {
-	s.Error(string(args[0].(pyString)))
+	s.Error("%s", string(args[0].(pyString)))
 	return None
 }
 

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -532,12 +532,12 @@ func (s *scope) interpretStatements(statements []*Statement) pyObject {
 				if stmt.Assert.Message == nil {
 					s.Error("assertion failed")
 				} else {
-					s.Error(s.interpretExpression(stmt.Assert.Message).String())
+					s.Error("%s", s.interpretExpression(stmt.Assert.Message))
 				}
 			}
 		} else if stmt.Raise != nil {
 			log.Warning("The raise keyword is deprecated, please use fail() instead. See https://github.com/thought-machine/please/issues/1598 for more information.")
-			s.Error(s.interpretExpression(stmt.Raise).String())
+			s.Error("%s", s.interpretExpression(stmt.Raise))
 		} else if stmt.Literal != nil {
 			s.interpretExpression(stmt.Literal)
 		} else if stmt.Continue {

--- a/src/parse/asp/lexer.go
+++ b/src/parse/asp/lexer.go
@@ -58,7 +58,7 @@ func newLexer(r io.Reader) *lex {
 	// This should work OK as long as BUILD files are relatively small.
 	b, err := io.ReadAll(r)
 	if err != nil {
-		fail(NameOfReader(r), 0, err.Error())
+		fail(NameOfReader(r), 0, "%s", err.Error())
 	}
 	// If the file doesn't end in a newline, we will reject it with an "unexpected end of file"
 	// error. That's a bit crap so quietly fix it up here.

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -384,9 +384,9 @@ func convertError(err *rpcstatus.Status) error {
 func wrap(err error, msg string, args ...interface{}) error {
 	s, ok := status.FromError(err)
 	if !ok {
-		return fmt.Errorf(fmt.Sprintf(msg, args...) + ": " + err.Error())
+		return fmt.Errorf(fmt.Sprintf(msg, args...) + ": " + err.Error()) //nolint:govet
 	}
-	return status.Errorf(s.Code(), fmt.Sprintf(msg, args...)+": "+s.Message())
+	return status.Errorf(s.Code(), fmt.Sprintf(msg, args...)+": "+s.Message()) //nolint:govet
 }
 
 // timeout returns either a build or test timeout from a target.

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -303,21 +303,21 @@ func logTargetResults(state *core.BuildState, target *core.BuildTarget, coverage
 		resultMsg = "Tests failed"
 		for _, testCase := range target.Test.Results.TestCases {
 			if len(testCase.Failures()) > 0 {
-				resultErr = fmt.Errorf(testCase.Failures()[0].Failure.Message)
+				resultErr = fmt.Errorf("%s", testCase.Failures()[0].Failure.Message)
 			}
 		}
 	} else if target.Test.Results.Errors() > 0 {
 		resultMsg = "Tests errored"
 		for _, testCase := range target.Test.Results.TestCases {
 			if len(testCase.Errors()) > 0 {
-				resultErr = fmt.Errorf(testCase.Errors()[0].Error.Message)
+				resultErr = fmt.Errorf("%s", testCase.Errors()[0].Error.Message)
 			}
 		}
 	} else {
 		resultErr = fmt.Errorf("unknown error")
 		resultMsg = "Something went wrong"
 	}
-	state.LogTestResult(target, run, core.TargetTestFailed, target.Test.Results, coverage, resultErr, resultMsg)
+	state.LogTestResult(target, run, core.TargetTestFailed, target.Test.Results, coverage, resultErr, "%s", resultMsg)
 }
 
 func logTestSuccess(state *core.BuildState, target *core.BuildTarget, run int, results *core.TestSuite, coverage *core.TestCoverage) {
@@ -329,7 +329,7 @@ func logTestSuccess(state *core.BuildState, target *core.BuildTarget, run int, r
 	} else {
 		description = fmt.Sprintf("%d %s passed.", len(results.TestCases), tests)
 	}
-	state.LogTestResult(target, run, core.TargetTested, results, coverage, nil, description)
+	state.LogTestResult(target, run, core.TargetTested, results, coverage, nil, "%s", description)
 }
 
 func pluralise(word string, quantity int) string {

--- a/third_party/binary/BUILD
+++ b/third_party/binary/BUILD
@@ -1,4 +1,4 @@
-GO_CI_LINT_VERSION = "1.58.2"
+GO_CI_LINT_VERSION = "1.60.3"
 
 remote_file(
     name = "golangci-lint",
@@ -6,10 +6,10 @@ remote_file(
     exported_files = ["golangci-lint-%s-${OS}-${ARCH}/golangci-lint" % GO_CI_LINT_VERSION],
     extract = True,
     hashes = [
-        "9d8c372fabff0917a0502c86381e9de291bef274b5ccc8e6b849fccb257cfefd",  # darwin-amd64
-        "99ba8037946fb3e3976a0004c93eb0df9f6efc50500f506665f1091ddf5aaba5",  # darwin-arm64
-        "6236a423ea74cc0de61862da007a063f6187ad929bdb3fb54eb12cd689006a99",  # linux-amd64
-        "549a714657e80942166ecb4327bfb21487af872945b50b155339b0b5cc3fa2f2",  # linux-arm64
+        "faf60366f99bb4010b634a030c45eaf57baae6c0b7e10be151139871e3fef40e", # golangci-lint-1.60.3-darwin-amd64.tar.gz
+        "deb0fbd0b99992d97808614db1214f57d5bdc12b907581e2ef10d3a392aca11f", # golangci-lint-1.60.3-darwin-arm64.tar.gz
+        "4037af8122871f401ed874852a471e54f147ff8ce80f5a304e020503bdb806ef", # golangci-lint-1.60.3-linux-amd64.tar.gz
+        "74782943b2d2edae1208be3701e0cafe62817ba90b9b4cc5ca52bdef26df12f9", # golangci-lint-1.60.3-linux-arm64.tar.gz
     ],
     url = "https://github.com/golangci/golangci-lint/releases/download/v%s/golangci-lint-%s-%s-%s.tar.gz" % (
         GO_CI_LINT_VERSION,


### PR DESCRIPTION
Fixes a couple of warnings about a moved config option and a now irrelevant linter.
There's also a new linter checking for printf bits which seems legit enough to be worth fixing (apart from one case, anyway)