### PR TITLE
Detach codepath adds env vars

### DIFF
--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -191,6 +191,7 @@ func run(ctx context.Context, state *core.BuildState, label core.AnnotatedOutput
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Dir = dir
+		cmd.Env = env
 		return nil, nil, toExitError(cmd.Start(), args, nil)
 	}
 	// Run as a normal subcommand.

--- a/tools/http_cache/BUILD
+++ b/tools/http_cache/BUILD
@@ -11,6 +11,6 @@ go_binary(
 
 sh_cmd(
     name = "run_local",
-    srcs = [":http_cache"],
-    cmd = "exec $(out_location :http_cache) -p 1771 -d /tmp/please_http_cache",
+    data = [":http_cache"],
+    cmd = r"exec \\$DATA -p 1771 -d /tmp/please_http_cache",
 )


### PR DESCRIPTION
Only needed one line. Updated http cache test (where I found it originally)

Fixes #3240 