### PR TITLE
Update to Go 1.23.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,16 @@ jobs:
    build-alpine:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_alpine:20240901
+       - image: thoughtmachine/please_alpine:20240906
      resource_class: large
      environment:
        PLZ_ARGS: "-p --profile ci --profile alpine --exclude no-musl"
      steps:
        - checkout
        - restore_cache:
-           key: go-mod-alpine-v8-{{ checksum "go.mod" }}
+           key: go-mod-alpine-v9-{{ checksum "go.mod" }}
        - restore_cache:
-           key: go-alpine-main-v8-{{ checksum "third_party/go/BUILD" }}
+           key: go-alpine-main-v9-{{ checksum "third_party/go/BUILD" }}
        - restore_cache:
            key: python-alpine-main-v3-{{ checksum "third_party/python/BUILD" }}
        - run:
@@ -30,11 +30,11 @@ jobs:
        - store_artifacts:
            path: plz-out/log
        - save_cache:
-           key: go-mod-alpine-v8-{{ checksum "go.mod" }}
+           key: go-mod-alpine-v9-{{ checksum "go.mod" }}
            paths:
              - "~/go/pkg/mod"
        - save_cache:
-           key: go-alpine-main-v8-{{ checksum "third_party/go/BUILD" }}
+           key: go-alpine-main-v9-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
        - save_cache:
            key: python-alpine-main-v3-{{ checksum "third_party/python/BUILD" }}
@@ -43,16 +43,16 @@ jobs:
    build-linux:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20240901
+       - image: thoughtmachine/please_ubuntu:20240906
      resource_class: large
      environment:
        PLZ_ARGS: "-p --profile ci"
      steps:
        - checkout
        - restore_cache:
-           key: go-mod-linux-v8-{{ checksum "go.mod" }}
+           key: go-mod-linux-v9-{{ checksum "go.mod" }}
        - restore_cache:
-           key: go-linux-main-v8-{{ checksum "third_party/go/BUILD" }}
+           key: go-linux-main-v9-{{ checksum "third_party/go/BUILD" }}
        - restore_cache:
            key: python-linux-main-v3-{{ checksum "third_party/python/BUILD" }}
        - run:
@@ -78,11 +78,11 @@ jobs:
            name: Test perf framework
            command: plz-out/bin/tools/performance/gen_parse_tree.pex --plz plz-out/bin/src/please --size 1 && plz-out/bin/tools/performance/parse_perf_test.pex --plz plz-out/bin/src/please -n 1
        - save_cache:
-           key: go-mod-linux-v8-{{ checksum "go.mod" }}
+           key: go-mod-linux-v9-{{ checksum "go.mod" }}
            paths:
              - "~/go/pkg/mod"
        - save_cache:
-           key: go-linux-main-v8-{{ checksum "third_party/go/BUILD" }}
+           key: go-linux-main-v9-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
        - save_cache:
            key: python-linux-main-v3-{{ checksum "third_party/python/BUILD" }}
@@ -180,7 +180,7 @@ jobs:
    build-linux-arm64:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20240901
+       - image: thoughtmachine/please_ubuntu:20240906
      resource_class: large
      steps:
        - checkout
@@ -250,7 +250,7 @@ jobs:
    test-rex:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20240901
+       - image: thoughtmachine/please_ubuntu:20240906
      resource_class: xlarge
      steps:
        - checkout
@@ -267,7 +267,7 @@ jobs:
    test-http-cache:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu:20240901
+       - image: thoughtmachine/please_ubuntu:20240906
      resource_class: large
      steps:
        - checkout
@@ -283,7 +283,7 @@ jobs:
    # Releases to github and homebrew
    release:
      docker:
-       - image: thoughtmachine/please_ubuntu:20240901
+       - image: thoughtmachine/please_ubuntu:20240906
      environment:
        GOOGLE_APPLICATION_CREDENTIALS=/tmp/service_account.json
      steps:
@@ -298,7 +298,7 @@ jobs:
    # Releases the docs and the binaries to gs for please.build and get.please.build
    release-gs:
      docker:
-       - image: thoughtmachine/please_ubuntu:20240901
+       - image: thoughtmachine/please_ubuntu:20240906
      environment:
        GOOGLE_APPLICATION_CREDENTIALS=/tmp/service_account.json
      steps:
@@ -310,7 +310,7 @@ jobs:
    # Runs a benchmarking test and records some performance results.
    perf-test:
      docker:
-       - image: thoughtmachine/please_ubuntu:20240901
+       - image: thoughtmachine/please_ubuntu:20240906
      environment:
        GOOGLE_APPLICATION_CREDENTIALS=/tmp/service_account.json
      resource_class: xlarge  # Want to run these tests with a significant amount of parallelism

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
        - attach_workspace:
            at: /tmp/workspace
        - restore_cache:
-           key: go-darwin-amd64-v4-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-amd64-v5-{{ checksum "third_party/go/BUILD" }}
        - run:
            name: Install deps
            command: ./.circleci/setup_osx.sh
@@ -148,7 +148,7 @@ jobs:
        - store_artifacts:
            path: plz-out/log
        - save_cache:
-           key: go-darwin-amd64-v4-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-amd64-v5-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
 
    build-freebsd:
@@ -187,7 +187,7 @@ jobs:
        - attach_workspace:
            at: /tmp/workspace
        - restore_cache:
-           key: go-linux-arm64-v2-{{ checksum "third_party/go/BUILD" }}
+           key: go-linux-arm64-v3-{{ checksum "third_party/go/BUILD" }}
        - run:
            name: Extract plz
            command: tar -xzf /tmp/workspace/linux_amd64/please_*.tar.gz
@@ -201,7 +201,7 @@ jobs:
        - store_artifacts:
            path: plz-out/log
        - save_cache:
-           key: go-linux-arm64-v2-{{ checksum "third_party/go/BUILD" }}
+           key: go-linux-arm64-v3-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
    build-darwin:
       macos:
@@ -212,9 +212,9 @@ jobs:
       steps:
        - checkout
        - restore_cache:
-           key: go-mod-darwin-arm64-v7-{{ checksum "bootstrap.sh" }}
+           key: go-mod-darwin-arm64-v8-{{ checksum "bootstrap.sh" }}
        - restore_cache:
-           key: go-darwin-arm64-go121-v1-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-arm64-go123-v1-{{ checksum "third_party/go/BUILD" }}
        - restore_cache:
            key: python-darwin-arm64-v3-{{ checksum "third_party/python/BUILD" }}
        - run:
@@ -237,11 +237,11 @@ jobs:
        - store_artifacts:
            path: /tmp/artifacts
        - save_cache:
-           key: go-mod-darwin-arm64-v7-{{ checksum "go.mod" }}
+           key: go-mod-darwin-arm64-v8-{{ checksum "go.mod" }}
            paths:
              - "~/go/pkg/mod"
        - save_cache:
-           key: go-darwin-arm64-go121-v1-{{ checksum "third_party/go/BUILD" }}
+           key: go-darwin-arm64-go123-v1-{{ checksum "third_party/go/BUILD" }}
            paths: [ ".plz-cache/third_party/go" ]
        - save_cache:
            key: python-darwin-arm64-v3-{{ checksum "third_party/python/BUILD" }}

--- a/.circleci/setup_osx.sh
+++ b/.circleci/setup_osx.sh
@@ -4,7 +4,7 @@ set -eu
 
 # /usr/local/go might get cached.
 if [ ! -d "/usr/local/go" ]; then
-    curl -fsSL https://dl.google.com/go/go1.21.5.darwin-arm64.tar.gz | sudo tar -xz -C /usr/local
+    curl -fsSL https://dl.google.com/go/go1.23.1.darwin-arm64.tar.gz | sudo tar -xz -C /usr/local
 fi
 sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
 

--- a/tools/images/alpine/Dockerfile
+++ b/tools/images/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine
+FROM golang:1.23-alpine
 MAINTAINER peter.ebden@gmail.com
 
 RUN apk update && apk add --no-cache git patch gcc g++ libc-dev bash libgcc xz protoc protobuf-dev perl-utils

--- a/tools/images/ubuntu/Dockerfile
+++ b/tools/images/ubuntu/Dockerfile
@@ -16,7 +16,7 @@ RUN truncate -s0 /tmp/preseed.cfg; \
     apt-get clean
 
 # Go - we want a specific package version here.
-RUN curl -fsSL https://dl.google.com/go/go1.22.6.linux-amd64.tar.gz | tar -xzC /usr/local
+RUN curl -fsSL https://dl.google.com/go/go1.23.1.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Locale


### PR DESCRIPTION
Also 1.22.7 for the alternate Ubuntu build to make sure that still works.

_Theoretically_ this should be okay to go. Let's see what happens on CircleCI...