### PR TITLE
Avoid storing package cache in Alpine build image

### DIFF
--- a/tools/images/alpine/Dockerfile
+++ b/tools/images/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.23-alpine
 MAINTAINER peter.ebden@gmail.com
 
-RUN apk update && apk add --no-cache git patch gcc g++ libc-dev bash libgcc xz protoc protobuf-dev perl-utils
+RUN apk add --no-cache git patch gcc g++ libc-dev bash libgcc xz protoc protobuf-dev perl-utils
 
 # Ensure this is where we expect on the PATH
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go


### PR DESCRIPTION
`apk add --no-cache` updates the package cache but doesn't store it on the file system after the transaction completes, making the preceding `apk update` unnecessary.