### PR TITLE
Fix a couple of things on arm64

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.7.3",
     "java": "v0.4.2",
-    "go": "v1.21.2",
+    "go": "v1.21.3",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/src/fs/hash.go
+++ b/src/fs/hash.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/xattr"
 )
@@ -270,8 +271,9 @@ func (hasher *PathHasher) timestampHash(h hash.Hash, filename string) error {
 	if err != nil {
 		return err
 	}
+
 	// This doesn't account for the last changed time on macos which is set when modifying permissions etc.
-	h.Write([]byte(file.ModTime().UTC().String()))
+	h.Write([]byte(file.ModTime().UTC().Format(time.DateTime)))
 	return err
 }
 

--- a/src/fs/hash.go
+++ b/src/fs/hash.go
@@ -8,13 +8,15 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/pkg/xattr"
 )
 
 // boolTrueHashValue is used when we need to write something indicating a bool in the input.
 var boolTrueHashValue = []byte{2}
+
+// The format we serialise times in when checking whether something has changed (when we do it by timestamp)
+const timeFormat = "2006-01-02 15:04:05.000000000"
 
 // A PathHasher is responsible for hashing & remembering paths.
 type PathHasher struct {
@@ -273,7 +275,7 @@ func (hasher *PathHasher) timestampHash(h hash.Hash, filename string) error {
 	}
 
 	// This doesn't account for the last changed time on macos which is set when modifying permissions etc.
-	h.Write([]byte(file.ModTime().UTC().Format(time.DateTime)))
+	h.Write([]byte(file.ModTime().UTC().Format(timeFormat)))
 	return err
 }
 

--- a/src/fs/hash_test.go
+++ b/src/fs/hash_test.go
@@ -70,12 +70,13 @@ func TestHashLastModified(t *testing.T) {
 	require.NoError(t, err)
 	h := NewPathHasher(wd, true, sha256.New, "_256")
 	path := "src/fs/test_data/test_subfolder1/a.txt"
-	modTime := time.Now().UTC()
+	// Truncate to seconds since some filesystems seem not to support sub-second precision
+	modTime := time.Now().UTC().Truncate(time.Second)
 	err = os.Chtimes(path, modTime, modTime)
 	require.NoError(t, err)
 
 	sha256Hash := sha256.New()
-	sha256Hash.Write([]byte(modTime.Format(time.DateTime)))
+	sha256Hash.Write([]byte(modTime.Format(timeFormat)))
 	expected := sha256Hash.Sum(nil)
 
 	b, err := h.Hash("src/fs/test_data/test_subfolder1/a.txt", false, false, true)

--- a/src/fs/hash_test.go
+++ b/src/fs/hash_test.go
@@ -75,7 +75,7 @@ func TestHashLastModified(t *testing.T) {
 	require.NoError(t, err)
 
 	sha256Hash := sha256.New()
-	sha256Hash.Write([]byte(modTime.String()))
+	sha256Hash.Write([]byte(modTime.Format(time.DateTime)))
 	expected := sha256Hash.Sum(nil)
 
 	b, err := h.Hash("src/fs/test_data/test_subfolder1/a.txt", false, false, true)

--- a/test/please_shim/BUILD
+++ b/test/please_shim/BUILD
@@ -4,7 +4,7 @@ please_repo_e2e_test(
     name = "install",
     expect_output_contains = {
         # Version installed must match the one in the .plzconfig file.
-        "plz_version.txt": "Please version 16.18.0",
+        "plz_version.txt": "Please version 17.11.0",
     },
     plz_command = " && ".join([
         # Install Please since it won't find it. Please location
@@ -41,9 +41,9 @@ please_repo_e2e_test(
     name = "update",
     expect_output_contains = {
         # Version installed must match the one in the .plzconfig file.
-        "install_version.txt": "Please version 16.18.0",
+        "install_version.txt": "Please version 17.11.0",
         # Update version.
-        "update_version.txt": "Please version 16.17.0",
+        "update_version.txt": "Please version 17.10.0",
     },
     plz_command = " && ".join([
         # Install binary first.

--- a/test/please_shim/test_repo/.plzconfig
+++ b/test/please_shim/test_repo/.plzconfig
@@ -1,3 +1,3 @@
 [please]
 location = ./please
-version = 16.18.0
+version = 17.11.0

--- a/test/please_shim/test_repo/.plzconfig.update_version
+++ b/test/please_shim/test_repo/.plzconfig.update_version
@@ -1,2 +1,2 @@
 [please]
-version = 16.17.0
+version = 17.10.0

--- a/test/stamp/BUILD
+++ b/test/stamp/BUILD
@@ -15,7 +15,7 @@ sh_test(
     data = [":stamp"],
 )
 
-if is_platform(os = "linux", arch = "amd64"):
+if is_platform(os = "linux"):
     go_binary(
         name = "stamp_static",
         srcs = ["main.go"],

--- a/test/stamp/BUILD
+++ b/test/stamp/BUILD
@@ -15,7 +15,7 @@ sh_test(
     data = [":stamp"],
 )
 
-if is_platform(os = "linux"):
+if is_platform(os = "linux", arch = "amd64"):
     go_binary(
         name = "stamp_static",
         srcs = ["main.go"],


### PR DESCRIPTION
Fix a failing test where it seems like sub-second precision is getting lost on the timestamps. I don't know why I'm seeing this (I'm pretty sure btrfs supports more than that, although I don't have a canonical source on that). Regardless, we shouldn't be using `time.Date.String()`:
```
The returned string is meant for debugging; for a stable serialized representation, use t.MarshalText, t.MarshalBinary, or t.Format with an explicit format string. 
```
So indeed, we now use an explicit format string.

Also update version of upgrade tests to be more recent (when we have builds for this target). In general it's probably good for this not to be _too_ ancient (this isn't meant to test upgrading from an arbitrarily old version).

Split out static build fixes to #3252