### PR TITLE
Remove alpine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,10 +58,6 @@ jobs:
        - run:
            name: Bootstrap & Build
            command: ./bootstrap.sh --test_results_file plz-out/results/please/test_results.xml
-       - persist_to_workspace:
-           root: plz-out/pkg
-           paths:
-             - linux_amd64/*
        - store_test_results:
            path: plz-out/results
        - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,14 +58,19 @@ jobs:
        - run:
            name: Bootstrap & Build
            command: ./bootstrap.sh --test_results_file plz-out/results/please/test_results.xml
+       - persist_to_workspace:
+           root: plz-out/pkg
+           paths:
+             - linux_amd64/*
        - store_test_results:
            path: plz-out/results
        - run:
            name: Package
-           command: plz-out/bin/src/please build //package:signer //tools/misc:gen_release //docs:tarball //docs:deep-tarball //tools/performance:all -p
+           command: plz-out/bin/src/please build //package:all //tools/misc:gen_release //docs:tarball //docs:deep-tarball //tools/performance:all -p
        - persist_to_workspace:
            root: plz-out/pkg
            paths:
+             - linux_amd64/*
              - gen_release.pex
              - release_signer
              - docs.tar.gz
@@ -325,34 +330,32 @@ workflows:
   version: 2
   build-all:
     jobs:
-      - build-alpine
       - build-linux
       - build-linux-alt
       - build-darwin:
           requires:
-            - build-alpine
+            - build-linux
       - build-freebsd:
           requires:
-            - build-alpine
+            - build-linux
       - test-rex:
           requires:
-            - build-alpine
+            - build-linux
       - test-http-cache:
           requires:
-            - build-alpine
+            - build-linux
       - build-linux-arm64:
           requires:
-            - build-alpine
+            - build-linux
       - build-darwin-amd64:
           requires:
             - build-darwin
       - release-gs:
           requires:
-            - build-alpine
+            - build-linux
             - build-freebsd
             - build-darwin-amd64
             - build-linux-arm64
-            - build-linux
             - build-linux-alt
             - build-darwin
             - test-rex
@@ -368,7 +371,6 @@ workflows:
               only: master
       - perf-test:
           requires:
-            - build-alpine
             - build-linux
           filters:
             branches:

--- a/.plzconfig.alpine
+++ b/.plzconfig.alpine
@@ -1,7 +1,0 @@
-[Plugin "go"]
-DefaultStatic = true
-GoTool = go
-Stdlib = //third_party/go:std
-
-[buildconfig]
-static-sandbox = true

--- a/tools/images/alpine/Dockerfile
+++ b/tools/images/alpine/Dockerfile
@@ -1,9 +1,0 @@
-FROM golang:1.23-alpine
-MAINTAINER peter.ebden@gmail.com
-
-RUN apk add --no-cache git patch gcc g++ libc-dev bash libgcc xz protoc protobuf-dev perl-utils
-
-# Ensure this is where we expect on the PATH
-RUN ln -s /usr/local/go/bin/go /usr/local/bin/go
-
-WORKDIR /tmp

--- a/tools/images/alpine/README.md
+++ b/tools/images/alpine/README.md
@@ -1,9 +1,0 @@
-Please Alpine image
--------------------
-
-This image contains everything needed to build Please and its
-associated tools. It is fairly minimal and doesn't contain everything
-needed to run all of the language-specific tests (see the Ubuntu image
-if that is of interest).
-This is the canonical build environment for Please in Linux that we
-use to release binaries from.

--- a/tools/sandbox/BUILD
+++ b/tools/sandbox/BUILD
@@ -9,7 +9,7 @@ c_library(
 c_binary(
     name = "please_sandbox",
     srcs = ["main.c"],
-    static = (CONFIG.get("STATIC_SANDBOX") is not None),
+    static = is_platform(os = "linux"),
     visibility = ["PUBLIC"],
     deps = [":sandbox"],
 )
@@ -17,7 +17,7 @@ c_binary(
 c_binary(
     name = "nonet_sandbox",
     srcs = ["nonet_main.c"],
-    static = (CONFIG.get("STATIC_SANDBOX") is not None),
+    static = is_platform(os = "linux"),
     visibility = ["PUBLIC"],
     deps = [":sandbox"],
 )


### PR DESCRIPTION
I don't think this is necessary any more. We're building static Go binaries anyway as of #3252 and I seem to just be able to build static versions of the sandbox anyway. It feels simpler not to have to manage another OS configuration.

I assume that I will find out from circleci if it has any issues.