### PR TITLE
Change iterable interface to be more flexible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
    build-linux-alt:
      working_directory: ~/please
      docker:
-       - image: thoughtmachine/please_ubuntu_alt:20240906
+       - image: thoughtmachine/please_ubuntu_alt:20240910
      resource_class: large
      environment:
        PLZ_ARGS: "-p -c cover --profile ci-alt"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '^1.22'
+          go-version: '^1.23'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.60
+          version: v1.61
           args: src/... tools/...
           skip-pkg-cache: true

--- a/README.md
+++ b/README.md
@@ -188,10 +188,7 @@ file.
 
 To build Please yourself, run `./bootstrap.sh` in the repo root.
 This will bootstrap a minimal version of Please using Go and then
-rebuild it using itself.
-
-You'll need to have Go 1.21+ installed to build Please although once
-built it can target any recent version (we think back to about 1.8ish).
+rebuild it using itself. You'll need to have Go 1.23+ installed.
 
 Optional dependencies for various tests include Python, Java, clang,
 gold and docker - none of those are required to build components so

--- a/go.mod
+++ b/go.mod
@@ -115,4 +115,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.21
+go 1.23

--- a/src/BUILD.plz
+++ b/src/BUILD.plz
@@ -53,7 +53,7 @@ filegroup(
 if is_platform(os = "linux"):
     gentest(
         name = "static_test",
-        test_cmd = "ldd $DATA && exit 1 || exit 0",
         data = [":please"],
         no_test_output = True,
+        test_cmd = "ldd $DATA && exit 1 || exit 0",
     )

--- a/src/cache/BUILD
+++ b/src/cache/BUILD
@@ -1,6 +1,9 @@
 go_library(
     name = "cache",
-    srcs = glob(["*.go"], exclude=["*_test.go"]),
+    srcs = glob(
+        ["*.go"],
+        exclude = ["*_test.go"],
+    ),
     pgo_file = "//:pgo",
     visibility = ["PUBLIC"],
     deps = [

--- a/src/fs/BUILD
+++ b/src/fs/BUILD
@@ -1,6 +1,9 @@
 go_library(
     name = "fs",
-    srcs = glob(["*.go"], exclude=["*_test.go"]),
+    srcs = glob(
+        ["*.go"],
+        exclude = ["*_test.go"],
+    ),
     pgo_file = "//:pgo",
     visibility = ["PUBLIC"],
     deps = [
@@ -13,7 +16,13 @@ go_library(
 
 go_test(
     name = "fs_test",
-    srcs = glob(["*_test.go"], exclude=["glob_integration_test.go", "*_benchmark_test.go"]),
+    srcs = glob(
+        ["*_test.go"],
+        exclude = [
+            "glob_integration_test.go",
+            "*_benchmark_test.go",
+        ],
+    ),
     data = ["test_data"],
     deps = [
         ":fs",

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -1079,7 +1079,7 @@ func (r *pyRange) Item(index int) pyObject {
 func (r *pyRange) Iter() iter.Seq[pyObject] {
 	return func(yield func(pyObject) bool) {
 		for i := r.Start; i < r.Stop; i += r.Step {
-			if !yield(pyInt(i)) {
+			if !yield(i) {
 				break
 			}
 		}

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -37,7 +37,6 @@ type freezable interface {
 // An iterable represents an object that can be iterated (the y in `for x in y`).
 // Not all pyObjects implement this.
 type iterable interface {
-	pyObject
 	Iter() iter.Seq[pyObject]
 }
 

--- a/third_party/binary/BUILD
+++ b/third_party/binary/BUILD
@@ -1,16 +1,10 @@
-GO_CI_LINT_VERSION = "1.60.3"
+GO_CI_LINT_VERSION = "1.61.0"
 
 remote_file(
     name = "golangci-lint",
     binary = True,
     exported_files = ["golangci-lint-%s-${OS}-${ARCH}/golangci-lint" % GO_CI_LINT_VERSION],
     extract = True,
-    hashes = [
-        "faf60366f99bb4010b634a030c45eaf57baae6c0b7e10be151139871e3fef40e", # golangci-lint-1.60.3-darwin-amd64.tar.gz
-        "deb0fbd0b99992d97808614db1214f57d5bdc12b907581e2ef10d3a392aca11f", # golangci-lint-1.60.3-darwin-arm64.tar.gz
-        "4037af8122871f401ed874852a471e54f147ff8ce80f5a304e020503bdb806ef", # golangci-lint-1.60.3-linux-amd64.tar.gz
-        "74782943b2d2edae1208be3701e0cafe62817ba90b9b4cc5ca52bdef26df12f9", # golangci-lint-1.60.3-linux-arm64.tar.gz
-    ],
     url = "https://github.com/golangci/golangci-lint/releases/download/v%s/golangci-lint-%s-%s-%s.tar.gz" % (
         GO_CI_LINT_VERSION,
         GO_CI_LINT_VERSION,

--- a/tools/http_cache/BUILD
+++ b/tools/http_cache/BUILD
@@ -11,6 +11,6 @@ go_binary(
 
 sh_cmd(
     name = "run_local",
-    data = [":http_cache"],
     cmd = r"exec \\$DATA -p 1771 -d /tmp/please_http_cache",
+    data = [":http_cache"],
 )

--- a/tools/images/ubuntu_alt/Dockerfile
+++ b/tools/images/ubuntu_alt/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get clean
 
 # Go
-RUN curl -fsSL https://dl.google.com/go/go1.22.7.linux-amd64.tar.gz | tar -xzC /usr/local
+RUN curl -fsSL https://dl.google.com/go/go1.23.1.linux-amd64.tar.gz | tar -xzC /usr/local
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Locale


### PR DESCRIPTION
Rather than using length + index for everything, this leverages 1.23 iterators. It doesn't really change much fundamental yet, but does move towards being able to iterate things like dicts without extra list allocations.

Benchmarks locally actually seem to do slightly better. I'm not really sure why - I don't especially expect this to improve things dramatically as is - but the main thing is it's not getting worse.