### PR TITLE
plz query changes --inexact is more selective about parsing

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -961,7 +961,7 @@ func (target *BuildTarget) CheckTargetOwnsBuildOutputs(state *BuildState) error 
 			continue
 		}
 
-		pkg := FindOwningPackage(state, out)
+		pkg := FindOwningPackage(state.Config, out)
 		if targetPackage != pkg.PackageName {
 			return fmt.Errorf("trying to output file %s, but that directory belongs to another package (%s)", out, pkg.PackageName)
 		}
@@ -997,7 +997,7 @@ func (target *BuildTarget) checkTargetOwnsBuildInput(state *BuildState, input Bu
 }
 
 func (target *BuildTarget) checkTargetOwnsFileAndSubDirectories(state *BuildState, file string) error {
-	pkg := FindOwningPackage(state, file)
+	pkg := FindOwningPackage(state.Config, file)
 	if target.Label.PackageName != pkg.PackageName {
 		return fmt.Errorf("package %s is trying to use file %s, but that belongs to another package (%s)", target.Label.PackageName, file, pkg.PackageName)
 	}

--- a/src/core/package.go
+++ b/src/core/package.go
@@ -214,10 +214,10 @@ func (pkg *Package) verifyOutputs() []string {
 }
 
 // FindOwningPackages returns build labels corresponding to the packages that own each of the given files.
-func FindOwningPackages(state *BuildState, files []string) []BuildLabel {
+func FindOwningPackages(config *Configuration, files []string) []BuildLabel {
 	ret := make([]BuildLabel, len(files))
 	for i, file := range files {
-		ret[i] = FindOwningPackage(state, file)
+		ret[i] = FindOwningPackage(config, file)
 		if ret[i].PackageName == "" {
 			log.Fatalf("No BUILD file owns file %s", file)
 		}
@@ -226,10 +226,10 @@ func FindOwningPackages(state *BuildState, files []string) []BuildLabel {
 }
 
 // FindOwningPackage returns a build label identifying the package that owns a given file.
-func FindOwningPackage(state *BuildState, file string) BuildLabel {
+func FindOwningPackage(config *Configuration, file string) BuildLabel {
 	f := filepath.Dir(file)
 	for f != "." {
-		if fs.IsPackage(state.Config.Parse.BuildFileName, f) {
+		if fs.IsPackage(config.Parse.BuildFileName, f) {
 			return BuildLabel{PackageName: f, Name: "all"}
 		}
 		f = filepath.Dir(f)

--- a/src/core/package_test.go
+++ b/src/core/package_test.go
@@ -89,9 +89,9 @@ func TestAllChildren(t *testing.T) {
 }
 
 func TestFindOwningPackages(t *testing.T) {
-	state := NewDefaultBuildState()
-	state.Config.Parse.BuildFileName = []string{"BUILD_FILE"}
-	pkgs := FindOwningPackages(state, []string{"src/core/test_data/test_subfolder1/whatever.txt"})
+	config := DefaultConfiguration()
+	config.Parse.BuildFileName = []string{"BUILD_FILE"}
+	pkgs := FindOwningPackages(config, []string{"src/core/test_data/test_subfolder1/whatever.txt"})
 	assert.Equal(t, []BuildLabel{ParseBuildLabel("//src/core/test_data:all", "")}, pkgs)
 }
 

--- a/src/please.go
+++ b/src/please.go
@@ -907,14 +907,14 @@ var buildFunctions = map[string]func() int{
 			level = 0
 		}
 		runInexact := func(files []string) int {
-			return runQuery(true, core.WholeGraph, func(state *core.BuildState) {
+			return runQuery(true, core.FindOwningPackages(config, files), func(state *core.BuildState) {
 				for _, target := range query.Changes(state, files, level, includeSubrepos) {
 					fmt.Println(target.String())
 				}
 			})
 		}
 		if len(opts.Query.Changes.Args.Files) > 0 {
-			return runInexact(opts.Query.Changes.Args.Files.Get())
+			return runInexact(makePathsRelative(opts.Query.Changes.Args.Files.Get()))
 		}
 		scm := scm.MustNew(core.RepoRoot)
 		if opts.Query.Changes.In != "" {


### PR DESCRIPTION
I'm not sure why we didn't do this already - we already have all the tech for `query whatinputs`. Maybe that got added later.

Anyway, `--inexact` and friends only care about a set of files that have changed, and hence only need to parse the relevant packages for them, not the whole graph. That is pretty easy to do - most of this is a bit of cleanup, & sharing some other code to make paths relative so now `plz query changes /home/peter/git/please/src/please.go` works the same as `plz query changes src/please.go`, before it just returned nothing.