### PR TITLE
Minor clean up to len()

### DIFF
--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -418,17 +418,8 @@ func lenFunc(s *scope, args []pyObject) pyObject {
 }
 
 func objLen(obj pyObject) pyInt {
-	switch t := obj.(type) {
-	case pyList:
-		return newPyInt(len(t))
-	case pyFrozenList:
-		return newPyInt(len(t.pyList))
-	case pyDict:
-		return newPyInt(len(t))
-	case pyFrozenDict:
-		return newPyInt(len(t.pyDict))
-	case pyString:
-		return newPyInt(len([]rune(t)))
+	if l, ok := obj.(lengthable); ok {
+		return newPyInt(l.Len())
 	}
 	panic("object of type " + obj.Type() + " has no len()")
 }

--- a/src/parse/asp/builtins_test.go
+++ b/src/parse/asp/builtins_test.go
@@ -103,3 +103,12 @@ func TestStrFormat4(t *testing.T) {
 		pyString(`echo "{}@${}" > $OUT`), pyString("tools/images/please_ubuntu"), pyString("please_ubuntu_digest"),
 	}))
 }
+
+func TestObjLen(t *testing.T) {
+	l := pyList{pyInt(1)}
+	assert.EqualValues(t, 1, objLen(l))
+	assert.EqualValues(t, 1, objLen(l.Freeze()))
+	d := pyDict{"1": pyInt(1)}
+	assert.EqualValues(t, 1, objLen(d))
+	assert.EqualValues(t, 1, objLen(d.Freeze()))
+}

--- a/src/parse/asp/objects.go
+++ b/src/parse/asp/objects.go
@@ -40,9 +40,14 @@ type iterable interface {
 	Iter() iter.Seq[pyObject]
 }
 
-// An indexable represents an object that knows its length and can be indexed into.
-type indexable interface {
+// A lengthable represents an object that knows its own length.
+type lengthable interface {
 	Len() int
+}
+
+// An indexable represents an object that can be indexed into. It also implicitly knows its length.
+type indexable interface {
+	lengthable
 	Item(index int) pyObject
 }
 
@@ -338,6 +343,10 @@ func (s pyString) String() string {
 	return string(s)
 }
 
+func (s pyString) Len() int {
+	return len([]rune(s))
+}
+
 type pyList []pyObject
 
 var emptyList pyObject = make(pyList, 0) // want this to explicitly have zero capacity
@@ -451,7 +460,7 @@ func (l pyList) Repeat(n pyInt) pyList {
 	return ret
 }
 
-// Len returns the length of this list, implementing indexable.
+// Len returns the length of this list, implementing lengthable.
 func (l pyList) Len() int {
 	return len(l)
 }
@@ -526,6 +535,10 @@ func (d pyDict) Operator(operator Operator, operand pyObject) pyObject {
 		return ret
 	}
 	panic("Unsupported operator on dict")
+}
+
+func (d pyDict) Len() int {
+	return len(d)
 }
 
 func (d pyDict) IndexAssign(index, value pyObject) {


### PR DESCRIPTION
Use an interface rather than a type switch, continuing on the theme of objects implementing additional interfaces for extra functionality