### PR TITLE
Some small optimisations

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -59,7 +59,7 @@ genrule(
 plugins = {
     "python": "v1.7.3",
     "java": "v0.4.2",
-    "go": "v1.21.4",
+    "go": "v1.21.5",
     "cc": "v0.4.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1193,7 +1193,7 @@ func (target *BuildTarget) AddProvide(language string, labels []BuildLabel) {
 	if target.Provides == nil {
 		target.Provides = map[string][]BuildLabel{language: labels}
 	} else {
-		target.Provides[language] = labels
+		target.Provides[language] = slices.Clip(labels)  // Clip so we don't have issues appending in provideFor
 	}
 }
 
@@ -1227,9 +1227,10 @@ func (target *BuildTarget) provideFor(other *BuildTarget) ([]BuildLabel, bool) {
 	for _, require := range other.Requires {
 		if label, present := target.Provides[require]; present {
 			if ret == nil {
-				ret = make([]BuildLabel, 0, len(other.Requires))
+				ret = label
+			} else {
+				ret = append(ret, label...)
 			}
-			ret = append(ret, label...)
 			found = true
 		}
 	}

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1193,7 +1193,7 @@ func (target *BuildTarget) AddProvide(language string, labels []BuildLabel) {
 	if target.Provides == nil {
 		target.Provides = map[string][]BuildLabel{language: labels}
 	} else {
-		target.Provides[language] = slices.Clip(labels)  // Clip so we don't have issues appending in provideFor
+		target.Provides[language] = slices.Clip(labels) // Clip so we don't have issues appending in provideFor
 	}
 }
 

--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -108,10 +108,19 @@ func resolvePluginValue(values []string, subrepo string) []string {
 				continue // I guess it wasn't a build label. Leave it alone.
 			}
 			// Force the full build label including empty subrepo so this is portable
-			v = fmt.Sprintf("///%v//%v:%v", l.Subrepo, l.PackageName, l.Name)
+			var buf strings.Builder
+			buf.Grow(len(l.Subrepo) + len(l.PackageName) + len(l.Name) + len(annotation) + 7)  // +7 for the delimiters
+			buf.WriteString("///")
+			buf.WriteString(l.Subrepo)
+			buf.WriteString("//")
+			buf.WriteString(l.PackageName)
+			buf.WriteByte(':')
+			buf.WriteString(l.Name)
 			if annotation != "" {
-				v = fmt.Sprintf("%v|%v", v, annotation)
+				buf.WriteByte('|')
+				buf.WriteString(annotation)
 			}
+			v = buf.String()
 		}
 		ret[i] = v
 	}
@@ -155,7 +164,7 @@ func pluginConfig(pluginState *core.BuildState, pkgState *core.BuildState) pyDic
 			continue
 		}
 
-		fullConfigKey := fmt.Sprintf("%v.%v", pluginName, configKey)
+		fullConfigKey := pluginName + "." + configKey
 		value, ok := extraVals[strings.ToLower(configKey)]
 		if !ok {
 			// The default values are defined in the subrepo so should be parsed in that scope

--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -239,9 +239,9 @@ func toPyObject(key, val, toType string, optional bool) pyObject {
 	case "bool":
 		switch strings.ToLower(val) {
 		case "true", "yes", "on", "1":
-			return pyBool(true)
+			return True
 		case "false", "no", "off", "0":
-			return pyBool(false)
+			return False
 		default:
 			log.Fatalf("%s: invalid bool value: %v", key, val)
 			return pyNone{}
@@ -252,7 +252,7 @@ func toPyObject(key, val, toType string, optional bool) pyObject {
 			log.Fatalf("%s: invalid int value: %v", key, val)
 			return pyNone{}
 		}
-		return pyInt(i)
+		return newPyInt(i)
 	default:
 		log.Fatalf("%s: invalid plugin configuration field type: %v", key, toType)
 		return pyNone{}

--- a/src/parse/asp/config.go
+++ b/src/parse/asp/config.go
@@ -109,7 +109,7 @@ func resolvePluginValue(values []string, subrepo string) []string {
 			}
 			// Force the full build label including empty subrepo so this is portable
 			var buf strings.Builder
-			buf.Grow(len(l.Subrepo) + len(l.PackageName) + len(l.Name) + len(annotation) + 7)  // +7 for the delimiters
+			buf.Grow(len(l.Subrepo) + len(l.PackageName) + len(l.Name) + len(annotation) + 7) // +7 for the delimiters
 			buf.WriteString("///")
 			buf.WriteString(l.Subrepo)
 			buf.WriteString("//")


### PR DESCRIPTION
Reduces one allocation in `provideFor` and a few other things in paths of varying temperatures (notably getting rid of `fmt.Sprintf` which isn't the most efficient way to put strings together, although it is fairly concise).
Before:
```
INFO: Run 1 of 5
INFO: Complete in 9.62s, using 6172140 KB
INFO: Run 2 of 5
INFO: Complete in 9.18s, using 5655136 KB
INFO: Run 3 of 5
INFO: Complete in 9.62s, using 6437840 KB
INFO: Run 4 of 5
INFO: Complete in 9.68s, using 6682404 KB
INFO: Run 5 of 5
INFO: Complete in 9.61s, using 6525640 KB
INFO: Complete, median time: 9.62s, median mem: 6437840.00 KB
```
After:
```
INFO: Run 1 of 5
INFO: Complete in 9.42s, using 6408832 KB
INFO: Run 2 of 5
INFO: Complete in 9.30s, using 6354172 KB
INFO: Run 3 of 5
INFO: Complete in 9.18s, using 6287200 KB
INFO: Run 4 of 5
INFO: Complete in 9.28s, using 5919368 KB
INFO: Run 5 of 5
INFO: Complete in 9.40s, using 6682712 KB
INFO: Complete, median time: 9.30s, median mem: 6354172.00 KB
```