### PR TITLE
Refactor to remove test args from remote test command

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -158,9 +158,6 @@ func (c *Client) buildTestCommand(state *core.BuildState, target *core.BuildTarg
 		commandPrefix += `export TEST="$TEST_DIR/` + outs[0] + `" && `
 	}
 	cmd, err := core.ReplaceTestSequences(state, target, target.GetTestCommand(state))
-	if len(state.TestArgs) != 0 {
-		cmd += " " + strings.Join(state.TestArgs, " ")
-	}
 	return &pb.Command{
 		Platform: &pb.Platform{
 			Properties: []*pb.Platform_Property{


### PR DESCRIPTION
**Context**

`plz test [TARGET]` can take an argument to specify specific parts of a test target to run.

For example, `plz test //[TARGET] -- [TestSubTarget]` runs the subtarget function rather than all of the test functions in the target.

You can also specify what tests to run at a more granular level: e.g. [TestSubTarget/[NestedTestFunction]/[NestedTestFunction]

**Problem**
When specifying subtargets in `plz test ...` you get an error when you pass an argument that has a slash (e.g. `plz test //[TARGET] -- TestSubTarget/MyTestFunction`.

This shows up by running an additional test that errors, such as 

```
tee: TestSubTarget/TestMyTestFunction/BulkGetMyResources: No such file or directory
```

**Root cause**

Please is constructing a `cmd` that calls `tee` and appends `TestArgs` at the end.

```
cmd, err := core.ReplaceTestSequences(state, target, target.GetTestCommand(state))
if len(state.TestArgs) != 0 {
	cmd += " " + strings.Join(state.TestArgs, " ")
}
``` 

This constructs a command like `$TEST  2>&1 | tee $TMP_DIR/test.results [one or more subtests]`.

This is relevant because `tee` reads from `stdin` (`$TEST  2>&1`) and writes to `stdout` and files (`$TMP_DIR/test.results [one or more subtests]`). 

Thus, this means that
- `plz test //[TARGET] -- [TestSubTarget]` creates and writes to the file `TestSubTarget`
- `plz test //[TARGET] -- [TestSubTarget/[NestedTestFunction]/[NestedTestFunction]` interprets the forward slashes as file paths and tries to create a file in said path but errors because the directory doesn't exist 

**Solution**
The implication is that we need to avoid passing the subtests before the pipe to `tee`.

I thus removed the `if` statement to avoid passing the test arguments in the command.

**Testing**
I built Please with these changes and it worked as expected, only printing the subtests I passed and no erroring like it does now.

I'm concerned about any regressions and am not sure how to best test this.

**Pending work**
This only solves the problem on remote execution, not local execution.