### PR TITLE
Fix bash completion around = character

### DIFF
--- a/tools/misc/plz_complete.sh
+++ b/tools/misc/plz_complete.sh
@@ -8,10 +8,10 @@
 
 _plz_complete_bash() {
     COMP_WORDBREAKS=${COMP_WORDBREAKS//:}
-    LINE="${COMP_LINE:0:$COMP_POINT}"
-    ARGS="${LINE#$COMP_WORDS[0]}"
+    COMP_WORDBREAKS=${COMP_WORDBREAKS//=}
+    args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
     local IFS=$'\n'
-    COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} -p -v 0 --noupdate "$ARGS"))
+    COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} -p -v 0 --noupdate "${args[@]}"))
     return 0
 }
 

--- a/tools/misc/plz_complete.sh
+++ b/tools/misc/plz_complete.sh
@@ -8,9 +8,10 @@
 
 _plz_complete_bash() {
     COMP_WORDBREAKS=${COMP_WORDBREAKS//:}
-    args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+    LINE="${COMP_LINE:0:$COMP_POINT}"
+    ARGS="${LINE#$COMP_WORDS[0]}"
     local IFS=$'\n'
-    COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} -p -v 0 --noupdate "${args[@]}"))
+    COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} -p -v 0 --noupdate "$ARGS"))
     return 0
 }
 


### PR DESCRIPTION
This makes it not be a word break; previously it would turn `plz --log_file=plz-out/log/build.log //` into `['plz', '--log_file', '=', 'plz-out/log/build.log', '//']` which then creates a log file named `=`.

It seems to pretty much work as I expect; completion for `--log_file=` actually seems to work more than before (it prefixes all options with the flag which is a bit unusual but at least it's doing _something_)

Fixes #3262 