### PR TITLE
Expand home path in `fs.PathExists`

### DIFF
--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -483,7 +483,7 @@ func secretHash(state *core.BuildState, target *core.BuildTarget) ([]byte, error
 	}
 	h := sha1.New()
 	for _, secret := range target.Secrets {
-		ph, err := state.PathHasher.Hash(secret, false, false, false)
+		ph, err := state.PathHasher.Hash(fs.ExpandHomePath(secret), false, false, false)
 		if err != nil && os.IsNotExist(err) {
 			return noSecrets, nil // Not having the secrets is not an error yet.
 		} else if err != nil {

--- a/src/fs/fs.go
+++ b/src/fs/fs.go
@@ -45,19 +45,19 @@ func OpenDirFile(filename string, flag int, perm os.FileMode) (*os.File, error) 
 
 // PathExists returns true if the given path exists, as a file or a directory.
 func PathExists(filename string) bool {
-	_, err := os.Lstat(filename)
+	_, err := os.Lstat(ExpandHomePath(filename))
 	return err == nil
 }
 
 // FileExists returns true if the given path exists and is a file.
 func FileExists(filename string) bool {
-	info, err := os.Lstat(filename)
+	info, err := os.Lstat(ExpandHomePath(filename))
 	return err == nil && !info.IsDir()
 }
 
 // IsSymlink returns true if the given path exists and is a symlink.
 func IsSymlink(filename string) bool {
-	info, err := os.Lstat(filename)
+	info, err := os.Lstat(ExpandHomePath(filename))
 	return err == nil && (info.Mode()&os.ModeSymlink) != 0
 }
 
@@ -71,7 +71,7 @@ func IsSameFile(a, b string) bool {
 
 // getFileInfo returns the FileInfo of a file.
 func getFileInfo(filename string) (os.FileInfo, error) {
-	fi, err := os.Stat(filename)
+	fi, err := os.Stat(ExpandHomePath(filename))
 	if err != nil {
 		return nil, err
 	}

--- a/src/fs/fs.go
+++ b/src/fs/fs.go
@@ -45,19 +45,19 @@ func OpenDirFile(filename string, flag int, perm os.FileMode) (*os.File, error) 
 
 // PathExists returns true if the given path exists, as a file or a directory.
 func PathExists(filename string) bool {
-	_, err := os.Lstat(ExpandHomePath(filename))
+	_, err := os.Lstat(filename)
 	return err == nil
 }
 
 // FileExists returns true if the given path exists and is a file.
 func FileExists(filename string) bool {
-	info, err := os.Lstat(ExpandHomePath(filename))
+	info, err := os.Lstat(filename)
 	return err == nil && !info.IsDir()
 }
 
 // IsSymlink returns true if the given path exists and is a symlink.
 func IsSymlink(filename string) bool {
-	info, err := os.Lstat(ExpandHomePath(filename))
+	info, err := os.Lstat(filename)
 	return err == nil && (info.Mode()&os.ModeSymlink) != 0
 }
 
@@ -71,7 +71,7 @@ func IsSameFile(a, b string) bool {
 
 // getFileInfo returns the FileInfo of a file.
 func getFileInfo(filename string) (os.FileInfo, error) {
-	fi, err := os.Stat(ExpandHomePath(filename))
+	fi, err := os.Stat(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A build rule like this

```python
genrule(
    name = name,
    secrets = ["~/test.yaml"],
)
```

fails building with this error

```
failed to calculate hash: Attempting to record rule hash: cannot calculate hash for ~/test.yaml: file does not exist
```

The hash functions use `os.Lstat` to check for file existence, and `lstat(2)` does not seem to expand the home path itself.

So this PR calls the `ExpandHomePath` before `os.Lstat` in the functions which check file presence. I've tested it by bootstrapping `please` on this branch and building the rule that initially failed.

Not sure if this is the best approach, if there are better suggestions I'm happy to look into it.