### PR TITLE
Add AppArmor profile for Ubuntu Noble

### DIFF
--- a/docs/config.html
+++ b/docs/config.html
@@ -918,6 +918,14 @@
       </div>
     </li>
   </ul>
+  <p>N.B. On Ubuntu Noble (24.04) or later, sandboxing may fail with a "Permission denied" error (often referring
+    to <code class="code">/proc/self/setgroups</code>). This is due to a
+    <a href="https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces">security change</a>
+    which prohibits unprivileged user namespaces, which the sandboxing relies upon.<br/>
+    To fix this, you need to create an AppArmor profile allowing it; we have an
+    <a href="https://github.com/thought-machine/please/blob/master/tools/misc/apparmor_profile">example</a>
+    for the default install location, which you should copy to <code class="code">/etc/apparmor.d/build.please</code>,
+    then run <code class="code">sudo systemctl reload apparmor</code> to apply the new profile.</p>
 </section>
 
 <section class="mt4">

--- a/tools/misc/apparmor_profile
+++ b/tools/misc/apparmor_profile
@@ -1,0 +1,12 @@
+# Allow Please and its sandbox binary to create unprivileged user namespaces.
+# These are used for sandboxing build actions when the appropriate config is enabled.
+
+abi <abi/4.0>,
+include <tunables/global>
+
+profile /home/*/.please/please /home/*/.please/please_sandbox flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/please>
+}


### PR DESCRIPTION
They are [restricting unprivileged user namespaces](https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces), which causes our sandboxing to fail. This adds an example AppArmor profile to allow it again, and adds a note in the docs explaining.

Have tried this on a machine running Noble (N.B. it has to be a real machine, not just a container) and `plz test //src/core:core_test -o sandbox.test:true` now works.