### PR TITLE
Require building tasks to complete before shutdown

### DIFF
--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -59,8 +59,8 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, config *
 	}()
 	go func() {
 		for task := range actions {
+			wg.Add(1)
 			go func(task core.Task) {
-				wg.Add(1)
 				defer wg.Done()
 				remote := anyRemote && !task.Target.Local
 				if remote {

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -60,6 +60,8 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, config *
 	go func() {
 		for task := range actions {
 			go func(task core.Task) {
+				wg.Add(1)
+				defer wg.Done()
 				remote := anyRemote && !task.Target.Local
 				if remote {
 					remoteLimiter.Acquire()


### PR DESCRIPTION
Generally this is fine but I've occasionally seen a 'send on closed channel' from the async cache. This is because we're shutting it down while something is still trying to write to it, which seems like a Bad Idea.

This requires that every task completes before we continue. The `TaskDone()` call on line 79 is meant to do that, but it's rather more indirect. I can't think of a reason that this shouldn't work...