### PR TITLE
Pluralise parsing message correctly

### DIFF
--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -46,7 +46,7 @@ type plainDisplay struct {
 
 func (d *plainDisplay) Update(targets []buildingTarget) {
 	localbusy, remotebusy := countActive(targets)
-	log.Notice("Build running for %s, %d / %d tasks done, %s busy, parsing %d BUILD files", time.Since(d.state.StartTime).Round(time.Second), d.state.NumDone(), d.state.NumActive(), pluralise(localbusy+remotebusy, "worker", "workers"), d.state.Parses().Load())
+	log.Notice("Build running for %s, %d / %d tasks done, %s busy, parsing %s", time.Since(d.state.StartTime).Round(time.Second), d.state.NumDone(), d.state.NumActive(), pluralise(localbusy+remotebusy, "worker", "workers"), pluralise(int(d.state.Parses().Load()), "BUILD file", "BUILD files"))
 }
 
 func countActive(targets []buildingTarget) (local int, remote int) {


### PR DESCRIPTION
Inevitably, the very first one I looked at _after_ rolling this out said `Parsing 1 BUILD files`.
This has annoyed me sufficiently to fix it (given we have a thing for it already)