### PR TITLE
Fix limiter deadlock with queuing data for tests

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -80,9 +80,6 @@ func Build(state *core.BuildState, target *core.BuildTarget, remote bool) {
 	}
 	// Mark the target as having finished building.
 	target.FinishBuild()
-	if target.IsTest() && state.NeedTests && state.IsOriginalTarget(target) {
-		state.QueueTestTarget(target)
-	}
 }
 
 func validateBuildTargetBeforeBuild(state *core.BuildState, target *core.BuildTarget) error {

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -712,8 +712,8 @@ func (target *BuildTarget) FinishBuild() {
 }
 
 // WaitForBuild blocks until this target has finished building.
-func (target *BuildTarget) WaitForBuild() {
-	<-target.finishedBuilding
+func (target *BuildTarget) WaitForBuild(dependant BuildLabel) {
+	waitOnChan(target.finishedBuilding, "Still waiting on (target %v).WaitForBuild(dependant %v)", target.Label, dependant)
 }
 
 // DeclaredOutputs returns the outputs from this target's original declaration.

--- a/src/core/state.go
+++ b/src/core/state.go
@@ -904,7 +904,7 @@ func (state *BuildState) WaitForBuiltTarget(l, dependent BuildLabel, mode ParseM
 		return make(chan struct{})
 	}); !inserted {
 		// Something's already registered for this, get on the train
-		waitOnChan(ch, "Still waiting on WaitForBuiltTarget(%v, %v, %v)", l, dependent, mode)
+		waitOnChan(ch, "Still waiting on WaitForBuiltTarget(label %v, dependant %v, ParseMode(%v))", l, dependent, mode)
 		return state.Graph.Target(l)
 	}
 	if err := state.queueTarget(l, dependent, mode.IsForSubinclude(), mode); err != nil {
@@ -1187,7 +1187,7 @@ func (state *BuildState) queueTargetAsync(target *BuildTarget, forceBuild, build
 		// Wait for these targets to actually build.
 		if building {
 			for _, t := range target.Dependencies() {
-				t.WaitForBuild()
+				t.WaitForBuild(target.Label)
 				if t.State() >= DependencyFailed { // Either the target failed or its dependencies failed
 					// Give up and set the original target as dependency failed
 					target.SetState(DependencyFailed)


### PR DESCRIPTION
We would hold the action limiter for too long. The build action is holding the lock while waiting for built targets, but if those targets can't acquire the limitter then we deadlock. 