### PR TITLE
Add local IP and default gateway to network for sandbox tool

### DIFF
--- a/tools/sandbox/sandbox.c
+++ b/tools/sandbox/sandbox.c
@@ -23,7 +23,7 @@
 #include <linux/rtnetlink.h>
 #include <arpa/inet.h>
 
-inline int perror_sock(char *errmsg, const int sock) {
+int perror_sock(char *errmsg, const int sock) {
     close(sock);
     perror(errmsg);
     return 1;

--- a/tools/sandbox/sandbox.c
+++ b/tools/sandbox/sandbox.c
@@ -44,13 +44,13 @@ int lo_up() {
     memset(&req, 0, sizeof(req));
     strncpy(req.ifr_name, "lo", IFNAMSIZ);
     if (ioctl(sock, SIOCGIFFLAGS, &req) < 0) {
-      perror_sock("SIOCGIFFLAGS", sock);
+        perror_sock("SIOCGIFFLAGS", sock);
         return 1;
     }
 
     req.ifr_flags |= IFF_UP;
     if (ioctl(sock, SIOCSIFFLAGS, &req) < 0) {
-      perror_sock("SIOCSIFFLAGS", sock);
+        perror_sock("SIOCSIFFLAGS", sock);
         return 1;
     }
     close(sock);


### PR DESCRIPTION
These were internal TM changes that I'm trying to move back now. Basically adds a 10.x IP address and routing to it for k8s envtest which can't run on localhost.