### PR TITLE
Don't queue a target up for test if the target failed to build

### DIFF
--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -57,6 +57,11 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, config *
 			return
 		}
 
+		if !task.Target.State().IsBuilt() {
+			state.TaskDone()
+			return
+		}
+
 		if state.NeedTests && task.Target.IsTest() && state.IsOriginalTarget(task.Target) {
 			state.QueueTestTarget(task.Target)
 		}


### PR DESCRIPTION
This causes a lockup when the test target fails to build. Surprised this hasn't come up sooner. 