### PR TITLE
Using remote builds with buildbarn

### DIFF
--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -579,11 +579,10 @@ func removeOutputs(target *core.BuildTarget) error {
 
 // subresourceIntegrity returns a string corresponding to a target's hashes in the Subresource Integrity format.
 func subresourceIntegrity(target *core.BuildTarget) string {
-	ret := make([]string, len(target.Hashes))
-	for i, h := range target.Hashes {
-		ret[i] = reencodeSRI(target, h)
+	if len(target.Hashes) == 1 {
+		return reencodeSRI(target, target.Hashes[0])
 	}
-	return strings.Join(ret, " ")
+	return ""
 }
 
 // reencodeSRI re-encodes a hash from the hex format we use to base64-encoded.


### PR DESCRIPTION
Using remote builds with buildbarn (bb-deployment with docker-compose)

Changes were made accordingly to existing project already using please, so they might be biased (wrong).
So, these changes are more like questions. 

* Ignore symlinks while checking outputs. This one seems a legit fix.

* Use sri.checksums only if just one hash is available. bb-remote-asset currently only takes one hash and I could not find anything defining if multiple hashes are good or not. 

* Entrypoints checks on outputs considering OutputPaths. Currently we have multiple targets with entrypoints, and some have `outs` and other `output_dirs`. The ones with `output_dirs` seems to forced to have these dirs in the entrypoints path.