### PR TITLE
Record transitive subincludes for plz exports

### DIFF
--- a/src/core/graph.go
+++ b/src/core/graph.go
@@ -24,7 +24,7 @@ type BuildGraph struct {
 	subrepos *cmap.Map[string, *Subrepo]
 	// Subincludes that are subincluded by other subincludes
 	subincludeSubincludes map[BuildLabel]labelSet
-	subincMux             sync.RWMutex
+	subincMux             sync.Mutex
 }
 
 // AddTarget adds a new target to the graph.
@@ -173,8 +173,8 @@ func (graph *BuildGraph) DependentTargets(from, to BuildLabel) []BuildLabel {
 
 // TransitiveSubincludes returns all the subincludes made by a given subinclude
 func (graph *BuildGraph) TransitiveSubincludes(l BuildLabel) []BuildLabel {
-	graph.subincMux.RLock()
-	defer graph.subincMux.RUnlock()
+	graph.subincMux.Lock()
+	defer graph.subincMux.Unlock()
 
 	incs := make(labelSet)
 	graph.findTransitiveSubincludes(l, incs)

--- a/src/core/package.go
+++ b/src/core/package.go
@@ -101,6 +101,26 @@ func (pkg *Package) RegisterSubinclude(label BuildLabel) {
 	}
 }
 
+// AllSubincludes returns the full set of subincludes needed for this package, including transitive subincludes
+func (pkg *Package) AllSubincludes(graph *BuildGraph) []BuildLabel {
+	includes := make(labelSet, len(pkg.Subincludes))
+
+	for _, s := range pkg.Subincludes {
+		includes[s] = struct{}{}
+		for _, inc := range graph.TransitiveSubincludes(s) {
+			includes[inc] = struct{}{}
+		}
+	}
+
+	ret := make(BuildLabels, 0, len(includes))
+	for l := range includes {
+		ret = append(ret, l)
+	}
+
+	sort.Sort(ret)
+	return ret
+}
+
 // HasSubinclude returns true if the package has subincluded the given label.
 func (pkg *Package) HasSubinclude(label BuildLabel) bool {
 	for _, l := range pkg.Subincludes {

--- a/src/core/package.go
+++ b/src/core/package.go
@@ -2,7 +2,9 @@ package core
 
 import (
 	"fmt"
+	"maps"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -106,18 +108,13 @@ func (pkg *Package) AllSubincludes(graph *BuildGraph) []BuildLabel {
 	includes := make(labelSet, len(pkg.Subincludes))
 
 	for _, s := range pkg.Subincludes {
-		includes[s] = struct{}{}
-		for _, inc := range graph.TransitiveSubincludes(s) {
-			includes[inc] = struct{}{}
+		for _, inc := range append(graph.TransitiveSubincludes(s), s) {
+			includes.add(inc)
 		}
 	}
 
-	ret := make(BuildLabels, 0, len(includes))
-	for l := range includes {
-		ret = append(ret, l)
-	}
-
-	sort.Sort(ret)
+	ret := slices.Collect(maps.Keys(includes))
+	sort.Sort(BuildLabels(ret))
 	return ret
 }
 

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -405,11 +405,10 @@ func subincludeTarget(s *scope, l core.BuildLabel) *core.BuildTarget {
 	}
 
 	t := s.WaitForSubincludedTarget(l, pkgLabel)
-
-	// TODO(jpoole): when pkg is nil, that means this subinclude was made by another subinclude. We're currently loosing
-	// this information here. We probably need a way to transitively record the subincludes.
 	if s.pkg != nil {
 		s.pkg.RegisterSubinclude(l)
+	} else if s.subincludeLabel != nil { // If this is nil, that indicates a preloadedSubinclude
+		s.state.Graph.RegisterTransitiveSubinclude(*s.subincludeLabel, l)
 	}
 	return t
 }

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -296,7 +296,7 @@ type scope struct {
 	filename        string
 	state           *core.BuildState
 	pkg             *core.Package
-	subincludeLabel *core.BuildLabel
+	subincludeLabel *core.BuildLabel // If set, label of the subinclude we're currently interpreting
 	parsingFor      *parseTarget
 	parent          *scope
 	locals          pyDict

--- a/test/export/BUILD
+++ b/test/export/BUILD
@@ -2,5 +2,5 @@ subinclude("//test/build_defs")
 
 plz_e2e_test(
     name = "export_src_please_test",
-    cmd = "plz export --output plz-out/plzexport //src:please && plz --repo_root=$(plz query reporoot)/plz-out/plzexport build //src:please",
+    cmd = "plz export --output plz-out/plzexport //src/core && plz --repo_root=$(plz query reporoot)/plz-out/plzexport build //src/core",
 )

--- a/test/export/BUILD
+++ b/test/export/BUILD
@@ -1,0 +1,6 @@
+subinclude("//test/build_defs")
+
+plz_e2e_test(
+    name = "export_src_please_test",
+    cmd = "plz export --output plz-out/plzexport //src:please && plz --repo_root=$(plz query reporoot)/plz-out/plzexport build //src:please",
+)


### PR DESCRIPTION
Working through a few issues to try and uncover all the blockers with exporting targets. We're currently missing transitive subincludes. This PR records these so we can export them as well. 

This might be useful elsewhere for things like `plz query deps` but I haven't hooked that in yet. So far, I've used this in `plz export` to make sure these are picked up. 