### PR TITLE
Log at notice level during CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
        - image: thoughtmachine/please_alpine:20240906
      resource_class: large
      environment:
-       PLZ_ARGS: "-p -v2 --profile ci --profile alpine --exclude no-musl"
+       PLZ_ARGS: "--profile ci --profile alpine --exclude no-musl"
      steps:
        - checkout
        - restore_cache:
@@ -46,7 +46,7 @@ jobs:
        - image: thoughtmachine/please_ubuntu:20240906
      resource_class: large
      environment:
-       PLZ_ARGS: "-p -v2 --profile ci"
+       PLZ_ARGS: "--profile ci"
      steps:
        - checkout
        - restore_cache:
@@ -94,7 +94,7 @@ jobs:
        - image: thoughtmachine/please_ubuntu_alt:20240910
      resource_class: large
      environment:
-       PLZ_ARGS: "-p -v2 -c cover --profile ci-alt"
+       PLZ_ARGS: "-c cover --profile ci-alt"
        PLZ_COVER: "cover --nocoverage_report"
      steps:
        - checkout
@@ -208,7 +208,7 @@ jobs:
         xcode: "13.4.1"
       resource_class: macos.m1.medium.gen1
       environment:
-        PLZ_ARGS: "-p -v2 --profile ci --exclude pip --exclude embed"
+        PLZ_ARGS: "--profile ci --exclude pip --exclude embed"
       steps:
        - checkout
        - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
        - image: thoughtmachine/please_alpine:20240906
      resource_class: large
      environment:
-       PLZ_ARGS: "-p --profile ci --profile alpine --exclude no-musl"
+       PLZ_ARGS: "-p -v2 --profile ci --profile alpine --exclude no-musl"
      steps:
        - checkout
        - restore_cache:
@@ -22,7 +22,7 @@ jobs:
            path: plz-out/results
        - run:
            name: Package
-           command: plz-out/bin/src/please build //package:all -p --profile ci --profile alpine
+           command: plz-out/bin/src/please build //package:all -p -v2 --profile ci --profile alpine
        - persist_to_workspace:
            root: plz-out/pkg
            paths:
@@ -46,7 +46,7 @@ jobs:
        - image: thoughtmachine/please_ubuntu:20240906
      resource_class: large
      environment:
-       PLZ_ARGS: "-p --profile ci"
+       PLZ_ARGS: "-p -v2 --profile ci"
      steps:
        - checkout
        - restore_cache:
@@ -94,7 +94,7 @@ jobs:
        - image: thoughtmachine/please_ubuntu_alt:20240910
      resource_class: large
      environment:
-       PLZ_ARGS: "-p -c cover --profile ci-alt"
+       PLZ_ARGS: "-p -v2 -c cover --profile ci-alt"
        PLZ_COVER: "cover --nocoverage_report"
      steps:
        - checkout
@@ -140,7 +140,7 @@ jobs:
            command: tar -xzf /tmp/workspace/darwin_arm64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:true -o plugin.go.cctool:clang -o "plugin.go.cflags:-target x86_64-apple-macos13" //package:release_files
+           command: ./please/please build -p -v2 --profile ci --arch darwin_amd64 -o plugin.go.cgoenabled:true -o plugin.go.cctool:clang -o "plugin.go.cflags:-target x86_64-apple-macos13" //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:
@@ -167,7 +167,7 @@ jobs:
            command: tar -xzf /tmp/workspace/linux_amd64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch freebsd_amd64 //package:release_files
+           command: ./please/please build -p -v2 --profile ci --arch freebsd_amd64 //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:
@@ -193,7 +193,7 @@ jobs:
            command: tar -xzf /tmp/workspace/linux_amd64/please_*.tar.gz
        - run:
            name: Cross-compile
-           command: ./please/please build -p --profile ci --arch linux_arm64 -o please.location:~/please/please //package:release_files
+           command: ./please/please build -p -v2 --profile ci --arch linux_arm64 -o please.location:~/please/please //package:release_files
        - persist_to_workspace:
            root: plz-out/pkg
            paths:
@@ -208,7 +208,7 @@ jobs:
         xcode: "13.4.1"
       resource_class: macos.m1.medium.gen1
       environment:
-        PLZ_ARGS: "-p --profile ci --exclude pip --exclude embed"
+        PLZ_ARGS: "-p -v2 --profile ci --exclude pip --exclude embed"
       steps:
        - checkout
        - restore_cache:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,7 +9,7 @@ PLZ_ARGS="${PLZ_ARGS:-}"
 
 # Now invoke Go to run Please to build itself.
 notice "Bootstrapping please..."
-go run -race src/please.go $PLZ_ARGS --log_file plz-out/log/bootstrap_build.log build //src:please
+go run -race src/please.go -p -v2 $PLZ_ARGS --log_file plz-out/log/bootstrap_build.log build //src:please
 
 if [ $# -gt 0 ] && [ "$1" == "--skip_tests" ]; then
     notice "Skipping tests... done."

--- a/test.sh
+++ b/test.sh
@@ -40,9 +40,9 @@ eval `go env`
 # repo that are optional and exercise specific rules, and require extra dependencies.
 EXCLUDES=$(check_path_for_excludes)
 
-plz-out/bin/src/please $PLZ_ARGS ${PLZ_COVER:-test} $EXCLUDES --exclude=e2e --log_file plz-out/log/test_build.log --log_file_level 4 --trace_file plz-out/log/trace.json $@
+plz-out/bin/src/please -p -v2 $PLZ_ARGS ${PLZ_COVER:-test} $EXCLUDES --exclude=e2e --log_file plz-out/log/test_build.log --log_file_level 4 --trace_file plz-out/log/trace.json $@
 
 # We run the end-to-end tests separately to ensure things don't fight with one another; they are
 # finicky about some things due to running plz recursively and disabling the lock.
 notice "Running end-to-end tests..."
-plz-out/bin/src/please $PLZ_ARGS ${PLZ_COVER:-test} $EXCLUDES --include=e2e --log_file plz-out/log/e2e_build.log --log_file_level 4 $@
+plz-out/bin/src/please -p -v2 $PLZ_ARGS ${PLZ_COVER:-test} $EXCLUDES --include=e2e --log_file plz-out/log/e2e_build.log --log_file_level 4 $@


### PR DESCRIPTION
By default, we log at warning level. This means that during a `-p` build, there will be no output. Logging with `-v2` includes the notice logs like `11:56:14.577  NOTICE: Build running for 10s, 8714 / 8780 tasks done, 17 workers busy`

We can't set this using PLZ_ARGS unfortunately as this gets passed through to the e2e tests and causes us to fail asserting on stderr generated by various please commands. 