### PR TITLE
Add `--notrim` flag to `plz export`

### DIFF
--- a/src/please.go
+++ b/src/please.go
@@ -314,6 +314,7 @@ var opts struct {
 
 	Export struct {
 		Output string `short:"o" long:"output" required:"true" description:"Directory to export into"`
+		NoTrim bool   `long:"notrim" description:"export the build file as is, without trying to trim unused targets"`
 		Args   struct {
 			Targets []core.BuildLabel `positional-arg-name:"targets" description:"Labels to export."`
 		} `positional-args:"true"`
@@ -759,7 +760,7 @@ var buildFunctions = map[string]func() int{
 	"export": func() int {
 		success, state := runBuild(opts.Export.Args.Targets, false, false, false)
 		if success {
-			export.ToDir(state, opts.Export.Output, state.ExpandOriginalLabels())
+			export.ToDir(state, opts.Export.Output, opts.Export.NoTrim, state.ExpandOriginalLabels())
 		}
 		return toExitCode(success, state)
 	},


### PR DESCRIPTION
Please tries to trim a BUILD file down when exporting so that we only have the targets that are actually needed by the exported target. Build definitions can produce multiple targets, so when we depend on a target, Please needs to figure out which build rule produced it. The way plz export figures this out is through the parent/child naming convention i.e. `:_{name}#{tag}` is a child of `:{name}`. When we depend on `:_foo#tag`, we know we need to keep `xxx_xxx(name="foo").

When the build definition doesn't follow this convention, Please will erroneously trim out targets. This flag allows us to opt out of this behaviour. We may end up with more targets that necessary, and they won't build because we don't export their deps, but at least the targets we do export are guaranteed to work.  