### PR TITLE
Cirrus CI: bootstrap using Go 1.24

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
 
 task:
   install_script:
-    "pkg install -y bash protobuf go121 git python3 && python3 -m ensurepip && ln -s `command -v go121` /usr/local/bin/go"
+    "pkg install -y bash protobuf go124 git python3 && python3 -m ensurepip && ln -s `command -v go124` /usr/local/bin/go"
   build_script: ./bootstrap.sh --exclude pip --exclude py2 --exclude=py3 --exclude=python3 --exclude no_cirrus
   always:
     log_artifacts:


### PR DESCRIPTION
`go121` has gone away from ports; use `go124` instead.