### PR TITLE
Cirrus CI: bootstrap using official Go 1.24 tarball on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
 
 task:
   install_script:
-    "pkg install -y bash protobuf go121 git python3 && python3 -m ensurepip && ln -s `command -v go121` /usr/local/bin/go"
+    "pkg install -y bash protobuf git python3 && python3 -m ensurepip && curl -L https://go.dev/dl/go1.24.2.freebsd-amd64.tar.gz | tar -C /usr/local -zx && ln -s /usr/local/go/bin/go /usr/local/bin/go"
   build_script: ./bootstrap.sh --exclude pip --exclude py2 --exclude=py3 --exclude=python3 --exclude no_cirrus
   always:
     log_artifacts:


### PR DESCRIPTION
All amd64 `lang/go*` packages for FreeBSD have disappeared from Ports because of a bug in Go that is triggered on the package builders (see https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=285963). The packages have been missing for over a week now and there's no ETA for them being re-added, so install Go from Google's official binary tarball rather than Ports on FreeBSD.