### PR TITLE
continue on empty globs when keepgoing=true; add config option

### DIFF
--- a/docs/config.html
+++ b/docs/config.html
@@ -211,10 +211,18 @@
     </li>
     <li>
       <div>
-        <h3 class="mt1 f6 lh-title" id="please.autoclean">Autoclean <span class="normal">(b ool)</span></h3>
+        <h3 class="mt1 f6 lh-title" id="please.autoclean">Autoclean <span class="normal">(bool)</span></h3>
 
         <p>
           Automatically clean stale versions without prompting. Defaults to true.
+        </p>
+      </div>
+    </li>
+    <li>
+      <div>
+        <h3 class="mt1 f6 lh-title" id="please.keepgoing">KeepGoing <span class="normal">(bool)</span></h3>
+        <p>
+          Continue as much as possible after an error. While the target that failed and those that depend on it cannot be built, other prerequisites of these targets can be. Default to false.
         </p>
       </div>
     </li>

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -376,6 +376,7 @@ func DefaultConfiguration() *Configuration {
 	config.Please.SelfUpdate = true
 	config.Please.Autoclean = true
 	config.Please.DownloadLocation = "https://get.please.build"
+	config.Please.KeepGoing = false
 	config.Please.NumOldVersions = 10
 	config.Please.NumThreads = runtime.NumCPU() + 2
 	config.Parse.NumThreads = config.Please.NumThreads
@@ -490,6 +491,7 @@ type Configuration struct {
 		Motd             []string    `help:"Message of the day; is displayed once at the top during builds. If multiple are given, one is randomly chosen."`
 		DefaultRepo      string      `help:"Location of the default repository; this is used if plz is invoked when not inside a repo, it changes to that directory then does its thing."`
 		PluginRepo       []string    `help:"A list of template URLS used to download plugins from. The download should be an archive e.g. .tar.gz, or .zip. Templatized variables should be surrounded in curly braces, and the available options are: owner, revision and plugin. Defaults to github and gitlab." example:"https://gitlab.you.org/{owner}/{plugin}/-/archive/{revision}/{plugin}-{revision}.zip" var:"PLUGIN_REPOS"`
+		KeepGoing        bool        `help:"Continue as much as possible after an error. Builds prerequisites of failed targets and disables safety checks." var:"KEEP_GOING"`
 	} `help:"The [please] section in the config contains non-language-specific settings defining how Please should operate."`
 	Parse struct {
 		ExperimentalDir    []string     `help:"Directory containing experimental code. This is subject to some extra restrictions:\n - Code in the experimental dir can override normal visibility constraints\n - Code outside the experimental dir can never depend on code inside it\n - Tests are excluded from general detection." example:"experimental"`

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -491,7 +491,7 @@ type Configuration struct {
 		Motd             []string    `help:"Message of the day; is displayed once at the top during builds. If multiple are given, one is randomly chosen."`
 		DefaultRepo      string      `help:"Location of the default repository; this is used if plz is invoked when not inside a repo, it changes to that directory then does its thing."`
 		PluginRepo       []string    `help:"A list of template URLS used to download plugins from. The download should be an archive e.g. .tar.gz, or .zip. Templatized variables should be surrounded in curly braces, and the available options are: owner, revision and plugin. Defaults to github and gitlab." example:"https://gitlab.you.org/{owner}/{plugin}/-/archive/{revision}/{plugin}-{revision}.zip" var:"PLUGIN_REPOS"`
-		KeepGoing        bool        `help:"Continue as much as possible after an error. Builds prerequisites of failed targets and disables safety checks." var:"KEEP_GOING"`
+		KeepGoing        bool        `help:"Continue as much as possible after an error. While the target that failed and those that depend on it cannot be built, other prerequisites of these targets can be." var:"KEEP_GOING"`
 	} `help:"The [please] section in the config contains non-language-specific settings defining how Please should operate."`
 	Parse struct {
 		ExperimentalDir    []string     `help:"Directory containing experimental code. This is subject to some extra restrictions:\n - Code in the experimental dir can override normal visibility constraints\n - Code outside the experimental dir can never depend on code inside it\n - Tests are excluded from general detection." example:"experimental"`

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -678,9 +678,12 @@ func glob(s *scope, args []pyObject) pyObject {
 	if !allowEmpty && len(glob) == 0 {
 		// Strip build file name from exclude list for error message
 		exclude = exclude[:len(exclude)-len(s.state.Config.Parse.BuildFileName)]
-		log.Fatalf("glob(include=%s, exclude=%s) in %s returned no files. If this is intended, set allow_empty=True on the glob.", include, exclude, s.pkg.Filename)
+		if s.state.KeepGoing {
+			log.Warningf("glob(include=%s, exclude=%s) in %s returned no files; continuing due to enabled KeepGoing option.", include, exclude, s.pkg.Filename)
+		} else {
+			log.Fatalf("glob(include=%s, exclude=%s) in %s returned no files. If this is intended, set allow_empty=True on the glob.", include, exclude, s.pkg.Filename)
+		}
 	}
-
 	return fromStringList(glob)
 }
 

--- a/src/please.go
+++ b/src/please.go
@@ -89,7 +89,7 @@ var opts struct {
 		KeepWorkdirs       bool    `long:"keep_workdirs" description:"Don't clean directories in plz-out/tmp after successfully building targets."`
 		HTTPProxy          cli.URL `long:"http_proxy" env:"HTTP_PROXY" description:"HTTP proxy to use for downloads"`
 		Debug              bool    `long:"debug" description:"When enabled, Please will enter into an interactive debugger when breakpoint() is called during parsing."`
-		KeepGoing          bool    `long:"keep_going" description:"Continue as much as possible after an error. While the target that failed and those that depend on it cannot be build, other prerequisites of these targets can be."`
+		KeepGoing          bool    `long:"keep_going" description:"Continue as much as possible after an error. Builds prerequisites of failed targets and disables safety checks."`
 		AllowSudo          bool    `long:"allow_sudo" hidden:"true" description:"Allow running under sudo (normally this is a very bad idea)"`
 	} `group:"Options that enable / disable certain behaviors"`
 
@@ -1128,7 +1128,7 @@ func Please(targets []core.BuildLabel, config *core.Configuration, shouldBuild, 
 		config.Build.Config = "dbg"
 	}
 	state := core.NewBuildState(config)
-	state.KeepGoing = opts.BehaviorFlags.KeepGoing
+	state.KeepGoing = opts.BehaviorFlags.KeepGoing || config.Please.KeepGoing
 	state.VerifyHashes = !opts.BehaviorFlags.NoHashVerification
 	// Only one of these two can be passed
 	state.NumTestRuns = uint16(opts.Test.NumRuns)

--- a/src/please.go
+++ b/src/please.go
@@ -89,7 +89,7 @@ var opts struct {
 		KeepWorkdirs       bool    `long:"keep_workdirs" description:"Don't clean directories in plz-out/tmp after successfully building targets."`
 		HTTPProxy          cli.URL `long:"http_proxy" env:"HTTP_PROXY" description:"HTTP proxy to use for downloads"`
 		Debug              bool    `long:"debug" description:"When enabled, Please will enter into an interactive debugger when breakpoint() is called during parsing."`
-		KeepGoing          bool    `long:"keep_going" description:"Continue as much as possible after an error. Builds prerequisites of failed targets and disables safety checks."`
+		KeepGoing          bool    `long:"keep_going" description:"Continue as much as possible after an error. While the target that failed and those that depend on it cannot be built, other prerequisites of these targets can be."`
 		AllowSudo          bool    `long:"allow_sudo" hidden:"true" description:"Allow running under sudo (normally this is a very bad idea)"`
 	} `group:"Options that enable / disable certain behaviors"`
 

--- a/test/keep_going/BUILD
+++ b/test/keep_going/BUILD
@@ -34,3 +34,24 @@ please_repo_e2e_test(
     plz_command = "plz build --keep_going //package:all //package2:all",
     repo = "test_repo",
 )
+
+please_repo_e2e_test(
+    name = "test_parse_empty_glob_default",
+    expected_failure = True,
+    plz_command = "plz build //parse_empty_glob:all",
+    repo = "test_repo",
+)
+
+please_repo_e2e_test(
+    name = "test_parse_empty_glob_keep_going_flag",
+    expected_failure = False,
+    plz_command = "plz --keep_going build //parse_empty_glob:all",
+    repo = "test_repo",
+)
+
+please_repo_e2e_test(
+    name = "test_parse_empty_glob_keep_going_option",
+    expected_failure = False,
+    plz_command = "plz -o please.keepgoing:true build //parse_empty_glob:all",
+    repo = "test_repo",
+)

--- a/test/keep_going/test_repo/parse_empty_glob/BUILD_FILE
+++ b/test/keep_going/test_repo/parse_empty_glob/BUILD_FILE
@@ -1,0 +1,6 @@
+build_rule(
+    name = "pass",
+    srcs = glob([]),
+    cmd = "touch $OUTS",
+    outs = ["pass"],
+)


### PR DESCRIPTION
- Make empty globs non-critical when KeepGoing is enabled
- Add a please.keepgoing config option to complement the CLI flag

This allows us to execute nested `plz run` commands on partial trees exported via `plz export`.

A possible alternative implementation is to reintroduce the `ErrorOnEmptyGlob` flag. #2730