### PR TITLE
Implement `key` parameter for `sorted` built-in function

### DIFF
--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -158,9 +158,12 @@
       <span>
         <code class="code"
           ><span class="fn-name">sorted</span><span class="fn-p">(</span
-          ><span class="fn-arg">seq</span><span class="fn-p">)</span></code
+          ><span class="fn-arg">seq</span>[,<span class="fn-arg">key</span
+          >]<span class="fn-p">)</span></code
         >
-        - returns a copy of the given list with the contents sorted.
+        - returns a copy of <code class="code">seq</code> with the contents
+        sorted. <code class="code">key</code> is a function that is applied
+        to each item before comparison.
       </span>
     </li>
     <li>

--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -125,7 +125,7 @@ def glob(include:list|str, exclude:list|str&excludes=[], hidden:bool=CONFIG.BAZE
 def package():
     pass
 
-def sorted(seq:list) -> list:
+def sorted(seq:list, key:function=None) -> list:
     pass
 
 def reversed(seq:list) -> list:

--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -169,8 +169,9 @@ func TestInterpreterSlicing(t *testing.T) {
 func TestInterpreterSorting(t *testing.T) {
 	s, err := parseFile("src/parse/asp/test_data/interpreter/sorted.build")
 	require.NoError(t, err)
-	assert.Equal(t, pyList{pyInt(1), pyInt(2), pyInt(3)}, s.Lookup("y"))
 	// N.B. sorted() sorts in-place, unlike Python's one. We may change that later.
+	assert.Equal(t, pyList{pyInt(1), pyInt(2), pyInt(3)}, s.Lookup("r1"))
+	assert.Equal(t, pyList{pyString("ONE"), pyString("THREE"), pyString("two")}, s.Lookup("r2"))
 }
 
 func TestReversed(t *testing.T) {

--- a/src/parse/asp/test_data/interpreter/sorted.build
+++ b/src/parse/asp/test_data/interpreter/sorted.build
@@ -1,2 +1,6 @@
-x = [3, 2, 1]
-y = sorted(x)
+l1 = [3, 2, 1]
+r1 = sorted(l1)
+
+# key parameter test
+l2 = ["ONE", "two", "THREE"]
+r2 = sorted(l2, key=lambda s: s.lower())


### PR DESCRIPTION
This is optional, and behaves similarly to the `key` parameter in Python's `sorted` built-in function: the value is a function that is applied to each item in the list before they are compared.