### PR TITLE
CI: run golangci-lint v2.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '^1.23'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.61
+          version: v2.1
           args: src/... tools/...
           skip-pkg-cache: true


### PR DESCRIPTION
Bumping the action to v8 also resolves CI failures caused by the version of golangci-lint being built with an older version of Go than Please is, leading to dozens of fatal `typecheck` errors.