### PR TITLE
Simplify Boolean logic expressions

### DIFF
--- a/src/build/filegroup.go
+++ b/src/build/filegroup.go
@@ -90,7 +90,7 @@ func (builder *filegroupBuilder) Build(state *core.BuildState, target *core.Buil
 	} else {
 		// Copy source files when they're binary to avoid nuking their permissions.
 		isSourceFile := !strings.HasPrefix(from, "plz-out/")
-		if err := fs.RecursiveCopyOrLinkFile(from, to, target.OutMode(), !(target.IsBinary && isSourceFile), true); err != nil {
+		if err := fs.RecursiveCopyOrLinkFile(from, to, target.OutMode(), !target.IsBinary || !isSourceFile, true); err != nil {
 			return true, err
 		}
 	}

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -915,7 +915,7 @@ func (target *BuildTarget) CheckDependencyVisibility(state *BuildState) error {
 		dep := state.Graph.TargetOrDie(*d.declared)
 		if !target.CanSee(state, dep) {
 			return fmt.Errorf("Target %s isn't visible to %s", dep.Label, target.Label)
-		} else if dep.TestOnly && !(target.IsTest() || target.TestOnly) {
+		} else if dep.TestOnly && !target.IsTest() && !target.TestOnly {
 			if target.Label.isExperimental(state) {
 				log.Info("Test-only restrictions suppressed for %s since %s is in the experimental tree", dep.Label, target.Label)
 			} else {

--- a/src/core/package.go
+++ b/src/core/package.go
@@ -222,7 +222,7 @@ func (pkg *Package) verifyOutputs() []string {
 	ret := []string{}
 	for filename, target := range pkg.Outputs {
 		for dir := filepath.Dir(filename); dir != "."; dir = filepath.Dir(dir) {
-			if target2, present := pkg.Outputs[dir]; present && target2 != target && !(target.HasDependency(target2.Label.Parent()) || target.HasDependency(target2.Label)) {
+			if target2, present := pkg.Outputs[dir]; present && target2 != target && !target.HasDependency(target2.Label.Parent()) && !target.HasDependency(target2.Label) {
 				ret = append(ret, fmt.Sprintf("Target %s outputs files into the directory %s, which is separately output by %s. This can cause errors based on build order - you should add a dependency.", target.Label, dir, target2.Label))
 			}
 		}


### PR DESCRIPTION
Per De Morgan's laws, replace instances of `!(A && B)` with `!A || !B` and instances of `!(A || B)` with `!A && !B` to make the expressions easier to understand.