### PR TITLE
Simplify more complex Boolean logic expressions

### DIFF
--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -642,7 +642,7 @@ func (c *Client) retrieveResults(target *core.BuildTarget, command *pb.Command, 
 // maybeRetrieveResults is like retrieveResults but only retrieves if we aren't forcing a rebuild of the target
 // (i.e. not if we're doing plz build --rebuild or plz test --rerun).
 func (c *Client) maybeRetrieveResults(target *core.BuildTarget, command *pb.Command, digest *pb.Digest, isTest, needStdout bool, run int) (*core.BuildMetadata, *pb.ActionResult) {
-	if !c.state.ShouldRebuild(target) && !(c.state.NeedTests && isTest && c.state.ForceRerun) {
+	if !c.state.ShouldRebuild(target) && (!c.state.NeedTests || !isTest || !c.state.ForceRerun) {
 		if metadata, ar := c.retrieveResults(target, command, digest, needStdout, isTest, run); metadata != nil {
 			return metadata, ar
 		}

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -137,11 +137,8 @@ func printMilestoneMessage(pleaseVersion string) {
 		printLn("Read all about it here: %v#cli", milestoneURL)
 		printLn("")
 		fmt.Fprintf(os.Stderr, "%s\n", border)
-		return
-	}
-
-	// If we get a 40x resp back, assume there's no milestone release. Cloudfront gives 403s rather than 404s.
-	if !(resp.StatusCode >= 400 && resp.StatusCode < 500) {
+	} else if resp.StatusCode < 400 || resp.StatusCode >= 500 {
+		// If we get a 40x resp back, assume there's no milestone release. Cloudfront gives 403s rather than 404s.
 		body, _ := io.ReadAll(resp.Body)
 		log.Warningf("Got unexpected error code from %v: %v\n %v", milestoneURL, resp.StatusCode, string(body))
 	}


### PR DESCRIPTION
Apply De Morgan's laws to some expressions with more complicated propositions, for the sake of readability.