### PR TITLE
Pre-allocate slices known to require a specific length

### DIFF
--- a/docs/tools/plugin_templater/main.go
+++ b/docs/tools/plugin_templater/main.go
@@ -49,15 +49,15 @@ func main() {
 	flags.ParseFlagsOrDie("Docs template", &opts, nil)
 	basename := filepath.Base(opts.PluginsTemplate)
 
-	var plugins Plugins
+	plugins := make(Plugins, len(opts.Args.Plugins))
 	allRules := &rules.Rules{Functions: map[string]*rules.Rule{}}
-	for _, rulesFile := range opts.Args.Plugins {
+	for i, rulesFile := range opts.Args.Plugins {
 		b, err := os.ReadFile(rulesFile)
 		must(err)
 
 		p := &plugin.Plugin{}
 		must(json.Unmarshal(b, p))
-		plugins = append(plugins, p)
+		plugins[i] = p
 		for k, v := range p.Rules.Functions {
 			allRules.Functions[k] = v
 		}

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -12,9 +12,9 @@ func AllAssets() ([]string, error) {
 		return nil, err
 	}
 
-	var filepaths []string
-	for _, entry := range assets {
-		filepaths = append(filepaths, entry.Name())
+	filepaths := make([]string, len(assets))
+	for i, entry := range assets {
+		filepaths[i] = entry.Name()
 	}
 
 	return filepaths, nil


### PR DESCRIPTION
We know the required length of these slices at the time of declaration, so pre-allocate them and avoid using `append` to assign values to their elements.