### PR TITLE
Write format strings to `io.Writer`s using `fmt.Fprintf`

### DIFF
--- a/src/output/interactive_display.go
+++ b/src/output/interactive_display.go
@@ -282,6 +282,6 @@ func setWindowTitle(state *core.BuildState, running bool) {
 // SetWindowTitle sets the title of the current shell window.
 func SetWindowTitle(title string) {
 	if cli.StdErrIsATerminal && terminalClaimsToBeXterm {
-		os.Stderr.Write([]byte(fmt.Sprintf("\033]0;%s\007", title)))
+		fmt.Fprintf(os.Stderr, "\033]0;%s\007", title)
 	}
 }

--- a/tools/http_cache/cache/cache.go
+++ b/tools/http_cache/cache/cache.go
@@ -34,7 +34,7 @@ func (c *Cache) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		if err != nil {
 			log.Errorf("Failed to store in cache: %v", err)
 			resp.WriteHeader(http.StatusInternalServerError)
-			_, _ = resp.Write([]byte(fmt.Sprintf("failed to store in cache: %v", err)))
+			fmt.Fprintf(resp, "failed to store in cache: %v", err)
 		}
 	case http.MethodGet:
 		http.ServeFile(resp, req, filepath.Join(c.Dir, uri))


### PR DESCRIPTION
There's no need to convert the interpolated format string into a byte slice and write the byte slice to the `io.Writer` - `fmt.Fprintf` accepts an `io.Writer` and a format string, and does all of that itself.