### PR TITLE
golangci-lint: output all linter issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,7 @@
 version: "2"
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 linters:
   default: none
   enable:


### PR DESCRIPTION
By default, golangci-lint only displays up to 50 issues per linter and up to 3 instances of each issue. Playing whack-a-mole with linters isn't fun, so disable both of these limits.