### PR TITLE
golangci-lint: disable staticcheck's error formatting checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,11 @@ linters:
       # revive getting a bit too pushy here
       - path: (.+)\.go$
         text: indent-error-flow
+      # Agree with this in principle, but there are too many instances of it to justify enabling it right now
+      - linters:
+          - staticcheck
+        path: (.+)\.go$
+        text: ST1005
     paths:
       - test_data
       - third_party$


### PR DESCRIPTION
These checks relate to the capitalisation of leading letters and the existence of trailing punctuation characters in `error`s. While we ought to be following the Go conventions for these, there are too many instances (84) of them right now, and the affected errors are so deeply nested that it's difficult to identify the impact that reformatting them will have on Please's output. Disable the issue for now.