### PR TITLE
Enable linting of Go source files repo-wide

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,4 +19,3 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.2
-          args: src/... tools/...

--- a/docs/test/docs_test.go
+++ b/docs/test/docs_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/thought-machine/please/src/core"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/html"
+
+	"github.com/thought-machine/please/src/core"
 )
 
 func TestAllLinksAreLive(t *testing.T) {
@@ -54,7 +54,6 @@ func TestAllLinksAreLive(t *testing.T) {
 							allnames[filename+"#"+attr.Val] = true
 						}
 					}
-
 				}
 			}
 			for c := n.FirstChild; c != nil; c = c.NextSibling {
@@ -89,7 +88,7 @@ var ignoreConfigFields = map[string]struct{}{
 }
 
 // IDs in the html that are for other purposes other than documenting config.
-var nonConfigIds = map[string]struct{}{
+var nonConfigIDs = map[string]struct{}{
 	"menu-list":    {},
 	"nav-graphic":  {},
 	"side-images":  {},
@@ -124,7 +123,7 @@ func TestConfigDocumented(t *testing.T) {
 	}
 
 	for id := range ids {
-		if _, ok := nonConfigIds[id]; ok {
+		if _, ok := nonConfigIDs[id]; ok {
 			continue
 		}
 		if _, ok := configFields[id]; !ok {
@@ -156,7 +155,6 @@ func findConfigFields(path string, configType reflect.Type) []string {
 		if t.Kind() == reflect.Struct {
 			fields = append(fields, findConfigFields(name, t)...)
 		}
-
 	}
 	return fields
 }

--- a/docs/tools/lexicon_templater/template_lexicon.go
+++ b/docs/tools/lexicon_templater/template_lexicon.go
@@ -8,12 +8,10 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/thought-machine/please/docs/tools/lexicon_templater/rules"
-
 	"github.com/peterebden/go-cli-init/v5/flags"
+
+	"github.com/thought-machine/please/docs/tools/lexicon_templater/rules"
 )
-
-
 
 func must(err error) {
 	if err != nil {

--- a/docs/tools/plugin_config_tool/plugin/plugin.go
+++ b/docs/tools/plugin_config_tool/plugin/plugin.go
@@ -10,6 +10,6 @@ type Plugin struct {
 }
 
 type ConfigField struct {
-	Name, Type, Help, DefaultValue string
+	Name, Type, Help, DefaultValue          string
 	Inherit, Repeatable, Defaults, Optional bool
 }

--- a/docs/tools/plugin_config_tool/plugin_config_tool.go
+++ b/docs/tools/plugin_config_tool/plugin_config_tool.go
@@ -10,12 +10,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/peterebden/go-cli-init/v5/flags"
+	"github.com/please-build/gcfg"
+
 	"github.com/thought-machine/please/docs/tools/lexicon_templater/rules"
 	"github.com/thought-machine/please/docs/tools/plugin_config_tool/plugin"
 	"github.com/thought-machine/please/src/core"
-
-	"github.com/peterebden/go-cli-init/v5/flags"
-	"github.com/please-build/gcfg"
 )
 
 // formatConfigKey converts the config key from snake_case to CamelCase
@@ -61,7 +61,6 @@ func getConfigFields(config *core.Configuration) []*plugin.ConfigField {
 			f.Type = "string"
 		}
 		fields = append(fields, f)
-
 	}
 	return fields
 }

--- a/docs/tools/plugin_templater/main.go
+++ b/docs/tools/plugin_templater/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/thought-machine/please/docs/tools/lexicon_templater/rules"
 	htmltemplate "html/template"
 	"os"
 	"path/filepath"
@@ -10,9 +9,10 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/thought-machine/please/docs/tools/plugin_config_tool/plugin"
-
 	"github.com/peterebden/go-cli-init/v5/flags"
+
+	"github.com/thought-machine/please/docs/tools/lexicon_templater/rules"
+	"github.com/thought-machine/please/docs/tools/plugin_config_tool/plugin"
 )
 
 func must(err error) {
@@ -40,9 +40,7 @@ func (p Plugins) Less(i, j int) bool {
 }
 
 func (p Plugins) Swap(i, j int) {
-	iVal := p[i]
-	p[i] = p[j]
-	p[j] = iVal
+	p[i], p[j] = p[j], p[i]
 }
 
 func main() {


### PR DESCRIPTION
Fix import ordering, stray newline, variable naming and idiomatic Go issues in Go source files under `docs/`. This allows us to run golangci-lint on the entire repo.