### PR TITLE
fix docs typo for --nocoverage_report

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -531,7 +531,7 @@
     <li>
       <div>
         <h3 class="mt1 f6 lh-title">
-          <code class="code">--no_coverage_report</code>
+          <code class="code">--nocoverage_report</code>
         </h3>
 
         <p>Suppresses the coverage report output to the shell.</p>


### PR DESCRIPTION
It should be:
`plz cover --nocoverage_report  //path/to/somewhere`
not
`plz cover --no_coverage_report  //path/to/somewhere`