### PR TITLE
Add formatting tests for raw string literals

### DIFF
--- a/src/format/test_data/raw_string_literal.after.build
+++ b/src/format/test_data/raw_string_literal.after.build
@@ -1,0 +1,26 @@
+# A single-quoted raw string literal containing no double quotes; should be rewritten with
+# double-quote delimiters
+a = r"a\raw\string\literal"
+
+# A single-quoted raw string literal containing double quotes; should be left unmodified
+b = r'a\"raw\string\"literal'
+
+# A double-quoted raw string literal; should be left unmodified
+c = r"a\raw\string\literal"
+
+# A single-quoted raw docstring literal containing no double quotes; should be rewritten with
+# double-quote delimiters
+r"""
+Single-quoted: r'a\raw\string\literal'
+"""
+
+# A double-quoted raw docstring literal containing double quotes; should be left unmodified
+r"""
+Single-quoted: r'a\raw\string\literal'
+
+Double-quoted: r"a\raw\string\literal"
+"""
+
+# Raw string literals inside comments; should be left unmodified, because they're comments
+# Single-quoted: r'a\raw\string\literal'
+# Double-quoted: r"a\raw\string\literal"

--- a/src/format/test_data/raw_string_literal.before.build
+++ b/src/format/test_data/raw_string_literal.before.build
@@ -1,0 +1,26 @@
+# A single-quoted raw string literal containing no double quotes; should be rewritten with
+# double-quote delimiters
+a = r'a\raw\string\literal'
+
+# A single-quoted raw string literal containing double quotes; should be left unmodified
+b = r'a\"raw\string\"literal'
+
+# A double-quoted raw string literal; should be left unmodified
+c = r"a\raw\string\literal"
+
+# A single-quoted raw docstring literal containing no double quotes; should be rewritten with
+# double-quote delimiters
+r'''
+Single-quoted: r'a\raw\string\literal'
+'''
+
+# A double-quoted raw docstring literal containing double quotes; should be left unmodified
+r"""
+Single-quoted: r'a\raw\string\literal'
+
+Double-quoted: r"a\raw\string\literal"
+"""
+
+# Raw string literals inside comments; should be left unmodified, because they're comments
+# Single-quoted: r'a\raw\string\literal'
+# Double-quoted: r"a\raw\string\literal"


### PR DESCRIPTION
Wrote these while debugging #3394 - I'm not convinced that bug report is valid but the test cases will probably still come in useful, given that raw string literals aren't a feature in Bazel and that we've hacked buildtools to support formatting of them in Please.