### PR TITLE
Fix parsing of break statements inside for loops

### DIFF
--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -584,10 +584,10 @@ func (s *scope) interpretFor(stmt *ForStatement) pyObject {
 	for li := range s.iterable(&stmt.Expr) {
 		s.unpackNames(stmt.Names, li)
 		if ret := s.interpretStatements(stmt.Statements); ret != nil {
-			switch ret {
-			case continueIteration:
+			if ret == continueIteration {
 				continue
-			case stopIteration:
+			}
+			if ret == stopIteration {
 				break
 			}
 			return ret


### PR DESCRIPTION
Fixes issue https://github.com/thought-machine/please/issues/3404

`break` and `continue` inside loop bodies were behaving like `return` because `interpretFor` always returned the sentinel from interpretStatements after a switch that only broke the switch, not the loop.

This change drops the switch and performs explicit checks before any return.