### PR TITLE
Improve `break` interpreter test

### DIFF
--- a/src/parse/asp/interpreter_test.go
+++ b/src/parse/asp/interpreter_test.go
@@ -728,5 +728,5 @@ func TestListConcatenation(t *testing.T) {
 func TestBreakLoop(t *testing.T) {
 	s, err := parseFile("src/parse/asp/test_data/interpreter/break_loop.build")
 	assert.NoError(t, err)
-	assert.EqualValues(t, 1, s.Lookup("i"))
+	assert.EqualValues(t, pyString("ok"), s.Lookup("x"))
 }

--- a/src/parse/asp/test_data/interpreter/break_loop.build
+++ b/src/parse/asp/test_data/interpreter/break_loop.build
@@ -1,2 +1,13 @@
-for i in range(1, 3):
-    break
+# This test checks that the "break" keyword correctly breaks out of a for loop.
+
+def fn():
+    ret = "pre-loop"
+    for i in range(1, 3):
+        if i == 2:
+            ret = "ok"
+            break
+        else:
+            ret = "not ok"
+    return ret
+
+x = fn()


### PR DESCRIPTION
Improve the existing test for the behaviour of the `break` keyword in ASP by ensuring that the use of `break` inside a `for` loop inside a function causes control to pass to the end of the `for` loop, not the function caller. This will prevent regressions of #3404.