### PR TITLE
Log to debug logger when registering an architecture subrepo

### DIFF
--- a/src/core/subrepo.go
+++ b/src/core/subrepo.go
@@ -76,6 +76,7 @@ func (s *Subrepo) Equal(other *Subrepo) bool {
 
 // SubrepoForArch creates a new subrepo for the given architecture.
 func SubrepoForArch(state *BuildState, arch cli.Arch) *Subrepo {
+	log.Debugf("Registering subrepo for architecture %s", arch.String())
 	s := NewSubrepo(state.ForArch(arch), arch.String(), "", nil, arch, true)
 	if err := s.State.Initialise(s); err != nil {
 		// We always return nil as we shortcut loading config for architecture subrepos, but check non-the-less incase


### PR DESCRIPTION
This was helpful while identifying the root cause of #3408.