### PR TITLE
Add `arch` test

### DIFF
--- a/test/subrepo/custom_arch/BUILD
+++ b/test/subrepo/custom_arch/BUILD
@@ -1,0 +1,10 @@
+subinclude("//test/build_defs")
+
+please_repo_e2e_test(
+    name = "custom_arch_test",
+    expected_output = {
+        "plz-out/gen/darwin_ppc/test/arch": "darwin_ppc",
+    },
+    plz_command = "plz build ///darwin_ppc//test:print_arch",
+    repo = "test_repo",
+)

--- a/test/subrepo/custom_arch/test_repo/BUILD_FILE
+++ b/test/subrepo/custom_arch/test_repo/BUILD_FILE
@@ -1,0 +1,5 @@
+arch(
+    name = "darwin_ppc",
+    os = "darwin",
+    arch = "ppc",
+)

--- a/test/subrepo/custom_arch/test_repo/test/BUILD_FILE
+++ b/test/subrepo/custom_arch/test_repo/test/BUILD_FILE
@@ -1,0 +1,5 @@
+genrule(
+    name = "print_arch",
+    outs = ["arch"],
+    cmd = f"echo '{CONFIG.OS}_{CONFIG.ARCH}' > $OUTS",
+)


### PR DESCRIPTION
The test suite doesn't currently contain a test ensuring that the `arch` built-in correctly registers an architecture-specific subrepo - add one.