### PR TITLE
CI: use CodeQL Action v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,10 +23,10 @@ jobs:
       with:
         fetch-depth: 2
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
CodeQL Action v2 was [deprecated](https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/) on 2025-01-10 - new CodeQL analysis capabilities are only available to v3, so we're missing out by not upgrading.