### PR TITLE
Fix typo in `plz generate` documentation

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -948,7 +948,7 @@
   </p>
 
   <p>
-    Please can also update a gitignore file, ignoring all the gnerated files automatically:
+    Please can also update a gitignore file, ignoring all the generated files automatically:
     <code class="code">plz generate --update_gitignore .gitignore</code>
   </p>
 


### PR DESCRIPTION
Spotted this typo, fixing it. gnerated -> generated