### PR TITLE
Use arcat v1.2.0

### DIFF
--- a/src/parse/internal.tmpl
+++ b/src/parse/internal.tmpl
@@ -1,14 +1,14 @@
 remote_file(
     name = "arcat",
-    url = f"https://github.com/please-build/arcat/releases/download/v1.0.2/arcat-1.0.2-{CONFIG.HOSTOS}_{CONFIG.HOSTARCH}",
+    url = f"https://github.com/please-build/arcat/releases/download/v1.2.0/arcat-1.2.0-{CONFIG.HOSTOS}_{CONFIG.HOSTARCH}",
     out = "arcat",
     binary = True,
     hashes = [
-        "c28fcbcb9d9e4d97fe9f7d7cc4c9b277985464f6d3230192a059a8e317c76a86", # darwin_amd64
-        "fc6a2c621bc9158a1b63bf76b5662e354d1427ead0cb880b87e7cc61e7e40879", # darwin_arm64
-        "83bc947a01543106d24709f9bf039b3f57e9e5f0944bc4b3d86d8cbb732ab343", # freebsd_amd64
-        "3040191290ba7803ea5dbfa4ad2ab13ba0d0aac4b2c205bd4453f8b08d5d2485", # linux_amd64
-        "d96b71aee29b5784a41bf13a11e8d57037f665a48f8f76b3c5f511ee8d1be75a", # linux_arm64
+        "d10c553f40a41cdb46e557c1e78715c2a6553a7b2545d65d5c316b83db76c642", # darwin_amd64
+        "a5e80db04c65fabe7692b1a819da5cccf5433efe548993975d501c3b2e4f8a64", # darwin_arm64
+        "21601b47312c45dfd72810b57b1f7c26d5aa03776a9a64a4783cc9a238c27c84", # freebsd_amd64
+        "36df2f5ec786fdabf3f09392b16d7fa8d4444d796b2f65913ef6a1bba4bfc9cd", # linux_amd64
+        "fbc112555403176cf4b38e8310c27792c77acb0a68328b69843cc8d820203d2d", # linux_arm64
     ],
     visibility = ["PUBLIC"],
 )


### PR DESCRIPTION
This version of arcat fixes the long-running problem with long file names in GNU-style ar archives, along with more robust ar handling generally.