### PR TITLE
CI: use Xcode 16.4.0 image on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
    build-darwin-amd64:
      working_directory: ~/please
      macos:
-       xcode: "26.1.0"
+       xcode: "16.4.0"
      resource_class: macos.m1.medium.gen1
      steps:
        - checkout
@@ -205,7 +205,7 @@ jobs:
            paths: [ ".plz-cache/third_party/go" ]
    build-darwin:
       macos:
-        xcode: "26.1.0"
+        xcode: "16.4.0"
       resource_class: macos.m1.medium.gen1
       environment:
         PLZ_ARGS: "--profile ci --exclude pip --exclude embed"


### PR DESCRIPTION
The Xcode 13.4.1 image has been deprecated and will be removed on 2025-11-07. The Xcode 16.4.0 image is the most recent one we can use on the resource class we're currently using.