### PR TITLE
Define `PLZ_ENV` in build environments

### DIFF
--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -22,6 +22,7 @@ type BuildEnv map[string]string
 // on any specific target etc.
 func GeneralBuildEnvironment(state *BuildState) BuildEnv {
 	env := BuildEnv{
+		"PLZ_ENV": "1",
 		// Need this for certain tools, for example sass
 		"LANG": state.Config.Build.Lang,
 		// Need to know these for certain rules.

--- a/src/core/build_env_test.go
+++ b/src/core/build_env_test.go
@@ -65,6 +65,7 @@ func TestExecEnvironment(t *testing.T) {
 
 	env := ExecEnvironment(NewDefaultBuildState(), target, "/path/to/runtime/dir")
 
+	assert.Equal(t, env["PLZ_ENV"], "1")
 	assert.Equal(t, env["DATA"], "pkg/data_file1")
 	assert.Equal(t, env["TMP_DIR"], "/path/to/runtime/dir")
 	assert.Equal(t, env["TMPDIR"], "/path/to/runtime/dir")
@@ -104,6 +105,7 @@ func TestExecEnvironmentTestTarget(t *testing.T) {
 
 	env := ExecEnvironment(state, testTarget, "/path/to/runtime/dir")
 
+	assert.Equal(t, env["PLZ_ENV"], "1")
 	assert.Equal(t, env["DATA"], "pkg/data_file1 pkg/data_file2")
 	assert.Equal(t, env["DATA_FILE2"], "pkg/data_file2")
 	assert.Equal(t, env["TOOLS"], "plz-out/bin/tool1 plz-out/bin/tool2")
@@ -138,6 +140,7 @@ func TestExecEnvironmentDebugTarget(t *testing.T) {
 
 	env := ExecEnvironment(state, target, "/path/to/runtime/dir")
 
+	assert.Equal(t, env["PLZ_ENV"], "1")
 	assert.Equal(t, env["DEBUG_DATA"], "pkg/data_file1")
 	assert.Equal(t, env["DEBUG_TOOLS"], "plz-out/bin/tool1")
 	assert.Equal(t, env["DEBUG_TOOLS_TOOL1"], "plz-out/bin/tool1")
@@ -173,6 +176,7 @@ func TestExecEnvironmentDebugTestTarget(t *testing.T) {
 
 	env := ExecEnvironment(state, testTarget, "/path/to/runtime/dir")
 
+	assert.Equal(t, env["PLZ_ENV"], "1")
 	assert.Equal(t, env["DEBUG_DATA"], "pkg/data_file1")
 	assert.Equal(t, env["DEBUG_TOOLS"], "plz-out/bin/tool1")
 	assert.Equal(t, env["DEBUG_TOOLS_TOOL1"], "plz-out/bin/tool1")


### PR DESCRIPTION
It would be useful for executables to be able to tell whether they are running within a Please build environment, whether or not that environment is sandboxed. One definitive use case is when deciding whether or not resources should be loaded from `$TMP_DIR`, which has a special (and well-defined) meaning within a Please build environment but not outside of one, even though the variable may still be defined in the environment. The java-rules and python-rules plugins would both benefit from this, given that `java_binary` JARs and `python_binary` pexes have runtimes that are expected to be discovered dynamically but will be located at different paths depending on whether they are executing under `plz test` (inside a build environment) or `plz run` (outside a build environment).

Define the `PLZ_ENV` variable in Please build environments. This of course does not guarantee that the environment was created by Please, but is a better indicator of that than heuristics such as testing for the presence of other variables that happen to be defined in certain build environments, such as `BUILD_CONFIG` and `_TEST_ID`.