### PR TITLE
Bump cc-rules plugin to v0.6.0

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -60,7 +60,7 @@ plugins = {
     "python": "v1.14.0",
     "java": "v0.4.5",
     "go": "v1.26.0",
-    "cc": "v0.5.4",
+    "cc": "v0.6.0",
     "shell": "v0.2.0",
     "go-proto": "v0.3.0",
     "python-proto": "v0.1.0",

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -7,7 +7,7 @@ plugin_repo(
 plugin_repo(
     name = "cc",
     plugin = "cc-rules",
-    revision = "v0.5.4",
+    revision = "v0.6.0",
 )
 
 plugin_repo(


### PR DESCRIPTION
The only notable (but minor) change caused by this is that symbols are now stripped from the please_sandbox binary.