### PR TITLE
Clean up pleasew platform detection logic

### DIFF
--- a/pleasew
+++ b/pleasew
@@ -38,7 +38,7 @@ case "$(uname)" in
     FreeBSD)
         OS=freebsd
         case "$(uname -m)" in
-            aarch64*) ARCH=arm64 ;;
+            amd64) ARCH=amd64 ;;
         esac
         ;;
     *)


### PR DESCRIPTION
At the start of the script, ensure that `uname` and `uname -m` produce an OS and architecture that are supported by Please. If they do, set `OS` and `ARCH` to the names of the OS and architecture as Please knows them; if they don't, exit unsuccessfully.

Fixes #3457.