### PR TITLE
Add `maxdepth` parameter to `get_labels` function

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -243,7 +243,7 @@ def dirname(p:str) -> str:
 
 
 # Post-build callback functions.
-def get_labels(name:str, prefix:str, all:bool=False, transitive=True, maxdepth:int=-1) -> list:
+def get_labels(name:str, prefix:str, all:bool=False, transitive:bool=None, maxdepth:int=-1) -> list:
     pass
 def has_label(name:str, prefix:str, all:bool=False) -> bool:
     return len(get_labels(name, prefix, all)) > 0

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -1093,12 +1093,13 @@ func getLabels(s *scope, args []pyObject) pyObject {
 	name := string(args[0].(pyString))
 	prefix := string(args[1].(pyString))
 	all := args[2].IsTruthy()
-	transitive := args[3].IsTruthy()
+	transitive := args[3]
 	maxDepth := int(args[4].(pyInt))
-	if transitive {
-		s.Assert(maxDepth >= -1, "get_labels: maxdepth must be at least -1")
-	} else {
-		maxDepth = 0
+	if transitiveBool, ok := transitive.(pyBool); ok {
+		s.Assert(maxDepth == -1, "get_labels: only one of transitive and maxdepth may be specified, not both")
+		if !transitiveBool.IsTruthy() {
+			maxDepth = 0
+		}
 	}
 	if core.LooksLikeABuildLabel(name) {
 		label := core.ParseBuildLabel(name, s.pkg.Name)
@@ -1130,7 +1131,7 @@ func getLabelsInternal(target *core.BuildTarget, prefix string, minState core.Bu
 		log.Fatalf("get_labels called on a target that is not yet built: %s", target.Label)
 	}
 	if all && maxDepth != -1 {
-		log.Fatalf("get_labels can't be called with all set to True when transitive is set to False")
+		log.Fatalf("get_labels: if all is True, transitive must be True or maxdepth must be -1")
 	}
 	labels := map[string]bool{}
 	done := map[*core.BuildTarget]bool{}

--- a/test/get_labels/BUILD
+++ b/test/get_labels/BUILD
@@ -41,7 +41,7 @@ def dep(name:str, deps:list=None):
 
 def echo_name_labels_up_to(maxdepth:int):
     def echo(name:str):
-        labels = get_labels(name, "name:", transitive=True, maxdepth=maxdepth)
+        labels = get_labels(name, "name:", maxdepth=maxdepth)
         set_command(name, "opt", " && ".join([get_command(name, "opt")] + [f"echo 'echo {l}' >> $OUTS" for l in labels]))
     return echo
 
@@ -80,6 +80,7 @@ maxdepth_test(
     deps = [
         ":dep1",
         ":dep2",
+        ":dep3",
     ],
     maxdepth = 2,
     expected = [


### PR DESCRIPTION
Add a `maxdepth` parameter to the `get_labels` built-in function that controls the maximum depth of `get_labels`' recursive dependency search.  The default is -1, meaning "no limit". The main use case is to help limit the collection of `cc:inc:` labels to direct dependencies in the cc-rules plugin, since headers used by transitive (library) dependencies shouldn't be required at compilation time.

This is an alternative to (and is in fact a superset of the functionality offered by) the `transitive` parameter: `transitive=True` is equivalent to `maxdepth=-1`, and `transitive=False` is equivalent to `maxdepth=0`. The `transitive` parameter remains for backwards compatibility, although it could now be removed in a future major release.