### PR TITLE
CI: use FreeBSD 14.3-RELEASE runner on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-14-2
+  image_family: freebsd-14-3
 
 env:
   GOPROXY: https://proxy.golang.org


### PR DESCRIPTION
The FreeBSD 14.2-RELEASE runner seems to have been deprecated in the last week.