### PR TITLE
Traverse `data` and `debug_data` for run-time dependencies

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -750,6 +750,32 @@ func (target *BuildTarget) IterAllRuntimeDependencies(graph *BuildGraph) iter.Se
 				}
 			}
 		}
+		// Include the run-time dependencies of data targets, but not the data targets themselves. (We needn't worry
+		// about data files here - they can't have run-time dependencies of their own.)
+		for _, data := range t.AllData() {
+			dataLabel, ok := data.Label()
+			if !ok {
+				continue
+			}
+			for _, providedDep := range graph.TargetOrDie(dataLabel).ProvideFor(t) {
+				if !push(graph.TargetOrDie(providedDep), yield) {
+					return false
+				}
+			}
+		}
+		if t.Debug != nil {
+			for _, data := range t.AllDebugData() {
+				dataLabel, ok := data.Label()
+				if !ok {
+					continue
+				}
+				for _, providedDep := range graph.TargetOrDie(dataLabel).ProvideFor(t) {
+					if !push(graph.TargetOrDie(providedDep), yield) {
+						return false
+					}
+				}
+			}
+		}
 		if t.RuntimeDependenciesFromSources || t.RuntimeDependenciesFromDependencies {
 			for _, dep := range t.dependencies {
 				// If required, include the run-time dependencies of sources, but not the sources themselves.

--- a/test/runtime_deps/BUILD
+++ b/test/runtime_deps/BUILD
@@ -74,6 +74,15 @@ please_repo_e2e_test(
 )
 
 please_repo_e2e_test(
+    name = "runtime_deps_from_data_test",
+    plz_command = " && ".join([
+        "plz test //from_data_test:runtime_deps_from_data_test_case",
+        "plz -c dbg test //from_data_test:runtime_deps_from_data_test_case",
+    ]),
+    repo = "repo",
+)
+
+please_repo_e2e_test(
     name = "runtime_deps_from_deps_test",
     plz_command = "plz test //from_deps_test:runtime_deps_from_deps_test_case",
     repo = "repo",

--- a/test/runtime_deps/repo/build_defs/test.build_defs
+++ b/test/runtime_deps/repo/build_defs/test.build_defs
@@ -6,9 +6,9 @@ def not_exists(file:str):
     path = join_path(package_name(), file)
     return f"echo -n '{path} does not exist: '; if [ -f '{path}' ]; then echo FAIL; exit 1; else echo OK; fi"
 
-def target(name:str, srcs:list=[], build_tests:list=[], post_build:function=None, requires:list=None,
-           provides:dict=None, runtime_deps:list=[], runtime_deps_from_srcs:bool=False, runtime_deps_from_deps:bool=False,
-           exported_deps:list=[], deps:list=[]):
+def target(name:str, srcs:list=[], build_tests:list=[], data:list=[], debug_data:list=[], post_build:function=None,
+           requires:list=None, provides:dict=None, runtime_deps:list=[], runtime_deps_from_srcs:bool=False,
+           runtime_deps_from_deps:bool=False, exported_deps:list=[], deps:list=[]):
     # Ensure that run-time dependencies are not present at build time, unless they are also
     # explicitly given as build-time dependencies. (The lstrips here turn build target names
     # into the names of files they output - they're slightly grungy, but they allow us to
@@ -17,14 +17,16 @@ def target(name:str, srcs:list=[], build_tests:list=[], post_build:function=None
     # target's.)
     cmd = [not_exists(r.lstrip(":")) for r in runtime_deps if r not in deps]
     cmd += [exists(d.lstrip(":")) for d in deps]
-    return genrule(
+    return build_rule(
         name = name,
         srcs = srcs,
         outs = [name],
         # Assume that if a post-build function is defined, it dynamically adds a run-time
         # dependency, which requires this target to be marked as binary.
         binary = len(runtime_deps) > 0 or post_build is not None,
-        cmd = cmd + build_tests + ["touch $OUTS"],
+        cmd = " && ".join(cmd + build_tests + ["touch $OUTS"]),
+        data = data,
+        debug_data = debug_data,
         post_build = post_build,
         requires = requires,
         provides = provides,

--- a/test/runtime_deps/repo/from_data_test/BUILD_FILE
+++ b/test/runtime_deps/repo/from_data_test/BUILD_FILE
@@ -1,0 +1,42 @@
+subinclude("//build_defs:test")
+
+target(
+    name = "runtime_deps_from_data",
+    data = [":data_with_runtime_dep"],
+    debug_data = [":debug_data_with_runtime_dep"],
+)
+
+target(
+    name = "data_with_runtime_dep",
+    runtime_deps = [":data_runtime_dep"],
+)
+
+target(
+    name = "debug_data_with_runtime_dep",
+    runtime_deps = [":debug_data_runtime_dep"],
+)
+
+runtime_dep("data_runtime_dep")
+runtime_dep("debug_data_runtime_dep")
+
+gentest(
+    name = "runtime_deps_from_data_test_case",
+    outs = ["runtime_deps_from_data_test_case"],
+    cmd = [
+        not_exists("data_runtime_dep"),
+        not_exists("debug_data_runtime_dep"),
+        "touch $OUTS",
+    ],
+    data = [":runtime_deps_from_data"],
+    no_test_output = True,
+    test_cmd = {
+        "opt": " && ".join([
+            exists("data_runtime_dep"),
+            not_exists("debug_data_runtime_dep"),
+        ]),
+        "dbg": " && ".join([
+            exists("data_runtime_dep"),
+            exists("debug_data_runtime_dep"),
+        ]),
+    },
+)


### PR DESCRIPTION
`data` (and `debug_data`) targets themselves may have their own run-time dependencies - also mark those targets as prerequisites for executing the top-level target.