### PR TITLE
pleasew: find repo root by traversing up from PWD

### DIFF
--- a/pleasew
+++ b/pleasew
@@ -79,9 +79,8 @@ find_repo_root() {
     dir="$PWD"
     while true; do
         [ -f "$dir/.plzconfig" ] && echo "$dir" && return 0
-        [ "$dir" = "/" ] && return 1
-        dir="${dir%/*}"
-        [ -z "$dir" ] && dir="/"
+        [ "$dir" = "/" ] && return 0
+        dir="$(dirname "$dir")"
     done
 }
 


### PR DESCRIPTION
Instead of looking for .plzconfig in the current directory only, traverse upwards until we find it. This replicates the behavior of getRepoRoot in src/core/utils.go.

Fixes #3473