### PR TITLE
Switch Please to use m4pro.medium resource class on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
      working_directory: ~/please
      macos:
        xcode: "16.4.0"
-     resource_class: macos.m1.medium.gen1
+     resource_class: m4pro.medium
      steps:
        - checkout
        - attach_workspace:
@@ -206,7 +206,7 @@ jobs:
    build-darwin:
       macos:
         xcode: "16.4.0"
-      resource_class: macos.m1.medium.gen1
+      resource_class: m4pro.medium
       environment:
         PLZ_ARGS: "--profile ci --exclude pip --exclude embed"
       steps:


### PR DESCRIPTION
M1 is [deprecated](https://circleci.com/changelog/deprecation-of-mac-m1-and-m2-resource-classes), and `m4pro.medium` is the new hotness (with significantly more RAM...)