### PR TITLE
Add ShortenAbsoluteLabelsToRelative configuration option

### DIFF
--- a/docs/config.html
+++ b/docs/config.html
@@ -1212,6 +1212,24 @@
 </section>
 
 <section class="mt4">
+  <h2 id="format" class="title-2">[Format]</h2>
+
+  <ul class="bulleted-list">
+    <li>
+      <div>
+        <h3 class="mt1 f6 lh-title" id="format.shortenabsolutelabelstorelative">
+          ShortenAbsoluteLabelsToRelative <span class="normal">(bool)</span>
+        </h3>
+
+        <p>
+          Shortens absolute labels to relative when running <code class="code">plz format</code> if the label is in the same package as the associated target.
+        </p>
+      </div>
+    </li>
+  </ul>
+</section>
+
+<section class="mt4">
   <h2 id="test" class="title-2">[Test]</h2>
 
   <ul class="bulleted-list">

--- a/src/core/config.go
+++ b/src/core/config.go
@@ -546,6 +546,9 @@ type Configuration struct {
 		StoreCommand               string       `help:"Use a custom command to store cache entries."`
 		RetrieveCommand            string       `help:"Use a custom command to retrieve cache entries."`
 	} `help:"Please has several built-in caches that can be configured in its config file.\n\nThe simplest one is the directory cache which by default is written into the .plz-cache directory. This allows for fast retrieval of code that has been built before (for example, when swapping Git branches).\n\nThere is also a remote RPC cache which allows using a centralised server to store artifacts. A typical pattern here is to have your CI system write artifacts into it and give developers read-only access so they can reuse its work.\n\nFinally there's a HTTP cache which is very similar, but a little obsolete now since the RPC cache outperforms it and has some extra features. Otherwise the two have similar semantics and share quite a bit of implementation.\n\nPlease has server implementations for both the RPC and HTTP caches."`
+	Format struct {
+		ShortenAbsoluteLabelsToRelative bool `help:"Shortens absolute labels to relative if the label is in the same package as the associated target."`
+	} `help:"A config section describing settings related to the 'format' sub command."`
 	Test struct {
 		Timeout                  cli.Duration `help:"Default timeout applied to all tests. Can be overridden on a per-rule basis."`
 		DisableCoverage          []string     `help:"Disables coverage for tests that have any of these labels spcified."`

--- a/src/format/BUILD
+++ b/src/format/BUILD
@@ -5,6 +5,7 @@ go_library(
     visibility = ["//src/..."],
     deps = [
         "///third_party/go/github.com_please-build_buildtools//build",
+        "///third_party/go/github.com_please-build_buildtools//tables",
         "///third_party/go/golang.org_x_sync//errgroup",
         "//src/cli/logging",
         "//src/core",

--- a/src/format/fmt_test.go
+++ b/src/format/fmt_test.go
@@ -17,18 +17,30 @@ const testDir = "src/format/test_data"
 func TestFormat(t *testing.T) {
 	files, err := os.ReadDir(testDir)
 	assert.NoError(t, err)
+
+	patchConfigByFile := map[string]func(*core.Configuration) {
+		"shorten_labels":  func(c *core.Configuration) {
+			c.Format.ShortenAbsoluteLabelsToRelative = true
+		},
+	}
+
 	for _, file := range files {
 		if test, isBefore := strings.CutSuffix(file.Name(), ".before.build"); isBefore {
 			t.Run(test, func(t *testing.T) {
 				before := filepath.Join(testDir, test+".before.build")
 				after := filepath.Join(testDir, test+".after.build")
 
-				changed, err := Format(core.DefaultConfiguration(), []string{before}, false, true)
+				config := core.DefaultConfiguration()
+				if patchConfig := patchConfigByFile[test]; patchConfig != nil {
+					patchConfig(config)
+				}
+
+				changed, err := Format(config, []string{before}, false, true)
 				assert.NoError(t, err)
 				assert.True(t, changed)
 
 				// N.B. this rewrites the file; be careful if you're adding more tests here.
-				changed, err = Format(core.DefaultConfiguration(), []string{before}, true, false)
+				changed, err = Format(config, []string{before}, true, false)
 				assert.NoError(t, err)
 				assert.True(t, changed)
 

--- a/src/format/test_data/shorten_labels.after.build
+++ b/src/format/test_data/shorten_labels.after.build
@@ -1,0 +1,7 @@
+go_library(
+    name = "name",
+    srcs = [
+        "src.go",
+    ],
+    deps = [":test_data"],
+)

--- a/src/format/test_data/shorten_labels.before.build
+++ b/src/format/test_data/shorten_labels.before.build
@@ -1,0 +1,14 @@
+go_library(
+    name = "name",
+    srcs = [
+        "src.go",
+    ],
+    deps = [
+        "//src/format/test_data:test_data",
+        "//src/format/test_data:test_data",
+        "//src/format/test_data",
+        "//src/format/test_data",
+        ":test_data",
+        ":test_data",
+    ],
+)

--- a/src/format/test_data/shorten_labels_no_config.after.build
+++ b/src/format/test_data/shorten_labels_no_config.after.build
@@ -1,0 +1,10 @@
+go_library(
+    name = "name",
+    srcs = [
+        "src.go",
+    ],
+    deps = [
+        ":test_data",
+        "//src/format/test_data",
+    ],
+)

--- a/src/format/test_data/shorten_labels_no_config.before.build
+++ b/src/format/test_data/shorten_labels_no_config.before.build
@@ -1,0 +1,14 @@
+go_library(
+    name = "name",
+    srcs = [
+        "src.go",
+    ],
+    deps = [
+        "//src/format/test_data:test_data",
+        "//src/format/test_data:test_data",
+        "//src/format/test_data",
+        "//src/format/test_data",
+        ":test_data",
+        ":test_data",
+    ],
+)


### PR DESCRIPTION
This change ensures that absolute labels to package-local targets (e.g. `//a/b/c:d`) are transformed into local labels (e.g. `:d`) by the please format command when the new `Format.ShortenAbsoluteLabelsToRelative` config option is enabled.

The aim of this change is to address https://github.com/thought-machine/please/issues/3471.

This change supercedes https://github.com/please-build/buildtools/pull/10.