### PR TITLE
fix: skip verification of symlink digests for compatibility with Buil…

### DIFF
--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -521,8 +521,8 @@ func (c *Client) verifyActionResult(target *core.BuildTarget, command *pb.Comman
 	// At this point it's verified all the directories, but not the files themselves.
 	digests := make([]digest.Digest, 0, len(outputs))
 	for _, output := range outputs {
-		// Skip empty directories and symlinks - they don't have digests to verify
-		if output.IsEmptyDirectory || output.SymlinkTarget != "" {
+		// Skip empty directories, symlinks, and any output with an empty digest - they have no blob to verify
+		if output.IsEmptyDirectory || output.SymlinkTarget != "" || output.Digest.Hash == "" {
 			continue
 		}
 		digests = append(digests, output.Digest)

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -521,10 +521,11 @@ func (c *Client) verifyActionResult(target *core.BuildTarget, command *pb.Comman
 	// At this point it's verified all the directories, but not the files themselves.
 	digests := make([]digest.Digest, 0, len(outputs))
 	for _, output := range outputs {
-		// FlattenTree doesn't populate the digest in for empty dirs... we don't need to check them anyway
-		if !output.IsEmptyDirectory {
-			digests = append(digests, output.Digest)
+		// Skip empty directories and symlinks - they don't have digests to verify
+		if output.IsEmptyDirectory || output.SymlinkTarget != "" {
+			continue
 		}
+		digests = append(digests, output.Digest)
 	}
 	if missing, err := c.client.MissingBlobs(context.Background(), digests); err != nil {
 		return fmt.Errorf("Failed to verify action result outputs: %s", err)


### PR DESCRIPTION
BuildBarn sometimes returns results without Digest field. So far I observed it only with for symlinks.

The error then manifests as:
```
Failed to verify action result outputs: rpc error: code = InvalidArgument desc = rpc error: code = InvalidArgument desc = Hash has length 0, while 64 characters were expected
```

This patch enables compatibility with BuildBarn under such circumstances.