### PR TITLE
Pre-allocate pyList in mapFunc()

### DIFF
--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -913,14 +913,14 @@ func mapFunc(s *scope, args []pyObject) pyObject {
 	s.Assert(isFunc, "Argument mapper must be callable, not %s", args[0].Type())
 	s.Assert(isList, "Argument seq must be a list, not %s", args[1].Type())
 
-	var ret pyList
-	for _, li := range l {
+	ret := make(pyList, len(l))
+	for i, li := range l {
 		c := &Call{
 			Arguments: []CallArgument{{
 				Value: Expression{optimised: &optimisedExpression{Constant: li}},
 			}},
 		}
-		ret = append(ret, mapper.Call(s, c))
+		ret[i] = mapper.Call(s, c)
 	}
 	return ret
 }


### PR DESCRIPTION
This got missed in #3522, and cropped up again in #3498 to haunt me.

This is some minor performance boost, but the upgraded linter gets sad about it, so let's fix it before #3498