### PR TITLE
Output default values for plugin config fields from plz query config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 __pycache__
 
 .idea
+.vscode
 *.iml
 /venv
 /out

--- a/src/query/BUILD
+++ b/src/query/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//src/core",
         "//src/fs",
         "//src/parse",
+        "//src/plz",
     ],
 )
 

--- a/src/query/config.go
+++ b/src/query/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/please-build/gcfg"
 
 	"github.com/thought-machine/please/src/core"
+	"github.com/thought-machine/please/src/plz"
 )
 
 // Config prints configuration settings in human-readable format.
@@ -29,7 +30,15 @@ func Config(config *core.Configuration, options []string) {
 
 			values, err := gcfg.Get(config, section, subsection, name)
 			if err != nil {
-				log.Fatalf("Failed to get %s: %s", option, err)
+				if section == "plugin" {
+					if defaultValues, ok := pluginConfigFieldDefaultValues(config, subsection, name); ok {
+						values = defaultValues
+						err = nil
+					}
+				}
+				if err != nil {
+					log.Fatalf("Failed to get %s: %s", option, err)
+				}
 			}
 
 			for _, value := range values {
@@ -37,6 +46,53 @@ func Config(config *core.Configuration, options []string) {
 			}
 		}
 	}
+}
+
+// pluginConfigFieldDefaultValues returns the default values of a plugin config field and a boolean indicating whether
+// the plugin field actually exists.
+func pluginConfigFieldDefaultValues(config *core.Configuration, pluginName string, name string) ([]string, bool) {
+	plugin, ok := config.Plugin[pluginName]
+	if !ok {
+		return nil, false
+	}
+
+	state := core.NewBuildState(config)
+	plz.Run([]core.BuildLabel{plugin.Target}, nil, state, state.Config, state.TargetArch)
+	subrepo := state.Graph.SubrepoOrDie(pluginName)
+	subrepo.State.Initialise(subrepo)
+
+	for key, field := range subrepo.State.RepoConfig.PluginConfig {
+		configKey := field.ConfigKey
+		if configKey == "" {
+			configKey = strings.ReplaceAll(key, "_", "")
+		}
+		if strings.EqualFold(configKey, name) {
+			values := normaliseBuildLabels(field.DefaultValue, subrepo.Name)
+			return values, true
+		}
+	}
+
+	return nil, false
+}
+
+// normaliseBuildLabels returns a copy of values with each build label made absolute.
+// For example, //tools/bar in subrepo foo is replaced by ///foo//tools/bar.
+func normaliseBuildLabels(values []string, subrepo string) []string {
+	valuesCopy := make([]string, len(values))
+	for i, value := range values {
+		if core.LooksLikeABuildLabel(value) {
+			target, annotation := core.SplitLabelAnnotation(value)
+			if label, err := core.TryParseBuildLabel(target, "", subrepo); err == nil {
+				annotatedLabel := core.AnnotatedOutputLabel{
+					BuildLabel: label,
+					Annotation: annotation,
+				}
+				value = annotatedLabel.String()
+			}
+		}
+		valuesCopy[i] = value
+	}
+	return valuesCopy
 }
 
 // ConfigJSON prints the configuration settings as JSON.

--- a/test/plz_query/config/BUILD
+++ b/test/plz_query/config/BUILD
@@ -17,6 +17,27 @@ BUILD.plz
 60000000000""",
 )
 
+please_repo_e2e_test(
+    name = "plugin_config_field_default_value",
+    repo = "test_repo",
+    data = {"plugin": [":foo_plugin"]},
+    plz_command = "plz -o please.pluginrepo:file://$TMP_DIR/$DATA_PLUGIN query config plugin.foo.fooctool plugin.foo.bartools > output.txt",
+    expected_output = {"output.txt": """fooc
+///foo//tools/bar:bar
+///baz//tools/bar:bar
+"""},
+)
+
+genrule(
+    name = "foo_plugin",
+    srcs = {
+        "plugin": ["foo_plugin"],
+        "tool": ["//test/plugins/tools:fooc"],
+    },
+    outs = ["foo_plugin.tar.gz"],
+    cmd = "mv $SRCS_PLUGIN foo_plugin && mv $SRCS_TOOL foo_plugin/tools && tar -czf $OUT foo_plugin",
+)
+
 plz_e2e_test(
     name = "json_config",
     cmd = "plz query config --json",

--- a/test/plz_query/config/foo_plugin/.plzconfig
+++ b/test/plz_query/config/foo_plugin/.plzconfig
@@ -1,0 +1,10 @@
+[PluginDefinition]
+name = foo
+
+[PluginConfig "fooc_tool"]
+DefaultValue = fooc
+
+[PluginConfig "bar_tools"]
+Repeatable = true
+DefaultValue = //tools/bar
+DefaultValue = ///baz//tools/bar

--- a/test/plz_query/config/test_repo/.plzconfig
+++ b/test/plz_query/config/test_repo/.plzconfig
@@ -1,0 +1,2 @@
+[Plugin "foo"]
+Target = //:foo

--- a/test/plz_query/config/test_repo/BUILD_FILE
+++ b/test/plz_query/config/test_repo/BUILD_FILE
@@ -1,0 +1,4 @@
+plugin_repo(
+    name = "foo",
+    revision = "v1.0.0",
+)


### PR DESCRIPTION
## Problem
`plz query config` correctly outputs the values of a plugin config field if it has been explicitly set in `.plzconfig`. However, it errors if not. 

For example, in this repository: 
* `plz query config plugin.go.gotool` outputs `//third_party/go:toolchain|go` which has been explicitly set in [.plzconfig](https://github.com/thought-machine/please/blob/857c8aea4138d8a828442b04eb26334c547831a7/.plzconfig?plain=1#L11)
* `plz query config plugin.go.delvetool` errors with `Failed to get plugin.go.delvetool: Settable field not defined: plugin.go.delvetool`

This is annoying for external consumers of these values as they have to hardcode the default values in their logic.

## Solution
Update `config.Config` so that when we fail to look up a value from the `"plugin"` section of the configuration, we attempt to read the default values from the plugin's `.plzconfig`. 

Default values which look like build labels are normalised. For example: `plz query config plugin.go.pleasegotool` outputs `///go//tools:please_go` instead of `//tools:please_go` which was what was actually specified by the go plugin. This allows consumers of the values to not care were they came from (if they want to build the target for example).