### PR TITLE
List tools and integrations for working with Please in docs

### DIFF
--- a/docs/dependencies.html
+++ b/docs/dependencies.html
@@ -471,6 +471,6 @@
     <a class="copy-link" href="/basics.html">Please basics</a>
   </div>
   <div class="pagination__next">
-    <a class="copy-link" href="/quickstart_dropoff.html">What's next?</a>
+    <a class="copy-link" href="/tooling.html">Tooling</a>
   </div>
 </div>

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -96,36 +96,6 @@
 </section>
 
 <section class="mt4">
-  <h2 id="lang-server" class="title-2">
-    BUILD file Language Protocol Server
-  </h2>
-
-  <p>
-    Please ships with a language server for build files. It follows the
-    <a
-      class="copy-link"
-      href="https://langserver.org/"
-      target="_blank"
-      rel="noopener"
-      >language server protocol</a
-    >
-    from VS Code.
-  </p>
-
-  <p>
-    To use LPS, simply download the language server protocol plugin for your
-    favourite editor, and run the binary with the command
-    <code class="code">plz tool lps</code>.
-  </p>
-
-  <p>
-    Currently LPS supports auto-completion (this works with build labels too!),
-    hover, goto definition, diagnostics, signature help, auto-formatting and
-    references.
-  </p>
-</section>
-
-<section class="mt4">
   <h2 id="getting-started" class="title-2">Getting started</h2>
 
   <p>

--- a/docs/quickstart_dropoff.html
+++ b/docs/quickstart_dropoff.html
@@ -89,6 +89,6 @@
 
 <div class="pagination">
   <div class="pagination__previous">
-    <a class="copy-link" href="/dependencies.html">Third-party dependencies</a>
+    <a class="copy-link" href="/tooling.html">Tooling</a>
   </div>
 </div>

--- a/docs/template.html
+++ b/docs/template.html
@@ -82,7 +82,7 @@
           </div>
 
           <ul class="sticky top-1 ttu essential-pragmata-pro" role="menu">
-            {{$isItemActive := matches .Filename "quickstart.html" "codelabs.html" "basics.html" "dependencies.html" "quickstart_dropoff.html"}}
+            {{$isItemActive := matches .Filename "quickstart.html" "codelabs.html" "basics.html" "dependencies.html" "tooling.html" "quickstart_dropoff.html"}}
             <li
                     class="mv2 {{boolOption $isItemActive "white before-dw-arrow" "violet before-rw-arrow hover-before-white"}}"
                     role="menuitem">
@@ -119,6 +119,13 @@
                             class="{{isFilenameOption "dependencies.html" "white" "silver"}} no-underline"
                             href="/dependencies.html"
                     >Third-party dependencies</a
+                    >
+                  </li>
+                  <li class="pl4" role="menuitem">
+                    <a
+                            class="{{isFilenameOption "tooling.html" "white" "silver"}} no-underline"
+                            href="/tooling.html"
+                    >Tooling</a
                     >
                   </li>
                   <li class="pl4" role="menuitem">

--- a/docs/tooling.html
+++ b/docs/tooling.html
@@ -1,0 +1,121 @@
+<h1 id="tooling" class="title-1">Tooling</h1>
+
+<p>This page lists tools and integrations for working with Please.</p>
+
+<section class="mt4">
+  <h2 id="editor-integrations" class="title-2">Editor integrations</h2>
+
+  <ul class="bulleted-list">
+    <li>
+      <span>
+        <a
+          class="copy-link"
+          href="https://github.com/marcuscaisey/please.nvim"
+          target="_blank"
+          rel="noopener"
+          >Please plugin for Neovim</a
+        >.
+      </span>
+    </li>
+    <li>
+      <span>
+        <a
+          class="copy-link"
+          href="https://marketplace.visualstudio.com/items?itemName=please-build.plz-vscode"
+          target="_blank"
+          rel="noopener"
+          >Please extension for Visual Studio Code</a
+        >.
+      </span>
+    </li>
+    <li>
+      <span>
+        <a
+          class="copy-link"
+          href="https://plugins.jetbrains.com/plugin/16816-please"
+          target="_blank"
+          rel="noopener"
+          >Please plugin for IntelliJ</a
+        >.
+      </span>
+    </li>
+  </ul>
+</section>
+
+<section class="mt4">
+  <h2 id="build-file-maintenance" class="title-2">BUILD file maintenance</h2>
+
+  <ul class="bulleted-list">
+    <li>
+      <span>
+        <a class="copy-link" href="/commands.html#fmt">plz fmt</a>
+        formats BUILD files.
+      </span>
+    </li>
+    <li>
+      <span>
+        <a
+          class="copy-link"
+          href="https://github.com/please-build/puku"
+          target="_blank"
+          rel="noopener"
+          >puku</a
+        >
+        maintains Go targets in BUILD files.
+      </span>
+    </li>
+  </ul>
+</section>
+
+<section class="mt4">
+  <h2 id="lang-server" class="title-2">BUILD file Language Protocol Server</h2>
+
+  <p>
+    Please ships with a language server for BUILD files. It follows the
+    <a
+      class="copy-link"
+      href="https://langserver.org/"
+      target="_blank"
+      rel="noopener"
+      >language server protocol</a
+    >
+    from Visual Studio Code.
+  </p>
+
+  <p>
+    To use LPS, simply download the language server protocol plugin for your
+    favourite editor, and run the binary with the command
+    <code class="code">plz tool lps</code>. The
+    <a
+      class="copy-link"
+      href="https://github.com/marcuscaisey/please.nvim"
+      target="_blank"
+      rel="noopener"
+      >Neovim plugin</a
+    >
+    and
+    <a
+      class="copy-link"
+      href="https://marketplace.visualstudio.com/items?itemName=please-build.plz-vscode"
+      target="_blank"
+      rel="noopener"
+      >Visual Studio Code extension</a
+    >
+    set this up for you.
+  </p>
+
+  <p>
+    Currently LPS supports auto-completion (this works with build labels too!),
+    hover, goto definition, diagnostics, signature help, auto-formatting and
+    references.
+  </p>
+</section>
+
+<div class="pagination">
+  <div class="pagination__previous">
+    <a class="copy-link" href="/dependencies.html">Third-party dependencies</a>
+  </div>
+  <div class="pagination__next">
+    <a class="copy-link" href="/quickstart_dropoff.html">What's next?</a>
+  </div>
+</div>

--- a/docs/tools/templater/template.go
+++ b/docs/tools/templater/template.go
@@ -64,6 +64,7 @@ var pageTitles = map[string]string{
 	"remote_builds.html":      "Remote build execution",
 	"require_provide.html":    "Require & Provide",
 	"quickstart.html":         "Please quickstart",
+	"tooling.html":            "Tooling",
 	"tests.html":              "Testing with Please",
 }
 


### PR DESCRIPTION
# Problem

Various tools and integrations exist for working with please, but they're not all discoverable from the documentation.

# Solution

Add a new "Tooling" page under the "Getting started" section which lists available tools and integrations. I've moved the "BUILD file Language Protocol Server" section from the "Please quickstart" page to this new page as well.

Screenshot of the new page:
<img width="1512" height="921" alt="image" src="https://github.com/user-attachments/assets/3f66aa3d-51db-418e-8a4c-b145c5a837cf" />
