### PR TITLE
Bump go-m1cpu to v0.2.1 to fix crash on Apple M5 Pro

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
       steps:
        - checkout
        - restore_cache:
-           key: go-mod-darwin-arm64-v8-{{ checksum "bootstrap.sh" }}
+           key: go-mod-darwin-arm64-v8-{{ checksum "go.mod" }}
        - restore_cache:
            key: go-darwin-arm64-go123-v1-{{ checksum "third_party/go/BUILD" }}
        - restore_cache:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,8 +8,10 @@ source ./log.sh
 PLZ_ARGS="${PLZ_ARGS:-}"
 
 # Now invoke Go to run Please to build itself.
+# CGO_ENABLED=0 avoids segfaults from go-m1cpu's IOKit code on Apple Silicon during bootstrap.
+# The final binary built by Please also disables CGO, so this is consistent.
 notice "Bootstrapping please..."
-go run -race src/please.go -p -v2 $PLZ_ARGS --log_file plz-out/log/bootstrap_build.log build //src:please
+CGO_ENABLED=0 go run -race src/please.go -p -v2 $PLZ_ARGS --log_file plz-out/log/bootstrap_build.log build //src:please
 
 if [ $# -gt 0 ] && [ "$1" == "--skip_tests" ]; then
     notice "Skipping tests... done."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,7 +11,10 @@ PLZ_ARGS="${PLZ_ARGS:-}"
 # CGO_ENABLED=0 avoids segfaults from go-m1cpu's IOKit code on Apple Silicon during bootstrap.
 # The final binary built by Please also disables CGO, so this is consistent.
 notice "Bootstrapping please..."
-CGO_ENABLED=0 go run -race src/please.go -p -v2 $PLZ_ARGS --log_file plz-out/log/bootstrap_build.log build //src:please
+
+# -race requires cgo on non-apple platforms, account for that
+[ "$(go env GOOS)" = "darwin" ] && export CGO_ENABLED=0
+go run -race src/please.go -p -v2 $PLZ_ARGS --log_file plz-out/log/bootstrap_build.log build //src:please
 
 if [ $# -gt 0 ] && [ "$1" == "--skip_tests" ]; then
     notice "Skipping tests... done."

--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/procfs v0.13.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.8.0 // indirect
-	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	github.com/shoenig/go-m1cpu v0.2.1 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/tklauser/go-sysconf v0.3.13 // indirect
 	github.com/tklauser/numcpus v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,10 +220,12 @@ github.com/secure-systems-lab/go-securesystemslib v0.8.0 h1:mr5An6X45Kb2nddcFlbm
 github.com/secure-systems-lab/go-securesystemslib v0.8.0/go.mod h1:UH2VZVuJfCYR8WgMlCU1uFsOUU+KeyrTWcSS73NBOzU=
 github.com/shirou/gopsutil/v3 v3.24.2 h1:kcR0erMbLg5/3LcInpw0X/rrPSqq4CDPyI6A6ZRC18Y=
 github.com/shirou/gopsutil/v3 v3.24.2/go.mod h1:tSg/594BcA+8UdQU2XcW803GWYgdtauFFPgJCJKZlVk=
-github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
-github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
+github.com/shoenig/go-m1cpu v0.2.1 h1:yqRB4fvOge2+FyRXFkXqsyMoqPazv14Yyy+iyccT2E4=
+github.com/shoenig/go-m1cpu v0.2.1/go.mod h1:KkDOw6m3ZJQAPHbrzkZki4hnx+pDRR1Lo+ldA56wD5w=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/shoenig/test v1.7.0 h1:eWcHtTXa6QLnBvm0jgEabMRN/uJ4DMV3M8xUGgRkZmk=
+github.com/shoenig/test v1.7.0/go.mod h1:UxJ6u/x2v/TNs/LoLxBNJRV9DiwBBKYxXSyczsBHFoI=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/sigstore/sigstore v1.8.2 h1:0Ttjcn3V0fVQXlYq7+oHaaHkGFIt3ywm7SF4JTU/l8c=

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -664,7 +664,7 @@ go_repo(
 go_repo(
     licences = ["MPL-2.0"],
     module = "github.com/shoenig/go-m1cpu",
-    version = "v0.1.6",
+    version = "v0.2.1",
 )
 
 go_repo(


### PR DESCRIPTION
Bump the go-m1cpu dependency to fix #3536