### PR TITLE
Allow __TEST_ARGS__ placeholder in test commands

### DIFF
--- a/src/test/results_test.go
+++ b/src/test/results_test.go
@@ -181,3 +181,51 @@ func TestParseGoFileWithLogging(t *testing.T) {
 	assert.Equal(t, 3, results.Passes())
 	assert.Equal(t, 0, results.Failures())
 }
+
+func TestTestCommandAndEnv(t *testing.T) {
+	state := core.NewBuildState(core.DefaultConfiguration())
+
+	t.Run("with placeholder and test args", func(t *testing.T) {
+		target := core.NewBuildTarget(core.ParseBuildLabel("//src/test:placeholder_test", ""))
+		target.Test = &core.TestFields{
+			Command: "./my_test_binary __TEST_ARGS__ 2>&1",
+		}
+		state.TestArgs = []string{"--flag1", "--flag2"}
+		cmd, _, err := testCommandAndEnv(state, target, 1)
+		assert.NoError(t, err)
+		assert.Equal(t, "./my_test_binary --flag1 --flag2 2>&1", cmd)
+	})
+
+	t.Run("with placeholder and no test args", func(t *testing.T) {
+		target := core.NewBuildTarget(core.ParseBuildLabel("//src/test:placeholder_test", ""))
+		target.Test = &core.TestFields{
+			Command: "./my_test_binary __TEST_ARGS__ 2>&1",
+		}
+		state.TestArgs = nil
+		cmd, _, err := testCommandAndEnv(state, target, 1)
+		assert.NoError(t, err)
+		assert.Equal(t, "./my_test_binary  2>&1", cmd)
+	})
+
+	t.Run("without placeholder and test args", func(t *testing.T) {
+		target := core.NewBuildTarget(core.ParseBuildLabel("//src/test:placeholder_test", ""))
+		target.Test = &core.TestFields{
+			Command: "./my_test_binary 2>&1",
+		}
+		state.TestArgs = []string{"--flag1", "--flag2"}
+		cmd, _, err := testCommandAndEnv(state, target, 1)
+		assert.NoError(t, err)
+		assert.Equal(t, "./my_test_binary 2>&1 --flag1 --flag2", cmd)
+	})
+
+	t.Run("without placeholder and no test args", func(t *testing.T) {
+		target := core.NewBuildTarget(core.ParseBuildLabel("//src/test:placeholder_test", ""))
+		target.Test = &core.TestFields{
+			Command: "./my_test_binary 2>&1",
+		}
+		state.TestArgs = nil
+		cmd, _, err := testCommandAndEnv(state, target, 1)
+		assert.NoError(t, err)
+		assert.Equal(t, "./my_test_binary 2>&1", cmd)
+	})
+}

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -343,7 +343,14 @@ func pluralise(word string, quantity int) string {
 func testCommandAndEnv(state *core.BuildState, target *core.BuildTarget, run int) (string, core.BuildEnv, error) {
 	replacedCmd, err := core.ReplaceTestSequences(state, target, target.GetTestCommand(state))
 	env := core.TestEnvironment(state, target, filepath.Join(core.RepoRoot, target.TestDir(run)), run)
-	if len(state.TestArgs) > 0 {
+	if strings.Contains(replacedCmd, "__TEST_ARGS__") {
+		args := ""
+		if len(state.TestArgs) > 0 {
+			args = strings.Join(state.TestArgs, " ")
+		}
+		newCmd := strings.ReplaceAll(replacedCmd, "__TEST_ARGS__", args)
+		replacedCmd = newCmd
+	} else if len(state.TestArgs) > 0 {
 		replacedCmd += " " + strings.Join(state.TestArgs, " ")
 	}
 	return replacedCmd, env, err

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -348,8 +348,7 @@ func testCommandAndEnv(state *core.BuildState, target *core.BuildTarget, run int
 		if len(state.TestArgs) > 0 {
 			args = strings.Join(state.TestArgs, " ")
 		}
-		newCmd := strings.ReplaceAll(replacedCmd, "__TEST_ARGS__", args)
-		replacedCmd = newCmd
+		replacedCmd = strings.ReplaceAll(replacedCmd, "__TEST_ARGS__", args)
 	} else if len(state.TestArgs) > 0 {
 		replacedCmd += " " + strings.Join(state.TestArgs, " ")
 	}


### PR DESCRIPTION
Test args are currently appended to the end of the test command. This may result in an invalid command though, as is the case with go_test, which pipes the output into `tee`, so while you want to pass the arguments to your test binary, they actually get passed to `tee`.

This introduces a `__TEST_ARGS__` placeholder which can be put into the test command, and will be used as the location to put the test args, instead of just appending them.

Tested on a local repository that uses please and a fork of go-rules that made use of the placeholder. The args could
be passed to test via `-- --test-arg`, though it did interfere with test name pattern matching which necessitated appending a `.` on the end. That's a separate issue though and doesn't invalidate this change.