### PR TITLE
Make the test args placeholder configurable

### DIFF
--- a/rules/builtins.build_defs
+++ b/rules/builtins.build_defs
@@ -59,6 +59,7 @@ def build_rule(
     _subrepo:bool=False,
     no_test_coverage:bool=False,
     src_list_files:bool=False,
+    test_cmd_args_placeholder:str=None,
 ):
     pass
 

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -252,6 +252,7 @@ func ruleHash(state *core.BuildState, target *core.BuildTarget, runtime bool) []
 			}
 			hashOptionalBool(h, target.Test.Sandbox)
 			h.Write([]byte(target.GetTestCommand(state)))
+			h.Write([]byte(target.Test.ArgsPlaceholder))
 		}
 	}
 

--- a/src/build/incrementality_test.go
+++ b/src/build/incrementality_test.go
@@ -58,12 +58,13 @@ var KnownFields = map[string]bool{
 	"Test": true, // We hash the children of this
 
 	// Contribute to the runtime hash
-	"Test.Sandbox":    true,
-	"Test.Commands":   true,
-	"Test.Command":    true,
-	"Test.tools":      true,
-	"Test.namedTools": true,
-	"Test.Outputs":    true,
+	"Test.Sandbox":         true,
+	"Test.Commands":        true,
+	"Test.Command":         true,
+	"Test.ArgsPlaceholder": true,
+	"Test.tools":           true,
+	"Test.namedTools":      true,
+	"Test.Outputs":         true,
 
 	// These don't need to be hashed
 	"Test.NoOutput":   true,

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -87,6 +87,8 @@ type TestFields struct {
 	// Default is false, where tests are expected to, but we don't error if it's not there;
 	// this is mostly relevant for remote execution.
 	NoCoverage bool `name:"no_test_coverage"`
+	// The placeholder for test arguments. If not set, test args are appended to the command.
+	ArgsPlaceholder string `name:"test_cmd_args_placeholder"`
 }
 
 type DebugFields struct {

--- a/src/parse/asp/targets.go
+++ b/src/parse/asp/targets.go
@@ -76,6 +76,7 @@ const (
 	subrepoArgIdx
 	noTestCoverageArgIdx
 	srcListFilesIdx
+	testCmdArgsPlaceholderBuildRuleArgIdx
 )
 
 // createTarget creates a new build target as part of build_rule().
@@ -177,6 +178,9 @@ func createTarget(s *scope, args []pyObject) *core.BuildTarget {
 		target.Test.Sandbox = isTruthy(testSandboxBuildRuleArgIdx)
 		target.Test.NoOutput = isTruthy(noTestOutputBuildRuleArgIdx)
 		target.Test.NoCoverage = target.Test.NoOutput || isTruthy(noTestCoverageArgIdx)
+		if argsPlaceholder := args[testCmdArgsPlaceholderBuildRuleArgIdx]; argsPlaceholder != nil && argsPlaceholder != None {
+			target.Test.ArgsPlaceholder = string(argsPlaceholder.(pyString))
+		}
 	}
 
 	if err := validateSandbox(s.state, target); err != nil {

--- a/src/test/results_test.go
+++ b/src/test/results_test.go
@@ -185,10 +185,11 @@ func TestParseGoFileWithLogging(t *testing.T) {
 func TestTestCommandAndEnv(t *testing.T) {
 	state := core.NewBuildState(core.DefaultConfiguration())
 
-	t.Run("with placeholder and test args", func(t *testing.T) {
+	t.Run("with configured __TEST_ARGS__ placeholder and test args", func(t *testing.T) {
 		target := core.NewBuildTarget(core.ParseBuildLabel("//src/test:placeholder_test", ""))
 		target.Test = &core.TestFields{
-			Command: "./my_test_binary __TEST_ARGS__ 2>&1",
+			Command:         "./my_test_binary __TEST_ARGS__ 2>&1",
+			ArgsPlaceholder: "__TEST_ARGS__",
 		}
 		state.TestArgs = []string{"--flag1", "--flag2"}
 		cmd, _, err := testCommandAndEnv(state, target, 1)
@@ -196,15 +197,27 @@ func TestTestCommandAndEnv(t *testing.T) {
 		assert.Equal(t, "./my_test_binary --flag1 --flag2 2>&1", cmd)
 	})
 
-	t.Run("with placeholder and no test args", func(t *testing.T) {
+	t.Run("with configured __TEST_ARGS__ placeholder and no test args", func(t *testing.T) {
 		target := core.NewBuildTarget(core.ParseBuildLabel("//src/test:placeholder_test", ""))
 		target.Test = &core.TestFields{
-			Command: "./my_test_binary __TEST_ARGS__ 2>&1",
+			Command:         "./my_test_binary __TEST_ARGS__ 2>&1",
+			ArgsPlaceholder: "__TEST_ARGS__",
 		}
 		state.TestArgs = nil
 		cmd, _, err := testCommandAndEnv(state, target, 1)
 		assert.NoError(t, err)
 		assert.Equal(t, "./my_test_binary  2>&1", cmd)
+	})
+
+	t.Run("without placeholder but with __TEST_ARGS__ string present and test args", func(t *testing.T) {
+		target := core.NewBuildTarget(core.ParseBuildLabel("//src/test:placeholder_test", ""))
+		target.Test = &core.TestFields{
+			Command: "./my_test_binary __TEST_ARGS__ 2>&1",
+		}
+		state.TestArgs = []string{"--flag1", "--flag2"}
+		cmd, _, err := testCommandAndEnv(state, target, 1)
+		assert.NoError(t, err)
+		assert.Equal(t, "./my_test_binary __TEST_ARGS__ 2>&1 --flag1 --flag2", cmd)
 	})
 
 	t.Run("without placeholder and test args", func(t *testing.T) {

--- a/src/test/test_step.go
+++ b/src/test/test_step.go
@@ -343,12 +343,15 @@ func pluralise(word string, quantity int) string {
 func testCommandAndEnv(state *core.BuildState, target *core.BuildTarget, run int) (string, core.BuildEnv, error) {
 	replacedCmd, err := core.ReplaceTestSequences(state, target, target.GetTestCommand(state))
 	env := core.TestEnvironment(state, target, filepath.Join(core.RepoRoot, target.TestDir(run)), run)
-	if strings.Contains(replacedCmd, "__TEST_ARGS__") {
-		args := ""
-		if len(state.TestArgs) > 0 {
-			args = strings.Join(state.TestArgs, " ")
+	if target.Test != nil && target.Test.ArgsPlaceholder != "" {
+		placeholder := target.Test.ArgsPlaceholder
+		if strings.Contains(replacedCmd, placeholder) {
+			args := ""
+			if len(state.TestArgs) > 0 {
+				args = strings.Join(state.TestArgs, " ")
+			}
+			replacedCmd = strings.ReplaceAll(replacedCmd, placeholder, args)
 		}
-		replacedCmd = strings.ReplaceAll(replacedCmd, "__TEST_ARGS__", args)
 	} else if len(state.TestArgs) > 0 {
 		replacedCmd += " " + strings.Join(state.TestArgs, " ")
 	}


### PR DESCRIPTION
Update to #3547  - this effectively preserves the previous behaviour unless `test_cmd_args_placeholder` is set, making it a little safer if somebody already has `__TEST_ARGS__` in their test command for some other purpose.