### PR TITLE
Fix logging output in please_shim

### DIFF
--- a/tools/please_shim/BUILD
+++ b/tools/please_shim/BUILD
@@ -14,6 +14,7 @@ go_binary(
         "///third_party/go/github.com_thought-machine_go-flags//:go-flags",
         "///third_party/go/gopkg.in_op_go-logging.v1//:go-logging.v1",
         "//src/cli",
+        "//src/cli/logging",
         "//src/core",
         "//src/fs",
         "//src/update",

--- a/tools/please_shim/main.go
+++ b/tools/please_shim/main.go
@@ -10,16 +10,16 @@ import (
 	"syscall"
 
 	"github.com/thought-machine/go-flags"
-	"gopkg.in/op/go-logging.v1"
 
 	"github.com/thought-machine/please/src/cli"
+	"github.com/thought-machine/please/src/cli/logging"
 	"github.com/thought-machine/please/src/core"
 	"github.com/thought-machine/please/src/fs"
 	"github.com/thought-machine/please/src/update"
 	"github.com/thought-machine/please/src/version"
 )
 
-var log = logging.MustGetLogger("plz")
+var log = logging.Log
 
 var opts struct {
 	BuildFlags struct {


### PR DESCRIPTION
When not run in a repo, this always outputs its `Trying to find the default repo root on global config files` message. It's not meant to - that should happen at debug level.

This fixes it by having it use the same singleton logger instance everything else does so when it configures the logger, that takes effect as expected.