### PR TITLE
Fix cache key in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
       steps:
        - checkout
        - restore_cache:
-           key: go-mod-darwin-arm64-v8-{{ checksum "bootstrap.sh" }}
+           key: go-mod-darwin-arm64-v8-{{ checksum "go.mod" }}
        - restore_cache:
            key: go-darwin-arm64-go123-v1-{{ checksum "third_party/go/BUILD" }}
        - restore_cache:


### PR DESCRIPTION
Originally found in #3537 - have split this out because that was overcome by various merge conflicts.

This is ancient, it looks like it _should_ have changed to go.mod (probably when Go modules came out) but was missed, and has just hung around ever since.