### PR TITLE
Make the build-darwin CircleCI job time out after 15 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,16 @@ jobs:
            command: ./.circleci/setup_osx.sh
        - run:
            name: Bootstrap & Build
-           command: ./bootstrap.sh --test_results_file plz-out/results/please/test_results.xml
+           # TODO(#3556): fix the data race/segfaults and maybe remove this timeout
+           command: |
+             python3 -c "
+             import subprocess, sys
+             try:
+                 subprocess.run(['./bootstrap.sh', '--test_results_file', 'plz-out/results/please/test_results.xml'], timeout=900, check=True)
+             except subprocess.TimeoutExpired:
+                 print('Build timed out after 15 minutes', file=sys.stderr)
+                 sys.exit(1)
+             "
        - store_test_results:
            path: plz-out/results
        - store_artifacts:


### PR DESCRIPTION
Relates to #3556 

Unfortunately darwin doesn't have the coreutils `timeout` command which would make this much nicer. I considered whether we should have this timeout on every task, and then decided against it.

When it does succeed, the `build-darwin` job takes ~7 minutes, so this is a relatively generous timeout.