### PR TITLE
Fix segfault on --shell on non-test targets

### DIFF
--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -427,6 +427,9 @@ func printTempDirs(state *core.BuildState, duration time.Duration, shell, shellR
 		env := core.StampedBuildEnvironment(state, target, nil, filepath.Join(core.RepoRoot, target.TmpDir()), target.Stamp)
 		shouldSandbox := target.Sandbox
 		if state.NeedTests {
+			if !target.IsTest() {
+				continue
+			}
 			cmd, err = core.TestCommand(state, target)
 			dir = filepath.Join(core.RepoRoot, target.TestDir(1))
 			env = core.TestEnvironment(state, target, dir, 1)


### PR DESCRIPTION
It's maybe a little unintuitive that it just doesn't do anything, but  that's consistent with `plz test //:non_test_target` which doesn't error in this scenario either.

Fixes #3447 