### PR TITLE
Print test output directly

### DIFF
--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -199,7 +199,7 @@ func printTestResults(state *core.BuildState, failedTargets map[core.BuildLabel]
 					}
 					if failure != nil {
 						if failure.Message != "" {
-							printf("%s\n", failure.Message)
+							fmt.Println(failure.Message)
 						}
 						printf("%s\n", failure.Traceback)
 						if len(execution.Stdout) > 0 {


### PR DESCRIPTION
Our `printf` function does a bunch of stuff for colourisation etc which is losing the `{}` along the way.
Just send this through `fmt.Println` instead, we don't need to interpret it.

Fixes #3490 