### PR TITLE
Refactor build_target to remove most of dependency resolution

### DIFF
--- a/src/build/build_step.go
+++ b/src/build/build_step.go
@@ -70,7 +70,7 @@ func Build(state *core.BuildState, target *core.BuildTarget, remote bool) error 
 			return nil
 		}
 		state.LogBuildError(target.Label, core.TargetBuildFailed, err, "Build failed: %s", err)
-		if err := RemoveOutputs(target); err != nil {
+		if err := RemoveOutputs(state, target); err != nil {
 			log.Errorf("Failed to remove outputs for %s: %s", target.Label, err)
 		}
 		target.SetState(core.Failed)
@@ -93,7 +93,7 @@ func validateBuildTargetBeforeBuild(state *core.BuildState, target *core.BuildTa
 	}
 	// We can't do this check until build time, until then we don't know what all the outputs
 	// will be (eg. for filegroups that collect outputs of other rules).
-	if err := target.CheckDuplicateOutputs(); err != nil {
+	if err := target.CheckDuplicateOutputs(state.Graph); err != nil {
 		return err
 	}
 
@@ -137,7 +137,7 @@ func prepareOnly(state *core.BuildState, target *core.BuildTarget) error {
 		return errStop
 	}
 
-	if err := prepareDirectories(target); err != nil {
+	if err := prepareDirectories(state, target); err != nil {
 		return err
 	}
 	if err := prepareSources(state, state.Graph, target); err != nil {
@@ -279,7 +279,7 @@ func buildTarget(state *core.BuildState, target *core.BuildTarget, runRemotely b
 			return nil
 		}
 
-		if err := prepareDirectories(target); err != nil {
+		if err := prepareDirectories(state, target); err != nil {
 			return fmt.Errorf("Error preparing directories for %s: %s", target.Label, err)
 		}
 
@@ -287,7 +287,7 @@ func buildTarget(state *core.BuildState, target *core.BuildTarget, runRemotely b
 		//
 		// N.B. Important we do not go through state.TargetHasher here since it memoises and
 		//      this calculation might be incorrect.
-		oldOutputHash := outputHashOrNil(target, target.FullOutputs(), state.PathHasher, state.PathHasher.NewHash)
+		oldOutputHash := outputHashOrNil(target, target.FullOutputs(state.Graph), state.PathHasher, state.PathHasher.NewHash)
 		cacheKey = mustShortTargetHash(state, target)
 
 		if state.Cache != nil && !runRemotely && !state.ShouldRebuild(target) {
@@ -340,12 +340,12 @@ func buildTarget(state *core.BuildState, target *core.BuildTarget, runRemotely b
 	}
 
 	if target.PostBuildFunction != nil {
-		outs := target.Outputs()
+		outs := target.Outputs(state.Graph)
 		if err := runPostBuildFunction(state, target, string(metadata.Stdout), postBuildOutput); err != nil {
 			return err
 		}
 
-		if runRemotely && len(outs) != len(target.Outputs()) {
+		if runRemotely && len(outs) != len(target.Outputs(state.Graph)) {
 			// postBuildFunction has changed the target - must rebuild it
 			log.Info("Rebuilding %s after post-build function", target)
 			metadata, err = state.RemoteClient.Build(target)
@@ -471,7 +471,7 @@ func retrieveArtifacts(state *core.BuildState, target *core.BuildTarget, oldOutp
 
 	cacheKey := mustShortTargetHash(state, target)
 
-	if md := retrieveFromCache(state.Cache, target, cacheKey, target.Outputs()); md != nil {
+	if md := retrieveFromCache(state.Cache, target, cacheKey, target.Outputs(state.Graph)); md != nil {
 		// Retrieve additional optional outputs from metadata
 		if len(md.OptionalOutputs) > 0 {
 			state.Cache.Retrieve(target, cacheKey, md.OptionalOutputs)
@@ -482,7 +482,7 @@ func retrieveArtifacts(state *core.BuildState, target *core.BuildTarget, oldOutp
 		newOutputHash, err := calculateAndCheckRuleHash(state, target)
 		if err != nil { // Most likely hash verification failure
 			log.Warning("Error retrieving cached artifacts for %s: %s", target.Label, err)
-			RemoveOutputs(target)
+			RemoveOutputs(state, target)
 			return false
 		} else if oldOutputHash == nil || !bytes.Equal(oldOutputHash, newOutputHash) {
 			target.SetState(core.Cached)
@@ -529,7 +529,7 @@ func runBuildCommand(state *core.BuildState, target *core.BuildTarget, command s
 
 // buildTextFile runs the build action for text_file() rules
 func buildTextFile(state *core.BuildState, target *core.BuildTarget) error {
-	outs := target.Outputs()
+	outs := target.Outputs(state.Graph)
 	if len(outs) != 1 {
 		return fmt.Errorf("text_file %s should have a single output, has %d", target.Label, len(outs))
 	}
@@ -544,14 +544,14 @@ func buildTextFile(state *core.BuildState, target *core.BuildTarget) error {
 }
 
 // prepareOutputDirectories creates any directories the target has declared it will output into as a nicety
-func prepareOutputDirectories(target *core.BuildTarget) error {
+func prepareOutputDirectories(state *core.BuildState, target *core.BuildTarget) error {
 	for _, dir := range target.OutputDirectories {
 		if err := prepareParentDirs(target, dir.Dir()); err != nil {
 			return err
 		}
 	}
 
-	for _, out := range target.Outputs() {
+	for _, out := range target.Outputs(state.Graph) {
 		if err := prepareParentDirs(target, out); err != nil {
 			return err
 		}
@@ -574,11 +574,11 @@ func prepareParentDirs(target *core.BuildTarget, out string) error {
 }
 
 // Prepares the temp and out directories for a target
-func prepareDirectories(target *core.BuildTarget) error {
+func prepareDirectories(state *core.BuildState, target *core.BuildTarget) error {
 	if err := prepareDirectory(target.TmpDir(), true); err != nil {
 		return err
 	}
-	if err := prepareOutputDirectories(target); err != nil {
+	if err := prepareOutputDirectories(state, target); err != nil {
 		return err
 	}
 	return prepareDirectory(target.OutDir(), false)
@@ -605,7 +605,7 @@ func prepareSources(state *core.BuildState, graph *core.BuildGraph, target *core
 		}
 	}
 	if target.Stamp {
-		if err := fs.WriteFile(bytes.NewReader(core.StampFile(state.Config, target)), filepath.Join(target.TmpDir(), target.StampFileName()), 0644); err != nil {
+		if err := fs.WriteFile(bytes.NewReader(core.StampFile(state, target)), filepath.Join(target.TmpDir(), target.StampFileName()), 0644); err != nil {
 			return err
 		}
 	}
@@ -700,7 +700,7 @@ func moveOutputs(state *core.BuildState, target *core.BuildTarget) ([]string, bo
 	changed := false
 	tmpDir := target.TmpDir()
 	outDir := target.OutDir()
-	outs := target.Outputs()
+	outs := target.Outputs(state.Graph)
 	allOuts := make([]string, len(outs), len(outs)+len(target.OutputDirectories))
 	for i, output := range outs {
 		allOuts[i] = output
@@ -780,8 +780,8 @@ func moveOutput(state *core.BuildState, target *core.BuildTarget, tmpOutput, rea
 }
 
 // RemoveOutputs removes all generated outputs for a rule.
-func RemoveOutputs(target *core.BuildTarget) error {
-	for _, output := range target.Outputs() {
+func RemoveOutputs(state *core.BuildState, target *core.BuildTarget) error {
+	for _, output := range target.Outputs(state.Graph) {
 		out := filepath.Join(target.OutDir(), output)
 		if err := fs.RemoveAll(out); err != nil {
 			return err
@@ -833,7 +833,7 @@ func calculateAndCheckRuleHash(state *core.BuildState, target *core.BuildTarget)
 	}
 	// Set appropriate permissions on outputs
 	if target.IsBinary {
-		for _, output := range target.FullOutputs() {
+		for _, output := range target.FullOutputs(state.Graph) {
 			// Walk through the output,
 			// if the output is a directory, apply output mode to the file instead of the directory
 			err := fs.Walk(output, func(path string, isDir bool) error {
@@ -891,7 +891,7 @@ func (h *targetHasher) SetHash(target *core.BuildTarget, hash []byte) {
 
 // outputHash calculates the output hash for a target, choosing an appropriate strategy.
 func (h *targetHasher) outputHash(target *core.BuildTarget) ([]byte, error) {
-	outs := target.FullOutputs()
+	outs := target.FullOutputs(h.State.Graph)
 	if len(outs) == 1 && fs.FileExists(outs[0]) {
 		return outputHash(target, outs, h.State.PathHasher, nil)
 	}
@@ -931,7 +931,7 @@ func checkRuleHashes(state *core.BuildState, target *core.BuildTarget, hash []by
 	if len(target.Hashes) == 0 {
 		return nil // nothing to check
 	}
-	outputs := target.FullOutputs()
+	outputs := target.FullOutputs(state.Graph)
 	hashes := target.UnprefixedHashes()
 	// Check if the hash we've already calculated matches any of these before we go off
 	// trying any other combinations.
@@ -1030,7 +1030,7 @@ func buildLinksOfType(state *core.BuildState, target *core.BuildTarget, prefix s
 		for _, dest := range labels {
 			destDir := filepath.Join(core.RepoRoot, os.Expand(dest, env.ReplaceEnvironment))
 			srcDir := filepath.Join(core.RepoRoot, target.OutDir())
-			for _, out := range target.Outputs() {
+			for _, out := range target.Outputs(state.Graph) {
 				if direct {
 					fs.LinkDestination(filepath.Join(srcDir, out), destDir, f)
 				} else {
@@ -1083,7 +1083,8 @@ func fetchOneRemoteFile(state *core.BuildState, target *core.BuildTarget, url st
 
 	env := core.BuildEnvironment(state, target, filepath.Join(core.RepoRoot, target.TmpDir()))
 	url = os.Expand(url, env.ReplaceEnvironment)
-	tmpPath := filepath.Join(target.TmpDir(), target.Outputs()[0])
+	outputs := target.Outputs(state.Graph)
+	tmpPath := filepath.Join(target.TmpDir(), outputs[0])
 	f, err := os.Create(tmpPath)
 	if err != nil {
 		return err

--- a/src/build/build_step_test.go
+++ b/src/build/build_step_test.go
@@ -114,7 +114,7 @@ func TestPostBuildFunction(t *testing.T) {
 	err := buildTarget(state, target, false)
 	assert.NoError(t, err)
 	assert.Equal(t, core.Built, target.State())
-	assert.Equal(t, []string{"file7"}, target.Outputs())
+	assert.Equal(t, []string{"file7"}, target.Outputs(state.Graph))
 }
 
 func TestOutputDir(t *testing.T) {
@@ -131,7 +131,7 @@ func TestOutputDir(t *testing.T) {
 
 	err := buildTarget(state, target, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"file7"}, target.Outputs())
+	assert.Equal(t, []string{"file7"}, target.Outputs(state.Graph))
 
 	md, err := loadTargetMetadata(target)
 	require.NoError(t, err)
@@ -143,7 +143,7 @@ func TestOutputDir(t *testing.T) {
 	state, target = newTarget()
 	err = buildTarget(state, target, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"file7"}, target.Outputs())
+	assert.Equal(t, []string{"file7"}, target.Outputs(state.Graph))
 	assert.Equal(t, core.Reused, target.State())
 }
 
@@ -166,7 +166,7 @@ func TestOutputDirDoubleStar(t *testing.T) {
 
 	err := buildTarget(state, target, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"foo"}, target.Outputs())
+	assert.Equal(t, []string{"foo"}, target.Outputs(state.Graph))
 
 	md, err := loadTargetMetadata(target)
 	require.NoError(t, err)
@@ -182,7 +182,7 @@ func TestOutputDirDoubleStar(t *testing.T) {
 
 	err = buildTarget(state, target, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"foo/file7"}, target.Outputs())
+	assert.Equal(t, []string{"foo/file7"}, target.Outputs(state.Graph))
 
 	info, err = os.Lstat(filepath.Join(target.OutDir(), "foo/file7"))
 	require.NoError(t, err)

--- a/src/build/incrementality.go
+++ b/src/build/incrementality.go
@@ -81,7 +81,7 @@ func needsBuilding(state *core.BuildState, target *core.BuildTarget, postBuild b
 	// Check the outputs of this rule exist. This would only happen if the user had
 	// removed them but it's incredibly aggravating if you remove an output and the
 	// rule won't rebuild itself.
-	for _, output := range target.Outputs() {
+	for _, output := range target.Outputs(state.Graph) {
 		realOutput := filepath.Join(target.OutDir(), output)
 		if !core.PathExists(realOutput) {
 			log.Debug("Output %s doesn't exist for rule %s; will rebuild.", realOutput, target.Label)
@@ -150,7 +150,14 @@ func RuleHash(state *core.BuildState, target *core.BuildTarget, runtime, postBui
 func ruleHash(state *core.BuildState, target *core.BuildTarget, runtime bool) []byte {
 	h := sha1.New()
 	h.Write([]byte(target.Label.String()))
-	for _, dep := range target.DeclaredDependencies() {
+	// Sort here so the hash is independent of the order deps were declared in the BUILD file;
+	// DeclaredDependencies yields them in declaration order.
+	var deps core.BuildLabels
+	for dep := range target.DeclaredDependencies() {
+		deps = append(deps, dep)
+	}
+	sort.Sort(deps)
+	for _, dep := range deps {
 		h.Write([]byte(dep.String()))
 	}
 	for _, vis := range target.Visibility {
@@ -293,7 +300,7 @@ type ruleHashes struct {
 // If postBuild is true then the rule hash will be the post-build one if present.
 func readRuleHashFromXattrs(state *core.BuildState, target *core.BuildTarget, postBuild bool) ruleHashes {
 	var h []byte
-	for _, output := range target.FullOutputs() {
+	for _, output := range target.FullOutputs(state.Graph) {
 		b := fs.ReadAttr(output, xattrName, state.XattrsSupported)
 		if b == nil {
 			return ruleHashes{}
@@ -348,7 +355,7 @@ func writeRuleHash(state *core.BuildState, target *core.BuildTarget) error {
 		return err
 	}
 	hash = append(hash, secretHash...)
-	outputs := target.FullOutputs()
+	outputs := target.FullOutputs(state.Graph)
 	if len(outputs) == 0 {
 		// Target has no outputs, have to use the fallback file.
 		return fs.RecordAttrFile(filepath.Join(target.OutDir(), target.Label.Name), hash)

--- a/src/cache/async_cache_test.go
+++ b/src/cache/async_cache_test.go
@@ -14,7 +14,7 @@ import (
 func TestStore(t *testing.T) {
 	mCache, aCache := makeCaches()
 	target := makeTarget1("//pkg1:test_store")
-	aCache.Store(target, nil, target.Outputs())
+	aCache.Store(target, nil, target.Outputs(nil))
 	aCache.Shutdown()
 	assert.False(t, mCache.inFlight[target])
 	assert.True(t, mCache.completed[target])
@@ -23,7 +23,7 @@ func TestStore(t *testing.T) {
 func TestRetrieve(t *testing.T) {
 	mCache, aCache := makeCaches()
 	target := makeTarget1("//pkg1:test_retrieve")
-	aCache.Retrieve(target, nil, target.Outputs())
+	aCache.Retrieve(target, nil, target.Outputs(nil))
 	aCache.Shutdown()
 	assert.False(t, mCache.inFlight[target])
 	assert.True(t, mCache.completed[target])

--- a/src/cache/cmd_cache_test.go
+++ b/src/cache/cmd_cache_test.go
@@ -71,7 +71,7 @@ func TestCmdStoreInvalidCommand(t *testing.T) {
 
 	// cache interface does not provide any result here...
 	// but we should at least not panic or that alike
-	cache.Store(target, key, target.Outputs())
+	cache.Store(target, key, target.Outputs(nil))
 }
 
 func TestCmdStoreAndRetrieve(t *testing.T) {
@@ -84,7 +84,7 @@ func TestCmdStoreAndRetrieve(t *testing.T) {
 
 	key := []byte("TestCmdStoreAndRetrieve")
 	os.Chdir("src/cache/test_data")
-	cache.Store(target, key, target.Outputs())
+	cache.Store(target, key, target.Outputs(nil))
 
 	b, err := os.ReadFile("plz-out/gen/pkg/name/testfile2")
 	assert.NoError(t, err)
@@ -107,7 +107,7 @@ func TestCmdStoreAndRetrieveExitCode(t *testing.T) {
 
 	key := []byte("TestCmdStoreAndRetrieveExitCode")
 	os.Chdir("src/cache/test_data")
-	cache.Store(target, key, target.Outputs())
+	cache.Store(target, key, target.Outputs(nil))
 
 	hit := cache.Retrieve(target, key, nil)
 	// expected to fail because of "exit 1"

--- a/src/cache/dir_cache_test.go
+++ b/src/cache/dir_cache_test.go
@@ -29,7 +29,7 @@ func cachePath(target *core.BuildTarget, compress bool) string {
 	if compress {
 		return filepath.Join(".plz-cache-"+target.Label.PackageName, target.Label.PackageName, target.Label.Name, b64Hash+".tar.gz")
 	}
-	return filepath.Join(".plz-cache-"+target.Label.PackageName, target.Label.PackageName, target.Label.Name, b64Hash, target.Outputs()[0])
+	return filepath.Join(".plz-cache-"+target.Label.PackageName, target.Label.PackageName, target.Label.Name, b64Hash, target.Outputs(nil)[0])
 }
 
 func inCache(target *core.BuildTarget) bool {
@@ -47,23 +47,23 @@ func inCompressedCache(target *core.BuildTarget) bool {
 func TestStoreAndRetrieve(t *testing.T) {
 	cache := makeCache(".plz-cache-test1", false)
 	target := makeTarget2("//test1:target1", 20)
-	cache.Store(target, hash, target.Outputs())
+	cache.Store(target, hash, target.Outputs(nil))
 	// Should now exist in cache at this path
 	assert.True(t, inCache(target))
-	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs()))
+	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs(nil)))
 	// Should be able to store it again without problems
-	cache.Store(target, hash, target.Outputs())
+	cache.Store(target, hash, target.Outputs(nil))
 	assert.True(t, inCache(target))
-	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs()))
+	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs(nil)))
 }
 
 func TestCleanNoop(t *testing.T) {
 	cache := makeCache(".plz-cache-test2", false)
 	target1 := makeTarget2("//test2:target1", 2000)
-	cache.Store(target1, hash, target1.Outputs())
+	cache.Store(target1, hash, target1.Outputs(nil))
 	assert.True(t, inCache(target1))
 	target2 := makeTarget2("//test2:target2", 2000)
-	cache.Store(target2, hash, target2.Outputs())
+	cache.Store(target2, hash, target2.Outputs(nil))
 	assert.True(t, inCache(target2))
 	// Doesn't clean anything this time because the high water mark is sufficiently high
 	totalSize := cache.clean(20000, 1000)
@@ -75,10 +75,10 @@ func TestCleanNoop(t *testing.T) {
 func TestCleanNoop2(t *testing.T) {
 	cache := makeCache(".plz-cache-test3", false)
 	target1 := makeTarget2("//test3:target1", 2000)
-	cache.Store(target1, hash, target1.Outputs())
+	cache.Store(target1, hash, target1.Outputs(nil))
 	assert.True(t, inCache(target1))
 	target2 := makeTarget2("//test3:target2", 2000)
-	cache.Store(target2, hash, target2.Outputs())
+	cache.Store(target2, hash, target2.Outputs(nil))
 	assert.True(t, inCache(target2))
 	// Doesn't clean anything this time, the high water mark is lower but both targets have
 	// just been built.
@@ -91,7 +91,7 @@ func TestCleanNoop2(t *testing.T) {
 func TestCleanForReal(t *testing.T) {
 	cache := makeCache(".plz-cache-test4", false)
 	target1 := makeTarget2("//test4:target1", 2000)
-	cache.Store(target1, hash, target1.Outputs())
+	cache.Store(target1, hash, target1.Outputs(nil))
 	assert.True(t, inCache(target1))
 	target2 := makeTarget2("//test4:target2", 2000)
 	writeFile(cachePath(target2, false), 2000)
@@ -109,7 +109,7 @@ func TestCleanForReal2(t *testing.T) {
 	writeFile(cachePath(target1, false), 2000)
 	assert.True(t, inCache(target1))
 	target2 := makeTarget2("//test5:target2", 2000)
-	cache.Store(target2, hash, target2.Outputs())
+	cache.Store(target2, hash, target2.Outputs(nil))
 	assert.True(t, inCache(target2))
 	// This time it should clean target1, because target2 has just been stored
 	totalSize := cache.clean(10000, 1000)
@@ -121,14 +121,14 @@ func TestCleanForReal2(t *testing.T) {
 func TestStoreAndRetrieveCompressed(t *testing.T) {
 	cache := makeCache(".plz-cache-test6", true)
 	target := makeTarget2("//test6:target6", 20)
-	cache.Store(target, hash, target.Outputs())
+	cache.Store(target, hash, target.Outputs(nil))
 	// Should now exist in cache at this path
 	assert.True(t, inCompressedCache(target))
-	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs()))
+	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs(nil)))
 	// Should be able to store it again without problems
-	cache.Store(target, hash, target.Outputs())
+	cache.Store(target, hash, target.Outputs(nil))
 	assert.True(t, inCompressedCache(target))
-	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs()))
+	assert.NotNil(t, cache.Retrieve(target, hash, target.Outputs(nil)))
 }
 
 func TestCleanCompressed(t *testing.T) {
@@ -137,7 +137,7 @@ func TestCleanCompressed(t *testing.T) {
 	writeFile(cachePath(target1, true), 2000)
 	assert.True(t, inCompressedCache(target1))
 	target2 := makeTarget2("//test7:target2", 2000)
-	cache.Store(target2, hash, target2.Outputs())
+	cache.Store(target2, hash, target2.Outputs(nil))
 	assert.True(t, inCompressedCache(target2))
 	// Don't want to assert the size here since it depends on how well gzip compresses.
 	// It's a bit hard to know exactly what the sizes here should be too but we'll guess

--- a/src/cache/http_cache_test.go
+++ b/src/cache/http_cache_test.go
@@ -35,7 +35,7 @@ func TestStoreAndRetrieveHTTP(t *testing.T) {
 	cache := newHTTPCache(config)
 
 	key := []byte("test_key")
-	cache.Store(target, key, target.Outputs())
+	cache.Store(target, key, target.Outputs(nil))
 
 	b, err := os.ReadFile("plz-out/gen/pkg/name/testfile2")
 	assert.NoError(t, err)

--- a/src/clean/clean.go
+++ b/src/clean/clean.go
@@ -51,7 +51,7 @@ func Targets(state *core.BuildState, labels []core.BuildLabel) {
 }
 
 func cleanTarget(state *core.BuildState, target *core.BuildTarget) {
-	if err := build.RemoveOutputs(target); err != nil {
+	if err := build.RemoveOutputs(state, target); err != nil {
 		log.Fatalf("Failed to remove output: %s", err)
 	}
 	if target.IsTest() {

--- a/src/core/build_env.go
+++ b/src/core/build_env.go
@@ -73,7 +73,7 @@ func TargetEnvironment(state *BuildState, target *BuildTarget) BuildEnv {
 func BuildEnvironment(state *BuildState, target *BuildTarget, tmpDir string) BuildEnv {
 	env := TargetEnvironment(state, target)
 	sources := target.AllSourcePaths(state.Graph)
-	outEnv := target.GetTmpOutputAll(target.Outputs())
+	outEnv := target.GetTmpOutputAll(target.Outputs(state.Graph))
 	abs := filepath.IsAbs(tmpDir)
 
 	env["TMP_DIR"] = tmpDir
@@ -174,8 +174,8 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string, run
 		env["COVERAGE"] = "true"
 		env["COVERAGE_FILE"] = filepath.Join(testDir, CoverageFile)
 	}
-	if len(target.Outputs()) > 0 {
-		env["TEST"] = resolveOut(target.Outputs()[0], testDir, target.Test.Sandbox)
+	if outputs := target.Outputs(state.Graph); len(outputs) > 0 {
+		env["TEST"] = resolveOut(outputs[0], testDir, target.Test.Sandbox)
 	}
 	// Bit of a hack for gcov which needs access to its .gcno files.
 	if target.HasLabel("cc") {
@@ -197,7 +197,7 @@ func TestEnvironment(state *BuildState, target *BuildTarget, testDir string, run
 func RunEnvironment(state *BuildState, target *BuildTarget, inTmpDir bool) BuildEnv {
 	env := RuntimeEnvironment(state, target, true, inTmpDir)
 
-	outEnv := target.Outputs()
+	outEnv := target.Outputs(state.Graph)
 	env["OUTS"] = strings.Join(outEnv, " ")
 	// The OUT variable is only available on rules that have a single output.
 	if len(outEnv) == 1 {
@@ -217,7 +217,7 @@ func ExecEnvironment(state *BuildState, target *BuildTarget, execDir string) Bui
 	// of input and output in the terminal where the program is run.
 	env["TERM"] = os.Getenv("TERM")
 
-	outEnv := target.Outputs()
+	outEnv := target.Outputs(state.Graph)
 	// OUTS/OUT environment variables being always set is for backwards-compatibility.
 	// Ideally, if the target is a test these variables shouldn't be set.
 	env["OUTS"] = strings.Join(outEnv, " ")
@@ -349,7 +349,7 @@ func toolPath(state *BuildState, tool BuildInput, abs bool) string {
 		if o, ok := tool.(AnnotatedOutputLabel); ok {
 			entryPoint = o.Annotation
 		}
-		path := state.Graph.TargetOrDie(label).toolPath(abs, entryPoint)
+		path := state.Graph.TargetOrDie(label).toolPath(state.Graph, abs, entryPoint)
 		if !strings.Contains(path, "/") {
 			path = "./" + path
 		}

--- a/src/core/build_input.go
+++ b/src/core/build_input.go
@@ -241,7 +241,7 @@ func (label AnnotatedOutputLabel) Paths(graph *BuildGraph) []string {
 		return label.BuildLabel.Paths(graph)
 	}
 
-	return addPathPrefix(target.NamedOutputs(label.Annotation), target.PackageDir())
+	return addPathPrefix(target.NamedOutputs(graph, label.Annotation), target.PackageDir())
 }
 
 // FullPaths is like Paths but includes the leading plz-out/gen directory.
@@ -250,7 +250,7 @@ func (label AnnotatedOutputLabel) FullPaths(graph *BuildGraph) []string {
 	if _, ok := target.EntryPoints[label.Annotation]; ok {
 		return label.BuildLabel.FullPaths(graph)
 	}
-	return addPathPrefix(target.NamedOutputs(label.Annotation), target.OutDir())
+	return addPathPrefix(target.NamedOutputs(graph, label.Annotation), target.OutDir())
 }
 
 // LocalPaths returns paths within the local package
@@ -259,7 +259,7 @@ func (label AnnotatedOutputLabel) LocalPaths(graph *BuildGraph) []string {
 	if _, ok := target.EntryPoints[label.Annotation]; ok {
 		return label.BuildLabel.LocalPaths(graph)
 	}
-	return target.NamedOutputs(label.Annotation)
+	return target.NamedOutputs(graph, label.Annotation)
 }
 
 // Label returns the build rule associated with this input. For a AnnotatedOutputLabel it's always non-nil.

--- a/src/core/build_label.go
+++ b/src/core/build_label.go
@@ -342,13 +342,13 @@ func (label BuildLabel) Less(other BuildLabel) bool {
 // Paths is an implementation of BuildInput interface; we use build labels directly as inputs.
 func (label BuildLabel) Paths(graph *BuildGraph) []string {
 	target := graph.TargetOrDie(label)
-	return addPathPrefix(target.Outputs(), target.PackageDir())
+	return addPathPrefix(target.Outputs(graph), target.PackageDir())
 }
 
 // FullPaths is an implementation of BuildInput interface.
 func (label BuildLabel) FullPaths(graph *BuildGraph) []string {
 	target := graph.TargetOrDie(label)
-	return addPathPrefix(target.Outputs(), target.OutDir())
+	return addPathPrefix(target.Outputs(graph), target.OutDir())
 }
 
 // addPathPrefix adds a prefix to all the entries in a slice.
@@ -362,7 +362,7 @@ func addPathPrefix(paths []string, prefix string) []string {
 
 // LocalPaths is an implementation of BuildInput interface.
 func (label BuildLabel) LocalPaths(graph *BuildGraph) []string {
-	return graph.TargetOrDie(label).Outputs()
+	return graph.TargetOrDie(label).Outputs(graph)
 }
 
 // Label is an implementation of BuildInput interface. It always returns this label.

--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -13,8 +13,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/thought-machine/please/src/fs"
 )
 
@@ -116,7 +114,7 @@ type BuildTarget struct {
 	// Dependencies of this target.
 	// Maps the original declaration to whatever dependencies actually got attached,
 	// which may be more than one in some cases. Also contains info about exporting etc.
-	dependencies []depInfo `name:"deps"`
+	dependencies []DeclaredDependency `name:"deps"`
 	// The run-time dependencies of this target.
 	runtimeDependencies []BuildLabel `name:"runtime_deps"`
 	// Whether to consider the run-time dependencies of this target's sources to be additional
@@ -312,15 +310,14 @@ type PostBuildFunction interface {
 	Call(target *BuildTarget, output string) error
 }
 
-type depInfo struct {
-	declared *BuildLabel    // the originally declared dependency
-	deps     []*BuildTarget // list of actual deps
-	resolved bool           // has the graph resolved it
-	exported bool           // is it an exported dependency
-	internal bool           // is it an internal dependency (that is not picked up implicitly by transitive searches)
-	runtime  bool           // is it a run-time (and therefore implicitly transitive) dependency
-	source   bool           // is it implicit because it's a source (not true if it's a dependency too)
-	data     bool           // is it a data item for a test
+// A DeclaredDependency represents a dependency declared by a target.
+type DeclaredDependency struct {
+	Label    BuildLabel // the originally declared dependency
+	Exported bool       // is it an exported dependency
+	Internal bool       // is it an internal dependency (that is not picked up implicitly by transitive searches)
+	Runtime  bool       // is it a run-time (and therefore implicitly transitive) dependency
+	Source   bool       // is it implicit because it's a source (not true if it's a dependency too)
+	Data     bool       // is it a data item for a test
 }
 
 // OutputDirectory is an output directory for the build rule. It may have a suffix of /** which means that we should
@@ -558,125 +555,74 @@ func (target *BuildTarget) AllURLs(state *BuildState) []string {
 	return ret
 }
 
-// resolveDependencies matches up all declared dependencies to the actual build targets.
-// TODO(peterebden,tatskaari): Work out if we really want to have this and how the suite of *Dependencies functions
-//
-//	below should behave (preferably nicely).
-func (target *BuildTarget) resolveDependencies(graph *BuildGraph, callback func(*BuildTarget) error) error {
-	var g errgroup.Group
-	target.mutex.RLock()
-	for i := range target.dependencies {
-		dep := &target.dependencies[i] // avoid using a loop variable here as it mutates each iteration
-		if len(dep.deps) > 0 {
-			continue // already done
-		}
-		g.Go(func() error {
-			if err := target.resolveOneDependency(graph, dep); err != nil {
-				return err
-			}
-			for _, d := range dep.deps {
-				if err := callback(d); err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-	}
-	target.mutex.RUnlock()
-	return g.Wait()
-}
-
-func (target *BuildTarget) resolveOneDependency(graph *BuildGraph, dep *depInfo) error {
-	depTarget := graph.WaitForTarget(*dep.declared)
-	if depTarget == nil {
-		return fmt.Errorf("Couldn't find dependency %s", dep.declared)
-	}
-	dep.declared = &depTarget.Label // saves memory by not storing the label twice once resolved
-
-	providesLabels, ok := depTarget.provideFor(target)
-	if !ok {
-		target.mutex.Lock()
-		defer target.mutex.Unlock()
-
-		// Small optimisation to avoid re-looking-up the same target again.
-		dep.deps = []*BuildTarget{depTarget}
-		return nil
-	}
-
-	deps := make([]*BuildTarget, 0, len(providesLabels))
-	for _, l := range providesLabels {
-		providesTarget := graph.WaitForTarget(l)
-		if providesTarget == nil {
-			return fmt.Errorf("%s depends on %s (provided by %s), however that target doesn't exist", target, l, depTarget)
-		}
-		deps = append(deps, providesTarget)
-	}
-
-	target.mutex.Lock()
-	defer target.mutex.Unlock()
-
-	dep.deps = deps
-
-	return nil
-}
-
-// MustResolveDependencies is exposed only for testing purposes.
-// TODO(peterebden, tatskaari): See if we can get rid of this.
-func (target *BuildTarget) ResolveDependencies(graph *BuildGraph) error {
-	return target.resolveDependencies(graph, func(*BuildTarget) error { return nil })
-}
-
 // DeclaredDependencies returns all the targets this target declared any kind of dependency on (including sources and tools).
-func (target *BuildTarget) DeclaredDependencies() []BuildLabel {
-	target.mutex.RLock()
-	defer target.mutex.RUnlock()
-	ret := make(BuildLabels, len(target.dependencies))
-	for i, dep := range target.dependencies {
-		ret[i] = *dep.declared
+func (target *BuildTarget) DeclaredDependencies() iter.Seq[BuildLabel] {
+	return func(yield func(BuildLabel) bool) {
+		target.mutex.RLock()
+		defer target.mutex.RUnlock()
+		for _, dep := range target.dependencies {
+			if !yield(dep.Label) {
+				break
+			}
+		}
 	}
-	sort.Sort(ret)
-	return ret
 }
 
 // DeclaredDependenciesStrict returns the original declaration of this target's dependencies.
-func (target *BuildTarget) DeclaredDependenciesStrict() []BuildLabel {
+func (target *BuildTarget) DeclaredDependenciesStrict() iter.Seq[BuildLabel] {
+	return func(yield func(BuildLabel) bool) {
+		target.mutex.RLock()
+		defer target.mutex.RUnlock()
+		for _, dep := range target.dependencies {
+			if !dep.Runtime && !dep.Exported && !dep.Source && !target.IsTool(dep.Label) {
+				if !yield(dep.Label) {
+					break
+				}
+			}
+		}
+	}
+}
+
+// Dependencies returns the resolved dependencies of this target, applying any require/provide
+// relationships to map each declared dependency to the target(s) that actually satisfy it.
+// It requires the graph to look targets up, since a BuildTarget no longer caches these itself.
+func (target *BuildTarget) Dependencies(graph *BuildGraph) []*BuildTarget {
 	target.mutex.RLock()
-	defer target.mutex.RUnlock()
-	ret := make(BuildLabels, 0, len(target.dependencies))
-	for _, dep := range target.dependencies {
-		if !dep.runtime && !dep.exported && !dep.source && !target.IsTool(*dep.declared) {
-			ret = append(ret, *dep.declared)
+	labels := make([]BuildLabel, len(target.dependencies))
+	for i, dep := range target.dependencies {
+		labels[i] = dep.Label
+	}
+	target.mutex.RUnlock()
+	ret := make(BuildTargets, 0, len(labels))
+	for _, l := range labels {
+		depTarget := graph.TargetOrDie(l)
+		for _, provided := range depTarget.ProvideFor(target) {
+			ret = append(ret, graph.TargetOrDie(provided))
 		}
 	}
 	sort.Sort(ret)
 	return ret
 }
 
-// Dependencies returns the resolved dependencies of this target.
-func (target *BuildTarget) Dependencies() []*BuildTarget {
+// ExternalDependencies returns the resolved dependencies of this target, with any internal
+// dependencies (i.e. "_target#tag" ones sharing this target's parent) flattened out to the
+// external targets they in turn depend on. Require/provide relationships are applied as in Dependencies.
+func (target *BuildTarget) ExternalDependencies(graph *BuildGraph) []*BuildTarget {
 	target.mutex.RLock()
-	defer target.mutex.RUnlock()
-	ret := make(BuildTargets, 0, len(target.dependencies))
-	for _, deps := range target.dependencies {
-		for _, dep := range deps.deps {
-			ret = append(ret, dep)
-		}
+	labels := make([]BuildLabel, len(target.dependencies))
+	for i, dep := range target.dependencies {
+		labels[i] = dep.Label
 	}
-	sort.Sort(ret)
-	return ret
-}
-
-// ExternalDependencies returns the non-internal dependencies of this target (i.e. not "_target#tag" ones).
-func (target *BuildTarget) ExternalDependencies() []*BuildTarget {
-	target.mutex.RLock()
-	defer target.mutex.RUnlock()
-	ret := make(BuildTargets, 0, len(target.dependencies))
-	for _, deps := range target.dependencies {
-		for _, dep := range deps.deps {
+	target.mutex.RUnlock()
+	ret := make(BuildTargets, 0, len(labels))
+	for _, l := range labels {
+		depTarget := graph.TargetOrDie(l)
+		for _, provided := range depTarget.ProvideFor(target) {
+			dep := graph.TargetOrDie(provided)
 			if dep.Label.Parent() != target.Label {
 				ret = append(ret, dep)
 			} else {
-				ret = append(ret, dep.ExternalDependencies()...)
+				ret = append(ret, dep.ExternalDependencies(graph)...)
 			}
 		}
 	}
@@ -684,30 +630,14 @@ func (target *BuildTarget) ExternalDependencies() []*BuildTarget {
 	return ret
 }
 
-// BuildDependencies returns the build-time dependencies of this target (i.e. not run-time dependencies, data, internal nor source).
-func (target *BuildTarget) BuildDependencies() []*BuildTarget {
-	target.mutex.RLock()
-	defer target.mutex.RUnlock()
-	ret := make(BuildTargets, 0, len(target.dependencies))
-	for _, deps := range target.dependencies {
-		if !deps.runtime && !deps.data && !deps.internal && !deps.source {
-			for _, dep := range deps.deps {
-				ret = append(ret, dep)
-			}
-		}
-	}
-	sort.Sort(ret)
-	return ret
-}
-
-// BuildDependencyLabels returns the build-time dependency labels of this target (i.e. not run-time dependencies, data, internal nor source).
+// BuildDependencies returns the build-time dependency labels of this target (i.e. not run-time dependencies, data, internal nor source).
 func (target *BuildTarget) BuildDependencyLabels() iter.Seq[BuildLabel] {
 	return func(yield func(BuildLabel) bool) {
 		target.mutex.RLock()
 		defer target.mutex.RUnlock()
 		for _, deps := range target.dependencies {
-			if !deps.runtime && !deps.data {
-				if !yield(*deps.declared) {
+			if !deps.Runtime && !deps.Data {
+				if !yield(deps.Label) {
 					break
 				}
 			}
@@ -716,138 +646,135 @@ func (target *BuildTarget) BuildDependencyLabels() iter.Seq[BuildLabel] {
 }
 
 // ExportedDependencies returns any exported dependencies of this target.
-func (target *BuildTarget) ExportedDependencies() []BuildLabel {
-	target.mutex.RLock()
-	defer target.mutex.RUnlock()
-	ret := make(BuildLabels, 0, len(target.dependencies))
-	for _, info := range target.dependencies {
-		if info.exported {
-			ret = append(ret, *info.declared)
+func (target *BuildTarget) ExportedDependencies() iter.Seq[BuildLabel] {
+	return func(yield func(BuildLabel) bool) {
+		target.mutex.RLock()
+		defer target.mutex.RUnlock()
+		for _, deps := range target.dependencies {
+			if deps.Exported {
+				if !yield(deps.Label) {
+					break
+				}
+			}
 		}
 	}
-	return ret
+}
+
+// BuildDependencies returns the build-time dependencies of this target (i.e. not run-time dependencies, data, internal nor source).
+func (target *BuildTarget) BuildDependencies() iter.Seq[BuildLabel] {
+	return func(yield func(BuildLabel) bool) {
+		target.mutex.RLock()
+		defer target.mutex.RUnlock()
+		for _, deps := range target.dependencies {
+			if !deps.Runtime && !deps.Data && !deps.Internal && !deps.Source {
+				if !yield(deps.Label) {
+					break
+				}
+			}
+		}
+	}
 }
 
 // RuntimeDependencies returns any run-time dependencies of this target.
 //
 // Although run-time dependencies are transitive, RuntimeDependencies only returns this target's direct run-time
 // dependencies. Use IterAllRuntimeDependencies to iterate over the target's run-time dependencies transitively.
-func (target *BuildTarget) RuntimeDependencies() []BuildLabel {
-	target.mutex.RLock()
-	defer target.mutex.RUnlock()
-	ret := make(BuildLabels, 0, len(target.dependencies))
-	for _, deps := range target.dependencies {
-		if deps.runtime {
-			ret = append(ret, *deps.declared)
+func (target *BuildTarget) RuntimeDependencies() iter.Seq[BuildLabel] {
+	return func(yield func(BuildLabel) bool) {
+		target.mutex.RLock()
+		defer target.mutex.RUnlock()
+		for _, deps := range target.dependencies {
+			if deps.Runtime {
+				if !yield(deps.Label) {
+					break
+				}
+			}
 		}
 	}
-	return ret
 }
 
 // IterAllRuntimeDependencies returns an iterator over the transitive run-time dependencies of this target.
 // Require/provide relationships between pairs of targets are resolved as they are with build-time dependencies.
 func (target *BuildTarget) IterAllRuntimeDependencies(graph *BuildGraph) iter.Seq[BuildLabel] {
-	var (
-		push func(*BuildTarget, func(BuildLabel) bool) bool
-		done = make(map[string]bool)
-	)
-	push = func(t *BuildTarget, yield func(BuildLabel) bool) bool {
-		if done[t.String()] {
-			return true
-		}
-		done[t.String()] = true
-		for _, dep := range t.runtimeDependencies {
-			depLabel, _ := dep.Label()
-			for _, providedDep := range graph.TargetOrDie(depLabel).ProvideFor(t) {
-				if !yield(providedDep) {
-					return false
-				}
-				if !push(graph.TargetOrDie(providedDep), yield) {
-					return false
-				}
+	return func(yield func(BuildLabel) bool) {
+		done := map[BuildLabel]bool{}
+		var push func(*BuildTarget) bool
+		push = func(t *BuildTarget) bool {
+			if done[t.Label] {
+				return true
 			}
-		}
-		// Include the run-time dependencies of data targets, but not the data targets themselves. (We needn't worry
-		// about data files here - they can't have run-time dependencies of their own.)
-		for _, data := range t.AllData() {
-			dataLabel, ok := data.Label()
-			if !ok {
-				continue
-			}
-			for _, providedDep := range graph.TargetOrDie(dataLabel).ProvideFor(t) {
-				if !push(graph.TargetOrDie(providedDep), yield) {
-					return false
+			done[t.Label] = true
+			for _, dep := range t.runtimeDependencies {
+				depLabel, _ := dep.Label()
+				for _, providedDep := range graph.TargetOrDie(depLabel).ProvideFor(t) {
+					if !yield(providedDep) {
+						return false
+					}
+					if !push(graph.TargetOrDie(providedDep)) {
+						return false
+					}
 				}
 			}
-		}
-		if t.Debug != nil {
-			for _, data := range t.AllDebugData() {
+			// Include the run-time dependencies of data targets, but not the data targets themselves. (We needn't worry
+			// about data files here - they can't have run-time dependencies of their own.)
+			for _, data := range t.AllData() {
 				dataLabel, ok := data.Label()
 				if !ok {
 					continue
 				}
 				for _, providedDep := range graph.TargetOrDie(dataLabel).ProvideFor(t) {
-					if !push(graph.TargetOrDie(providedDep), yield) {
+					if !push(graph.TargetOrDie(providedDep)) {
 						return false
 					}
 				}
 			}
-		}
-		if t.RuntimeDependenciesFromSources || t.RuntimeDependenciesFromDependencies {
-			for _, dep := range t.dependencies {
-				// If required, include the run-time dependencies of sources, but not the sources themselves.
-				if t.RuntimeDependenciesFromSources && dep.source {
-					depLabel, _ := dep.declared.Label()
-					for _, providedDep := range graph.TargetOrDie(depLabel).ProvideFor(t) {
-						if !push(graph.TargetOrDie(providedDep), yield) {
+			if t.Debug != nil {
+				for _, data := range t.AllDebugData() {
+					dataLabel, ok := data.Label()
+					if !ok {
+						continue
+					}
+					for _, providedDep := range graph.TargetOrDie(dataLabel).ProvideFor(t) {
+						if !push(graph.TargetOrDie(providedDep)) {
 							return false
 						}
 					}
 				}
-				// If required, include the run-time dependencies of dependencies, but not the dependencies themselves.
-				if t.RuntimeDependenciesFromDependencies && !dep.exported && !dep.source && !dep.internal && !dep.runtime {
-					depLabel, _ := dep.declared.Label()
-					depTarget := graph.TargetOrDie(depLabel)
-					for _, providedDep := range depTarget.ProvideFor(t) {
-						if !push(graph.TargetOrDie(providedDep), yield) {
-							return false
+			}
+			if t.RuntimeDependenciesFromSources || t.RuntimeDependenciesFromDependencies {
+				for _, dep := range t.dependencies {
+					// If required, include the run-time dependencies of sources, but not the sources themselves.
+					if t.RuntimeDependenciesFromSources && dep.Source {
+						for _, providedDep := range graph.TargetOrDie(dep.Label).ProvideFor(t) {
+							if !push(graph.TargetOrDie(providedDep)) {
+								return false
+							}
 						}
 					}
-					// Also include the run-time dependencies of the target's exported dependencies, but not the
-					// exported dependencies themselves.
-					for _, exportedDep := range depTarget.ExportedDependencies() {
-						for _, providedDep := range graph.TargetOrDie(exportedDep).ProvideFor(t) {
-							if !push(graph.TargetOrDie(providedDep), yield) {
+					// If required, include the run-time dependencies of dependencies, but not the dependencies themselves.
+					if t.RuntimeDependenciesFromDependencies && !dep.Exported && !dep.Source && !dep.Internal && !dep.Runtime {
+						depTarget := graph.TargetOrDie(dep.Label)
+						for _, providedDep := range depTarget.ProvideFor(t) {
+							if !push(graph.TargetOrDie(providedDep)) {
 								return false
+							}
+						}
+						// Also include the run-time dependencies of the target's exported dependencies, but not the
+						// exported dependencies themselves.
+						for exportedDep := range depTarget.ExportedDependencies() {
+							for _, providedDep := range graph.TargetOrDie(exportedDep).ProvideFor(t) {
+								if !push(graph.TargetOrDie(providedDep)) {
+									return false
+								}
 							}
 						}
 					}
 				}
 			}
+			return true
 		}
-		return true
+		push(target)
 	}
-	return func(yield func(BuildLabel) bool) {
-		push(target, yield)
-	}
-}
-
-// DependenciesFor returns the dependencies that relate to a given label.
-func (target *BuildTarget) DependenciesFor(label BuildLabel) []*BuildTarget {
-	target.mutex.RLock()
-	defer target.mutex.RUnlock()
-	return target.dependenciesFor(label)
-}
-
-func (target *BuildTarget) dependenciesFor(label BuildLabel) []*BuildTarget {
-	if info := target.dependencyInfo(label); info != nil {
-		return info.deps
-	} else if target.Label.Subrepo != "" && label.Subrepo == "" {
-		// Can implicitly use the target's subrepo.
-		label.Subrepo = target.Label.Subrepo
-		return target.dependenciesFor(label)
-	}
-	return nil
 }
 
 // FinishBuild marks this target as having built.
@@ -905,20 +832,40 @@ func (target *BuildTarget) DeclaredSourceNames() []string {
 	return ret
 }
 
-func (target *BuildTarget) filegroupOutputs(srcs []BuildInput) []string {
+// ResolveDependencySubrepo qualifies label with the target's subrepo if needed, returning the
+// resolved label and whether the target actually declares a dependency on it. This handles labels
+// (e.g. from command replacements like $(location :x)) that may be missing the subrepo the target
+// itself was built in, as happens when cross-compiling.
+func (target *BuildTarget) ResolveDependencySubrepo(label BuildLabel) (BuildLabel, bool) {
+	target.mutex.RLock()
+	defer target.mutex.RUnlock()
+	if target.dependencyInfo(label) != nil {
+		return label, true
+	}
+	if target.Label.Subrepo != "" && label.Subrepo == "" {
+		// Can implicitly use the target's subrepo.
+		label.Subrepo = target.Label.Subrepo
+		if target.dependencyInfo(label) != nil {
+			return label, true
+		}
+	}
+	return label, false
+}
+
+func (target *BuildTarget) filegroupOutputs(graph *BuildGraph, srcs []BuildInput) []string {
 	ret := make([]string, 0, len(srcs))
 	// Filegroups just re-output their inputs.
 	for _, src := range srcs {
 		if namedLabel, ok := src.(AnnotatedOutputLabel); ok {
 			// Bit of a hack, but this needs different treatment from either of the others.
-			for _, dep := range target.DependenciesFor(namedLabel.BuildLabel) {
-				ret = append(ret, dep.NamedOutputs(namedLabel.Annotation)...)
+			for _, dep := range graph.TargetOrDie(namedLabel.BuildLabel).ProvideFor(target) {
+				ret = append(ret, graph.TargetOrDie(dep).NamedOutputs(graph, namedLabel.Annotation)...)
 			}
 		} else if label, ok := src.nonOutputLabel(); !ok {
 			ret = append(ret, src.LocalPaths(nil)[0])
 		} else {
-			for _, dep := range target.DependenciesFor(label) {
-				ret = append(ret, dep.Outputs()...)
+			for _, dep := range graph.TargetOrDie(label).ProvideFor(target) {
+				ret = append(ret, graph.TargetOrDie(dep).Outputs(graph)...)
 			}
 		}
 	}
@@ -926,10 +873,10 @@ func (target *BuildTarget) filegroupOutputs(srcs []BuildInput) []string {
 }
 
 // Outputs returns a slice of all the outputs of this rule.
-func (target *BuildTarget) Outputs() []string {
+func (target *BuildTarget) Outputs(graph *BuildGraph) []string {
 	var ret []string
 	if target.IsFilegroup {
-		ret = target.filegroupOutputs(target.AllSources())
+		ret = target.filegroupOutputs(graph, target.AllSources())
 	} else {
 		// Must really copy the slice before sorting it ([:] is too shallow)
 		ret = make([]string, len(target.outputs))
@@ -945,8 +892,8 @@ func (target *BuildTarget) Outputs() []string {
 }
 
 // FullOutputs returns a slice of all the outputs of this rule with the target's output directory prepended.
-func (target *BuildTarget) FullOutputs() []string {
-	outs := target.Outputs()
+func (target *BuildTarget) FullOutputs(graph *BuildGraph) []string {
+	outs := target.Outputs(graph)
 	outDir := target.OutDir()
 	for i, out := range outs {
 		outs[i] = filepath.Join(outDir, out)
@@ -956,8 +903,8 @@ func (target *BuildTarget) FullOutputs() []string {
 
 // AllOutputs returns a slice of all the outputs of this rule, including any output directories.
 // Outs are passed through GetTmpOutput as appropriate.
-func (target *BuildTarget) AllOutputs() []string {
-	outs := target.Outputs()
+func (target *BuildTarget) AllOutputs(graph *BuildGraph) []string {
+	outs := target.Outputs(graph)
 	for i, out := range outs {
 		outs[i] = target.GetTmpOutput(out)
 	}
@@ -969,13 +916,13 @@ func (target *BuildTarget) AllOutputs() []string {
 
 // NamedOutputs returns a slice of all the outputs of this rule with a given name.
 // If the name is not declared by this rule it panics.
-func (target *BuildTarget) NamedOutputs(name string) []string {
+func (target *BuildTarget) NamedOutputs(graph *BuildGraph, name string) []string {
 	if target.IsFilegroup {
 		if target.NamedSources == nil {
 			return nil
 		}
 		if srcs, present := target.NamedSources[name]; present {
-			return target.filegroupOutputs(srcs)
+			return target.filegroupOutputs(graph, srcs)
 		}
 		return nil
 	}
@@ -1056,7 +1003,7 @@ func (target *BuildTarget) CanSee(state *BuildState, dep *BuildTarget) bool {
 // Returns an error if not, or nil if all's well.
 func (target *BuildTarget) CheckDependencyVisibility(state *BuildState) error {
 	for _, d := range target.dependencies {
-		dep := state.Graph.TargetOrDie(*d.declared)
+		dep := state.Graph.TargetOrDie(d.Label)
 		if !target.CanSee(state, dep) {
 			return fmt.Errorf("Target %s isn't visible to %s", dep.Label, target.Label)
 		} else if dep.TestOnly && !target.IsTest() && !target.TestOnly {
@@ -1072,9 +1019,9 @@ func (target *BuildTarget) CheckDependencyVisibility(state *BuildState) error {
 
 // CheckDuplicateOutputs checks if any of the outputs of this target duplicate one another.
 // Returns an error if so, or nil if all's well.
-func (target *BuildTarget) CheckDuplicateOutputs() error {
+func (target *BuildTarget) CheckDuplicateOutputs(graph *BuildGraph) error {
 	outputs := map[string]struct{}{}
-	for _, output := range target.Outputs() {
+	for _, output := range target.Outputs(graph) {
 		if _, present := outputs[output]; present {
 			return fmt.Errorf("Target %s declares output file %s multiple times", target.Label, output)
 		}
@@ -1092,7 +1039,7 @@ func (target *BuildTarget) CheckTargetOwnsBuildOutputs(state *BuildState) error 
 		return nil
 	}
 
-	for _, output := range target.Outputs() {
+	for _, output := range target.Outputs(state.Graph) {
 		targetPackage := target.Label.PackageName
 		out := filepath.Join(targetPackage, output)
 
@@ -1196,26 +1143,10 @@ func (target *BuildTarget) HasDependency(label BuildLabel) bool {
 	return target.dependencyInfo(label) != nil
 }
 
-// resolveDependency resolves a particular dependency on a target.
-// TODO(jpoole): this is only used by tests: remove
-func (target *BuildTarget) resolveDependency(label BuildLabel, dep *BuildTarget) {
-	target.mutex.Lock()
-	defer target.mutex.Unlock()
-	info := target.dependencyInfo(label)
-	if info == nil {
-		target.dependencies = append(target.dependencies, depInfo{declared: &label})
-		info = &target.dependencies[len(target.dependencies)-1]
-	}
-	if dep != nil {
-		info.deps = append(info.deps, dep)
-	}
-	info.resolved = true
-}
-
 // dependencyInfo returns the information about a declared dependency, or nil if the target doesn't have it.
-func (target *BuildTarget) dependencyInfo(label BuildLabel) *depInfo {
+func (target *BuildTarget) dependencyInfo(label BuildLabel) *DeclaredDependency {
 	for i, info := range target.dependencies {
-		if *info.declared == label {
+		if info.Label == label {
 			return &target.dependencies[i]
 		}
 	}
@@ -1225,7 +1156,7 @@ func (target *BuildTarget) dependencyInfo(label BuildLabel) *depInfo {
 // IsSourceOnlyDep returns true if the given dependency was only declared on the srcs of the target.
 func (target *BuildTarget) IsSourceOnlyDep(label BuildLabel) bool {
 	info := target.dependencyInfo(label)
-	return info != nil && info.source
+	return info != nil && info.Source
 }
 
 // State returns the target's current state.
@@ -1512,7 +1443,7 @@ func (target *BuildTarget) AddDatum(datum BuildInput) {
 	target.Data = append(target.Data, datum)
 	if label, ok := datum.Label(); ok {
 		target.AddDependency(label)
-		target.dependencyInfo(label).data = true
+		target.dependencyInfo(label).Data = true
 	}
 }
 
@@ -1524,7 +1455,7 @@ func (target *BuildTarget) AddNamedDatum(name string, datum BuildInput) {
 	target.NamedData[name] = append(target.NamedData[name], datum)
 	if label, ok := datum.Label(); ok {
 		target.AddDependency(label)
-		target.dependencyInfo(label).data = true
+		target.dependencyInfo(label).Data = true
 	}
 }
 
@@ -1536,7 +1467,7 @@ func (target *BuildTarget) AddDebugDatum(datum BuildInput) {
 	target.Debug.data = append(target.Debug.data, datum)
 	if label, ok := datum.Label(); ok {
 		target.AddDependency(label)
-		target.dependencyInfo(label).data = true
+		target.dependencyInfo(label).Data = true
 	}
 }
 
@@ -1551,7 +1482,7 @@ func (target *BuildTarget) AddDebugNamedDatum(name string, datum BuildInput) {
 	target.Debug.namedData[name] = append(target.Debug.namedData[name], datum)
 	if label, ok := datum.Label(); ok {
 		target.AddDependency(label)
-		target.dependencyInfo(label).data = true
+		target.dependencyInfo(label).Data = true
 	}
 }
 
@@ -1805,19 +1736,19 @@ func (target *BuildTarget) AddMaybeExportedDependency(dep BuildLabel, exported, 
 	}
 	info := target.dependencyInfo(dep)
 	if info == nil {
-		target.dependencies = append(target.dependencies, depInfo{
-			declared: &dep,
-			exported: exported,
-			source:   source,
-			internal: internal,
-			runtime:  runtime,
+		target.dependencies = append(target.dependencies, DeclaredDependency{
+			Label:    dep,
+			Exported: exported,
+			Source:   source,
+			Internal: internal,
+			Runtime:  runtime,
 		})
 	} else {
-		info.exported = info.exported || exported
-		info.source = info.source && source
-		info.internal = info.internal && internal
-		info.runtime = info.runtime && runtime
-		info.data = false // It's not *only* data any more.
+		info.Exported = info.Exported || exported
+		info.Source = info.Source && source
+		info.Internal = info.Internal && internal
+		info.Runtime = info.Runtime && runtime
+		info.Data = false // It's not *only* data any more.
 	}
 }
 
@@ -1849,7 +1780,7 @@ func (target *BuildTarget) isTool(tool BuildLabel, tools []BuildInput, namedTool
 }
 
 // toolPath returns a path to this target when used as a tool.
-func (target *BuildTarget) toolPath(abs bool, namedOutput string) string {
+func (target *BuildTarget) toolPath(graph *BuildGraph, abs bool, namedOutput string) string {
 	outToolPath := func(outputs ...string) string {
 		ret := make([]string, len(outputs))
 		for i, o := range outputs {
@@ -1871,7 +1802,7 @@ func (target *BuildTarget) toolPath(abs bool, namedOutput string) string {
 		}
 		panic(fmt.Sprintf("%v has no named output or entry point %v", target.Label, namedOutput))
 	}
-	return outToolPath(target.Outputs()...)
+	return outToolPath(target.Outputs(graph)...)
 }
 
 // AddOutput adds a new output to the target if it's not already there.
@@ -1905,7 +1836,7 @@ func (target *BuildTarget) AddEntryPoint(name, output string) {
 	if target.EntryPoints == nil {
 		target.EntryPoints = make(map[string]string)
 	}
-	if target.NamedOutputs(name) != nil {
+	if _, present := target.namedOutputs[name]; present {
 		panic(fmt.Sprintf("%v already has a named output named %v; entry points may not have the same name as a named output", target.Label, name))
 	}
 	if target.IsFilegroup && target.NamedSources[name] != nil {

--- a/src/core/build_target_test.go
+++ b/src/core/build_target_test.go
@@ -131,12 +131,12 @@ func TestCheckDependencyVisibility(t *testing.T) {
 	assert.NoError(t, target7.CheckDependencyVisibility(state))
 
 	// Now if we add a dep on this mock library, lib2 will fail because it's not a test.
-	target2.resolveDependency(target5.Label, target5)
+	target2.AddDependency(target5.Label)
 	assert.Error(t, target2.CheckDependencyVisibility(state))
 
 	// Similarly to above test, if we add a dep on something that can't be seen, we should
 	// get errors back from this function.
-	target3.resolveDependency(target1.Label, target1)
+	target3.AddDependency(target1.Label)
 	assert.Error(t, target3.CheckDependencyVisibility(state))
 }
 
@@ -145,8 +145,8 @@ func TestAddOutput(t *testing.T) {
 	target.AddOutput("thingy.py")
 	target.AddOutput("thingy2.py")
 	target.AddOutput("thingy.py")
-	if len(target.Outputs()) != 2 {
-		t.Errorf("Incorrect output length; should be 2, was %d", len(target.Outputs()))
+	if len(target.Outputs(nil)) != 2 {
+		t.Errorf("Incorrect output length; should be 2, was %d", len(target.Outputs(nil)))
 	}
 }
 
@@ -165,7 +165,7 @@ func TestAddOutputSorting(t *testing.T) {
 		"3.py",
 		"x.pyx",
 	}
-	assert.Equal(t, expected, target.Outputs())
+	assert.Equal(t, expected, target.Outputs(nil))
 }
 
 func TestAddOutputPanics(t *testing.T) {
@@ -182,7 +182,7 @@ func TestAddSource(t *testing.T) {
 	target.AddSource(ParseBuildLabel("//src/test/python:lib3", ""))
 	target.AddSource(ParseBuildLabel("//src/test/python:lib2", ""))
 	assert.Equal(t, 2, len(target.Sources))
-	assert.Equal(t, 2, len(target.DeclaredDependencies()))
+	assert.Equal(t, 2, len(slices.Collect(target.DeclaredDependencies())))
 }
 
 func TestOutputs(t *testing.T) {
@@ -195,17 +195,18 @@ func TestOutputs(t *testing.T) {
 	target3 := makeFilegroup("//src/test:target3", "PUBLIC", target2)
 	target3.AddSource(target2.Label)
 	addFilegroupSource(target3, "file4.go")
+	graph := graphWith(target1, target2, target3)
 
-	assert.Equal(t, []string{"file1.go", "file2.go"}, target1.Outputs())
-	assert.Equal(t, []string{"file1.go", "file2.go", "file3.go"}, target2.Outputs())
-	assert.Equal(t, []string{"file1.go", "file2.go", "file3.go", "file4.go"}, target3.Outputs())
+	assert.Equal(t, []string{"file1.go", "file2.go"}, target1.Outputs(graph))
+	assert.Equal(t, []string{"file1.go", "file2.go", "file3.go"}, target2.Outputs(graph))
+	assert.Equal(t, []string{"file1.go", "file2.go", "file3.go", "file4.go"}, target3.Outputs(graph))
 }
 
 func TestFullOutputs(t *testing.T) {
 	target := makeTarget1("//src/core:target1", "PUBLIC")
 	target.AddOutput("file1.go")
 	target.AddOutput("file2.go")
-	assert.Equal(t, []string{"plz-out/gen/src/core/file1.go", "plz-out/gen/src/core/file2.go"}, target.FullOutputs())
+	assert.Equal(t, []string{"plz-out/gen/src/core/file1.go", "plz-out/gen/src/core/file2.go"}, target.FullOutputs(nil))
 }
 
 func TestAllOutputs(t *testing.T) {
@@ -213,7 +214,7 @@ func TestAllOutputs(t *testing.T) {
 	target.AddOutput("please")
 	target.AddOutput("plz")
 	target.AddOutputDirectory("dir")
-	assert.Equal(t, []string{"please.out", "plz", "dir"}, target.AllOutputs())
+	assert.Equal(t, []string{"please.out", "plz", "dir"}, target.AllOutputs(nil))
 }
 
 func TestProvideFor(t *testing.T) {
@@ -262,10 +263,10 @@ func TestAddDatum(t *testing.T) {
 	target2 := makeTarget1("//src/core:target2", "PUBLIC")
 	target1.AddDatum(target2.Label)
 	assert.Equal(t, target1.Data, []BuildInput{target2.Label})
-	assert.True(t, target1.dependencies[0].data)
+	assert.True(t, target1.dependencies[0].Data)
 	// Now we add it as a dependency too, which unsets the data label
 	target1.AddMaybeExportedDependency(target2.Label, false, false, false, false)
-	assert.False(t, target1.dependencies[0].data)
+	assert.False(t, target1.dependencies[0].Data)
 }
 
 func TestCheckDuplicateOutputs(t *testing.T) {
@@ -274,14 +275,15 @@ func TestCheckDuplicateOutputs(t *testing.T) {
 	target2 := makeFilegroup("//src/core:target2", "PUBLIC", target1, target3)
 	addFilegroupSource(target1, "thingy.txt")
 	addFilegroupSource(target3, "thingy.txt")
-	assert.NoError(t, target1.CheckDuplicateOutputs())
+	graph := graphWith(target1, target2, target3)
+	assert.NoError(t, target1.CheckDuplicateOutputs(graph))
 	target2.AddSource(target1.Label)
 	target2.AddSource(target1.Label)
 	// Not an error yet because AddOutput deduplicates trivially identical outputs.
-	assert.NoError(t, target2.CheckDuplicateOutputs())
+	assert.NoError(t, target2.CheckDuplicateOutputs(graph))
 	// Will fail now we add the same output to another target.
 	target2.AddSource(target3.Label)
-	assert.Error(t, target2.CheckDuplicateOutputs())
+	assert.Error(t, target2.CheckDuplicateOutputs(graph))
 }
 
 func TestLabels(t *testing.T) {
@@ -396,8 +398,8 @@ func TestToolPath(t *testing.T) {
 	wd, _ := os.Getwd()
 	RepoRoot = wd
 	root := wd + "/plz-out/gen/src/core"
-	assert.Equal(t, fmt.Sprintf("%s/file1.go %s/file2.go", root, root), target.toolPath(true, ""))
-	assert.Equal(t, "src/core/file1.go src/core/file2.go", target.toolPath(false, ""))
+	assert.Equal(t, fmt.Sprintf("%s/file1.go %s/file2.go", root, root), target.toolPath(nil, true, ""))
+	assert.Equal(t, "src/core/file1.go src/core/file2.go", target.toolPath(nil, false, ""))
 }
 
 func TestToolPathWithEntryPoint(t *testing.T) {
@@ -408,20 +410,21 @@ func TestToolPathWithEntryPoint(t *testing.T) {
 	wd, _ := os.Getwd()
 	RepoRoot = wd
 	root := wd + "/plz-out/gen/src/core"
-	assert.Equal(t, root+"/file1.go", target.toolPath(true, "f1"))
-	assert.Equal(t, "src/core/file1.go", target.toolPath(false, "f1"))
+	assert.Equal(t, root+"/file1.go", target.toolPath(nil, true, "f1"))
+	assert.Equal(t, "src/core/file1.go", target.toolPath(nil, false, "f1"))
 }
 
 func TestDependencies(t *testing.T) {
 	target1 := makeTarget1("//src/core:target1", "")
 	target2 := makeTarget1("//src/core:target2", "", target1)
 	target3 := makeTarget1("//src/core:target3", "", target1, target2)
-	assert.Equal(t, []BuildLabel{}, target1.DeclaredDependencies())
-	assert.Equal(t, []*BuildTarget{}, target1.Dependencies())
-	assert.Equal(t, []BuildLabel{target1.Label}, target2.DeclaredDependencies())
-	assert.Equal(t, []*BuildTarget{target1}, target2.Dependencies())
-	assert.Equal(t, []BuildLabel{target1.Label, target2.Label}, target3.DeclaredDependencies())
-	assert.Equal(t, []*BuildTarget{target1, target2}, target3.Dependencies())
+	graph := graphWith(target1, target2, target3)
+	assert.Empty(t, slices.Collect(target1.DeclaredDependencies()))
+	assert.Empty(t, target1.Dependencies(graph))
+	assert.Equal(t, []BuildLabel{target1.Label}, slices.Collect(target2.DeclaredDependencies()))
+	assert.Equal(t, []*BuildTarget{target1}, target2.Dependencies(graph))
+	assert.Equal(t, []BuildLabel{target1.Label, target2.Label}, slices.Collect(target3.DeclaredDependencies()))
+	assert.Equal(t, []*BuildTarget{target1, target2}, target3.Dependencies(graph))
 }
 
 func TestBuildDependencies(t *testing.T) {
@@ -434,10 +437,10 @@ func TestBuildDependencies(t *testing.T) {
 	// BuildDependencies shouldn't return run-time dependencies:
 	target5.IsBinary = true
 	target5.AddMaybeExportedDependency(target4.Label, false, false, false, true) // runtime
-	assert.Equal(t, []*BuildTarget{}, target1.BuildDependencies())
-	assert.Equal(t, []*BuildTarget{target1}, target2.BuildDependencies())
-	assert.Equal(t, []*BuildTarget{target2}, target3.BuildDependencies())
-	assert.Equal(t, []*BuildTarget{}, target5.BuildDependencies())
+	assert.Empty(t, slices.Collect(target1.BuildDependencies()))
+	assert.Equal(t, []BuildLabel{target1.Label}, slices.Collect(target2.BuildDependencies()))
+	assert.Equal(t, []BuildLabel{target2.Label}, slices.Collect(target3.BuildDependencies()))
+	assert.Empty(t, slices.Collect(target5.BuildDependencies()))
 }
 
 func TestDeclaredDependenciesStrict(t *testing.T) {
@@ -450,10 +453,10 @@ func TestDeclaredDependenciesStrict(t *testing.T) {
 	// DeclaredDependenciesStrict shouldn't return run-time dependencies:
 	target5.IsBinary = true
 	target5.AddMaybeExportedDependency(target4.Label, false, false, false, true) // runtime
-	assert.Equal(t, []BuildLabel{}, target1.DeclaredDependenciesStrict())
-	assert.Equal(t, []BuildLabel{target1.Label}, target2.DeclaredDependenciesStrict())
-	assert.Equal(t, []BuildLabel{target2.Label}, target3.DeclaredDependenciesStrict())
-	assert.Equal(t, []*BuildTarget{}, target5.BuildDependencies())
+	assert.Empty(t, slices.Collect(target1.DeclaredDependenciesStrict()))
+	assert.Equal(t, []BuildLabel{target1.Label}, slices.Collect(target2.DeclaredDependenciesStrict()))
+	assert.Equal(t, []BuildLabel{target2.Label}, slices.Collect(target3.DeclaredDependenciesStrict()))
+	assert.Empty(t, slices.Collect(target5.DeclaredDependenciesStrict()))
 }
 
 func TestRuntimeDependencies(t *testing.T) {
@@ -465,9 +468,9 @@ func TestRuntimeDependencies(t *testing.T) {
 	target3.IsBinary = true
 	target3.AddMaybeExportedDependency(target2.Label, false, false, false, true) // runtime
 	// RuntimeDependencies shouldn't return transitive run-time dependencies.
-	assert.Equal(t, []BuildLabel{}, target1.RuntimeDependencies())
-	assert.Equal(t, []BuildLabel{target1.Label}, target2.RuntimeDependencies())
-	assert.Equal(t, []BuildLabel{target2.Label}, target3.RuntimeDependencies())
+	assert.Empty(t, slices.Collect(target1.RuntimeDependencies()))
+	assert.Equal(t, []BuildLabel{target1.Label}, slices.Collect(target2.RuntimeDependencies()))
+	assert.Equal(t, []BuildLabel{target2.Label}, slices.Collect(target3.RuntimeDependencies()))
 }
 
 func TestIterAllRuntimeDependencies(t *testing.T) {
@@ -491,17 +494,15 @@ func TestIterAllRuntimeDependencies(t *testing.T) {
 func TestAddDependency(t *testing.T) {
 	target1 := makeTarget1("//src/core:target1", "")
 	target2 := makeTarget1("//src/core:target2", "")
-	assert.Equal(t, []BuildLabel{}, target2.DeclaredDependencies())
-	assert.Equal(t, []BuildLabel{}, target2.ExportedDependencies())
+	assert.Empty(t, slices.Collect(target2.DeclaredDependencies()))
+	assert.Empty(t, slices.Collect(target2.ExportedDependencies()))
 	target2.AddDependency(target1.Label)
-	assert.Equal(t, []BuildLabel{target1.Label}, target2.DeclaredDependencies())
-	assert.Equal(t, []BuildLabel{}, target2.ExportedDependencies())
+	assert.Equal(t, []BuildLabel{target1.Label}, slices.Collect(target2.DeclaredDependencies()))
+	assert.Empty(t, slices.Collect(target2.ExportedDependencies()))
 	target2.AddMaybeExportedDependency(target1.Label, true, false, false, false)
-	assert.Equal(t, []BuildLabel{target1.Label}, target2.DeclaredDependencies())
-	assert.Equal(t, []BuildLabel{target1.Label}, target2.ExportedDependencies())
-	assert.Equal(t, []*BuildTarget{}, target2.Dependencies())
-	target2.resolveDependency(target1.Label, target1)
-	assert.Equal(t, []*BuildTarget{target1}, target2.Dependencies())
+	assert.Equal(t, []BuildLabel{target1.Label}, slices.Collect(target2.DeclaredDependencies()))
+	assert.Equal(t, []BuildLabel{target1.Label}, slices.Collect(target2.ExportedDependencies()))
+	assert.Equal(t, []*BuildTarget{target1}, target2.Dependencies(graphWith(target1, target2)))
 }
 
 func TestAddRuntimeDependency(t *testing.T) {
@@ -510,10 +511,10 @@ func TestAddRuntimeDependency(t *testing.T) {
 	target1.IsBinary = true
 	target1.AddMaybeExportedDependency(target2.Label, false, false, false, true) // runtime
 	assert.Equal(t, target1.runtimeDependencies, []BuildLabel{target2.Label})
-	assert.True(t, target1.dependencies[0].runtime)
+	assert.True(t, target1.dependencies[0].Runtime)
 	// Now we add it as a build-time dependency too, which should unset the runtime flag.
 	target1.AddMaybeExportedDependency(target2.Label, false, false, false, false)
-	assert.False(t, target1.dependencies[0].runtime)
+	assert.False(t, target1.dependencies[0].Runtime)
 }
 
 func TestAddDependencySource(t *testing.T) {
@@ -526,11 +527,14 @@ func TestAddDependencySource(t *testing.T) {
 	assert.False(t, target2.IsSourceOnlyDep(target1.Label))
 }
 
-func TestDependencyFor(t *testing.T) {
+func TestResolveDependencySubrepo(t *testing.T) {
 	target1 := makeTarget1("//src/core:target1", "")
 	target2 := makeTarget1("//src/core:target2", "", target1)
-	assert.Equal(t, []*BuildTarget{target1}, target2.DependenciesFor(target1.Label))
-	assert.Equal(t, []*BuildTarget(nil), target2.DependenciesFor(target2.Label))
+	l, ok := target2.ResolveDependencySubrepo(target1.Label)
+	assert.True(t, ok)
+	assert.Equal(t, target1.Label, l)
+	_, ok = target2.ResolveDependencySubrepo(target2.Label)
+	assert.False(t, ok)
 	assert.Equal(t, 1, len(target2.dependencies))
 }
 
@@ -582,7 +586,7 @@ func TestOutputOrdering(t *testing.T) {
 	target2.AddOutput("file2.txt")
 	target2.AddOutput("file1.txt")
 	assert.Equal(t, target1.DeclaredOutputs(), target2.DeclaredOutputs())
-	assert.Equal(t, target1.Outputs(), target2.Outputs())
+	assert.Equal(t, target1.Outputs(nil), target2.Outputs(nil))
 }
 
 func TestNamedOutputs(t *testing.T) {
@@ -594,12 +598,12 @@ func TestNamedOutputs(t *testing.T) {
 	target.AddNamedOutput("hdrs", "hdr1.h")
 	target.AddNamedOutput("hdrs", "hdr2.h")
 	target.AddNamedOutput("hdrs", "hdr2.h") // deliberate duplicate
-	assert.Equal(t, []string{"a.txt", "hdr1.h", "hdr2.h", "src1.c", "src2.c", "z.txt"}, target.Outputs())
+	assert.Equal(t, []string{"a.txt", "hdr1.h", "hdr2.h", "src1.c", "src2.c", "z.txt"}, target.Outputs(nil))
 	assert.Equal(t, []string{"a.txt", "z.txt"}, target.DeclaredOutputs())
 	assert.Equal(t, map[string][]string{"srcs": {"src1.c", "src2.c"}, "hdrs": {"hdr1.h", "hdr2.h"}}, target.DeclaredNamedOutputs())
-	assert.Equal(t, []string{"hdr1.h", "hdr2.h"}, target.NamedOutputs("hdrs"))
-	assert.Equal(t, []string{"src1.c", "src2.c"}, target.NamedOutputs("srcs"))
-	assert.Equal(t, 0, len(target.NamedOutputs("go_srcs")))
+	assert.Equal(t, []string{"hdr1.h", "hdr2.h"}, target.NamedOutputs(nil, "hdrs"))
+	assert.Equal(t, []string{"src1.c", "src2.c"}, target.NamedOutputs(nil, "srcs"))
+	assert.Equal(t, 0, len(target.NamedOutputs(nil, "go_srcs")))
 	assert.Equal(t, []string{"hdrs", "srcs"}, target.DeclaredOutputNames())
 }
 
@@ -743,7 +747,8 @@ func TestExternalDependencies(t *testing.T) {
 	t1 := makeTarget1("//src/core:target1", "PUBLIC", t1a)
 	t2a := makeTarget1("//src/core:_target2#a", "PUBLIC", t1)
 	t2 := makeTarget1("//src/core:target2", "PUBLIC", t2a)
-	assert.Equal(t, []*BuildTarget{t1}, t2.ExternalDependencies())
+	graph := graphWith(t1a, t1, t2a, t2)
+	assert.Equal(t, []*BuildTarget{t1}, t2.ExternalDependencies(graph))
 }
 
 func TestBuildTargetOwnBuildInputs(t *testing.T) {
@@ -1035,9 +1040,18 @@ func makeTarget1(label, visibility string, deps ...*BuildTarget) *BuildTarget {
 	}
 	for _, dep := range deps {
 		target.AddDependency(dep.Label)
-		target.resolveDependency(dep.Label, dep)
 	}
 	return target
+}
+
+// graphWith returns a graph populated with the given targets, for tests that need dependency
+// resolution (which now happens against the graph rather than being cached on the target).
+func graphWith(targets ...*BuildTarget) *BuildGraph {
+	graph := NewGraph()
+	for _, target := range targets {
+		graph.AddTarget(target)
+	}
+	return graph
 }
 
 func makeTarget1WithLabels(name string, labels ...string) *BuildTarget {

--- a/src/core/command_replacements.go
+++ b/src/core/command_replacements.go
@@ -252,22 +252,24 @@ func replaceSequenceLabel(state *BuildState, target *BuildTarget, label BuildLab
 	}
 	// TODO(jpoole): This doesn't handle tools when cross compiling. ///freebsd_amd64//tools:tool
 	// will not match the tool //tools:tool
-	deps := target.DependenciesFor(label)
-	if len(deps) == 0 {
+	label, ok := target.ResolveDependencySubrepo(label)
+	if !ok {
 		panic(fmt.Sprintf("Rule %s can't use %s; doesn't depend on target %s", target.Label, in, label))
 	}
+	deps := state.Graph.TargetOrDie(label).ProvideFor(target)
 	// TODO(pebers): this does not correctly handle the case where there are multiple deps here
 	//               (but is better than the previous case where it never worked at all)
-	return checkAndReplaceSequence(state, target, deps[0], ep, in, runnable, multiple, dir, outPrefix, hash, test, allOutputs, target.IsTool(label))
+	dep := state.Graph.TargetOrDie(deps[0])
+	return checkAndReplaceSequence(state, target, dep, ep, in, runnable, multiple, dir, outPrefix, hash, test, allOutputs, target.IsTool(label))
 }
 
 func checkAndReplaceSequence(state *BuildState, target, dep *BuildTarget, ep, in string, runnable, multiple, dir, outPrefix, hash, test, allOutputs, tool bool) string {
-	if allOutputs && !multiple && len(dep.Outputs()) > 1 && ep == "" {
+	if allOutputs && !multiple && len(dep.Outputs(state.Graph)) > 1 && ep == "" {
 		// Label must have only one output.
 		panic(fmt.Sprintf("Rule %s can't use %s; %s has multiple outputs.", target.Label, in, dep.Label))
 	} else if runnable && !dep.IsBinary {
 		panic(fmt.Sprintf("Rule %s can't $(exe %s), it's not executable", target.Label, dep.Label))
-	} else if runnable && len(dep.Outputs()) == 0 {
+	} else if runnable && len(dep.Outputs(state.Graph)) == 0 {
 		panic(fmt.Sprintf("Rule %s is tagged as binary but produces no output.", dep.Label))
 	} else if test && tool {
 		panic(fmt.Sprintf("Rule %s uses %s in its test command, but tools are not accessible at test time", target, dep))
@@ -281,7 +283,7 @@ func checkAndReplaceSequence(state *BuildState, target, dep *BuildTarget, ep, in
 	}
 	var outputBuilder strings.Builder
 	if ep == "" {
-		for _, out := range dep.Outputs() {
+		for _, out := range dep.Outputs(state.Graph) {
 			if allOutputs || out == in {
 				if tool && !state.WillRunRemotely(target) {
 					abs, err := filepath.Abs(handleDir(dep.OutDir(), out, dir))

--- a/src/core/command_replacements_test.go
+++ b/src/core/command_replacements_test.go
@@ -270,16 +270,13 @@ func makeTarget2(name string, command string, dep *BuildTarget) *BuildTarget {
 	target := NewBuildTarget(ParseBuildLabel(name, ""))
 	target.Command = command
 	target.AddOutput(target.Label.Name + ".py")
+	// Dependency resolution now happens against the graph at replacement time rather than being
+	// cached on the target, so the targets must live in the state's graph. These tests share a
+	// global state and reuse labels across tests, so we replace rather than AddTarget (which would
+	// panic on a duplicate label).
+	state.Graph.targets.Set(target.Label, target)
 	if dep != nil {
 		target.AddDependency(dep.Label)
-		// This is a bit awkward but I don't want to add a public interface just for a test.
-		graph := NewGraph()
-		graph.AddTarget(target)
-		graph.AddTarget(dep)
-		target.AddDependency(dep.Label)
-		if err := target.ResolveDependencies(graph); err != nil {
-			log.Fatalf("Failed to resolve some dependencies for %s: %s", target, err)
-		}
 	}
 	return target
 }

--- a/src/core/cycle_detector.go
+++ b/src/core/cycle_detector.go
@@ -35,7 +35,7 @@ func (c *cycleDetector) Check() *errCycle {
 			return []*BuildTarget{target}, false
 		}
 		partial[target] = struct{}{}
-		for _, dep := range target.Dependencies() {
+		for _, dep := range target.Dependencies(c.graph) {
 			if cycle, done := visit(dep); cycle != nil {
 				if done || target == cycle[len(cycle)-1] {
 					return cycle, true // This target is already in the cycle

--- a/src/core/cycle_detector_test.go
+++ b/src/core/cycle_detector_test.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,25 +18,6 @@ func TestCycleDetector(t *testing.T) {
 		return target
 	}
 
-	waitForDeps := func(state *BuildState) {
-		// Wait for all targets to have resolved all their dependencies.
-		allDepsResolved := func() bool {
-			for _, target := range state.Graph.AllTargets() {
-				if len(target.DeclaredDependencies()) != len(target.Dependencies()) {
-					return false
-				}
-			}
-			return true
-		}
-		for i := 0; i < 1000; i++ {
-			if allDepsResolved() {
-				return
-			}
-			time.Sleep(2 * time.Millisecond)
-		}
-		panic("not all dependencies resolved")
-	}
-
 	t.Run("NoCycle", func(t *testing.T) {
 		state := NewDefaultBuildState()
 		newTarget(state, "//src:a", "//src:b", "//src:c")
@@ -47,7 +27,6 @@ func TestCycleDetector(t *testing.T) {
 		newTarget(state, "//src:e", "//src:f")
 		newTarget(state, "//src:f", "//src:g")
 		newTarget(state, "//src:g")
-		waitForDeps(state)
 
 		detector := cycleDetector{graph: state.Graph}
 		assert.Nil(t, detector.Check())
@@ -62,7 +41,6 @@ func TestCycleDetector(t *testing.T) {
 		e := newTarget(state, "//src:e", "//src:f")
 		f := newTarget(state, "//src:f", "//src:g")
 		g := newTarget(state, "//src:g", "//src:e")
-		waitForDeps(state)
 
 		detector := cycleDetector{graph: state.Graph}
 		err := detector.Check()

--- a/src/core/stamp.go
+++ b/src/core/stamp.go
@@ -8,11 +8,11 @@ import (
 // a target that is marked stamp=True.
 // This file contains information about its transitive dependencies that can be used to
 // embed information into the output (for example information from labels or licences).
-func StampFile(config *Configuration, target *BuildTarget) []byte {
+func StampFile(state *BuildState, target *BuildTarget) []byte {
 	info := &stampInfo{
 		Targets: map[BuildLabel]targetInfo{},
 	}
-	populateStampInfo(config, target, info)
+	populateStampInfo(state, target, info)
 	b, err := json.MarshalIndent(info, "", "  ")
 	if err != nil {
 		log.Fatalf("Failed to encode stamp file: %s", err)
@@ -20,16 +20,16 @@ func StampFile(config *Configuration, target *BuildTarget) []byte {
 	return b
 }
 
-func populateStampInfo(config *Configuration, target *BuildTarget, info *stampInfo) {
-	accepted, _ := target.CheckLicences(config)
+func populateStampInfo(state *BuildState, target *BuildTarget, info *stampInfo) {
+	accepted, _ := target.CheckLicences(state.Config)
 	info.Targets[target.Label] = targetInfo{
 		Licences:        target.Licences,
 		AcceptedLicence: accepted,
 		Labels:          target.Labels,
 	}
-	for _, dep := range target.Dependencies() {
+	for _, dep := range target.Dependencies(state.Graph) {
 		if _, present := info.Targets[dep.Label]; !present {
-			populateStampInfo(config, dep, info)
+			populateStampInfo(state, dep, info)
 		}
 	}
 }

--- a/src/core/stamp_test.go
+++ b/src/core/stamp_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestStampFile(t *testing.T) {
-	config := DefaultConfiguration()
-	config.Licences.Accept = []string{"bsd-2-clause"}
+	state := NewDefaultBuildState()
+	state.Config.Licences.Accept = []string{"bsd-2-clause"}
 	t1 := NewBuildTarget(ParseBuildLabel("//src/core:core", ""))
 	t2 := NewBuildTarget(ParseBuildLabel("//src/fs:fs", ""))
 	t3 := NewBuildTarget(ParseBuildLabel("//third_party/go:errors", ""))
@@ -16,11 +16,11 @@ func TestStampFile(t *testing.T) {
 	t3.AddLabel("go_get:github.com/pkg/errors")
 	t3.AddLicence("bsd-2-clause")
 	t1.AddDependency(t2.Label)
-	t1.resolveDependency(t2.Label, t2)
 	t1.AddDependency(t3.Label)
-	t1.resolveDependency(t3.Label, t3)
 	t2.AddDependency(t3.Label)
-	t2.resolveDependency(t3.Label, t3)
+	state.Graph.AddTarget(t1)
+	state.Graph.AddTarget(t2)
+	state.Graph.AddTarget(t3)
 	expected := []byte(`{
   "targets": {
     "//src/core:core": {
@@ -40,5 +40,5 @@ func TestStampFile(t *testing.T) {
     }
   }
 }`)
-	assert.Equal(t, expected, StampFile(config, t1))
+	assert.Equal(t, expected, StampFile(state, t1))
 }

--- a/src/core/utils.go
+++ b/src/core/utils.go
@@ -171,8 +171,8 @@ func IterInputs(state *BuildState, graph *BuildGraph, target *BuildTarget, inclu
 
 			done[dependency.Label] = true
 			if target == dependency || (target.NeedsTransitiveDependencies && !dependency.OutputIsComplete) {
-				for _, dep := range dependency.BuildDependencies() {
-					for dep2 := range recursivelyProvideFor(graph, target, dependency, dep.Label) {
+				for dep := range dependency.BuildDependencies() {
+					for dep2 := range recursivelyProvideFor(graph, target, dependency, dep) {
 						if !done[dep2] && !dependency.IsTool(dep2) {
 							if !inner(graph.TargetOrDie(dep2)) {
 								return false
@@ -181,7 +181,7 @@ func IterInputs(state *BuildState, graph *BuildGraph, target *BuildTarget, inclu
 					}
 				}
 			} else {
-				for _, dep := range dependency.ExportedDependencies() {
+				for dep := range dependency.ExportedDependencies() {
 					for dep2 := range recursivelyProvideFor(graph, target, dependency, dep) {
 						if !done[dep2] {
 							if !inner(graph.TargetOrDie(dep2)) {
@@ -261,7 +261,7 @@ func IterRuntimeFiles(graph *BuildGraph, target *BuildTarget, absoluteOuts bool,
 		}
 
 		outDir := target.OutDir()
-		for _, out := range target.Outputs() {
+		for _, out := range target.Outputs(graph) {
 			if !pushOut(filepath.Join(outDir, out), out) {
 				return
 			}
@@ -431,8 +431,9 @@ func IterInputPaths(graph *BuildGraph, target *BuildTarget) iter.Seq[string] {
 				}
 
 				// Finally recurse for all the deps of this rule.
-				for _, dep := range target.Dependencies() {
-					for d := range recursivelyProvideFor(graph, target, dep, dep.Label) {
+				for dep := range target.DeclaredDependencies() {
+					t := graph.TargetOrDie(dep)
+					for d := range recursivelyProvideFor(graph, target, t, t.Label) {
 						if !inner(graph.TargetOrDie(d)) {
 							return false
 						}

--- a/src/core/utils_benchmark_test.go
+++ b/src/core/utils_benchmark_test.go
@@ -31,7 +31,6 @@ func BenchmarkIterInputsSimple(b *testing.B) {
 		}
 		state.Graph.AddTarget(dep)
 		target.AddDependency(dep.Label)
-		target.resolveDependency(target.Label, dep)
 	}
 
 	for i := 0; i < 25; i++ {
@@ -63,7 +62,6 @@ func BenchmarkIterInputsNamedSources(b *testing.B) {
 		}
 		state.Graph.AddTarget(dep)
 		target.AddDependency(dep.Label)
-		target.resolveDependency(target.Label, dep)
 	}
 
 	for i := 0; i < 5; i++ {

--- a/src/core/utils_test.go
+++ b/src/core/utils_test.go
@@ -172,7 +172,6 @@ func makeTarget4(graph *BuildGraph, label string, deps ...string) *BuildTarget {
 	for _, dep := range deps {
 		t := graph.TargetOrDie(ParseBuildLabel(dep, ""))
 		target.AddDependency(t.Label)
-		target.resolveDependency(target.Label, t)
 	}
 	target.Sources = append(target.Sources, FileLabel{
 		File:    target.Label.Name + ".go",

--- a/src/exec/exec.go
+++ b/src/exec/exec.go
@@ -134,7 +134,7 @@ func resolveCmd(state *core.BuildState, target *core.BuildTarget, overrideCmdArg
 		return core.ReplaceSequences(state, target, strings.Join(overrideCmdArgs, " "))
 	}
 
-	outs := target.Outputs()
+	outs := target.Outputs(state.Graph)
 	if len(outs) != 1 {
 		return "", fmt.Errorf("Target %s cannot be executed as it has %d outputs", target.Label, len(outs))
 	}

--- a/src/export/export.go
+++ b/src/export/export.go
@@ -186,7 +186,7 @@ func (e *export) export(target *core.BuildTarget) {
 	}
 
 	e.exportedTargets[target.Label] = true
-	for _, dep := range target.Dependencies() {
+	for _, dep := range target.Dependencies(e.state.Graph) {
 		e.export(dep)
 	}
 	for _, subinclude := range e.state.Graph.PackageOrDie(target.Label).AllSubincludes(e.state.Graph) {
@@ -201,7 +201,7 @@ func (e *export) export(target *core.BuildTarget) {
 func Outputs(state *core.BuildState, dir string, targets []core.BuildLabel) {
 	for _, label := range targets {
 		target := state.Graph.TargetOrDie(label)
-		for _, out := range target.Outputs() {
+		for _, out := range target.Outputs(state.Graph) {
 			fullPath := filepath.Join(dir, out)
 			outDir := filepath.Dir(fullPath)
 			if err := os.MkdirAll(outDir, core.DirPermissions); err != nil {

--- a/src/gc/gc.go
+++ b/src/gc/gc.go
@@ -167,10 +167,10 @@ func addTarget(graph *core.BuildGraph, m targetMap, target *core.BuildTarget) {
 	}
 	log.Debug("  %s", target.Label)
 	m[target] = true
-	for _, dep := range target.DeclaredDependencies() {
+	for dep := range target.DeclaredDependencies() {
 		addTarget(graph, m, graph.Target(dep))
 	}
-	for _, dep := range target.Dependencies() {
+	for _, dep := range target.Dependencies(graph) {
 		addTarget(graph, m, dep)
 	}
 	if target.Subrepo != nil && target.Subrepo.Target != nil {
@@ -199,7 +199,7 @@ func anyInclude(labels []core.BuildLabel, label core.BuildLabel) bool {
 // it will return //src/test:test for //src/test:container_test.
 func publicDependencies(graph *core.BuildGraph, target *core.BuildTarget) []*core.BuildTarget {
 	ret := []*core.BuildTarget{}
-	for _, dep := range target.DeclaredDependencies() {
+	for dep := range target.DeclaredDependencies() {
 		if depTarget := graph.Target(dep); depTarget != nil {
 			if depTarget.Label.Parent() == target.Label.Parent() {
 				ret = append(ret, publicDependencies(graph, depTarget)...)

--- a/src/generate/generate.go
+++ b/src/generate/generate.go
@@ -24,7 +24,7 @@ func UpdateGitignore(graph *core.BuildGraph, labels []core.BuildLabel, gitignore
 		if !t.HasLabel("codegen") {
 			continue
 		}
-		for _, out := range t.Outputs() {
+		for _, out := range t.Outputs(graph) {
 			relativePkg := t.Label.PackageName
 			if pkg != "." {
 				if !strings.HasPrefix(t.Label.PackageName, pkg) {
@@ -49,7 +49,7 @@ func allLabelGenOuts(graph *core.BuildGraph, labels []core.BuildLabel) []string 
 		if !t.HasLabel("codegen") {
 			continue
 		}
-		outs = append(outs, t.Outputs()...)
+		outs = append(outs, t.Outputs(graph)...)
 	}
 	return outs
 }
@@ -72,7 +72,7 @@ func LinkGeneratedSources(state *core.BuildState, labels []core.BuildLabel) {
 		if !target.HasLabel("codegen") {
 			continue
 		}
-		for _, out := range target.Outputs() {
+		for _, out := range target.Outputs(state.Graph) {
 			destDir := filepath.Join(core.RepoRoot, target.Label.PackageDir())
 			srcDir := filepath.Join(core.RepoRoot, target.OutDir())
 			fs.LinkDestination(filepath.Join(srcDir, out), filepath.Join(destDir, out), linker)

--- a/src/output/shell_output.go
+++ b/src/output/shell_output.go
@@ -373,7 +373,7 @@ func testResultMessage(results *core.TestSuite, showDuration bool) string {
 
 func printUnformattedBuildResults(state *core.BuildState) {
 	for _, label := range state.ExpandVisibleOriginalTargets() {
-		for _, result := range buildResult(state.Graph.TargetOrDie(label)) {
+		for _, result := range buildResult(state, state.Graph.TargetOrDie(label)) {
 			fmt.Printf("%s\n", result)
 		}
 	}
@@ -404,7 +404,7 @@ func printBuildResults(state *core.BuildState, duration time.Duration) {
 	for _, label := range state.ExpandVisibleOriginalTargets() {
 		target := state.Graph.TargetOrDie(label)
 		fmt.Printf("%s:\n", label)
-		for _, result := range buildResult(target) {
+		for _, result := range buildResult(state, target) {
 			fmt.Printf("  %s\n", result)
 		}
 	}
@@ -476,10 +476,10 @@ func printTempDirs(state *core.BuildState, duration time.Duration, shell, shellR
 	}
 }
 
-func buildResult(target *core.BuildTarget) []string {
+func buildResult(state *core.BuildState, target *core.BuildTarget) []string {
 	results := []string{}
 	if target != nil {
-		for _, out := range target.Outputs() {
+		for _, out := range target.Outputs(state.Graph) {
 			if core.StartedAtRepoRoot() {
 				results = append(results, filepath.Join(target.OutDir(), out))
 			} else {

--- a/src/parse/asp/builtins.go
+++ b/src/parse/asp/builtins.go
@@ -348,9 +348,9 @@ func subinclude(s *scope, args []pyObject) pyObject {
 
 		var outs []string
 		if len(annotation) > 0 {
-			outs = t.NamedOutputs(annotation)
+			outs = t.NamedOutputs(s.state.Graph, annotation)
 		} else {
-			outs = t.Outputs()
+			outs = t.Outputs(s.state.Graph)
 		}
 		for _, out := range outs {
 			s.SetAll(s.interpreter.Subinclude(s, filepath.Join(t.OutDir(), out), t.Label, false), false)
@@ -1137,10 +1137,10 @@ func getLabels(s *scope, args []pyObject) pyObject {
 	}
 	if core.LooksLikeABuildLabel(name) {
 		label := core.ParseBuildLabel(name, s.pkg.Name)
-		return getLabelsInternal(s.state.Graph.TargetOrDie(label), prefix, core.Built, all, maxDepth)
+		return getLabelsInternal(s.state.Graph, s.state.Graph.TargetOrDie(label), prefix, core.Built, all, maxDepth)
 	}
 	target := getTargetPost(s, name)
-	return getLabelsInternal(target, prefix, core.Building, all, maxDepth)
+	return getLabelsInternal(s.state.Graph, target, prefix, core.Building, all, maxDepth)
 }
 
 // addLabel adds a set of labels to the named rule
@@ -1160,7 +1160,7 @@ func addLabel(s *scope, args []pyObject) pyObject {
 	return None
 }
 
-func getLabelsInternal(target *core.BuildTarget, prefix string, minState core.BuildTargetState, all bool, maxDepth int) pyObject {
+func getLabelsInternal(graph *core.BuildGraph, target *core.BuildTarget, prefix string, minState core.BuildTargetState, all bool, maxDepth int) pyObject {
 	if target.State() < minState {
 		log.Fatalf("get_labels called on a target that is not yet built: %s", target.Label)
 	}
@@ -1181,7 +1181,7 @@ func getLabelsInternal(target *core.BuildTarget, prefix string, minState core.Bu
 			return
 		}
 		if !t.OutputIsComplete || t == target || all {
-			for _, dep := range t.Dependencies() {
+			for _, dep := range t.Dependencies(graph) {
 				if !done[dep] {
 					getLabels(dep, max(depth-1, -1))
 				}
@@ -1286,7 +1286,7 @@ func getOuts(s *scope, args []pyObject) pyObject {
 		target = getTargetPost(s, name)
 	}
 
-	outs := target.Outputs()
+	outs := target.Outputs(s.state.Graph)
 	ret := make(pyList, len(outs))
 	for i, out := range outs {
 		ret[i] = pyString(out)
@@ -1460,8 +1460,8 @@ func subrepo(s *scope, args []pyObject) pyObject {
 		// N.B. The target must be already registered on this package.
 		target = s.pkg.TargetOrDie(s.parseLabelInPackage(dep, s.pkg).Name)
 		root = target.Label.Name
-		if len(target.Outputs()) == 1 {
-			root = target.Outputs()[0]
+		if outputs := target.Outputs(s.state.Graph); len(outputs) == 1 {
+			root = outputs[0]
 		}
 		if target.Local || s.state.RemoteClient == nil {
 			root = filepath.Join(target.OutDir(), root)

--- a/src/parse/asp/builtins_test.go
+++ b/src/parse/asp/builtins_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/thought-machine/please/src/core"
 )
@@ -39,11 +38,6 @@ func TestGetLabels(t *testing.T) {
 	state.Graph.AddTarget(bottom)
 	state.Graph.AddTarget(middle)
 	state.Graph.AddTarget(top)
-
-	err := middle.ResolveDependencies(state.Graph)
-	require.NoError(t, err)
-	err = top.ResolveDependencies(state.Graph)
-	require.NoError(t, err)
 
 	s := &scope{state: state, pkg: core.NewPackage("pkg")}
 	ls := getLabels(s, []pyObject{pyString(":top"), pyString("target:"), False, True, pyInt(-1)}).(pyList) // transitive=True

--- a/src/parse/asp/interpreter.go
+++ b/src/parse/asp/interpreter.go
@@ -156,7 +156,7 @@ func (i *interpreter) preloadSubinclude(s *scope, label core.BuildLabel) (err er
 	}
 
 	s.interpreter.loadPluginConfig(s, includeState)
-	for _, out := range t.FullOutputs() {
+	for _, out := range t.FullOutputs(s.state.Graph) {
 		s.SetAll(s.interpreter.Subinclude(s, out, t.Label, true), false)
 	}
 	return nil

--- a/src/please.go
+++ b/src/please.go
@@ -481,7 +481,7 @@ var buildFunctions = map[string]func() int{
 		}
 		for _, label := range state.ExpandOriginalLabels() {
 			target := state.Graph.TargetOrDie((label))
-			for _, out := range target.Outputs() {
+			for _, out := range target.Outputs(state.Graph) {
 				from := filepath.Join(target.OutDir(), out)
 				fm, err := os.Lstat(from)
 				if err != nil {

--- a/src/plz/plz.go
+++ b/src/plz/plz.go
@@ -149,11 +149,6 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, progress
 
 		// TODO(peter): Need to handle targets getting extra deps added by post-build functions here.
 
-		// TODO(peter): Temporary, we are going to get rid of all this
-		if err := target.ResolveDependencies(state.Graph); err != nil {
-			return err
-		}
-
 		// Now we are ready to build this target. Grab a thread and get started.
 		remote := anyRemote && !target.Local
 		limiter := limiter(remote)
@@ -207,8 +202,7 @@ func Run(targets, preTargets []core.BuildLabel, state *core.BuildState, progress
 			_, err := state.Build(label)
 			return err
 		})
-		// TODO(peterebden): More restructuring here. It's sort of weird that this doesn't go through resolveTarget.
-		for dep := range target.IterAllRuntimeDependencies(state.Graph) {
+		for dep := range target.RuntimeDependencies() {
 			g.Go(func() error {
 				_, err := state.Build(dep)
 				return err

--- a/src/query/changes_test.go
+++ b/src/query/changes_test.go
@@ -155,9 +155,6 @@ func addTarget(state *core.BuildState, label string, dep *core.BuildTarget, sour
 		t.AddDependency(dep.Label)
 	}
 	state.Graph.AddTarget(t)
-	if err := t.ResolveDependencies(state.Graph); err != nil {
-		log.Fatalf("Failed to resolve dependency %s -> %s: %s", t, dep, err)
-	}
 	pkg := state.Graph.PackageByLabel(t.Label)
 	if pkg == nil {
 		pkg = core.NewPackageSubrepo(t.Label.PackageName, t.Label.Subrepo)

--- a/src/query/deps.go
+++ b/src/query/deps.go
@@ -3,6 +3,8 @@ package query
 import (
 	"fmt"
 	"io"
+	"slices"
+	"sort"
 	"strings"
 
 	"github.com/thought-machine/please/src/core"
@@ -31,7 +33,10 @@ func deps(out io.Writer, state *core.BuildState, target *core.BuildTarget, done 
 	if currentLevel == targetLevel {
 		return
 	}
-	for _, l := range target.DeclaredDependencies() {
+	// Sort so output is stable and readable; DeclaredDependencies yields in declaration order.
+	declaredDeps := core.BuildLabels(slices.Collect(target.DeclaredDependencies()))
+	sort.Sort(declaredDeps)
+	for _, l := range declaredDeps {
 		dep := state.Graph.TargetOrDie(l)
 		for _, l := range dep.ProvideFor(target) {
 			if !state.ShouldInclude(dep) || done[l] {

--- a/src/query/graph.go
+++ b/src/query/graph.go
@@ -133,7 +133,7 @@ func addJSONTarget(state *core.BuildState, graph *JSONGraph, label core.BuildLab
 			},
 		}
 	}
-	for _, dep := range target.Dependencies() {
+	for _, dep := range target.Dependencies(state.Graph) {
 		addJSONTarget(state, graph, dep.Label, done)
 	}
 }
@@ -154,10 +154,10 @@ func makeJSONTarget(state *core.BuildState, target *core.BuildTarget) JSONTarget
 	for in := range core.IterSources(state, state.Graph, target, false) {
 		t.Inputs = append(t.Inputs, in)
 	}
-	for _, out := range target.Outputs() {
+	for _, out := range target.Outputs(state.Graph) {
 		t.Outputs = append(t.Outputs, filepath.Join(target.Label.PackageName, out))
 	}
-	for _, dep := range target.Dependencies() {
+	for _, dep := range target.Dependencies(state.Graph) {
 		t.Deps = append(t.Deps, dep.Label.String())
 	}
 	// just use run 1 as this is only used to print the test dir

--- a/src/query/graph_test.go
+++ b/src/query/graph_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/thought-machine/please/src/core"
 )
@@ -55,8 +54,6 @@ func makeGraph(t *testing.T) *core.BuildState {
 	pkg2.AddTarget(t3)
 	graph.AddTarget(pkg2.Target("target3"))
 	graph.AddPackage(pkg2)
-	require.NoError(t, t2.ResolveDependencies(graph))
-	require.NoError(t, t3.ResolveDependencies(graph))
 	return state
 }
 

--- a/src/query/outputs.go
+++ b/src/query/outputs.go
@@ -21,7 +21,7 @@ func TargetOutputs(graph *core.BuildGraph, labels []core.BuildLabel, useJSON boo
 func targetOutputsFlat(graph *core.BuildGraph, labels []core.BuildLabel) {
 	for _, label := range labels {
 		target := graph.TargetOrDie(label)
-		for _, out := range target.Outputs() {
+		for _, out := range target.Outputs(graph) {
 			fmt.Printf("%s\n", filepath.Join(target.OutDir(), out))
 		}
 	}
@@ -31,7 +31,7 @@ func targetOutputsJSON(graph *core.BuildGraph, labels []core.BuildLabel) {
 	data := map[string][]string{}
 	for _, label := range labels {
 		target := graph.TargetOrDie(label)
-		for _, out := range target.Outputs() {
+		for _, out := range target.Outputs(graph) {
 			data[label.String()] = append(data[label.String()], filepath.Join(target.OutDir(), out))
 		}
 	}

--- a/src/query/print.go
+++ b/src/query/print.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -132,13 +133,13 @@ func specialFields() specialFieldsMap {
 			return ""
 		},
 		"deps": func(target *core.BuildTarget) interface{} {
-			return target.DeclaredDependenciesStrict()
+			return slices.Collect(target.DeclaredDependenciesStrict())
 		},
 		"exported_deps": func(target *core.BuildTarget) interface{} {
-			return target.ExportedDependencies()
+			return slices.Collect(target.ExportedDependencies())
 		},
 		"runtime_deps": func(target *core.BuildTarget) interface{} {
-			return target.RuntimeDependencies()
+			return slices.Collect(target.RuntimeDependencies())
 		},
 		"visibility": func(target *core.BuildTarget) interface{} {
 			if len(target.Visibility) == 1 && target.Visibility[0] == core.WholeGraph[0] {

--- a/src/query/reverse_deps.go
+++ b/src/query/reverse_deps.go
@@ -111,7 +111,7 @@ func buildRevdeps(graph *core.BuildGraph, includeSubrepos bool) map[core.BuildLa
 	targets := graph.AllTargets()
 	revdeps := make(map[core.BuildLabel][]*core.BuildTarget, len(targets))
 	for _, t := range targets {
-		for _, d := range t.DeclaredDependencies() {
+		for d := range t.DeclaredDependencies() {
 			if t2 := graph.Target(d); t2 == nil {
 				revdeps[d] = append(revdeps[d], t2)
 			} else {

--- a/src/query/reverse_deps_test.go
+++ b/src/query/reverse_deps_test.go
@@ -20,8 +20,6 @@ func TestReverseDeps(t *testing.T) {
 	graph.AddTarget(root)
 	graph.AddTarget(branch)
 	graph.AddTarget(leaf)
-	branch.ResolveDependencies(graph)
-	leaf.ResolveDependencies(graph)
 
 	pkg := core.NewPackage("package")
 	graph.AddPackage(pkg)

--- a/src/query/somepath.go
+++ b/src/query/somepath.go
@@ -92,7 +92,7 @@ func somePath(graph *core.BuildGraph, target1, target2 *core.BuildTarget, seen, 
 		return nil
 	}
 	seen[target1.Label] = struct{}{}
-	for _, dep := range target1.DeclaredDependencies() {
+	for dep := range target1.DeclaredDependencies() {
 		if t := graph.Target(dep); t != nil {
 			if _, present := except[t.Label]; present {
 				continue

--- a/src/query/whatoutputs.go
+++ b/src/query/whatoutputs.go
@@ -12,7 +12,7 @@ import (
 func WhatOutputs(graph *core.BuildGraph, files []string, printFiles bool) {
 	targets := graph.AllTargets()
 	for _, f := range files {
-		if t := whatOutputs(targets, f); len(t) > 0 {
+		if t := whatOutputs(graph, targets, f); len(t) > 0 {
 			for _, l := range t {
 				if printFiles {
 					fmt.Printf("%s ", f)
@@ -29,10 +29,10 @@ func WhatOutputs(graph *core.BuildGraph, files []string, printFiles bool) {
 	}
 }
 
-func whatOutputs(targets []*core.BuildTarget, file string) []core.BuildLabel {
+func whatOutputs(graph *core.BuildGraph, targets []*core.BuildTarget, file string) []core.BuildLabel {
 	ret := []core.BuildLabel{}
 	for _, t := range targets {
-		for _, output := range t.FullOutputs() {
+		for _, output := range t.FullOutputs(graph) {
 			if output == file {
 				ret = append(ret, t.Label)
 			}

--- a/src/query/whatoutputs_test.go
+++ b/src/query/whatoutputs_test.go
@@ -37,7 +37,7 @@ func makeTarget2(g *core.BuildGraph, label string, filegroup bool, outputs ...st
 func TestDetectsOutputs(t *testing.T) {
 	graph := core.NewGraph()
 	makeTarget2(graph, "//package1:target1", false, "out1", "out2")
-	targets := whatOutputs(graph.AllTargets(), "plz-out/gen/package1/out1")
+	targets := whatOutputs(graph, graph.AllTargets(), "plz-out/gen/package1/out1")
 	assert.Equal(t, []core.BuildLabel{{PackageName: "package1", Name: "target1"}}, targets)
 }
 
@@ -47,11 +47,11 @@ func TestDetectOutputsFilegroup(t *testing.T) {
 	graph := core.NewGraph()
 	makeTarget2(graph, "//package1:target1", true, "out1", "out2")
 	makeTarget2(graph, "//package1:target2", true, "out1")
-	targets := whatOutputs(graph.AllTargets(), "plz-out/gen/package1/out1")
+	targets := whatOutputs(graph, graph.AllTargets(), "plz-out/gen/package1/out1")
 	assert.Equal(t, []core.BuildLabel{
 		{PackageName: "package1", Name: "target1"},
 		{PackageName: "package1", Name: "target2"},
 	}, targets)
-	targets = whatOutputs(graph.AllTargets(), "plz-out/gen/package1/out2")
+	targets = whatOutputs(graph, graph.AllTargets(), "plz-out/gen/package1/out2")
 	assert.Equal(t, []core.BuildLabel{{PackageName: "package1", Name: "target1"}}, targets)
 }

--- a/src/remote/action.go
+++ b/src/remote/action.go
@@ -106,8 +106,8 @@ func (c *Client) buildCommand(target *core.BuildTarget, inputRoot *pb.Directory,
 		}
 	}
 
-	outs := target.AllOutputs()
-	if len(target.Outputs()) == 1 { // $OUT is relative when running remotely; make it absolute
+	outs := target.AllOutputs(c.state.Graph)
+	if len(target.Outputs(c.state.Graph)) == 1 { // $OUT is relative when running remotely; make it absolute
 		commandPrefixBuilder.WriteString(`export OUT="$TMP_DIR/$OUT" && `)
 	}
 	if target.IsRemoteFile {
@@ -156,7 +156,7 @@ func (c *Client) buildTestCommand(state *core.BuildState, target *core.BuildTarg
 		paths = append(paths, core.TestResultsFile)
 	}
 	commandPrefix := "export TMP_DIR=\"`pwd`\" TEST_DIR=\"`pwd`\" && "
-	if outs := target.Outputs(); len(outs) > 0 {
+	if outs := target.Outputs(state.Graph); len(outs) > 0 {
 		commandPrefix += `export TEST="$TEST_DIR/` + outs[0] + `" && `
 	}
 	cmd, err := core.TestCommand(state, target)
@@ -177,7 +177,7 @@ func (c *Client) buildTestCommand(state *core.BuildState, target *core.BuildTarg
 
 // buildRunCommand builds the command to run a target remotely.
 func (c *Client) buildRunCommand(state *core.BuildState, target *core.BuildTarget) (*pb.Command, error) {
-	outs := target.Outputs()
+	outs := target.Outputs(state.Graph)
 	if len(outs) == 0 {
 		return nil, fmt.Errorf("Target %s has no outputs, it can't be run with `plz run`", target)
 	}
@@ -287,7 +287,7 @@ func (c *Client) uploadInputDir(ch chan<- *uploadinfo.Entry, target *core.BuildT
 		}
 	}
 	if !isTest && target.Stamp {
-		stamp := core.StampFile(c.state.Config, target)
+		stamp := core.StampFile(c.state, target)
 		entry := uploadinfo.EntryFromBlob(stamp)
 		if ch != nil {
 			ch <- entry
@@ -539,7 +539,7 @@ func (c *Client) verifyActionResult(target *core.BuildTarget, command *pb.Comman
 
 // uploadLocalTarget uploads the outputs of a target that was built locally.
 func (c *Client) uploadLocalTarget(target *core.BuildTarget) error {
-	m, ar, err := c.client.ComputeOutputsToUpload(target.OutDir(), ".", target.Outputs(), filemetadata.NewNoopCache(), command.PreserveSymlink, map[string]*cpb.NodeProperties{})
+	m, ar, err := c.client.ComputeOutputsToUpload(target.OutDir(), ".", target.Outputs(c.state.Graph), filemetadata.NewNoopCache(), command.PreserveSymlink, map[string]*cpb.NodeProperties{})
 	if err != nil {
 		return err
 	}

--- a/src/remote/remote.go
+++ b/src/remote/remote.go
@@ -496,7 +496,7 @@ func (c *Client) download(target *core.BuildTarget, f func() error) error {
 func (c *Client) reallyDownload(target *core.BuildTarget, digest *pb.Digest, ar *pb.ActionResult) error {
 	log.Debug("Downloading outputs for %s", target)
 
-	if err := removeOutputs(target); err != nil {
+	if err := c.removeOutputs(target); err != nil {
 		return err
 	}
 	if err := c.downloadActionOutputs(context.Background(), ar, target); err != nil {
@@ -904,7 +904,7 @@ func (c *Client) fetchRemoteFile(target *core.BuildTarget, actionDigest *pb.Dige
 	}
 	c.state.LogBuildResult(target, core.TargetBuilding, "Downloaded.")
 	// If we get here, the blob exists in the CAS. Create an ActionResult corresponding to it.
-	outs := target.Outputs()
+	outs := target.Outputs(c.state.Graph)
 	ar := &pb.ActionResult{
 		OutputFiles: []*pb.OutputFile{{
 			Path:         outs[0],

--- a/src/remote/remote_test.go
+++ b/src/remote/remote_test.go
@@ -83,7 +83,7 @@ func TestExecutePostBuildFunction(t *testing.T) {
 	})
 	_, err := c.Build(target)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"somefile"}, target.Outputs())
+	assert.Equal(t, []string{"somefile"}, target.Outputs(c.state.Graph))
 }
 
 func TestExecuteFetch(t *testing.T) {
@@ -266,9 +266,9 @@ func TestOutDirsSetOutsOnTarget(t *testing.T) {
 	_, err := c.Build(outDirTarget)
 	require.NoError(t, err)
 
-	assert.Len(t, outDirTarget.Outputs(), 2)
-	assert.ElementsMatch(t, []string{"foo.txt", "bar.txt"}, outDirTarget.Outputs())
-	for _, out := range outDirTarget.Outputs() {
+	assert.Len(t, outDirTarget.Outputs(c.state.Graph), 2)
+	assert.ElementsMatch(t, []string{"foo.txt", "bar.txt"}, outDirTarget.Outputs(c.state.Graph))
+	for _, out := range outDirTarget.Outputs(c.state.Graph) {
 		assert.True(t, fs.FileExists(filepath.Join(outDirTarget.OutDir(), out)), "output %s doesn't exist in target out folder", out)
 	}
 }

--- a/src/remote/utils.go
+++ b/src/remote/utils.go
@@ -296,7 +296,7 @@ func (c *Client) retrieveLocalResults(target *core.BuildTarget, digest *pb.Diges
 // outputsExist returns true if the outputs for this target exist and are up to date.
 func (c *Client) outputsExist(target *core.BuildTarget, digest *pb.Digest) bool {
 	hash, _ := hex.DecodeString(digest.Hash)
-	for _, out := range target.FullOutputs() {
+	for _, out := range target.FullOutputs(c.state.Graph) {
 		if !bytes.Equal(hash, fs.ReadAttr(out, xattrName, c.state.XattrsSupported)) {
 			return false
 		}
@@ -307,7 +307,7 @@ func (c *Client) outputsExist(target *core.BuildTarget, digest *pb.Digest) bool 
 // recordAttrs sets the xattrs on output files which we will use in outputsExist in future runs.
 func (c *Client) recordAttrs(target *core.BuildTarget, digest *pb.Digest) {
 	hash, _ := hex.DecodeString(digest.Hash)
-	for _, out := range target.FullOutputs() {
+	for _, out := range target.FullOutputs(c.state.Graph) {
 		fs.RecordAttr(out, hash, xattrName, c.state.XattrsSupported)
 	}
 }
@@ -571,9 +571,9 @@ func (c *Client) targetPlatformProperties(target *core.BuildTarget) *pb.Platform
 }
 
 // removeOutputs removes all outputs for a target.
-func removeOutputs(target *core.BuildTarget) error {
+func (c *Client) removeOutputs(target *core.BuildTarget) error {
 	outDir := target.OutDir()
-	for _, out := range target.Outputs() {
+	for _, out := range target.Outputs(c.state.Graph) {
 		if err := fs.RemoveAll(filepath.Join(outDir, out)); err != nil {
 			return fmt.Errorf("Failed to remove output for %s: %s", target, err)
 		}

--- a/src/run/run_step.go
+++ b/src/run/run_step.go
@@ -105,8 +105,8 @@ func run(ctx context.Context, state *core.BuildState, label core.AnnotatedOutput
 	if !target.IsBinary && overrideCmd == "" {
 		log.Fatalf("Target %s cannot be run; it's not marked as binary", label)
 	}
-	if label.Annotation == "" && len(target.Outputs()) != 1 {
-		log.Fatalf("Targets %s cannot be run as it has %d outputs.", label, len(target.Outputs()))
+	if label.Annotation == "" && len(target.Outputs(state.Graph)) != 1 {
+		log.Fatalf("Targets %s cannot be run as it has %d outputs.", label, len(target.Outputs(state.Graph)))
 	}
 	if remote {
 		// Send this off to be done remotely.
@@ -148,7 +148,7 @@ func run(ctx context.Context, state *core.BuildState, label core.AnnotatedOutput
 		// out_exe handles java binary stuff by invoking the .jar with java as necessary
 		var command string
 		if tmpDir {
-			command = filepath.Join(dir, target.Outputs()[0])
+			command = filepath.Join(dir, target.Outputs(state.Graph)[0])
 		} else {
 			command, _ = core.ReplaceSequences(state, target, fmt.Sprintf("$(out_exe %s)", target.Label))
 			command = strings.Trim(command, "\"")

--- a/src/test/coverage.go
+++ b/src/test/coverage.go
@@ -74,7 +74,7 @@ func collectAllFiles(state *core.BuildState, target *core.BuildTarget, coverageF
 			}
 		}
 		if deps {
-			for _, dep := range target.ExternalDependencies() {
+			for _, dep := range target.ExternalDependencies(state.Graph) {
 				collectAllFiles(state, dep, coverageFiles, includeAllFiles, deps, doneTargets)
 			}
 		}

--- a/src/watch/watch.go
+++ b/src/watch/watch.go
@@ -103,7 +103,7 @@ func startWatching(watcher *fsnotify.Watcher, state *core.BuildState, labels []c
 				addSource(watcher, state, datum, dirs, files)
 			}
 		}
-		for _, dep := range target.Dependencies() {
+		for _, dep := range target.Dependencies(state.Graph) {
 			startWatch(dep)
 		}
 		pkg := state.Graph.PackageOrDie(target.Label)


### PR DESCRIPTION
Stacked on #3562 (sort of, I know they have `gh pr stack` now but it seems to want me to do them all at once and my conception of this works incrementally).

This refactors BuildTarget to remove the whole concept of "dependency resolution". It now only holds a sequence of BuildLabels, and turning those into BuildTargets and dealing with require/provide happens externally.
A bit of refactoring is needed since it can't provide the same interfaces any more; `Outputs()` and similar functions actually have the biggest knock-on effect since they're called more widely.

Have tried to make all the relevant test changes but there are still busted bits from #3562 which will get followed up in the next chapter.