### PR TITLE
Fix description of `:all` in `plz build` docs

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -416,19 +416,16 @@
       >
     </li>
     <li>
-      <span
-        ><code class="code">plz build //src/core:all</code> builds every target
-        in.</span
-      >
+      <span>
+        <code class="code">plz build //src/core:all</code> builds every target in
+        <code class="code">src/core/BUILD</code>.
+      </span>
     </li>
     <li>
-      <span><code class="code">src/core/BUILD</code>.</span>
-    </li>
-    <li>
-      <span
-        ><code class="code">plz build //src/...</code> builds every target in
-        <code class="code">src</code> and all subdirectories.</span
-      >
+      <span>
+        <code class="code">plz build //src/...</code> builds every target in
+        <code class="code">src</code> and all subdirectories.
+      </span>
     </li>
   </ul>
 </section>


### PR DESCRIPTION
Just stumbled across this, not sure how it's ended up as a new list item there.
I neatened up some of the HTML nearby too