### PR TITLE
Move cyclic_dependency_test to a plz_repo_e2e_test

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -307,16 +307,6 @@ plz_e2e_test(
     expected_output = "query_alltargets_2.txt",
 )
 
-plz_e2e_test(
-    name = "cyclic_dependency_test",
-    timeout = 30,
-    cmd = "plz test //plz-out/tmp/test/cyclic_dependency_test._test/run_1/test/cycle:all",
-    data = ["cycle/TEST_BUILD"],
-    expect_output_contains = "Dependency cycle found",
-    expected_failure = True,
-    pre_cmd = "mv test/cycle/TEST_BUILD test/cycle/BUILD",
-)
-
 # Used manually for testing the test flakiness stuff.
 python_test(
     name = "flaky_test",

--- a/test/cyclic_dependency/BUILD
+++ b/test/cyclic_dependency/BUILD
@@ -1,0 +1,11 @@
+subinclude("//test/build_defs")
+
+please_repo_e2e_test(
+    name = "cyclic_dependency_test",
+    expected_failure = True,
+    expect_output_contains = {
+        "output.txt": "Dependency cycle found",
+    },
+    plz_command = "plz test //cycle:all > output.txt 2>&1",
+    repo = "test_repo",
+)

--- a/test/cyclic_dependency/test_repo/.plzconfig
+++ b/test/cyclic_dependency/test_repo/.plzconfig
@@ -1,0 +1,3 @@
+[Parse]
+BuildFileName = BUILD_FILE
+

--- a/test/cyclic_dependency/test_repo/cycle/BUILD_FILE
+++ b/test/cyclic_dependency/test_repo/cycle/BUILD_FILE
@@ -1,12 +1,12 @@
 # A set of build targets that test issue #43.
 # Due to the nature of how we exercise the issue the test itself cannot be in this package.
 
-python_library(
+filegroup(
     name = "cycle_1",
     deps = [":cycle_2"],
 )
 
-python_library(
+filegroup(
     name = "cycle_2",
     deps = [":cycle_1"],
 )


### PR DESCRIPTION
Not a very big deal but it was annoying me, having the full `plz-out/tmp` path expressed in the test was gross.