### PR TITLE
Plugin updates to fix linux_arm64 build

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -60,7 +60,7 @@ plugins = {
     "python": "v2.0.2",
     "java": "v0.4.5",
     "go": "v1.32.0",
-    "cc": "v0.7.2",
+    "cc": "v0.7.3",
     "shell": "v0.2.1",
     "go-proto": "v0.3.0",
     "python-proto": "v0.1.0",

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -7,7 +7,7 @@ plugin_repo(
 plugin_repo(
     name = "cc",
     plugin = "cc-rules",
-    revision = "v0.7.1",
+    revision = "v0.7.2",
 )
 
 plugin_repo(

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -19,5 +19,5 @@ plugin_repo(
 plugin_repo(
     name = "python",
     plugin = "python-rules",
-    revision = "v1.14.0",
+    revision = "v2.0.2",
 )

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -7,7 +7,7 @@ plugin_repo(
 plugin_repo(
     name = "cc",
     plugin = "cc-rules",
-    revision = "v0.7.2",
+    revision = "v0.7.3",
 )
 
 plugin_repo(

--- a/src/plzinit/plugins.go
+++ b/src/plzinit/plugins.go
@@ -55,7 +55,6 @@ var pluginVersion16Map = map[string]v16Mapping{
 		"defaultpiprepo":      "DefaultPipRepo",
 		"wheelrepo":           "WheelRepo",
 		"wheelnamescheme":     "WheelNameScheme",
-		"interpreteroptions":  "InterpreterOptions",
 		"disablevendorflags":  "DisableVendorFlags",
 		"usepypi":             "UsePypi",
 		"testrunnerbootstrap": "TestrunnerDeps",

--- a/test.sh
+++ b/test.sh
@@ -15,8 +15,8 @@ check_path_for_excludes() {
   EXCLUDES=""
 
   if ! hash python3 2>/dev/null ; then
-      warn "python3 not found, excluding python3 tests"
-      EXCLUDES="${EXCLUDES} --exclude=py3 --exclude python3"
+      warn "python3 not found, excluding python tests"
+      EXCLUDES="${EXCLUDES} --exclude=py"
   fi
   if ! hash xz 2>/dev/null ; then
       warn "xz not found, excluding update tests"

--- a/test/BUILD
+++ b/test/BUILD
@@ -118,7 +118,7 @@ plz_e2e_test(
     name = "no_coverage_output_test",
     cmd = "plz test //test:_no_coverage_output_test",
     expect_file_doesnt_exist = "../../../bin/test/.test_coverage__no_coverage_output_test*",
-    labels = ["python3"],
+    labels = ["py"],
 )
 
 # Test that we do generate it when using plz cover.
@@ -181,7 +181,7 @@ plz_e2e_test(
     name = "individual_python_test",
     cmd = "plz test --rerun //test:individual_test_run_py TestRunningIndividualTests.test_first_thing",
     expect_output_contains = "1 test target and 1 test run",
-    labels = ["python3"],
+    labels = ["py"],
 )
 
 # Test re-runs.

--- a/test/BUILD
+++ b/test/BUILD
@@ -179,7 +179,7 @@ python_test(
 
 plz_e2e_test(
     name = "individual_python_test",
-    cmd = "plz test //test:individual_test_run_py TestRunningIndividualTests.test_first_thing",
+    cmd = "plz test --rerun //test:individual_test_run_py TestRunningIndividualTests.test_first_thing",
     expect_output_contains = "1 test target and 1 test run",
     labels = ["python3"],
 )


### PR DESCRIPTION
Notably this moves the Python plugin to v2. I don't think it's very different as far as this repo is concerned but one of the options goes away.

Also a minor test fix that goes a little wonky if it gets cached.