### PR TITLE
Drop deprecation mention from codelab

### DIFF
--- a/docs/codelabs/puku.md
+++ b/docs/codelabs/puku.md
@@ -12,7 +12,7 @@ Feedback Link: https://github.com/thought-machine/please
 ## Overview
 Duration: 2
 
-Notes: `go_module()` is deprecated in Core3. This codelab teaches a practical workflow that uses standard Go tooling (`go get` / `go mod`) together with Puku to generate and maintain third-party go targets (`go_repo`).
+Notes: This codelab teaches a practical workflow that uses standard Go tooling (`go get` / `go mod`) together with Puku to generate and maintain third-party go targets (`go_repo`).
 
 ### Goals and what you'll learn
 - Add and upgrade third‑party dependencies using `go get`


### PR DESCRIPTION
We don't need to talk about the deprecated `go_module` here, we'll just teach them the new way - also core3 isn't something external devs will know about since it's a TM-specific thing.