### PR TITLE
Update some Python libraries

### DIFF
--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -14,8 +14,8 @@ package(
 python_wheel(
     name = "six",
     outs = ["six.py"],
-    hashes = ["8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"],
-    version = "1.16.0",
+    hashes = ["4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"],
+    version = "1.17.0",
 )
 
 python_wheel(
@@ -34,8 +34,8 @@ python_wheel(
 
 python_wheel(
     name = "certifi",
-    hashes = ["017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"],
-    version = "2019.11.28",
+    hashes = ["62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775"],
+    version = "2026.7.22",
 )
 
 python_wheel(
@@ -52,8 +52,8 @@ python_wheel(
 
 python_wheel(
     name = "urllib3",
-    hashes = ["a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"],
-    version = "2.2.2",
+    hashes = ["9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"],
+    version = "2.7.0",
 )
 
 python_wheel(
@@ -65,12 +65,14 @@ python_wheel(
 python_wheel(
     name = "absl",
     package_name = "absl_py",
-    hashes = ["c106f6ef0ae86c1273b0858b40ee15b99fad1c223838387b9d11446a033bbcb1"],
-    version = "0.9.0",
+    hashes = ["0f17b89f2a4eaaedc4f28c622998aa690564b3012a396a4ffad0821007fe03ba"],
+    version = "2.5.0",
     deps = [":six"],
 )
 
 pip_library(
     name = "progress",
-    version = "1.5",
+    version = "1.6.1",
+    licences = ["ISC"],
+    hashes = ["34ce5c7402e39aa9b88b988bc8559bd35b22c589d18b480251c7c72e15eba944"],
 )

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -74,5 +74,4 @@ pip_library(
     name = "progress",
     version = "1.6.1",
     licences = ["ISC"],
-    hashes = ["34ce5c7402e39aa9b88b988bc8559bd35b22c589d18b480251c7c72e15eba944"],
 )

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -52,8 +52,9 @@ python_wheel(
 
 python_wheel(
     name = "urllib3",
-    hashes = ["9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"],
-    version = "2.7.0",
+    hashes = ["bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"],
+    version = "2.6.3",
+    licences = ["MIT"],
 )
 
 python_wheel(

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -65,8 +65,8 @@ python_wheel(
 python_wheel(
     name = "absl",
     package_name = "absl_py",
-    hashes = ["0f17b89f2a4eaaedc4f28c622998aa690564b3012a396a4ffad0821007fe03ba"],
-    version = "2.5.0",
+    hashes = ["526a04eadab8b4ee719ce68f204172ead1027549089702d99b9059f129ff1308"],
+    version = "2.1.0",
     deps = [":six"],
 )
 

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -70,8 +70,9 @@ python_wheel(
     deps = [":six"],
 )
 
-pip_library(
+python_wheel(
     name = "progress",
     version = "1.6.1",
     licences = ["ISC"],
+    hashes = ["5239f22f305c12fdc8ce6e0e47f70f21622a935e16eafc4535617112e7c7ea0b"],
 )


### PR DESCRIPTION
Fixing a warning about a missing licence and bringing some things more up to date. Tried a script or two locally and they still work.

I do wonder a little if we should drop all Python here and just do it all in Go, but it is sort of nice to illustrate that this is a multi-language build system.