### PR TITLE
Fix IsTool for debug tools

### DIFF
--- a/src/core/build_target.go
+++ b/src/core/build_target.go
@@ -1812,6 +1812,8 @@ func (target *BuildTarget) IsTool(tool BuildLabel) bool {
 		return true
 	} else if target.Test != nil && target.isTool(tool, target.Test.tools, target.Test.namedTools) {
 		return true
+	} else if target.Debug != nil && target.isTool(tool, target.Debug.tools, target.Debug.namedTools) {
+		return true
 	}
 	return false
 }

--- a/test/plz_debug/BUILD
+++ b/test/plz_debug/BUILD
@@ -11,3 +11,12 @@ please_repo_e2e_test(
     plz_command = "plz debug --port=31000 //:hello_world >output",
     repo = "test_repo",
 )
+
+# Regression test: a debug tool that provide()s something its dependent require()s must still be
+# built as itself, otherwise it's missing at test time under -c dbg (as happens with the Go plugin's
+# delve_tool, where every go_binary provides a "go" target and every go_test requires "go").
+please_repo_e2e_test(
+    name = "debug_tool_require_provide",
+    plz_command = "plz test -c dbg //:debug_tool_test && test -f plz-out/bin/debugger.sh",
+    repo = "test_repo",
+)

--- a/test/plz_debug/test_repo/BUILD_FILE
+++ b/test/plz_debug/test_repo/BUILD_FILE
@@ -12,3 +12,33 @@ build_rule(
     },
     binary = True,
 )
+
+# Mimics the Go plugin's delve tool
+build_rule(
+    name = "debugger_lib",
+    outs = ["debugger_lib.txt"],
+    cmd = "echo 'this is not the debugger' > $OUT",
+)
+
+build_rule(
+    name = "debugger",
+    outs = ["debugger.sh"],
+    cmd = "echo '#!/bin/sh' > $OUT && echo 'echo debugger ran' >> $OUT && chmod +x $OUT",
+    binary = True,
+    provides = {"debuggable": ":debugger_lib"},
+)
+
+build_rule(
+    name = "debug_tool_test",
+    outs = ["debug_tool_test.txt"],
+    cmd = "echo 'hello world' > $OUT",
+    debug_cmd = "$DEBUG_TOOLS_DEBUGGER $OUT",
+    debug_tools = {
+        "debugger": ":debugger",
+    },
+    no_test_output = True,
+    requires = ["debuggable"],
+    test = True,
+    # Runs the debug tool to prove the tool itself was built & staged, not the target it provides.
+    test_cmd = "$DEBUG_TOOLS_DEBUGGER | grep -q 'debugger ran'",
+)


### PR DESCRIPTION
Looks like `delve_tool` in go-rules is not working at all - with any `plz test -c dbg` I get errors about `cannot calculate hash for plz-out/.../dlv: file does not exist`. I've not traced whether there was a point that it did work, but the fix here is fairly clear: we need to inspect debug tools as well as test tools.

The included test of course fails without the fix to `build_target.go`.