### PR TITLE
Check target.Debug is not nil before we access it

### DIFF
--- a/src/debug/debug.go
+++ b/src/debug/debug.go
@@ -14,7 +14,7 @@ var log = logging.Log
 
 func Debug(state *core.BuildState, label core.BuildLabel, args, env []string, shareNetwork, shareMount bool) int {
 	target := state.Graph.TargetOrDie(label)
-	if len(target.Debug.Command) == 0 {
+	if target.Debug == nil || len(target.Debug.Command) == 0 {
 		log.Fatalf("The build definition used by %s doesn't appear to support debugging yet", target.Label)
 	}
 


### PR DESCRIPTION
Got a report of this line panicking; surely nothing has validated that the `.Debug` attribute is set on the target before it tries to dereference it.